### PR TITLE
Render AskUserQuestion as an answerable card in the desktop app

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -385,6 +385,20 @@ starts never runs its `finally`. Every caller-controlled wire string is bounded 
 ids are canonicalized by GUID parse, and a request kept for a subscriber that then leaves has no
 clock — it lives until the agent exits, the same stale card a TUI answer leaves.
 
+## Elicitation question cards for PTY sessions
+
+A PTY Claude session's `AskUserQuestion` already reaches the app as a pending permission entry
+(the `PermissionRequest` hook rides the permission lane end to end), so the desktop renders it
+as an answerable question card instead of a broken Allow/Deny card — classification is app-side,
+on the entry it already receives, and the answer is the existing resolve frame with `allow` plus
+the documented `updatedInput` answers shape. No wire, daemon, or CLI change: the feature works
+against any daemon advertising `permission/1`, and AI-2197 defines its own frames later for the
+structured ACP vendors. Core's `ClaudeElicitation` owns the contract: a strict, capped,
+parser-created immutable model and a composer that validates every answer against it, which is
+what bounds the outgoing resolve frame by arithmetic. An unparseable or oversized payload falls
+back to the permission card (Allow = let the TUI ask) with "Allow always" hidden for the
+question tool.
+
 ## Launch and stop command routing
 
 The receive pump no longer awaits launch/stop EXECUTION for either command format: arrival order is

--- a/docs/superpowers/plans/2026-08-30-ai2361-elicitation-question-cards.md
+++ b/docs/superpowers/plans/2026-08-30-ai2361-elicitation-question-cards.md
@@ -1,0 +1,1578 @@
+# Elicitation Question Cards (AI-2361) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Render a PTY Claude session's `AskUserQuestion` as an answerable question card in the desktop app, answering over the existing `permission/1` wire with `allow` + `updatedInput.answers`.
+
+**Architecture:** App-side classification of existing pending-permission entries — no daemon, CLI, or wire change. One Core helper (`ClaudeElicitation`) owns the parse (strict, capped, immutable model) and the answer composition (validated against the parse); the app service gains an `AnswerAsync` path and a single-snapshot `PendingSummary`; the Chat tab's NEEDS YOU row hosts mixed permission/question cards; the tray splits its wording.
+
+**Tech Stack:** .NET 10 NativeAOT, Avalonia (headless tests), ReactiveUI, DynamicData, TUnit on Microsoft Testing Platform.
+
+**Spec:** `docs/superpowers/specs/2026-08-30-ai2361-elicitation-question-cards-design.md` — read it first; every constraint below is argued there.
+
+## Global Constraints
+
+- No new `FrameType` values, no capability change, no daemon or CLI edits. The wire is `PermissionResolveDto(RequestId, "allow", ApplyPermissions: null, UpdatedInput: <composed>)`.
+- Caps (UTF-16 code units), Core constants: `MaxQuestions = 8`, `MaxOptionsPerQuestion = 16`, `MaxQuestionTextChars = 4096`, `MaxOptionLabelChars = 1024`, `MaxOtherTextChars = 8192`.
+- Answer shape: `{"questions": <original array verbatim>, "answers": {<question text>: string | string[]}}` — string for single-select, array for multi-select, values validated against the parsed options.
+- JSON reads go through `JsonElementExtensions` (`Prop`/`Str`/`Bool`/`IsObject`/`IsArray`) — raw `ValueKind` comparisons are banned by CLAUDE.md.
+- `new JsonArray(…)`/`JsonArray.Add(JsonNode)` only — a collection expression or the generic `Add<T>` requires dynamic code (AOT trap).
+- Returned/retained `JsonElement`s must be detached (`Clone()` off a scoped `JsonDocument`), never tied to a disposable owner.
+- Comments: scarce, per CLAUDE.md — do not imitate the long historical comments in neighboring files; never narrate the spec or review rounds.
+- Commit subjects: one imperative clause, ≤80 chars, **no issue reference** (no GitHub issue number exists for AI-2361 yet — never invent one).
+- Test conventions: TUnit; UI tests run under `AvaloniaSession` with `[NotInParallel("AvaloniaSession")]`; `WaitUntilAsync` from `WorkspaceFixtures` for async settling.
+- After all tasks: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` must print nothing.
+
+---
+
+### Task 1: Core parse — `ClaudeElicitation.TryParse` and the immutable model
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/ClaudeElicitation.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs` (create)
+
+**Interfaces:**
+- Consumes: `JsonElementExtensions` (`Prop`, `Str`, `Bool`, `IsObject`, `IsArray` — `src/Capacitor.Cli.Core/JsonElementExtensions.cs`).
+- Produces (later tasks depend on these exact names):
+  - `public static class ClaudeElicitation` with `public const string ToolName = "AskUserQuestion";`, the five cap constants above, and `public static ElicitationQuestions? TryParse(string? toolInputJson)`.
+  - `public sealed class ElicitationQuestions { public JsonElement QuestionsJson { get; } public ImmutableArray<ElicitationQuestion> Questions { get; } }` — internal ctor.
+  - `public sealed class ElicitationQuestion { public string Question { get; } public string? Header { get; } public bool MultiSelect { get; } public ImmutableArray<ElicitationOption> Options { get; } }` — internal ctor.
+  - `public sealed class ElicitationOption { public string Label { get; } public string? Description { get; } }` — internal ctor.
+
+- [ ] **Step 1: Create the branch and commit the spec**
+
+```bash
+git switch -c alexeyzimarev/ai-2361-desktop-shell-elicitation-questions-for-pty-sessions-through
+git add docs/superpowers/specs/2026-08-30-ai2361-elicitation-question-cards-design.md docs/superpowers/plans/2026-08-30-ai2361-elicitation-question-cards.md
+git commit -m "Add the AI-2361 elicitation question cards spec and plan"
+```
+
+- [ ] **Step 2: Write the failing parse tests**
+
+Create `test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs`. Helpers is a global using; no imports needed beyond the ones shown.
+
+```csharp
+using System.Collections.Immutable;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class ClaudeElicitationTests {
+    static string OneQuestion(string extra = "") =>
+        $$"""{"questions":[{"question":"Pick one","header":"Choice","options":[{"label":"A","description":"first"},{"label":"B"}]{{extra}}}]}""";
+
+    [Test]
+    public async Task Parses_every_question_in_payload_order() {
+        var parsed = ClaudeElicitation.TryParse(
+            """{"questions":[{"question":"Q1","options":[{"label":"A"}]},{"question":"Q2","multiSelect":true,"options":[{"label":"X"},{"label":"Y"}]}]}""");
+        await Assert.That(parsed).IsNotNull();
+        await Assert.That(parsed!.Questions.Length).IsEqualTo(2);
+        await Assert.That(parsed.Questions[0].Question).IsEqualTo("Q1");
+        await Assert.That(parsed.Questions[0].MultiSelect).IsFalse();
+        await Assert.That(parsed.Questions[1].Question).IsEqualTo("Q2");
+        await Assert.That(parsed.Questions[1].MultiSelect).IsTrue();
+        await Assert.That(parsed.Questions[1].Options.Select(o => o.Label)).IsEquivalentTo(["X", "Y"]);
+    }
+
+    [Test]
+    public async Task Header_and_description_carry_through_and_snake_case_flag_is_honored() {
+        var parsed = ClaudeElicitation.TryParse(
+            """{"questions":[{"question":"Q","header":"Scope","multi_select":true,"options":[{"label":"A","description":"first"}]}]}""");
+        await Assert.That(parsed!.Questions[0].Header).IsEqualTo("Scope");
+        await Assert.That(parsed.Questions[0].MultiSelect).IsTrue();
+        await Assert.That(parsed.Questions[0].Options[0].Description).IsEqualTo("first");
+    }
+
+    [Test]
+    [Arguments("""{"questions":[]}""")]                                              // empty array
+    [Arguments("""{"questions":{}}""")]                                              // not an array
+    [Arguments("""{"noquestions":true}""")]                                          // missing
+    [Arguments("""[1,2]""")]                                                         // input not an object
+    [Arguments("""{"questions":["notanobject"]}""")]                                 // entry not an object
+    [Arguments("""{"questions":[{"question":""}]}""")]                               // blank text
+    [Arguments("""{"questions":[{"question":"   "}]}""")]                            // whitespace text
+    [Arguments("""{"questions":[{"header":"h"}]}""")]                                // missing text
+    [Arguments("""{"questions":[{"question":42}]}""")]                               // wrong-typed text
+    [Arguments("""{"questions":[{"question":"Q"},{"question":"Q"}]}""")]             // duplicate texts
+    [Arguments("""{"questions":[{"question":"Q","multiSelect":"yes"}]}""")]          // non-boolean flag
+    [Arguments("""{"questions":[{"question":"Q","multiSelect":true,"multi_select":false}]}""")] // conflicting spellings
+    [Arguments("""{"questions":[{"question":"Q","options":{}}]}""")]                 // options not an array
+    [Arguments("""{"questions":[{"question":"Q","options":["x"]}]}""")]              // option not an object
+    [Arguments("""{"questions":[{"question":"Q","options":[{"label":""}]}]}""")]     // blank label
+    [Arguments("""{"questions":[{"question":"Q","options":[{"nolabel":1}]}]}""")]    // missing label
+    [Arguments("not json")]
+    [Arguments(null)]
+    public async Task Malformed_protocol_fields_fail_the_parse(string? payload) {
+        await Assert.That(ClaudeElicitation.TryParse(payload)).IsNull();
+    }
+
+    [Test]
+    public async Task Agreeing_flag_spellings_and_absent_options_are_fine() {
+        var both = ClaudeElicitation.TryParse("""{"questions":[{"question":"Q","multiSelect":true,"multi_select":true}]}""");
+        await Assert.That(both!.Questions[0].MultiSelect).IsTrue();
+        await Assert.That(both.Questions[0].Options.Length).IsEqualTo(0);
+        var empty = ClaudeElicitation.TryParse("""{"questions":[{"question":"Q","options":[]}]}""");
+        await Assert.That(empty!.Questions[0].Options.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Display_fields_with_wrong_types_or_whitespace_read_as_absent() {
+        var parsed = ClaudeElicitation.TryParse(
+            """{"questions":[{"question":"Q","header":42,"options":[{"label":"A","description":"  "}]}]}""");
+        await Assert.That(parsed!.Questions[0].Header).IsNull();
+        await Assert.That(parsed.Questions[0].Options[0].Description).IsNull();
+    }
+
+    [Test]
+    public async Task Duplicate_option_labels_keep_the_first() {
+        var parsed = ClaudeElicitation.TryParse(
+            """{"questions":[{"question":"Q","options":[{"label":"A","description":"one"},{"label":"A","description":"two"},{"label":"B"}]}]}""");
+        await Assert.That(parsed!.Questions[0].Options.Select(o => o.Label)).IsEquivalentTo(["A", "B"]);
+        await Assert.That(parsed.Questions[0].Options[0].Description).IsEqualTo("one");
+    }
+
+    [Test]
+    public async Task Caps_pass_at_the_boundary_and_fail_one_over() {
+        static string Questions(int n) =>
+            $$"""{"questions":[{{string.Join(",", Enumerable.Range(0, n).Select(i => $$"""{"question":"Q{{i}}"}"""))}}]}""";
+        await Assert.That(ClaudeElicitation.TryParse(Questions(ClaudeElicitation.MaxQuestions))).IsNotNull();
+        await Assert.That(ClaudeElicitation.TryParse(Questions(ClaudeElicitation.MaxQuestions + 1))).IsNull();
+
+        static string Options(int n) =>
+            $$"""{"questions":[{"question":"Q","options":[{{string.Join(",", Enumerable.Range(0, n).Select(i => $$"""{"label":"L{{i}}"}"""))}}]}]}""";
+        await Assert.That(ClaudeElicitation.TryParse(Options(ClaudeElicitation.MaxOptionsPerQuestion))).IsNotNull();
+        await Assert.That(ClaudeElicitation.TryParse(Options(ClaudeElicitation.MaxOptionsPerQuestion + 1))).IsNull();
+
+        static string Text(int chars) => $$"""{"questions":[{"question":"{{new string('q', chars)}}"}]}""";
+        await Assert.That(ClaudeElicitation.TryParse(Text(ClaudeElicitation.MaxQuestionTextChars))).IsNotNull();
+        await Assert.That(ClaudeElicitation.TryParse(Text(ClaudeElicitation.MaxQuestionTextChars + 1))).IsNull();
+
+        static string Label(int chars) => $$"""{"questions":[{"question":"Q","options":[{"label":"{{new string('l', chars)}}"}]}]}""";
+        await Assert.That(ClaudeElicitation.TryParse(Label(ClaudeElicitation.MaxOptionLabelChars))).IsNotNull();
+        await Assert.That(ClaudeElicitation.TryParse(Label(ClaudeElicitation.MaxOptionLabelChars + 1))).IsNull();
+    }
+
+    [Test]
+    public async Task Retained_questions_element_outlives_the_parse() {
+        var parsed = ClaudeElicitation.TryParse(OneQuestion());
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        await Assert.That(parsed!.QuestionsJson.GetRawText()).Contains("Pick one");
+    }
+
+    [Test]
+    public async Task Model_collections_are_immutable() {
+        var parsed = ClaudeElicitation.TryParse(OneQuestion());
+        await Assert.That(parsed!.Questions is ImmutableArray<ElicitationQuestion>).IsTrue();
+        await Assert.That(parsed.Questions[0].Options is ImmutableArray<ElicitationOption>).IsTrue();
+    }
+}
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/ClaudeElicitationTests/*"`
+Expected: build error — `ClaudeElicitation` does not exist.
+
+- [ ] **Step 4: Implement the parser and model**
+
+Create `src/Capacitor.Cli.Core/ClaudeElicitation.cs`:
+
+```csharp
+using System.Collections.Immutable;
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core;
+
+public sealed class ElicitationOption {
+    internal ElicitationOption(string label, string? description) { Label = label; Description = description; }
+    public string Label { get; }
+    public string? Description { get; }
+}
+
+public sealed class ElicitationQuestion {
+    internal ElicitationQuestion(string question, string? header, bool multiSelect, ImmutableArray<ElicitationOption> options) {
+        Question = question; Header = header; MultiSelect = multiSelect; Options = options;
+    }
+    public string Question { get; }
+    public string? Header { get; }
+    public bool MultiSelect { get; }
+    public ImmutableArray<ElicitationOption> Options { get; }
+}
+
+/// Parser-created only: internal ctor + immutable collections ground ComposeAnswers' validation
+/// in parse output, so no caller can hand it a fabricated or mutated model.
+public sealed class ElicitationQuestions {
+    internal ElicitationQuestions(JsonElement questionsJson, ImmutableArray<ElicitationQuestion> questions) {
+        QuestionsJson = questionsJson; Questions = questions;
+    }
+    /// Detached clone of the payload's questions array, replayed verbatim into the answer.
+    public JsonElement QuestionsJson { get; }
+    public ImmutableArray<ElicitationQuestion> Questions { get; }
+}
+
+/// The Claude AskUserQuestion contract: parsing the hook's tool_input and composing the
+/// updatedInput answer. Caps bound the composed resolve payload (spec decision 6); a payload
+/// over any cap is unparseable and falls back to the plain permission card.
+public static class ClaudeElicitation {
+    public const string ToolName = "AskUserQuestion";
+    public const int MaxQuestions = 8;
+    public const int MaxOptionsPerQuestion = 16;
+    public const int MaxQuestionTextChars = 4096;
+    public const int MaxOptionLabelChars = 1024;
+    public const int MaxOtherTextChars = 8192;
+
+    public static ElicitationQuestions? TryParse(string? toolInputJson) {
+        if (string.IsNullOrEmpty(toolInputJson)) return null;
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(toolInputJson); } catch (JsonException) { return null; }
+        using (doc) {
+            var root = doc.RootElement;
+            if (!root.IsObject || root.Prop("questions") is not { } arr || !arr.IsArray) return null;
+            var count = arr.GetArrayLength();
+            if (count is 0 or > MaxQuestions) return null;
+
+            var parsed = ImmutableArray.CreateBuilder<ElicitationQuestion>(count);
+            var texts = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var q in arr.EnumerateArray()) {
+                if (!q.IsObject) return null;
+                var text = ProtocolString(q, "question", MaxQuestionTextChars);
+                if (text is null || !texts.Add(text)) return null;
+                if (!TryReadFlag(q, out var multi)) return null;
+                if (!TryReadOptions(q, out var options)) return null;
+                parsed.Add(new ElicitationQuestion(text, DisplayString(q, "header"), multi, options));
+            }
+            return new ElicitationQuestions(arr.Clone(), parsed.MoveToImmutable());
+        }
+    }
+
+    // Protocol field: must be a non-blank string within the cap; anything else is null → fatal.
+    static string? ProtocolString(JsonElement obj, string name, int maxChars) {
+        if (obj.Prop(name) is null) return null;
+        var s = obj.Str(name)?.Trim();
+        return s is { Length: > 0 } && s.Length <= maxChars ? s : null;
+    }
+
+    // Display field: a non-blank string is used; wrong type or whitespace reads as absent.
+    static string? DisplayString(JsonElement obj, string name) {
+        var s = obj.Str(name)?.Trim();
+        return s is { Length: > 0 } ? s : null;
+    }
+
+    // Both spellings accepted; a present non-boolean or a disagreement is fatal — the flag
+    // decides string-versus-array in the answer, so guessing changes the answer type.
+    static bool TryReadFlag(JsonElement q, out bool multi) {
+        multi = false;
+        bool? camel = null, snake = null;
+        if (q.Prop("multiSelect") is not null && (camel = q.Bool("multiSelect")) is null) return false;
+        if (q.Prop("multi_select") is not null && (snake = q.Bool("multi_select")) is null) return false;
+        if (camel is not null && snake is not null && camel != snake) return false;
+        multi = camel ?? snake ?? false;
+        return true;
+    }
+
+    static bool TryReadOptions(JsonElement q, out ImmutableArray<ElicitationOption> options) {
+        options = ImmutableArray<ElicitationOption>.Empty;
+        if (q.Prop("options") is not { } el) return true;
+        if (!el.IsArray || el.GetArrayLength() > MaxOptionsPerQuestion) return false;
+
+        var builder = ImmutableArray.CreateBuilder<ElicitationOption>();
+        var labels = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var o in el.EnumerateArray()) {
+            if (!o.IsObject) return false;
+            var label = ProtocolString(o, "label", MaxOptionLabelChars);
+            if (label is null) return false;
+            // Duplicate labels collapse to the first: the label IS the answer value.
+            if (labels.Add(label)) builder.Add(new ElicitationOption(label, DisplayString(o, "description")));
+        }
+        options = builder.ToImmutable();
+        return true;
+    }
+}
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/ClaudeElicitationTests/*"`
+Expected: all PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/ClaudeElicitation.cs test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
+git commit -m "Parse AskUserQuestion payloads into an immutable capped model"
+```
+
+---
+
+### Task 2: Core compose — `ComposeAnswers`, the bound proof, and ownership
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/ClaudeElicitation.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs` (extend); crib the codec harness from `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/FrameCodecPermissionTests.cs`
+
+**Interfaces:**
+- Consumes: Task 1's model; `FrameCodec`, `LocalFrame.PermissionJson`, `FrameType.PermissionResolve`, `PermissionResolveDto` + `PermissionIpcJsonContext` (`src/Capacitor.Cli.Core/LocalIpc/`).
+- Produces: `public sealed record ElicitationAnswer(string Question, IReadOnlyList<string> SelectedLabels, string? OtherText);` and `public static JsonElement ComposeAnswers(ElicitationQuestions questions, IReadOnlyList<ElicitationAnswer> answers)` on `ClaudeElicitation` — throws `ArgumentException` on any invalid answer set.
+
+- [ ] **Step 1: Write the failing compose tests**
+
+Append to `ClaudeElicitationTests.cs`:
+
+```csharp
+    static ElicitationQuestions Parsed(string json) => ClaudeElicitation.TryParse(json)!;
+
+    const string MixedPayload =
+        """{"questions":[{"question":"Q1","options":[{"label":"A"},{"label":"B"}]},{"question":"Q2","multiSelect":true,"options":[{"label":"X"},{"label":"Y"},{"label":"Z"}]}]}""";
+
+    [Test]
+    public async Task Composes_the_documented_shape_with_passthrough_and_ordered_values() {
+        var q = Parsed(MixedPayload);
+        var composed = ClaudeElicitation.ComposeAnswers(q, [
+            new ElicitationAnswer("Q1", ["B"], null),
+            new ElicitationAnswer("Q2", ["Z", "X"], "custom"),
+        ]);
+        await Assert.That(composed.Prop("questions")!.Value.GetRawText()).IsEqualTo(q.QuestionsJson.GetRawText());
+        var answers = composed.Prop("answers")!.Value;
+        await Assert.That(answers.Str("Q1")).IsEqualTo("B");
+        // Multi-select: option order first, the genuine Other text last. Ordering.Matching —
+        // the default equivalence ignores order and would let the ordering rule regress.
+        await Assert.That(answers.Prop("Q2")!.Value.EnumerateArray().Select(v => v.GetString()))
+            .IsEquivalentTo(["X", "Z", "custom"], CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Single_select_accepts_other_text_as_the_one_value() {
+        var q = Parsed("""{"questions":[{"question":"Q","options":[{"label":"A"}]}]}""");
+        var composed = ClaudeElicitation.ComposeAnswers(q, [new ElicitationAnswer("Q", [], "  my own  ")]);
+        await Assert.That(composed.Prop("answers")!.Value.Str("Q")).IsEqualTo("my own");
+    }
+
+    [Test]
+    public async Task Other_text_equal_to_a_label_normalizes_into_the_selection() {
+        var q = Parsed("""{"questions":[{"question":"Q","multiSelect":true,"options":[{"label":"A"},{"label":"B"}]}]}""");
+        var fresh = ClaudeElicitation.ComposeAnswers(q, [new ElicitationAnswer("Q", ["B"], "A")]);
+        await Assert.That(fresh.Prop("answers")!.Value.Prop("Q")!.Value.EnumerateArray().Select(v => v.GetString()))
+            .IsEquivalentTo(["A", "B"], CollectionOrdering.Matching);
+        var already = ClaudeElicitation.ComposeAnswers(q, [new ElicitationAnswer("Q", ["A"], "A")]);
+        await Assert.That(already.Prop("answers")!.Value.Prop("Q")!.Value.EnumerateArray().Select(v => v.GetString()))
+            .IsEquivalentTo(["A"]);
+        // Single-select: the normalized pair collapses to one value instead of throwing.
+        var single = Parsed("""{"questions":[{"question":"S","options":[{"label":"A"}]}]}""");
+        var collapsed = ClaudeElicitation.ComposeAnswers(single, [new ElicitationAnswer("S", ["A"], "A")]);
+        await Assert.That(collapsed.Prop("answers")!.Value.Str("S")).IsEqualTo("A");
+    }
+
+    [Test]
+    public async Task Invalid_answer_sets_throw() {
+        var q = Parsed(MixedPayload);
+        List<IReadOnlyList<ElicitationAnswer>> bad = [
+            [new ElicitationAnswer("Q1", ["A"], null)],                                                 // missing Q2
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q1", ["B"], null)],       // duplicate key
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Nope", ["X"], null)],     // unknown key
+            [new ElicitationAnswer("Q1", ["C"], null), new ElicitationAnswer("Q2", ["X"], null)],       // label not an option
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", ["X", "X"], null)],  // label twice
+            [new ElicitationAnswer("Q1", ["A", "B"], null), new ElicitationAnswer("Q2", ["X"], null)],  // two for single-select
+            [new ElicitationAnswer("Q1", ["A"], "extra"), new ElicitationAnswer("Q2", ["X"], null)],    // label AND other for single-select
+            [new ElicitationAnswer("Q1", [], null), new ElicitationAnswer("Q2", ["X"], null)],          // neither for single-select
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", [], null)],          // empty multi-select
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", [], "   ")],         // blank other
+            [new ElicitationAnswer("Q1", ["A"], null),
+             new ElicitationAnswer("Q2", [], new string('x', ClaudeElicitation.MaxOtherTextChars + 1))], // over-cap other
+        ];
+        foreach (var answers in bad)
+            await Assert.That(() => ClaudeElicitation.ComposeAnswers(q, answers)).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Composed_element_outlives_every_composer_local_owner() {
+        var composed = ClaudeElicitation.ComposeAnswers(
+            Parsed("""{"questions":[{"question":"Q","options":[{"label":"A"}]}]}"""),
+            [new ElicitationAnswer("Q", ["A"], null)]);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        await Assert.That(composed.GetRawText()).Contains("\"answers\"");
+    }
+```
+
+And the codec bound test — worst-case content is a character that JSON-escapes to `\uXXXX` (use `'\u0001'`) so every capped char costs 6 encoded bytes:
+
+```csharp
+    [Test]
+    public async Task Maximal_composed_payload_fits_the_frame_codec() {
+        var esc = new string('\u0001', 1);
+        string Chars(int n) => string.Concat(Enumerable.Repeat(esc, n));
+        var questions = string.Join(",", Enumerable.Range(0, ClaudeElicitation.MaxQuestions).Select(i => {
+            var text = System.Text.Json.JsonEncodedText.Encode(Chars(ClaudeElicitation.MaxQuestionTextChars - 2) + i.ToString("00"));
+            var options = string.Join(",", Enumerable.Range(0, ClaudeElicitation.MaxOptionsPerQuestion).Select(j => {
+                var label = System.Text.Json.JsonEncodedText.Encode(Chars(ClaudeElicitation.MaxOptionLabelChars - 2) + j.ToString("00"));
+                return $$"""{"label":"{{label}}"}""";
+            }));
+            return $$"""{"question":"{{text}}","multiSelect":true,"options":[{{options}}]}""";
+        }));
+        var parsed = ClaudeElicitation.TryParse($$"""{"questions":[{{questions}}]}""");
+        await Assert.That(parsed).IsNotNull();
+
+        var answers = parsed!.Questions
+            .Select(q => new ElicitationAnswer(q.Question, q.Options.Select(o => o.Label).ToList(),
+                Chars(ClaudeElicitation.MaxOtherTextChars)))
+            .ToList();
+        var updated = ClaudeElicitation.ComposeAnswers(parsed, answers);
+
+        var dto = new PermissionResolveDto("r", "allow", null, updated);
+        var json = System.Text.Json.JsonSerializer.Serialize(dto, PermissionIpcJsonContext.Default.PermissionResolveDto);
+        var frame = LocalFrame.PermissionJson(FrameType.PermissionResolve, json);
+        using var stream = new MemoryStream();
+        await FrameCodec.WriteAsync(stream, frame, CancellationToken.None);
+        stream.Position = 0;
+        var read = await FrameCodec.ReadAsync(stream, CancellationToken.None);
+        await Assert.That(read!.Value.Type).IsEqualTo(FrameType.PermissionResolve);
+    }
+```
+
+Add `using Capacitor.Cli.Core.LocalIpc;` and `using TUnit.Assertions.Enums;` (for `CollectionOrdering`) to the test file. If `FrameCodec.WriteAsync`/`ReadAsync` signatures differ, mirror the exact call shape used in `LocalIpc/FrameCodecPermissionTests.cs` — the assertion that matters is a successful round-trip of the maximal frame.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/ClaudeElicitationTests/*"`
+Expected: build error — `ElicitationAnswer`/`ComposeAnswers` do not exist.
+
+- [ ] **Step 3: Implement the composer**
+
+Append to `ClaudeElicitation.cs` (add `using System.Text.Json.Nodes;`):
+
+```csharp
+public sealed record ElicitationAnswer(string Question, IReadOnlyList<string> SelectedLabels, string? OtherText);
+```
+
+and inside `ClaudeElicitation`:
+
+```csharp
+    /// Validates against the parsed questions — every question answered, labels from the parsed
+    /// options only, Other text bounded — and builds the answer updatedInput. ArgumentException
+    /// here is a programming error in the caller, never a user state.
+    public static JsonElement ComposeAnswers(ElicitationQuestions questions, IReadOnlyList<ElicitationAnswer> answers) {
+        ArgumentNullException.ThrowIfNull(questions);
+        ArgumentNullException.ThrowIfNull(answers);
+        if (answers.Count != questions.Questions.Length)
+            throw new ArgumentException($"expected {questions.Questions.Length} answer(s), got {answers.Count}", nameof(answers));
+
+        var byQuestion = new Dictionary<string, ElicitationAnswer>(StringComparer.Ordinal);
+        foreach (var answer in answers)
+            if (!byQuestion.TryAdd(answer.Question, answer))
+                throw new ArgumentException($"duplicate answer for \"{answer.Question}\"", nameof(answers));
+
+        var answersObj = new JsonObject();
+        foreach (var question in questions.Questions) {
+            if (!byQuestion.TryGetValue(question.Question, out var answer))
+                throw new ArgumentException($"missing answer for \"{question.Question}\"", nameof(answers));
+            answersObj[question.Question] = ComposeValue(question, answer);
+        }
+
+        var payload = new JsonObject {
+            ["questions"] = JsonNode.Parse(questions.QuestionsJson.GetRawText()),
+            ["answers"] = answersObj,
+        };
+        using var doc = JsonDocument.Parse(payload.ToJsonString());
+        return doc.RootElement.Clone();
+    }
+
+    static JsonNode ComposeValue(ElicitationQuestion question, ElicitationAnswer answer) {
+        var selected = new List<string>();
+        foreach (var label in answer.SelectedLabels) {
+            if (!question.Options.Any(o => string.Equals(o.Label, label, StringComparison.Ordinal)))
+                throw new ArgumentException($"\"{label}\" is not an option of \"{question.Question}\"", nameof(answer));
+            if (selected.Contains(label))
+                throw new ArgumentException($"\"{label}\" selected twice for \"{question.Question}\"", nameof(answer));
+            selected.Add(label);
+        }
+
+        var other = answer.OtherText?.Trim();
+        if (other is not null) {
+            if (other.Length == 0)
+                throw new ArgumentException($"blank Other text for \"{question.Question}\"", nameof(answer));
+            if (other.Length > MaxOtherTextChars)
+                throw new ArgumentException($"Other text over {MaxOtherTextChars} chars for \"{question.Question}\"", nameof(answer));
+            // An option label typed as Other IS that option — never a duplicate wire value.
+            if (question.Options.Any(o => string.Equals(o.Label, other, StringComparison.Ordinal))) {
+                if (!selected.Contains(other)) selected.Add(other);
+                other = null;
+            }
+        }
+
+        if (!question.MultiSelect) {
+            if (selected.Count + (other is null ? 0 : 1) != 1)
+                throw new ArgumentException($"single-select \"{question.Question}\" needs exactly one value", nameof(answer));
+            return JsonValue.Create(other ?? selected[0]);
+        }
+
+        if (selected.Count == 0 && other is null)
+            throw new ArgumentException($"multi-select \"{question.Question}\" needs at least one value", nameof(answer));
+
+        var array = new JsonArray();
+        foreach (var option in question.Options)
+            if (selected.Contains(option.Label)) array.Add((JsonNode)JsonValue.Create(option.Label));
+        if (other is not null) array.Add((JsonNode)JsonValue.Create(other));
+        return array;
+    }
+```
+
+- [ ] **Step 4: Run to verify pass, then the whole Core suite**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter "/*/*/ClaudeElicitationTests/*"`
+Expected: PASS. Then run the full project (no filter) — expected green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/ClaudeElicitation.cs test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
+git commit -m "Compose validated AskUserQuestion answers into updatedInput"
+```
+
+---
+
+### Task 3: Service — classification, `AnswerAsync`, `Summary`
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/IPermissionService.cs`
+- Modify: `src/Capacitor.App/Services/PermissionService.cs`
+- Modify: `test/Capacitor.App.Tests.Unit/FakePermissionService.cs`
+- Test: `test/Capacitor.App.Tests.Unit/PermissionServiceTests.cs` (extend)
+
+**Interfaces:**
+- Consumes: Task 1/2 (`ClaudeElicitation`, `ElicitationQuestions`, `ElicitationAnswer`).
+- Produces:
+  - `PendingPermissionRequest.Questions` → `ElicitationQuestions?`.
+  - `public readonly record struct PendingSummary(int Permissions, int Questions) { public int Total => Permissions + Questions; }` (in `IPermissionService.cs`).
+  - On `IPermissionService`: `IObservable<PendingSummary> Summary { get; }` and `Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target, IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct);`.
+
+- [ ] **Step 1: Write the failing service tests**
+
+Append to `PermissionServiceTests.cs`. Extend the local `Dto` helper with tool name/input parameters:
+
+```csharp
+    static PermissionPendingDto Dto2(string id, string agent, string vendor, string toolName, string? toolInputJson, bool omitted = false) {
+        System.Text.Json.JsonElement? input = null;
+        if (toolInputJson is not null) { using var d = System.Text.Json.JsonDocument.Parse(toolInputJson); input = d.RootElement.Clone(); }
+        return new PermissionPendingDto(id, agent, "s1", vendor, toolName, input, null, omitted, false, "2026-08-28T10:00:00.0000000+00:00");
+    }
+
+    const string QuestionInput = """{"questions":[{"question":"Pick","options":[{"label":"A"},{"label":"B"}]}]}""";
+
+    [Test]
+    public async Task Classification_requires_claude_the_tool_name_present_input_and_a_parse() {
+        using var h = new Harness();
+        await h.StartAsync();
+        var yes = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        await Assert.That(yes.Questions).IsNotNull();
+        var codex = await h.EmitAsync(Dto2("q2", "a1", "codex", ClaudeElicitation.ToolName, QuestionInput));
+        var wrongTool = await h.EmitAsync(Dto2("q3", "a1", "claude", "Bash", QuestionInput));
+        var omitted = await h.EmitAsync(Dto2("q4", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput, omitted: true));
+        var nullInput = await h.EmitAsync(Dto2("q5", "a1", "claude", ClaudeElicitation.ToolName, null));
+        var unparseable = await h.EmitAsync(Dto2("q6", "a1", "claude", ClaudeElicitation.ToolName, """{"questions":[]}"""));
+        foreach (var entry in new[] { codex, wrongTool, omitted, nullInput, unparseable })
+            await Assert.That(entry.Questions).IsNull();
+    }
+
+    [Test]
+    public async Task Answer_sends_allow_with_updated_input_and_concludes_on_either_ack() {
+        using var h = new Harness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+
+        h.Ops.QueuePermissionResolve(true);
+        var applied = await h.Service.AnswerAsync(entry, [new ElicitationAnswer("Pick", ["B"], null)], CancellationToken.None);
+        await Assert.That(applied.Kind).IsEqualTo(PermissionResolveKind.Applied);
+        var payload = h.Ops.PermissionResolvePayloads[0];
+        await Assert.That(payload.Decision).IsEqualTo("allow");
+        await Assert.That(payload.ApplyPermissions).IsNull();
+        await Assert.That(payload.UpdatedInput!.Value.Prop("answers")!.Value.Str("Pick")).IsEqualTo("B");
+        await Assert.That(h.View.Count).IsEqualTo(0);
+
+        var second = await h.EmitAsync(Dto2("q2", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        h.Ops.QueuePermissionResolve(false, "no pending permission request with that id");
+        var already = await h.Service.AnswerAsync(second, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None);
+        await Assert.That(already.Kind).IsEqualTo(PermissionResolveKind.AlreadyDecided);
+        await Assert.That(h.View.Count).IsEqualTo(0);
+
+        var third = await h.EmitAsync(Dto2("q3", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        h.Ops.QueuePermissionResolveFailure("daemon_unreachable");
+        var failed = await h.Service.AnswerAsync(third, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None);
+        await Assert.That(failed.Kind).IsEqualTo(PermissionResolveKind.TransportFailure);
+        await Assert.That(h.View.Count).IsEqualTo(1);
+
+        // A Resolved push after the failed send clears the survivor; a ghost replay stays dropped.
+        h.Stream.EmitResolved("q3", "server");
+        await WaitUntilAsync(() => h.View.Count == 0, what: "push cleared the survivor");
+    }
+
+    [Test]
+    public async Task Answer_rejects_an_unclassified_target_and_a_bad_answer_set_without_sending() {
+        using var h = new Harness();
+        await h.StartAsync();
+        var plain = await h.EmitAsync(Dto2("p1", "a1", "claude", "Bash", """{"command":"ls"}"""));
+        await Assert.That(() => h.Service.AnswerAsync(plain, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None))
+            .Throws<ArgumentException>();
+
+        var entry = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        await Assert.That(() => h.Service.AnswerAsync(entry, [], CancellationToken.None)).Throws<ArgumentException>();
+        await Assert.That(h.Ops.PermissionResolveCalls).IsEqualTo(0);
+        await Assert.That(h.View.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task A_resolved_push_landing_before_the_ack_ends_in_the_same_state() {
+        using var h = new Harness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+
+        var gate = h.Ops.ArmPermissionResolve();
+        var run = h.Service.AnswerAsync(entry, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None);
+        h.Stream.EmitResolved("q1", "server");
+        await WaitUntilAsync(() => h.View.Count == 0, what: "push evicted while the ack is in flight");
+        gate.SetResult(new PermissionAckDto(false, "no pending permission request with that id"));
+        var outcome = await run;
+        await Assert.That(outcome.Kind).IsEqualTo(PermissionResolveKind.AlreadyDecided);
+        await Assert.That(h.View.Count).IsEqualTo(0);
+
+        // The tombstoned id stays dead against a ghost replay.
+        h.Stream.EmitPending(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        await Task.Delay(50);
+        await Assert.That(h.View.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Summary_seeds_and_stays_a_consistent_pair() {
+        using var h = new Harness();
+        var summaries = new List<PendingSummary>();
+        using var sub = h.Service.Summary.Subscribe(summaries.Add);
+        await Assert.That(summaries[0]).IsEqualTo(new PendingSummary(0, 0));
+
+        await h.StartAsync();
+        await h.EmitAsync(Dto2("p1", "a1", "claude", "Bash", """{"command":"ls"}"""));
+        await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        await WaitUntilAsync(() => summaries[^1] == new PendingSummary(1, 1), what: "one of each");
+
+        h.Stream.EmitResolved("q1", "server");
+        await WaitUntilAsync(() => summaries[^1] == new PendingSummary(1, 0), what: "question settled");
+        foreach (var s in summaries) {
+            await Assert.That(s.Permissions).IsGreaterThanOrEqualTo(0);
+            await Assert.That(s.Questions).IsGreaterThanOrEqualTo(0);
+        }
+    }
+```
+
+Add `using Capacitor.Cli.Core;` to the test file's usings.
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/PermissionServiceTests/*"`
+Expected: build error — `Questions`/`AnswerAsync`/`Summary`/`PendingSummary` missing.
+
+- [ ] **Step 3: Implement**
+
+`IPermissionService.cs` — add `using Capacitor.Cli.Core;`; in `PendingPermissionRequest`'s ctor, after `RequestedAt`:
+
+```csharp
+        Questions = dto.Vendor == "claude" && dto.ToolName == ClaudeElicitation.ToolName && !dto.ToolInputOmitted
+            ? ClaudeElicitation.TryParse(ToolInputJson)
+            : null;
+```
+
+with property `public ElicitationQuestions? Questions { get; }`. Below the class:
+
+```csharp
+public readonly record struct PendingSummary(int Permissions, int Questions) {
+    public int Total => Permissions + Questions;
+}
+```
+
+On the interface:
+
+```csharp
+    /// One consistent pair per emission, from a single cache snapshot; replays on subscribe.
+    IObservable<PendingSummary> Summary { get; }
+    /// Answers a classified AskUserQuestion entry (Questions non-null; ArgumentException otherwise,
+    /// as for an invalid answer set — both thrown before anything reaches the wire).
+    Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target, IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct);
+```
+
+`PermissionService.cs` — extract `ResolveAsync`'s tail and add the new members:
+
+```csharp
+    public IObservable<PendingSummary> Summary =>
+        _cache.Connect()
+            .QueryWhenChanged(q => Summarize(q.Items))
+            .StartWith(Summarize(_cache.Items));
+
+    static PendingSummary Summarize(IEnumerable<PendingPermissionRequest> items) {
+        int permissions = 0, questions = 0;
+        foreach (var item in items) { if (item.Questions is null) permissions++; else questions++; }
+        return new PendingSummary(permissions, questions);
+    }
+
+    public async Task<PermissionResolveOutcome> ResolveAsync(PendingPermissionRequest target, PermissionAnswer answer, CancellationToken ct) {
+        var decision = answer == PermissionAnswer.Deny ? "deny" : "allow";
+        var apply = answer == PermissionAnswer.AllowAlways ? ClaudePermissions.AlwaysAllow(target.ToolName) : (System.Text.Json.JsonElement?)null;
+        return await SendResolveAsync(new PermissionResolveDto(target.RequestId, decision, apply, null), ct).ConfigureAwait(false);
+    }
+
+    public async Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target, IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct) {
+        if (target.Questions is null) throw new ArgumentException("not an elicitation entry", nameof(target));
+        var updated = ClaudeElicitation.ComposeAnswers(target.Questions, answers);
+        return await SendResolveAsync(new PermissionResolveDto(target.RequestId, "allow", null, updated), ct).ConfigureAwait(false);
+    }
+
+    async Task<PermissionResolveOutcome> SendResolveAsync(PermissionResolveDto dto, CancellationToken ct) {
+        PermissionAckDto ack;
+        try {
+            ack = await _ops.ResolvePermissionAsync(dto, ct).ConfigureAwait(false);
+        } catch (LocalControlOpsException ex) {
+            return new PermissionResolveOutcome(PermissionResolveKind.TransportFailure, ex.Reason);
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            Console.Error.WriteLine($"kcap: permission resolve failed unexpectedly: {ex.Message}");
+            return new PermissionResolveOutcome(PermissionResolveKind.TransportFailure, ex.Message);
+        }
+
+        Conclude(dto.RequestId);
+        return new PermissionResolveOutcome(ack.Ok ? PermissionResolveKind.Applied : PermissionResolveKind.AlreadyDecided, ack.Error);
+    }
+```
+
+`FakePermissionService.cs` — add matching members:
+
+```csharp
+    public readonly List<(string RequestId, IReadOnlyList<ElicitationAnswer> Answers)> Answered = [];
+
+    public IObservable<PendingSummary> Summary =>
+        Cache.Connect()
+            .QueryWhenChanged(q => Summarize(q.Items))
+            .StartWith(new PendingSummary(0, 0));
+
+    static PendingSummary Summarize(IEnumerable<PendingPermissionRequest> items) {
+        int permissions = 0, questions = 0;
+        foreach (var item in items) { if (item.Questions is null) permissions++; else questions++; }
+        return new PendingSummary(permissions, questions);
+    }
+
+    public async Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target, IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct) {
+        if (target.Questions is null) throw new ArgumentException("not an elicitation entry", nameof(target));
+        Answered.Add((target.RequestId, answers));
+        if (_outcomes.Count == 0) throw new InvalidOperationException("FakePermissionService: unscripted answer call");
+        var outcome = await _outcomes.Dequeue().Task;
+        if (outcome.Kind != PermissionResolveKind.TransportFailure) Cache.Remove(target.RequestId);
+        return outcome;
+    }
+```
+
+Add `using Capacitor.Cli.Core;` where missing, and give `PermissionEntries.Entry` an optional `toolName`-driven question entry helper:
+
+```csharp
+    public static PendingPermissionRequest Question(
+            string requestId = "q1", string agentId = "a1",
+            string toolInputJson = """{"questions":[{"question":"Pick","options":[{"label":"A"},{"label":"B"}]}]}""",
+            string requestedAt = "2026-08-28T10:00:00.0000000+00:00") =>
+        Entry(requestId, agentId, "claude", ClaudeElicitation.ToolName, toolInputJson, false, requestedAt);
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/PermissionServiceTests/*"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/Services/IPermissionService.cs src/Capacitor.App/Services/PermissionService.cs test/Capacitor.App.Tests.Unit/FakePermissionService.cs test/Capacitor.App.Tests.Unit/PermissionServiceTests.cs
+git commit -m "Classify question entries and answer them over the permission resolve"
+```
+
+---
+
+### Task 4: Card base class and the fallback card's Allow-always rule
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/PendingCardViewModel.cs`
+- Modify: `src/Capacitor.App/ViewModels/PermissionCardViewModel.cs`
+- Test: `test/Capacitor.App.Tests.Unit/PermissionCardViewModelTests.cs` (extend)
+
+**Interfaces:**
+- Produces: `public abstract class PendingCardViewModel : ReactiveObject, IDisposable` with `string RequestId`, `internal DateTimeOffset RequestedAt`, `bool IsBusy { get; protected set; }`, `string? ErrorText { get; protected set; }`, `protected BehaviorSubject<bool> Busy`, `protected CompositeDisposable Disposables`, `protected bool IsDisposed`, `public void Dispose()`. Property setters are no-ops after disposal (no notification of any kind). `PermissionCardViewModel : PendingCardViewModel`.
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `PermissionCardViewModelTests.cs`:
+
+```csharp
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Allow_always_hides_for_the_ask_user_question_fallback_card() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var svc = new FakePermissionService();
+            // Oversized questions payload: still ToolName AskUserQuestion, but unclassified.
+            using var fallback = new PermissionCardViewModel(
+                PermissionEntries.Entry(toolName: Capacitor.Cli.Core.ClaudeElicitation.ToolName, toolInputJson: null, omitted: true),
+                svc, new System.Reactive.Subjects.BehaviorSubject<string?>(null));
+            await Assert.That(fallback.ShowsAllowAlways).IsFalse();
+        });
+    }
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/PermissionCardViewModelTests/*"`
+Expected: the new test FAILS (`ShowsAllowAlways` is true for claude today).
+
+- [ ] **Step 3: Implement the base and rebase the permission card**
+
+Create `src/Capacitor.App/ViewModels/PendingCardViewModel.cs`:
+
+```csharp
+using System.Reactive.Disposables;
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+/// Shared shell of a NEEDS YOU card. Setters are no-ops after disposal: the pipeline disposes a
+/// card the instant its entry leaves the cache, and an in-flight submit continuation must not
+/// notify a removed card.
+public abstract class PendingCardViewModel : ReactiveObject, IDisposable {
+    protected readonly CompositeDisposable Disposables = new();
+    // canExecute feed; a BehaviorSubject rather than WhenAnyValue for the reason
+    // SessionRailViewModel documents (headless ReactiveUI init ordering).
+    protected readonly BehaviorSubject<bool> Busy = new(false);
+    bool _isBusy;
+    string? _errorText;
+
+    public string RequestId { get; }
+    internal DateTimeOffset RequestedAt { get; }
+    protected bool IsDisposed { get; private set; }
+
+    public bool IsBusy {
+        get => _isBusy;
+        protected set {
+            if (IsDisposed) return;
+            this.RaiseAndSetIfChanged(ref _isBusy, value);
+            Busy.OnNext(value);
+        }
+    }
+
+    public string? ErrorText {
+        get => _errorText;
+        protected set {
+            if (IsDisposed) return;
+            this.RaiseAndSetIfChanged(ref _errorText, value);
+        }
+    }
+
+    protected PendingCardViewModel(PendingPermissionRequest entry) {
+        RequestId = entry.RequestId;
+        RequestedAt = entry.RequestedAt;
+        Disposables.Add(Busy);
+    }
+
+    public void Dispose() {
+        IsDisposed = true;
+        Disposables.Dispose();
+    }
+}
+```
+
+Modify `PermissionCardViewModel` to derive from it: delete its own `RequestId`, `RequestedAt`, `_busy`, `IsBusy`, `ErrorText`, `_disposables` and `Dispose` members; rename internal uses of `_busy`→`Busy` and `_disposables`→`Disposables`; ctor becomes `public PermissionCardViewModel(PendingPermissionRequest entry, IPermissionService permissions, IObservable<string?> root) : base(entry)`. Change the Allow-always rule:
+
+```csharp
+        ShowsAllowAlways = entry.Vendor == "claude" && entry.ToolName != ClaudeElicitation.ToolName;
+```
+
+with `using Capacitor.Cli.Core;`.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/PermissionCardViewModelTests/*"`
+Expected: all PASS (including the pre-existing three).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/PendingCardViewModel.cs src/Capacitor.App/ViewModels/PermissionCardViewModel.cs test/Capacitor.App.Tests.Unit/PermissionCardViewModelTests.cs
+git commit -m "Lift the NEEDS YOU card shell into a base and gate Allow always"
+```
+
+---
+
+### Task 5: `QuestionCardViewModel`
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/QuestionCardViewModel.cs`
+- Test: `test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs` (create)
+
+**Interfaces:**
+- Consumes: Task 3's `AnswerAsync` and Task 4's base.
+- Produces:
+  - `public sealed class QuestionCardViewModel : PendingCardViewModel` — ctor `(PendingPermissionRequest entry, IPermissionService permissions)`; `IReadOnlyList<QuestionGroupViewModel> Questions`; `bool IsFastPath`; `bool ShowsSubmit`; `ReactiveCommand<Unit, Unit> SubmitCommand`.
+  - `public sealed class QuestionGroupViewModel : ReactiveObject` — `string? Header`, `string Text`, `bool MultiSelect`, `IReadOnlyList<QuestionOptionViewModel> Options`, `string OtherText { get; set; }`, `int MaxOtherLength`, `bool IsAnswered`, `ReactiveCommand<Unit, Unit> EnterCommand`, `bool ShowsOtherAnswer`.
+  - `public sealed class QuestionOptionViewModel : ReactiveObject` — `string Label`, `string? Description`, `bool IsMulti`, `bool IsSelected { get; set; }`, `ReactiveCommand<Unit, Unit> PickCommand`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs`:
+
+```csharp
+using System.Reactive.Threading.Tasks;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class QuestionCardViewModelTests {
+    const string SingleSelect = """{"questions":[{"question":"Pick","header":"Choice","options":[{"label":"A","description":"first"},{"label":"B"}]}]}""";
+    const string FreeTextOnly = """{"questions":[{"question":"Say"}]}""";
+    const string MultiAndSingle = """{"questions":[{"question":"Pick","options":[{"label":"A"},{"label":"B"}]},{"question":"Tags","multiSelect":true,"options":[{"label":"X"},{"label":"Y"}]}]}""";
+
+    static (FakePermissionService Svc, QuestionCardViewModel Card) Make(string input, string requestId = "q1") {
+        var svc = new FakePermissionService();
+        var entry = PermissionEntries.Question(requestId, toolInputJson: input);
+        svc.Add(entry);
+        return (svc, new QuestionCardViewModel(entry, svc));
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Fast_path_submits_on_option_click() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) using (card) {
+                await Assert.That(card.IsFastPath).IsTrue();
+                await Assert.That(card.ShowsSubmit).IsFalse();
+                svc.Queue(PermissionResolveKind.Applied);
+                await card.Questions[0].Options[1].PickCommand.Execute().ToTask();
+                await Assert.That(svc.Answered[0].Answers[0].SelectedLabels).IsEquivalentTo(["B"]);
+                await Assert.That(svc.Answered[0].Answers[0].OtherText).IsNull();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Fast_path_other_text_submits_on_enter_and_shows_the_inline_answer() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) using (card) {
+                var group = card.Questions[0];
+                await Assert.That(group.ShowsOtherAnswer).IsFalse();
+                group.OtherText = "my own";
+                await Assert.That(group.ShowsOtherAnswer).IsTrue();
+                svc.Queue(PermissionResolveKind.Applied);
+                await group.EnterCommand.Execute().ToTask();
+                await Assert.That(svc.Answered[0].Answers[0].OtherText).IsEqualTo("my own");
+                await Assert.That(svc.Answered[0].Answers[0].SelectedLabels.Count).IsEqualTo(0);
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Free_text_only_is_not_the_fast_path_and_whitespace_does_not_answer() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(FreeTextOnly);
+            using (svc) using (card) {
+                await Assert.That(card.IsFastPath).IsFalse();
+                await Assert.That(card.ShowsSubmit).IsTrue();
+                card.Questions[0].OtherText = "   ";
+                await Assert.That(card.Questions[0].IsAnswered).IsFalse();
+                card.Questions[0].OtherText = "hello";
+                await Assert.That(card.Questions[0].IsAnswered).IsTrue();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Submit_gates_on_every_question_and_sends_all_answers() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(MultiAndSingle);
+            using (svc) using (card) {
+                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsFalse();
+                card.Questions[0].Options[0].IsSelected = true;
+                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsFalse();
+                card.Questions[1].Options[0].IsSelected = true;
+                card.Questions[1].Options[1].IsSelected = true;
+                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsTrue();
+
+                svc.Queue(PermissionResolveKind.Applied);
+                await card.SubmitCommand.Execute().ToTask();
+                var answers = svc.Answered[0].Answers;
+                await Assert.That(answers[0].SelectedLabels).IsEquivalentTo(["A"]);
+                await Assert.That(answers[1].SelectedLabels).IsEquivalentTo(["X", "Y"]);
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Single_select_pick_and_other_text_displace_each_other() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(MultiAndSingle);
+            using (svc) using (card) {
+                var group = card.Questions[0];
+                group.Options[0].IsSelected = true;
+                group.OtherText = "custom";
+                await Assert.That(group.Options[0].IsSelected).IsFalse();
+                await group.Options[1].PickCommand.Execute().ToTask();
+                await Assert.That(group.OtherText).IsEqualTo("");
+                await Assert.That(group.Options[1].IsSelected).IsTrue();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Double_activation_sends_once_and_transport_failure_re_enables() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) using (card) {
+                var gate = svc.Arm();
+                var first = card.Questions[0].Options[0].PickCommand.Execute().ToTask();
+                await WaitUntilAsync(() => card.IsBusy, what: "busy in flight");
+                await card.Questions[0].Options[1].PickCommand.Execute().ToTask();
+                gate.SetResult(new PermissionResolveOutcome(PermissionResolveKind.TransportFailure, "daemon_unreachable"));
+                await first;
+                await Assert.That(svc.Answered.Count).IsEqualTo(1);
+                await Assert.That(card.IsBusy).IsFalse();
+                await Assert.That(card.ErrorText).IsEqualTo("Daemon unreachable — try again");
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Eviction_mid_flight_leaves_no_error_and_no_post_disposal_notification() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) {
+                var gate = svc.Arm();
+                var run = card.Questions[0].Options[0].PickCommand.Execute().ToTask();
+                await WaitUntilAsync(() => card.IsBusy, what: "busy in flight");
+
+                var notified = new List<string>();
+                card.PropertyChanged += (_, e) => notified.Add(e.PropertyName ?? "");
+                card.Dispose();
+                gate.SetResult(new PermissionResolveOutcome(PermissionResolveKind.TransportFailure, "daemon_unreachable"));
+                await run;
+                await Assert.That(notified).IsEmpty();
+                await Assert.That(card.ErrorText).IsNull();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_throwing_service_clears_busy_and_shows_the_generic_line() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) using (card) {
+                svc.Arm().SetException(new ArgumentException("composer rejected"));
+                await card.Questions[0].Options[0].PickCommand.Execute().ToTask();
+                await Assert.That(card.IsBusy).IsFalse();
+                await Assert.That(card.ErrorText).IsEqualTo("Something went wrong — try again");
+            }
+        });
+    }
+}
+```
+
+(`FirstAsync` comes from `System.Reactive.Linq` — add the using if the compiler asks.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/QuestionCardViewModelTests/*"`
+Expected: build error — `QuestionCardViewModel` missing.
+
+- [ ] **Step 3: Implement**
+
+Create `src/Capacitor.App/ViewModels/QuestionCardViewModel.cs`:
+
+```csharp
+using System.Reactive;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+public sealed class QuestionOptionViewModel : ReactiveObject {
+    bool _isSelected;
+
+    public string Label { get; }
+    public string? Description { get; }
+    public bool IsMulti { get; }
+    public ReactiveCommand<Unit, Unit> PickCommand { get; }
+
+    public bool IsSelected {
+        get => _isSelected;
+        set => this.RaiseAndSetIfChanged(ref _isSelected, value);
+    }
+
+    internal QuestionOptionViewModel(ElicitationOption option, bool isMulti, Func<QuestionOptionViewModel, Task> pick, IObservable<bool> idle) {
+        Label = option.Label;
+        Description = option.Description;
+        IsMulti = isMulti;
+        PickCommand = ReactiveCommand.CreateFromTask(() => pick(this), idle);
+    }
+}
+
+public sealed class QuestionGroupViewModel : ReactiveObject {
+    readonly BehaviorSubject<bool> _answered = new(false);
+    string _otherText = "";
+
+    public string? Header { get; }
+    public string Text { get; }
+    public bool MultiSelect { get; }
+    public IReadOnlyList<QuestionOptionViewModel> Options { get; }
+    public int MaxOtherLength => ClaudeElicitation.MaxOtherTextChars;
+    public ReactiveCommand<Unit, Unit> EnterCommand { get; }
+    internal IObservable<bool> Answered => _answered;
+
+    public string OtherText {
+        get => _otherText;
+        set {
+            this.RaiseAndSetIfChanged(ref _otherText, value);
+            // Single-select: typing Other displaces a picked option.
+            if (!MultiSelect && !string.IsNullOrWhiteSpace(value))
+                foreach (var option in Options) option.IsSelected = false;
+            Refresh();
+        }
+    }
+
+    public bool IsAnswered => Options.Any(o => o.IsSelected) || !string.IsNullOrWhiteSpace(OtherText);
+    public bool ShowsOtherAnswer => !string.IsNullOrWhiteSpace(OtherText);
+
+    internal QuestionGroupViewModel(ElicitationQuestion question, Func<QuestionOptionViewModel, QuestionGroupViewModel, Task> pick,
+            Func<QuestionGroupViewModel, Task> enter, IObservable<bool> idle) {
+        Header = question.Header;
+        Text = question.Question;
+        MultiSelect = question.MultiSelect;
+        Options = question.Options.Select(o => new QuestionOptionViewModel(o, question.MultiSelect, opt => pick(opt, this), idle)).ToList();
+        foreach (var option in Options)
+            option.WhenAnyValue(o => o.IsSelected).Subscribe(_ => Refresh());
+        EnterCommand = ReactiveCommand.CreateFromTask(() => enter(this), idle);
+    }
+
+    internal void SelectExclusively(QuestionOptionViewModel picked) {
+        foreach (var option in Options) option.IsSelected = ReferenceEquals(option, picked);
+        if (OtherText.Length != 0) { _otherText = ""; this.RaisePropertyChanged(nameof(OtherText)); }
+        Refresh();
+    }
+
+    internal ElicitationAnswer ToAnswer() => new(
+        Text,
+        Options.Where(o => o.IsSelected).Select(o => o.Label).ToList(),
+        string.IsNullOrWhiteSpace(OtherText) ? null : OtherText.Trim());
+
+    void Refresh() {
+        _answered.OnNext(IsAnswered);
+        this.RaisePropertyChanged(nameof(IsAnswered));
+        this.RaisePropertyChanged(nameof(ShowsOtherAnswer));
+    }
+}
+
+/// The NEEDS YOU question card: renders every question of an AskUserQuestion payload and answers
+/// them all in one resolve. No Deny and no Allow always by design.
+public sealed class QuestionCardViewModel : PendingCardViewModel {
+    readonly PendingPermissionRequest _entry;
+    readonly IPermissionService _permissions;
+    readonly CancellationTokenSource _lifetime = new();
+
+    public IReadOnlyList<QuestionGroupViewModel> Questions { get; }
+    public bool IsFastPath { get; }
+    public bool ShowsSubmit => !IsFastPath;
+    public ReactiveCommand<Unit, Unit> SubmitCommand { get; }
+
+    public QuestionCardViewModel(PendingPermissionRequest entry, IPermissionService permissions) : base(entry) {
+        _entry = entry;
+        _permissions = permissions;
+        var parsed = entry.Questions ?? throw new ArgumentException("not an elicitation entry", nameof(entry));
+
+        var idle = Busy.Select(b => !b);
+        Questions = parsed.Questions.Select(q => new QuestionGroupViewModel(q, PickAsync, EnterAsync, idle)).ToList();
+        IsFastPath = Questions.Count == 1 && !Questions[0].MultiSelect && Questions[0].Options.Count > 0;
+
+        var allAnswered = Questions.Select(q => q.Answered).CombineLatest(states => states.All(x => x));
+        SubmitCommand = ReactiveCommand.CreateFromTask(SubmitAsync, allAnswered.CombineLatest(idle, (a, i) => a && i));
+
+        Disposables.Add(SubmitCommand);
+        Disposables.Add(_lifetime);
+    }
+
+    Task PickAsync(QuestionOptionViewModel option, QuestionGroupViewModel group) {
+        if (group.MultiSelect) { option.IsSelected = !option.IsSelected; return Task.CompletedTask; }
+        group.SelectExclusively(option);
+        return IsFastPath ? SubmitAsync() : Task.CompletedTask;
+    }
+
+    Task EnterAsync(QuestionGroupViewModel group) {
+        if (IsFastPath) return group.ShowsOtherAnswer ? SubmitAsync() : Task.CompletedTask;
+        return Questions.All(q => q.IsAnswered) ? SubmitAsync() : Task.CompletedTask;
+    }
+
+    async Task SubmitAsync() {
+        if (IsBusy || IsDisposed) return;
+        IsBusy = true;
+        ErrorText = null;
+        try {
+            var answers = Questions.Select(q => q.ToAnswer()).ToList();
+            var outcome = await _permissions.AnswerAsync(_entry, answers, _lifetime.Token);
+            if (outcome.Kind == PermissionResolveKind.TransportFailure)
+                ErrorText = outcome.Error == "daemon_unreachable" ? "Daemon unreachable — try again" : $"Could not answer ({outcome.Error}) — try again";
+        } catch (OperationCanceledException) {
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: question submit failed unexpectedly: {ex.Message}");
+            ErrorText = "Something went wrong — try again";
+        } finally {
+            IsBusy = false;
+        }
+    }
+}
+```
+
+Notes for the implementer: the base's disposal-guarded setters are what make the `finally` and the error line safe on an evicted card — do not add a second guard, and do not move `IsBusy = true` after an await (single flight depends on it being synchronous). `Dispose` on the base runs before `_lifetime` is disposed via `Disposables`, so cancel it there: add `_lifetime.Cancel()` wrapped in try/catch(ObjectDisposedException) at the START of a `Disposables.Add(Disposable.Create(...))` registration, i.e. register `Disposables.Add(Disposable.Create(() => { try { _lifetime.Cancel(); } catch (ObjectDisposedException) { } }));` BEFORE adding `_lifetime` itself.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/QuestionCardViewModelTests/*"`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/QuestionCardViewModel.cs test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs
+git commit -m "Add the question card view model with fast path and single flight"
+```
+
+---
+
+### Task 6: Chat tab — mixed cards in the pipeline and the view
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/ChatTabViewModel.cs:128-160` (the permission pipeline)
+- Modify: `src/Capacitor.App/Views/ChatTabView.axaml:63-92` (the NEEDS YOU row)
+- Test: `test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs`, `test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs` (extend; fix `.Detail` accesses with a `PermissionCardViewModel` cast)
+
+**Interfaces:**
+- Consumes: Tasks 3–5.
+- Produces: `ChatTabViewModel.PendingPermissions` becomes `ReadOnlyObservableCollection<PendingCardViewModel>`; `HasPendingPermissions` unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+In `ChatTabViewModelTests.cs`, add (using its existing `Claude(seed)` harness factory and `PermissionEntries`):
+
+```csharp
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Question_entries_become_question_cards_beside_permission_cards() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var h = Claude(p => {
+                p.Add(PermissionEntries.Entry("r1", requestedAt: "2026-08-28T10:00:00.0000000+00:00"));
+                p.Add(PermissionEntries.Question("q1", requestedAt: "2026-08-28T10:00:01.0000000+00:00"));
+            });
+            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 2, what: "both cards");
+            await Assert.That(h.Chat.PendingPermissions[0]).IsTypeOf<PermissionCardViewModel>();
+            await Assert.That(h.Chat.PendingPermissions[1]).IsTypeOf<QuestionCardViewModel>();
+
+            h.Permissions.Remove("q1");
+            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 1, what: "question card removed");
+            await Assert.That(h.Chat.PendingPermissions[0].RequestId).IsEqualTo("r1");
+        });
+    }
+```
+
+(`PermissionEntries.Question` gained `requestedAt` in Task 3's helper — thread it through as `Entry` does.) In `ChatTabViewSmokeTests.cs`, add:
+
+```csharp
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Question_card_renders_options_other_and_coexists_with_a_permission_card() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            host.Permissions.Add(PermissionEntries.Entry("r1"));
+            host.Permissions.Add(PermissionEntries.Question("q1"));
+            host.Settle();
+
+            var buttons = host.View.GetVisualDescendants().OfType<Button>().Select(b => b.Content as string).ToList();
+            await Assert.That(buttons).Contains("Allow");           // the permission card
+            await Assert.That(buttons).Contains("A");               // a question option button
+            var otherBoxes = host.View.GetVisualDescendants().OfType<TextBox>()
+                .Where(t => t.Watermark == "Other…").ToList();
+            await Assert.That(otherBoxes.Count).IsEqualTo(1);
+            await Assert.That(host.View.GetVisualDescendants().OfType<TextBlock>().Any(t => t.Text == "Pick")).IsTrue();
+        });
+    }
+```
+
+(The exact `RunOnUiAsync`/`Settle` shape: mirror the file's other tests; the assertion targets are what matter.)
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/ChatTabViewModelTests/*"`
+Expected: build errors (type mismatch on `IsTypeOf<QuestionCardViewModel>` against `PermissionCardViewModel` collection).
+
+- [ ] **Step 3: Implement the pipeline branch**
+
+In `ChatTabViewModel.cs`, change the pipeline (line ~137):
+
+```csharp
+        var cards = permissions.Pending
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Filter(p => p.AgentId == agentId)
+            .Transform(p => p.Questions is null
+                ? (PendingCardViewModel)new PermissionCardViewModel(p, permissions, _rootSubject)
+                : new QuestionCardViewModel(p, permissions))
+            .DisposeMany()
+            .SortAndBind(out var pendingPermissions, Comparer<PendingCardViewModel>.Create((a, b) => {
+                var byTime = a.RequestedAt.CompareTo(b.RequestedAt);
+                return byTime != 0 ? byTime : string.CompareOrdinal(a.RequestId, b.RequestId);
+            }));
+        PendingPermissions = pendingPermissions;
+```
+
+and retype the property: `public ReadOnlyObservableCollection<PendingCardViewModel> PendingPermissions { get; }`. Fix the existing test sites that read `.Detail` off the collection (`ChatTabViewModelTests.cs:294-296`): `((PermissionCardViewModel)h.Chat.PendingPermissions[0]).Detail`.
+
+- [ ] **Step 4: Implement the view**
+
+In `ChatTabView.axaml`, replace the NEEDS YOU `ItemsControl` (lines 67-89): keep the existing permission template byte-for-byte but move it from `ItemsControl.ItemTemplate` into `ItemsControl.DataTemplates`, and add the question template beside it:
+
+```xml
+                    <ItemsControl ItemsSource="{Binding PendingPermissions}">
+                        <ItemsControl.DataTemplates>
+                            <DataTemplate x:DataType="vm:PermissionCardViewModel">
+                                <!-- existing permission card Border, unchanged -->
+                            </DataTemplate>
+                            <DataTemplate x:DataType="vm:QuestionCardViewModel">
+                                <Border Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapAccentBrush}"
+                                        BorderThickness="1" CornerRadius="10" Padding="13,10" Margin="0,0,0,6">
+                                    <StackPanel Spacing="8">
+                                        <ItemsControl ItemsSource="{Binding Questions}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:QuestionGroupViewModel">
+                                                    <StackPanel Spacing="5" Margin="0,0,0,4">
+                                                        <TextBlock Text="{Binding Header}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}"
+                                                                   IsVisible="{Binding Header, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                                        <TextBlock Text="{Binding Text}" FontWeight="SemiBold" FontSize="13" TextWrapping="Wrap"
+                                                                   Foreground="{StaticResource KcapTextBrush}" />
+                                                        <ItemsControl ItemsSource="{Binding Options}">
+                                                            <ItemsControl.ItemTemplate>
+                                                                <DataTemplate x:DataType="vm:QuestionOptionViewModel">
+                                                                    <StackPanel Margin="0,0,0,2">
+                                                                        <Button IsVisible="{Binding !IsMulti}" Command="{Binding PickCommand}"
+                                                                                HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
+                                                                                Padding="10,5" FontSize="12" CornerRadius="7"
+                                                                                Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1">
+                                                                            <StackPanel>
+                                                                                <TextBlock Text="{Binding Label}" Foreground="{StaticResource KcapTextBrush}" />
+                                                                                <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
+                                                                                           TextWrapping="Wrap"
+                                                                                           IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                                                            </StackPanel>
+                                                                        </Button>
+                                                                        <CheckBox IsVisible="{Binding IsMulti}" IsChecked="{Binding IsSelected}" FontSize="12">
+                                                                            <StackPanel>
+                                                                                <TextBlock Text="{Binding Label}" Foreground="{StaticResource KcapTextBrush}" />
+                                                                                <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
+                                                                                           TextWrapping="Wrap"
+                                                                                           IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                                                            </StackPanel>
+                                                                        </CheckBox>
+                                                                    </StackPanel>
+                                                                </DataTemplate>
+                                                            </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                        <DockPanel>
+                                                            <Button DockPanel.Dock="Right" Content="Answer" Command="{Binding EnterCommand}"
+                                                                    IsVisible="{Binding ShowsOtherAnswer}" Margin="6,0,0,0"
+                                                                    Padding="10,4" FontSize="12" CornerRadius="7"
+                                                                    Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                                                            <TextBox Text="{Binding OtherText}" Watermark="Other…" MaxLength="{Binding MaxOtherLength}"
+                                                                     AcceptsReturn="False" FontSize="12" MinHeight="30">
+                                                                <TextBox.KeyBindings>
+                                                                    <KeyBinding Gesture="Enter" Command="{Binding EnterCommand}" />
+                                                                </TextBox.KeyBindings>
+                                                            </TextBox>
+                                                        </DockPanel>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                        <TextBlock Text="{Binding ErrorText}" FontSize="11" Foreground="{StaticResource KcapDangerBrush}"
+                                                   IsVisible="{Binding ErrorText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                        <Button Content="Submit" Command="{Binding SubmitCommand}" IsVisible="{Binding ShowsSubmit}"
+                                                HorizontalAlignment="Right" Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
+                                                Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.DataTemplates>
+                    </ItemsControl>
+```
+
+Selected state for single-select option buttons: add to the question card's `Border` a `Styles` block scoping a selected look — a `Button` inside the option template gets `Classes.selected="{Binding IsSelected}"` and
+
+```xml
+        <Border.Styles>
+            <Style Selector="Button.selected">
+                <Setter Property="BorderBrush" Value="{StaticResource KcapAccentBrush}" />
+            </Style>
+        </Border.Styles>
+```
+
+- [ ] **Step 5: Run to verify pass**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/ChatTabViewModelTests/*"` then `-- --treenode-filter "/*/*/ChatTabViewSmokeTests/*"`
+Expected: PASS, including the pre-existing cases.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/ChatTabViewModel.cs src/Capacitor.App/Views/ChatTabView.axaml test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+git commit -m "Render question cards beside permission cards on the NEEDS YOU row"
+```
+
+---
+
+### Task 7: Tray — the summary input and split wording
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/TrayViewModel.cs:105-108,155-245`
+- Test: `test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs` (extend around line 1040)
+
+**Interfaces:**
+- Consumes: Task 3's `IPermissionService.Summary` / `PendingSummary`.
+- Produces: no public surface change; `Build` and `HeaderText`/`PendingBody` take a `PendingSummary` where they took `int pendingPermissions`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Beside the existing pending-permission tray test (~line 1040), mirroring its harness setup exactly:
+
+```csharp
+    [Test]
+    public async Task Pending_questions_split_the_header_wording() {
+        // Same service/pause/actions/consent setup as Pending_permissions_assert_attention... above.
+        using var permissions = new FakePermissionService();
+        using var vm = new TrayViewModel(service, pause, actions, consent, permissions: permissions);
+        service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["consent/1", "permission/1"]));
+        // ...emit the same snapshot the sibling test emits...
+
+        permissions.Add(PermissionEntries.Question("q1"));
+        await WaitUntilAsync(() => vm.MenuModel.State == TrayState.Attention, what: "attention on a question");
+        await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: 1 question waiting");
+
+        permissions.Add(PermissionEntries.Entry("r1"));
+        await WaitUntilAsync(() => vm.MenuModel.Header == "daemon-a: 1 question waiting, 1 permission request waiting",
+            what: "mixed wording");
+
+        permissions.Remove("q1");
+        permissions.Remove("r1");
+        await WaitUntilAsync(() => vm.MenuModel.State != TrayState.Attention, what: "cleared");
+    }
+```
+
+Copy the sibling test's exact `service`/`pause`/`actions`/`consent` construction and snapshot emission — the file's local fixtures own those shapes. Also extend the replay-guard test (the one asserting the `InvalidOperationException` message) if it names `PendingCount`: the message text changes to name `Summary` (Step 3).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/TrayViewModelTests/*"`
+Expected: the new test FAILS (header says "1 permission request waiting" for a question).
+
+- [ ] **Step 3: Implement**
+
+In `TrayViewModel.cs`:
+
+```csharp
+        var pendingSummary = permissions?.Summary ?? Observable.Return(default(PendingSummary));
+        var projected = service.Status.CombineLatest(snapshots, pause.State, actions.StopsInFlight, consent.PendingCount, attention, pendingSummary,
+            (status, snap, pauseState, inFlight, pending, lifecycleMsg, summary) =>
+                Build(service.DaemonName, status, snap, pauseState, inFlight, pending, lifecycleMsg, summary));
+```
+
+`Build`/`HeaderText`: parameter `int pendingPermissions` becomes `PendingSummary pendingSummary`; the attention predicate uses `pendingSummary.Total > 0`; `PendingBody`:
+
+```csharp
+    static string PendingBody(PendingSummary summary, int consent) {
+        var parts = new List<string>(3);
+        if (summary.Questions > 0) parts.Add($"{summary.Questions} question{(summary.Questions == 1 ? "" : "s")} waiting");
+        if (summary.Permissions > 0) parts.Add($"{summary.Permissions} permission request{(summary.Permissions == 1 ? "" : "s")} waiting");
+        if (consent > 0) parts.Add($"{consent} launch{(consent == 1 ? "" : "es")} awaiting approval");
+        return string.Join(", ", parts);
+    }
+```
+
+Update the replay-guard message (line ~131) to name `IPermissionService.Summary` instead of `PendingCount`, and trim the surrounding comment blocks it forces you to touch per the CLAUDE.md rewrite-as-you-go rule.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/TrayViewModelTests/*"`
+Expected: all PASS, pre-existing permission wording cases included.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/TrayViewModel.cs test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
+git commit -m "Split the tray wording for pending questions via one summary input"
+```
+
+---
+
+### Task 8: Docs, full suite, AOT gate
+
+**Files:**
+- Modify: `docs/CHANGES.md` (new feature section at the position the file's ordering convention dictates)
+
+- [ ] **Step 1: Write the CHANGES.md section**
+
+Follow the file's existing per-feature format (open it and match the heading style). Content to carry — the reasoning, not the diff:
+
+```markdown
+## Elicitation question cards for PTY sessions (AI-2361)
+
+A PTY Claude session's `AskUserQuestion` already reaches the app as a pending permission entry
+(the `PermissionRequest` hook rides the permission lane end to end), so the desktop renders it
+as an answerable question card instead of a broken Allow/Deny card — classification is app-side,
+on the entry it already receives, and the answer is the existing resolve frame with `allow` plus
+the documented `updatedInput` answers shape. No wire, daemon, or CLI change: the feature works
+against any daemon advertising `permission/1`, and AI-2197 defines its own frames later for the
+structured ACP vendors. Core's `ClaudeElicitation` owns the contract: a strict, capped,
+parser-created immutable model and a composer that validates every answer against it, which is
+what bounds the outgoing resolve frame by arithmetic. An unparseable or oversized payload falls
+back to the permission card (Allow = let the TUI ask) with "Allow always" hidden for the
+question tool.
+```
+
+- [ ] **Step 2: Run the full solution test suite**
+
+Run: `dotnet test --solution Capacitor.slnx`
+Expected: green, except the 7 unit + 1 integration session-start nudge tests that already fail on main in this environment (see auto-memory) — verify the failure list matches that pre-existing set exactly.
+
+- [ ] **Step 3: AOT publish gate**
+
+Run: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'`
+Expected: no output. (Core is compiled into the CLI; the `JsonNode`/`JsonValue.Create(string)`/`JsonArray.Add(JsonNode)` calls are the sites this gate watches.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/CHANGES.md
+git commit -m "Record the elicitation question cards feature in CHANGES"
+```
+
+---
+
+## PR notes (for the finishing step, not a task)
+
+- Title: `Render AskUserQuestion as an answerable card in the desktop app` (no reference in the title).
+- Description: follow `.github/PULL_REQUEST_TEMPLATE.md`'s comment block; the reference line carries `AI-2361` — **ask the user** whether a GitHub issue exists or should be created before adding a `Closes #N`.
+- The README is unchanged on purpose: no CLI surface changed (verify nothing in `src/Capacitor.Cli.Core/Resources/help-*.txt` was touched).

--- a/docs/superpowers/specs/2026-08-30-ai2361-elicitation-question-cards-design.md
+++ b/docs/superpowers/specs/2026-08-30-ai2361-elicitation-question-cards-design.md
@@ -221,9 +221,10 @@ Attention rule aggregate both kinds and need no change.
 small `PendingCardViewModel` base carrying what the pipeline and the row need
 (`RequestId`, `RequestedAt`, `IsBusy`, `ErrorText`, disposal), so one sorted
 collection — the existing `(RequestedAt, RequestId)` comparer — feeds the row.
-`PendingPermissions` keeps its name and becomes
-`ReadOnlyObservableCollection<PendingCardViewModel>`; `HasPendingPermissions`
-is unchanged. The view's `ItemsControl` moves from a single `DataTemplate` to
+`PendingPermissions` becomes `PendingCards` — a
+`ReadOnlyObservableCollection<PendingCardViewModel>` — and `HasPendingPermissions`
+becomes `HasPendingCards`: the row now holds both card kinds. The view's
+`ItemsControl` moves from a single `DataTemplate` to
 type-keyed `ItemsControl.DataTemplates` — the pattern the same file already
 uses for chat items. §1's caps bound a worst-case card at 8 question groups of
 16 options — a scale the row's existing `ScrollViewer` handles without

--- a/docs/superpowers/specs/2026-08-30-ai2361-elicitation-question-cards-design.md
+++ b/docs/superpowers/specs/2026-08-30-ai2361-elicitation-question-cards-design.md
@@ -1,0 +1,410 @@
+# Elicitation question cards for PTY sessions (AI-2361)
+
+Slice of the desktop shell (parent AI-2171), riding the AI-2308 rails. A PTY
+Claude session blocked on an `AskUserQuestion` shows nothing useful in the
+desktop app: the request reaches the app — since AI-2308 it is a pending
+permission entry — but renders as an Allow / Allow always / Deny card, none of
+which answers the question.
+
+What already exists, end to end: Claude fires the `PermissionRequest` hook for
+`AskUserQuestion` with the `questions[]` payload as `tool_input`; the hook posts
+to the daemon's `/claude/permission-request`; `LocalPermissionBridge` attributes
+it, registers it with `PermissionPromptBroker`, and streams it to the app as a
+`PermissionPendingDto` over `permission/1`. The server classifies the same
+request as an elicitation (tool name plus `questions[]` parse) and the web
+answers it via `RespondToPermission(behavior: "allow", updatedInput:
+{"answers": …})` — which returns to the daemon as an ordinary
+`PermissionResolved` push, settles through the broker's one claim point, and
+reaches the hook through the existing Claude response builder, `updatedInput`
+included. The app's `PermissionResolveDto` already carries `UpdatedInput`, and
+the daemon relays it verbatim into the hook response and the server leg.
+
+So the wire, broker, settlement, rail pips and tray Attention all carry the
+question already; only the app's rendering and answer shape are wrong. This
+slice is app-side plus one Core helper. No daemon, CLI, or wire change; the
+feature works against any daemon advertising `permission/1`.
+
+Out of scope: ACP elicitations from structured vendors (Cursor, Copilot, Kiro,
+OpenCode, Gemini — their `elicitation/create` goes daemon → server → web and
+never touches the local socket; AI-2197 owns bringing structured interactions
+to the app); Codex (no elicitation reaches the bridge, and its hook response
+builder strips `updatedInput`); detecting an answer given in the TUI;
+a deny/dismiss affordance on the question card; server-side multi-question
+rendering (AI-1052).
+
+## Decisions
+
+Settled with the owner during brainstorming, 2026-08-30:
+
+1. **App-side classification over a new frame family.** The issue sketched a
+   sibling `question/1` frame pair, written before the discovery that the
+   elicitation already rides the permission lane end to end. New frames would
+   re-buy the whole Core/daemon/app stack, make an older app show nothing for
+   a question, and still need an app-side fallback against the shipped daemon.
+   Classification therefore happens in the app, on the pending entry it
+   already receives; the answer travels as the existing resolve frame with
+   `Decision: "allow"` plus `UpdatedInput`. AI-2197 defines its own frames
+   later, with real ACP requirements in hand.
+2. **The answer shape is the documented Agent SDK contract**:
+   `{"questions": <original questions array, verbatim>, "answers":
+   {<question text>: <string | string[]>}}` — keys are the question texts,
+   multi-select values are arrays of labels, free text is a first-class value
+   (the "Other" affordance; the custom text is the answer, never the word
+   "Other"). Every question is answered — partial answers are undocumented and
+   never sent — and the composer enforces that, not just the card (§1). The
+   web omits the `questions` passthrough and works; this app composes the
+   documented form.
+3. **One fast path**: a payload with exactly one single-select question *that
+   has options* submits on option click. A free-text-only payload always has a
+   visible submit affordance (§3). Any multi-select or multi-question payload
+   gets selection state and one Submit, enabled once every question has an
+   answer.
+4. **The tray splits the wording**: "1 question waiting", "2 permission
+   requests waiting", both parts when mixed. The Attention rule is unchanged —
+   any pending entry asserts it. The split comes from one cache snapshot per
+   emission, never from combining two independently emitted counts (§4).
+5. **No Deny and no Allow always on the question card.** Deny's effect on
+   `AskUserQuestion` is undocumented, and a standing always-allow rule for the
+   question tool is never what the user means. The fallback permission card
+   (unparseable or oversized payload) keeps Allow/Deny — Allow means "let the
+   TUI ask" — but hides Allow always for this tool.
+6. **Core-enforced caps make the outgoing legs bounded by arithmetic.** The
+   incoming 64 KiB `MaxElementBytes` bound covers only the pending leg; the
+   resolve frame repeats the `questions` array and adds the answers, and its
+   own limit is `FrameCodec`'s 8 MiB frame cap. The parse caps and the
+   composer's answer validation (§1) bound every value that can reach the
+   composed `UpdatedInput` — the UI's input limit is a convenience mirror of
+   a Core constant, never the enforcement point. In encoded bytes, worst
+   case: the caps are UTF-16 code-unit counts and JSON escaping expands a
+   unit to at most 6 bytes (`\uXXXX`), so answers keys ≤ 8 × 4096 × 6 ≈
+   192 KiB, selected labels ≤ 8 × 16 × 1024 × 6 ≈ 768 KiB, Other texts ≤
+   8 × 8192 × 6 ≈ 384 KiB, plus the retained `questions` element (its source
+   was bounded at 64 KiB of raw UTF-8) and structural overhead — under 2 MiB
+   against the 8 MiB cap. No preflight or truncation path is needed, and the
+   same arithmetic bounds the hook response and the server relay (whose
+   free-text path already accepts the web's unbounded text today).
+
+## 1. Core: `ClaudeElicitation`
+
+Beside `ClaudePermissions` in `Capacitor.Cli.Core`, owning the Claude
+elicitation contract in one place.
+
+- `ToolName = "AskUserQuestion"`.
+- Caps, as constants beside the parser: `MaxQuestions = 8`,
+  `MaxOptionsPerQuestion = 16`, `MaxQuestionTextChars = 4096`,
+  `MaxOptionLabelChars = 1024`, and `MaxOtherTextChars = 8192` for the
+  composer's free-text values (the UI's `MaxLength` references this constant
+  rather than restating it). All are UTF-16 code-unit counts; decision 6
+  carries the byte conversion. Claude emits at most 4 questions of at most 4
+  options, so the caps are headroom, not a fit; they exist to bound the
+  resolve payload (decision 6) and the rendered control count (§3). A payload
+  over any cap fails the parse and falls back to the permission card.
+
+`TryParse(string? toolInputJson) → ElicitationQuestions?` reads **every**
+entry of `questions[]`, in payload order — never only `questions[0]`, the
+server parser's trap (AI-1052). `ElicitationQuestions` retains the original
+`questions` `JsonElement` (for the compose passthrough) plus the parsed list:
+per question `Question`, `Header`, `MultiSelect`,
+`Options[{Label, Description?}]`. The retained element is **detached** — a
+`Clone()` independent of any `JsonDocument` the parser created — because the
+result sits in the pending cache and is composed much later, long after every
+parser-local owner is gone. The model is **parser-created and immutable**:
+constructors are internal (only `TryParse` can produce one — Core already
+exposes internals to its own test assembly and to nothing else) and every
+collection is an immutable snapshot taken at parse. The composer's validation
+is therefore grounded in parse output by construction; no App code can
+fabricate an over-cap model or mutate one after the fact.
+
+Field rules — protocol fields are strict (any violation fails the whole
+parse → fallback card), display-only fields are tolerant:
+
+- **Protocol, strict**: input must be an object; `questions` must be a
+  non-empty array of objects, ≤ `MaxQuestions`. `question` must be a string,
+  non-blank after trim, ≤ `MaxQuestionTextChars`; two questions sharing a text
+  fail the parse (the answers map is keyed by text — duplicates cannot be
+  answered unambiguously). `multiSelect`/`multi_select`: absent means false;
+  when present it must be a boolean; when both spellings are present they must
+  agree, else the parse fails (the flag decides string-versus-array in the
+  answer — guessing changes the answer type). `options`, when present, must be
+  an array of objects, ≤ `MaxOptionsPerQuestion`, each `label` a non-blank
+  string ≤ `MaxOptionLabelChars`; an empty or absent array means free-text
+  only. Duplicate labels within one question are deduplicated keeping the
+  first — the label is the answer value, so the duplicates were
+  indistinguishable on the wire anyway.
+- **Display-only, tolerant**: `header` and `description` are used when they
+  are non-blank strings and treated as absent otherwise (wrong type,
+  whitespace); they never fail the parse and are trimmed with an ellipsis at
+  render, so they need no cap.
+
+`ComposeAnswers(ElicitationQuestions questions, IReadOnlyList<ElicitationAnswer>
+answers) → JsonElement`, with `ElicitationAnswer(string Question,
+IReadOnlyList<string> SelectedLabels, string? OtherText)`. The answer is
+validated **against the parsed question**, so the bound is structural rather
+than delegated to the UI: every entry of `SelectedLabels` must equal one of
+that question's parsed option labels (already capped in count and length by
+the parse); `OtherText`, when present, must be non-blank after trim and ≤
+`MaxOtherTextChars`. String-versus-array is derived from the **parsed**
+question's `MultiSelect`, never from a caller flag. The composer throws
+`ArgumentException` (a programming error, not a user state) when: the answer
+count differs from the question count; the answer keys are not exactly the
+parsed question texts (parse already guarantees the texts are unique, so set
+equality plus count is a bijection); a label is not among the question's
+options or appears twice; a single-select answer has other than exactly one
+of (one label, `OtherText`); a multi-select answer has neither a label nor
+`OtherText`; or `OtherText` is blank or over the cap. An `OtherText` that
+(after trim) exactly equals one of the question's option labels is
+**normalized to that option's selection** rather than emitted as a second
+copy: it merges into `SelectedLabels` (a no-op when already selected) — the
+same collapse the parser applies to duplicate option labels, so the composed
+value array never carries duplicates. The composer also owns value ordering:
+selected labels in the question's option order, a genuine `OtherText` last. Output is decision 2's shape — the retained `questions` element copied
+verbatim, and per answer a string or a `JsonArray` of the values — returned
+as a **detached** `JsonElement`, valid independently of any document or node
+the composer built it from. `new JsonArray(…)` constructor, never a
+collection expression (AOT).
+
+The classification rule, evaluated once per entry (§2): `Vendor == "claude"`
+and `ToolName == ClaudeElicitation.ToolName` and `!ToolInputOmitted` and
+`TryParse` succeeds.
+
+## 2. Service: the answer path
+
+`PendingPermissionRequest` gains `ElicitationQuestions? Questions`, computed in
+the constructor by the classification rule. Both the chat tab and the tray
+summary read this one property, so the two can never classify differently.
+
+`IPermissionService` gains:
+
+- `Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target,
+  IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct)`. Requires a
+  classified entry (`Questions` non-null; throw `ArgumentException`
+  otherwise). Builds `PermissionResolveDto(target.RequestId, "allow",
+  ApplyPermissions: null, UpdatedInput: ClaudeElicitation.ComposeAnswers(
+  target.Questions, answers))` — the composer's validation (§1) runs before
+  anything touches the wire — and shares `ResolveAsync`'s send/ack/tombstone
+  tail; the two methods differ only in how the DTO is built, so the tail is
+  extracted rather than duplicated. The exception boundary, exactly: the
+  unclassified-target check and the composer run synchronously **before** the
+  try that wraps the socket exchange (the same placement `ResolveAsync` gives
+  its DTO build), so their `ArgumentException`s propagate to the caller;
+  faults from the exchange itself map to `TransportFailure` as today; caller
+  cancellation propagates.
+- `IObservable<PendingSummary> Summary` with `PendingSummary(int Permissions,
+  int Questions)`. Derived from **one** cache query per change
+  (`QueryWhenChanged` counting classified and unclassified entries in the same
+  snapshot, with the `StartWith` seed pattern `AgentsWithPending` uses), so
+  every emission is a consistent pair — never a subtraction of two
+  independently emitted counts, which can interleave across cache states and
+  transiently miscount. Replays on subscribe.
+
+Cache ownership on an answer, stated precisely (it is `ResolveAsync`'s
+existing behaviour, now shared): **either ack concludes the entry** — under
+the service lock, tombstone the id and evict — so `Applied` and
+`AlreadyDecided` both remove the card at the ack, not at some later push. The
+`Resolved` push is idempotent against that (tombstone re-add and remove of an
+absent key are no-ops), whichever order push and ack land in. A
+`TransportFailure` (including a sent-but-ack-lost socket death, which surfaces
+as a transport error) leaves the entry in place; if the daemon did apply the
+decision, the settlement push clears it.
+`PendingCount` and `AgentsWithPending` stay totals: the rail pips and the tray
+Attention rule aggregate both kinds and need no change.
+`FakePermissionService` extends accordingly.
+
+## 3. Chat tab: mixed cards on the NEEDS YOU row
+
+`ChatTabViewModel`'s transform branches per entry: `Questions != null` →
+`QuestionCardViewModel`, else `PermissionCardViewModel`. Both derive from a
+small `PendingCardViewModel` base carrying what the pipeline and the row need
+(`RequestId`, `RequestedAt`, `IsBusy`, `ErrorText`, disposal), so one sorted
+collection — the existing `(RequestedAt, RequestId)` comparer — feeds the row.
+`PendingPermissions` keeps its name and becomes
+`ReadOnlyObservableCollection<PendingCardViewModel>`; `HasPendingPermissions`
+is unchanged. The view's `ItemsControl` moves from a single `DataTemplate` to
+type-keyed `ItemsControl.DataTemplates` — the pattern the same file already
+uses for chat items. §1's caps bound a worst-case card at 8 question groups of
+16 options — a scale the row's existing `ScrollViewer` handles without
+virtualization.
+
+`QuestionCardViewModel(PendingPermissionRequest, IPermissionService)`:
+
+- One group per question, in payload order: `Header` (muted chip when
+  present), `Question` (semibold), and either option buttons (single-select)
+  or checkboxes (multi-select), each option's `Description` beneath its label
+  in the muted style; plus an "Other…" free-text box per question —
+  single-line (`AcceptsReturn` off), `MaxLength` bound to
+  `ClaudeElicitation.MaxOtherTextChars`, trimmed before use; whitespace-only
+  text does not count as an answer.
+- Selection state: for single-select, picking an option clears the Other text
+  and typing Other text clears the picked option — exactly one of the two
+  holds at a time. For multi-select, the Other text joins the checked labels
+  as one more value. The card hands the service each question's
+  `SelectedLabels` and `OtherText` as they stand; ordering and validation are
+  the composer's (§1).
+- A question is answered when it has one selected option, ≥ 1 checked option,
+  or non-blank Other text. `SubmitCommand` is enabled only when every question
+  is answered and the card is not busy.
+- Decision 3's fast path — exactly one question, single-select, **with
+  options**: option buttons submit on click; the Other box submits on Enter,
+  and an inline "Answer" button appears beside it once the text is non-blank,
+  so mouse and touch users always have a visible, clickable affordance. A
+  free-text-only payload (zero options) is not the fast path: it renders the
+  standard Submit button.
+- **Single flight**: every submitting action runs on the UI thread and sets
+  `IsBusy` synchronously before its first await; each entry point returns
+  immediately when `IsBusy` is already set. A double click or click-plus-Enter
+  therefore cannot start two sends, with or without command requery. Controls
+  are disabled while busy.
+- Outcomes: `TransportFailure` clears `IsBusy` and sets `ErrorText`;
+  `Applied`/`AlreadyDecided` need no UI action — the ack already evicted the
+  entry (§2) and the card leaves with it. The submit continuation runs against
+  a card the pipeline may have disposed mid-flight (an ack or a `Resolved`
+  push evicts and disposes it — in the normal `Applied` path the card is
+  already disposed when `AnswerAsync` returns). Disposal and the continuation
+  both run on the UI thread, so the rule is race-free: **every property write
+  after the await is guarded by a disposal check** — a disposed card gets no
+  `IsBusy` clear, no `ErrorText`, no notification of any kind; a live card
+  always gets `IsBusy` cleared in the guarded `finally`. The command's catch
+  boundary, exactly: cancellation on the card's own lifetime token (cancelled
+  in `Dispose`) is swallowed; any other exception — which per §2's service
+  contract can only be a programming error such as the composer's
+  `ArgumentException` — is caught as a last resort, logged to stderr, and
+  rendered as a generic `ErrorText` line on a live card. Nothing escapes an
+  async command as an unobserved exception, and a bug stays visible in the UI
+  and the log rather than vanishing; the composer's rejections themselves are
+  pinned by direct Core tests, not by this backstop.
+- No Deny, no Allow always (decision 5).
+
+`PermissionCardViewModel` changes only twice: it derives from the base, and
+`ShowsAllowAlways` becomes `Vendor == "claude" && ToolName !=
+ClaudeElicitation.ToolName` — the fallback card for an unrenderable question
+must not offer a standing rule for the question tool.
+
+## 4. Tray
+
+The tray's `CombineLatest` is at its 7-source overload limit, so the
+`permissionCount` input becomes the service's `Summary` (§2) — one
+already-consistent `PendingSummary` per emission, replay-on-subscribe like the
+input it replaces; the replay guard extends to it. `PendingBody` renders the
+question part first, then permissions, then consent: "1 question waiting",
+"2 permission requests waiting", comma-joined when mixed. The Attention rule
+reads the summary's total, unchanged in effect. A null `IPermissionService`
+yields an empty summary, as it yields 0 today.
+
+## 5. Settlement: unchanged by construction
+
+Nothing here adds a settlement path or a cache transition the permission flow
+does not already have. The card-side interleavings and the ack-concludes rule
+are §2 and §3's contracts; beyond those:
+
+- An answer given on the web arrives as the existing `PermissionResolved`
+  push; agent withdrawal, daemon shutdown and session end settle exactly as
+  for a permission. Every settlement clears the card, the pips and the tray
+  from the one pending cache.
+- The app's answer wins or loses the broker claim exactly as an allow/deny
+  does. A withdrawal or session end racing the send loses it: the ack comes
+  back `Ok=false` → `AlreadyDecided`, and the push — before or after the ack —
+  is idempotent against the eviction.
+- The daemon's decision log records `allow`/`app` — the same outcome the web's
+  elicitation answer produces server-side.
+
+## 6. Edge cases
+
+- **Multi-question payloads**: all questions rendered, all required, one
+  resolve carries every answer. The web card still shows only `questions[0]`
+  (AI-1052, untouched here); the desktop is strictly better, and whichever
+  surface settles first wins the claim as today.
+- **Oversized (`ToolInputOmitted`), unparseable, or over-cap payload**:
+  permission fallback card — Allow lets the TUI ask, Deny blocks, Allow always
+  hidden (decision 5). Without a successful parse no answers object can be
+  composed, so a question card is impossible by construction.
+- **Answered in the TUI while the card is up**: the vendor proceeds; the entry
+  lingers until session end settles it — AI-2308's accepted limitation,
+  unchanged in either direction.
+- **Two surfaces answer**: the broker's claim decides; the loser's ack is
+  `Ok=false` → `AlreadyDecided` → the card leaves with no error shown.
+- **Options with empty labels / no options at all**: an empty label fails the
+  parse (fallback card); a question with zero options renders free-text only,
+  with a visible Submit (§3).
+- **Codex**: never classifies — the vendor gate is part of the rule.
+- **Older daemon without `permission/1`**: nothing lights up, exactly as for
+  permissions today.
+- **Older app, newer payloads**: an app without this slice keeps showing the
+  broken allow/deny card — no worse than today, and no protocol skew exists
+  because the wire did not change.
+
+## 7. Testing
+
+- **Core.Tests.Unit**, `ClaudeElicitation`:
+  - Parse: every question read (a two-question payload yields two), payload
+    order kept, `multiSelect` and `multi_select` both honored and their
+    disagreement fatal, non-boolean flag fatal, empty options → free-text
+    only, non-array `options` / non-object option / blank label fatal,
+    duplicate option labels deduplicated keeping the first, duplicate question
+    texts fatal, blank or missing question text fatal, non-object input and
+    non-array `questions` fatal, each §1 cap exercised at the boundary (at the
+    cap passes, one over fails), tolerant header/description (wrong type and
+    whitespace treated as absent, never fatal); the model's collections are
+    immutable (mutation attempts fail at the type) and independent of the
+    caller's input string.
+  - Compose: string vs array derived from the parsed flag, `questions` passed
+    through verbatim, the exact `answers` key set, values ordered by option
+    order with `OtherText` last; rejection of a missing, extra, unknown-key,
+    or duplicate-key answer, a label not among the question's options, a
+    label selected twice, a single-select answer with both a label and
+    `OtherText` or with neither, an empty multi-select answer, and a blank or
+    over-cap `OtherText`; an `OtherText` equal to an option label normalized
+    into the selection with no duplicate value emitted (both when that label
+    is already selected and when it is not); a maximal composed payload — every cap at its
+    bound, filled with worst-case content (characters that JSON-escape to
+    `\uXXXX` and multi-byte UTF-8, not plain ASCII) — stays under
+    `FrameCodec`'s frame cap, asserted through the codec itself so the bound
+    survives a DTO change.
+  - Ownership: parse, let every parser-local JSON owner go out of scope (and
+    force a GC in the test), then compose and serialize — both the retained
+    `questions` element and the composed output must still read back intact.
+- **App.Tests.Unit**:
+  - `PermissionServiceTests` — `AnswerAsync` sends `allow` with the composed
+    `UpdatedInput` and no `ApplyPermissions`; concludes (tombstone + evict) on
+    `Ok=true` and on `Ok=false`; leaves the entry on transport failure; a
+    `Resolved` push before the ack and after the ack both end in the same
+    state; throws on an unclassified entry and lets a composer rejection
+    propagate (nothing sent in either case); classification matrix (codex
+    vendor, wrong tool name, omitted input, null input, unparseable input all
+    stay unclassified); `Summary` seeds on subscribe and every emission is a
+    consistent pair while entries of both kinds are added and settled.
+  - `ChatTabViewModelTests` — an `AskUserQuestion` entry becomes a question
+    card and a plain tool a permission card in the same row, ordering across
+    kinds by `(RequestedAt, RequestId)`, removal on `Resolved` for both kinds.
+  - `QuestionCardViewModelTests` — fast path submits on option click, on
+    Other-text Enter, and via the inline Answer button; free-text-only payload
+    shows the standard Submit; multi-select and multi-question payloads gate
+    Submit on every question answered; single-select option pick and Other
+    text displace each other; whitespace-only Other does not count; double
+    activation sends once; a `Resolved` push evicting the card mid-flight
+    leaves no error, no exception, and raises no property-change notification
+    after disposal; transport failure shows the reason and
+    re-enables; a service that throws (the §3 backstop) clears `IsBusy`, sets
+    the generic error line and leaks no exception; the resolve payload shape.
+  - `PermissionCardViewModelTests` — `ShowsAllowAlways` false for the
+    `AskUserQuestion` fallback card, true for other Claude tools.
+  - `TrayViewModelTests` — wording for questions only, permissions only and
+    mixed; the replay-on-subscribe guard covers the summary.
+  - `ChatTabViewSmokeTests` — a question card renders headless (options,
+    checkboxes, Other, Submit) and both card kinds coexist on the row.
+- `docs/CHANGES.md` gains this feature's section. No README change — no CLI
+  surface changed.
+
+## Risks
+
+- **Undocumented contract corners.** The Agent SDK documents the answer shape,
+  multi-select arrays and free text; it does not document partial answers or
+  deny-for-`AskUserQuestion`. The composer makes partial answers
+  unrepresentable, the card never sends deny, and the fallback card is the
+  escape hatch if a payload defeats the parser.
+- **Contract drift.** If Claude Code reshapes `AskUserQuestion`'s input, the
+  parse fails and every question degrades to the fallback permission card —
+  ugly but answerable (the TUI asks), never silent.
+- **The `questions` passthrough.** The web answers without it and works; the
+  documented shape includes it and this app sends it. Both forms are accepted
+  today; if a future Claude Code rejects one, the documented form is the safer
+  side to be on.

--- a/docs/superpowers/specs/2026-08-30-ai2361-elicitation-question-cards-design.md
+++ b/docs/superpowers/specs/2026-08-30-ai2361-elicitation-question-cards-design.md
@@ -53,7 +53,11 @@ Settled with the owner during brainstorming, 2026-08-30:
    "Other"). Every question is answered — partial answers are undocumented and
    never sent — and the composer enforces that, not just the card (§1). The
    web omits the `questions` passthrough and works; this app composes the
-   documented form.
+   documented form. "Verbatim" is semantic, not byte-level: the composer
+   splices the retained array's raw bytes unchanged, but the local-IPC
+   serializer re-escapes strings with its default encoder on the wire — a
+   representation change every JSON consumer decodes identically, accepted
+   because changing wire serialization is out of this slice's scope.
 3. **One fast path**: a payload with exactly one single-select question *that
    has options* submits on option click. A free-text-only payload always has a
    visible submit affordance (§3). Any multi-select or multi-question payload

--- a/src/Capacitor.App/Services/IPermissionService.cs
+++ b/src/Capacitor.App/Services/IPermissionService.cs
@@ -35,6 +35,12 @@ public sealed class PendingPermissionRequest {
 
 public readonly record struct PendingSummary(int Permissions, int Questions) {
     public int Total => Permissions + Questions;
+
+    public static PendingSummary From(IEnumerable<PendingPermissionRequest> items) {
+        int permissions = 0, questions = 0;
+        foreach (var item in items) { if (item.Questions is null) permissions++; else questions++; }
+        return new PendingSummary(permissions, questions);
+    }
 }
 
 public interface IPermissionService : IDisposable {

--- a/src/Capacitor.App/Services/IPermissionService.cs
+++ b/src/Capacitor.App/Services/IPermissionService.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 
@@ -16,6 +17,9 @@ public sealed class PendingPermissionRequest {
         Dto = dto;
         RequestedAt = DateTimeOffset.TryParse(dto.RequestedAt, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var t)
             ? t : DateTimeOffset.MinValue;
+        Questions = dto.Vendor == "claude" && dto.ToolName == ClaudeElicitation.ToolName && !dto.ToolInputOmitted
+            ? ClaudeElicitation.TryParse(ToolInputJson)
+            : null;
     }
 
     public PermissionPendingDto Dto { get; }
@@ -26,6 +30,11 @@ public sealed class PendingPermissionRequest {
     public string? ToolInputJson => Dto.ToolInput?.GetRawText();
     public bool ToolInputOmitted => Dto.ToolInputOmitted;
     public DateTimeOffset RequestedAt { get; }
+    public ElicitationQuestions? Questions { get; }
+}
+
+public readonly record struct PendingSummary(int Permissions, int Questions) {
+    public int Total => Permissions + Questions;
 }
 
 public interface IPermissionService : IDisposable {
@@ -35,5 +44,10 @@ public interface IPermissionService : IDisposable {
     IObservable<int> PendingCount { get; }
     /// The distinct agent ids in the cache; replays the current set on subscribe.
     IObservable<IReadOnlySet<string>> AgentsWithPending { get; }
+    /// One consistent pair per emission, from a single cache snapshot; replays on subscribe.
+    IObservable<PendingSummary> Summary { get; }
     Task<PermissionResolveOutcome> ResolveAsync(PendingPermissionRequest target, PermissionAnswer answer, CancellationToken ct);
+    /// Answers a classified AskUserQuestion entry (Questions non-null; ArgumentException otherwise,
+    /// as for an invalid answer set — both thrown before anything reaches the wire).
+    Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target, IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct);
 }

--- a/src/Capacitor.App/Services/PermissionService.cs
+++ b/src/Capacitor.App/Services/PermissionService.cs
@@ -40,12 +40,30 @@ public sealed class PermissionService : IPermissionService {
         _cache.Connect()
             .QueryWhenChanged(q => (IReadOnlySet<string>)q.Items.Select(p => p.AgentId).ToHashSet(StringComparer.Ordinal))
             .StartWith((IReadOnlySet<string>)_cache.Items.Select(p => p.AgentId).ToHashSet(StringComparer.Ordinal));
+    public IObservable<PendingSummary> Summary =>
+        _cache.Connect()
+            .QueryWhenChanged(q => Summarize(q.Items))
+            .StartWith(Summarize(_cache.Items));
+
+    static PendingSummary Summarize(IEnumerable<PendingPermissionRequest> items) {
+        int permissions = 0, questions = 0;
+        foreach (var item in items) { if (item.Questions is null) permissions++; else questions++; }
+        return new PendingSummary(permissions, questions);
+    }
 
     public async Task<PermissionResolveOutcome> ResolveAsync(PendingPermissionRequest target, PermissionAnswer answer, CancellationToken ct) {
         var decision = answer == PermissionAnswer.Deny ? "deny" : "allow";
         var apply = answer == PermissionAnswer.AllowAlways ? ClaudePermissions.AlwaysAllow(target.ToolName) : (System.Text.Json.JsonElement?)null;
-        var dto = new PermissionResolveDto(target.RequestId, decision, apply, null);
+        return await SendResolveAsync(new PermissionResolveDto(target.RequestId, decision, apply, null), ct).ConfigureAwait(false);
+    }
 
+    public async Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target, IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct) {
+        if (target.Questions is null) throw new ArgumentException("not an elicitation entry", nameof(target));
+        var updated = ClaudeElicitation.ComposeAnswers(target.Questions, answers);
+        return await SendResolveAsync(new PermissionResolveDto(target.RequestId, "allow", null, updated), ct).ConfigureAwait(false);
+    }
+
+    async Task<PermissionResolveOutcome> SendResolveAsync(PermissionResolveDto dto, CancellationToken ct) {
         PermissionAckDto ack;
         try {
             ack = await _ops.ResolvePermissionAsync(dto, ct).ConfigureAwait(false);
@@ -56,7 +74,7 @@ public sealed class PermissionService : IPermissionService {
             return new PermissionResolveOutcome(PermissionResolveKind.TransportFailure, ex.Message);
         }
 
-        Conclude(target.RequestId);
+        Conclude(dto.RequestId);
         return new PermissionResolveOutcome(ack.Ok ? PermissionResolveKind.Applied : PermissionResolveKind.AlreadyDecided, ack.Error);
     }
 

--- a/src/Capacitor.App/Services/PermissionService.cs
+++ b/src/Capacitor.App/Services/PermissionService.cs
@@ -42,14 +42,8 @@ public sealed class PermissionService : IPermissionService {
             .StartWith((IReadOnlySet<string>)_cache.Items.Select(p => p.AgentId).ToHashSet(StringComparer.Ordinal));
     public IObservable<PendingSummary> Summary =>
         _cache.Connect()
-            .QueryWhenChanged(q => Summarize(q.Items))
-            .StartWith(Summarize(_cache.Items));
-
-    static PendingSummary Summarize(IEnumerable<PendingPermissionRequest> items) {
-        int permissions = 0, questions = 0;
-        foreach (var item in items) { if (item.Questions is null) permissions++; else questions++; }
-        return new PendingSummary(permissions, questions);
-    }
+            .QueryWhenChanged(q => PendingSummary.From(q.Items))
+            .StartWith(PendingSummary.From(_cache.Items));
 
     public async Task<PermissionResolveOutcome> ResolveAsync(PendingPermissionRequest target, PermissionAnswer answer, CancellationToken ct) {
         var decision = answer == PermissionAnswer.Deny ? "deny" : "allow";

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -54,7 +54,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
 
     public IAvaloniaReadOnlyList<ChatItemViewModel> Items => _items;
 
-    public ReadOnlyObservableCollection<PermissionCardViewModel> PendingPermissions { get; }
+    public ReadOnlyObservableCollection<PendingCardViewModel> PendingPermissions { get; }
     public IObservable<string?> Root => _rootSubject;
 
     readonly ObservableAsPropertyHelper<bool> _hasPendingPermissions;
@@ -137,9 +137,11 @@ public sealed class ChatTabViewModel : ReactiveObject {
         var cards = permissions.Pending
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Filter(p => p.AgentId == agentId)
-            .Transform(p => new PermissionCardViewModel(p, permissions, _rootSubject))
+            .Transform(p => p.Questions is null
+                ? (PendingCardViewModel)new PermissionCardViewModel(p, permissions, _rootSubject)
+                : new QuestionCardViewModel(p, permissions))
             .DisposeMany()
-            .SortAndBind(out var pendingPermissions, Comparer<PermissionCardViewModel>.Create((a, b) => {
+            .SortAndBind(out var pendingPermissions, Comparer<PendingCardViewModel>.Create((a, b) => {
                 var byTime = a.RequestedAt.CompareTo(b.RequestedAt);
                 return byTime != 0 ? byTime : string.CompareOrdinal(a.RequestId, b.RequestId);
             }));

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -54,11 +54,11 @@ public sealed class ChatTabViewModel : ReactiveObject {
 
     public IAvaloniaReadOnlyList<ChatItemViewModel> Items => _items;
 
-    public ReadOnlyObservableCollection<PendingCardViewModel> PendingPermissions { get; }
+    public ReadOnlyObservableCollection<PendingCardViewModel> PendingCards { get; }
     public IObservable<string?> Root => _rootSubject;
 
-    readonly ObservableAsPropertyHelper<bool> _hasPendingPermissions;
-    public bool HasPendingPermissions => _hasPendingPermissions.Value;
+    readonly ObservableAsPropertyHelper<bool> _hasPendingCards;
+    public bool HasPendingCards => _hasPendingCards.Value;
 
     ChatTabPhase _phase;
     public ChatTabPhase Phase {
@@ -141,23 +141,23 @@ public sealed class ChatTabViewModel : ReactiveObject {
                 ? (PendingCardViewModel)new PermissionCardViewModel(p, permissions, _rootSubject)
                 : new QuestionCardViewModel(p, permissions))
             .DisposeMany()
-            .SortAndBind(out var pendingPermissions, Comparer<PendingCardViewModel>.Create((a, b) => {
+            .SortAndBind(out var pendingCards, Comparer<PendingCardViewModel>.Create((a, b) => {
                 var byTime = a.RequestedAt.CompareTo(b.RequestedAt);
                 return byTime != 0 ? byTime : string.CompareOrdinal(a.RequestId, b.RequestId);
             }));
-        PendingPermissions = pendingPermissions;
+        PendingCards = pendingCards;
 
         // Hooked before the pipeline subscribes: on the UI thread the scheduler delivers an
         // already-populated cache inline, so a hook installed afterwards would miss the first fill.
         // The delegate-based overload, not the reflection one: ReadOnlyObservableCollection's
         // CollectionChanged is only reachable through this interface, and the reflection overload
         // (Observable.FromEventPattern(target, eventName)) looks up public events only.
-        var notifications = (INotifyCollectionChanged)pendingPermissions;
-        _hasPendingPermissions = Observable
+        var notifications = (INotifyCollectionChanged)pendingCards;
+        _hasPendingCards = Observable
             .FromEventPattern<NotifyCollectionChangedEventHandler, NotifyCollectionChangedEventArgs>(
                 h => notifications.CollectionChanged += h, h => notifications.CollectionChanged -= h)
-            .Select(_ => pendingPermissions.Count > 0)
-            .ToProperty(this, x => x.HasPendingPermissions, initialValue: pendingPermissions.Count > 0)
+            .Select(_ => pendingCards.Count > 0)
+            .ToProperty(this, x => x.HasPendingCards, initialValue: pendingCards.Count > 0)
             .DisposeWith(_disposables);
 
         cards.Subscribe().DisposeWith(_disposables);

--- a/src/Capacitor.App/ViewModels/PendingCardViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PendingCardViewModel.cs
@@ -1,0 +1,55 @@
+using System.Reactive.Disposables;
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+/// Shared shell of a NEEDS YOU card. Setters are no-ops after disposal: the pipeline disposes a
+/// card the instant its entry leaves the cache, and an in-flight submit continuation must not
+/// notify a removed card.
+public abstract class PendingCardViewModel : ReactiveObject, IDisposable {
+    // CA1051: both fields are the shared shell every card subclass wires its own commands and
+    // disposables into; a property indirection here buys nothing.
+#pragma warning disable CA1051
+    protected readonly CompositeDisposable Disposables = new();
+    // canExecute feed; a BehaviorSubject rather than WhenAnyValue for the reason
+    // SessionRailViewModel documents (headless ReactiveUI init ordering).
+    protected readonly BehaviorSubject<bool> Busy = new(false);
+#pragma warning restore CA1051
+    bool _isBusy;
+    string? _errorText;
+
+    public string RequestId { get; }
+    internal DateTimeOffset RequestedAt { get; }
+    protected bool IsDisposed { get; private set; }
+
+    public bool IsBusy {
+        get => _isBusy;
+        protected set {
+            if (IsDisposed) return;
+            this.RaiseAndSetIfChanged(ref _isBusy, value);
+            Busy.OnNext(value);
+        }
+    }
+
+    public string? ErrorText {
+        get => _errorText;
+        protected set {
+            if (IsDisposed) return;
+            this.RaiseAndSetIfChanged(ref _errorText, value);
+        }
+    }
+
+    protected PendingCardViewModel(PendingPermissionRequest entry) {
+        RequestId = entry.RequestId;
+        RequestedAt = entry.RequestedAt;
+        Disposables.Add(Busy);
+    }
+
+    public void Dispose() {
+        IsDisposed = true;
+        Disposables.Dispose();
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/Capacitor.App/ViewModels/PermissionCardViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PermissionCardViewModel.cs
@@ -1,71 +1,46 @@
 using System.Reactive;
-using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
-using System.Reactive.Subjects;
 using Capacitor.App.Services;
+using Capacitor.Cli.Core;
 using ReactiveUI;
 
 namespace Capacitor.App.ViewModels;
 
 /// One NEEDS YOU card. Detail follows the chat tab's root, which the agent stream delivers
 /// independently of the permission replay, so a card built first re-renders relative later.
-public sealed class PermissionCardViewModel : ReactiveObject, IDisposable {
+public sealed class PermissionCardViewModel : PendingCardViewModel {
     readonly PendingPermissionRequest _entry;
     readonly IPermissionService _permissions;
-    readonly CompositeDisposable _disposables = new();
     readonly ObservableAsPropertyHelper<string> _detail;
 
-    public string RequestId => _entry.RequestId;
     public string ToolName { get; }
     public string Detail => _detail.Value;
     public bool ShowsAllowAlways { get; }
-
-    /// The instant ChatTabViewModel's card comparer orders by.
-    internal DateTimeOffset RequestedAt => _entry.RequestedAt;
-
-    // Feeds AllowCommand/AllowAlwaysCommand/DenyCommand's canExecute via this subject rather than
-    // this.WhenAnyValue: that call routes through ReactiveUI's ObservableForProperty/RxAppBuilder
-    // global init, which is only reliably primed when some other test has already pumped the
-    // headless dispatcher first (SessionRailViewModel's own reason for the same substitution).
-    readonly BehaviorSubject<bool> _busy = new(false);
-
-    bool _isBusy;
-    public bool IsBusy {
-        get => _isBusy;
-        private set {
-            this.RaiseAndSetIfChanged(ref _isBusy, value);
-            _busy.OnNext(value);
-        }
-    }
-
-    string? _errorText;
-    public string? ErrorText { get => _errorText; private set => this.RaiseAndSetIfChanged(ref _errorText, value); }
 
     public ReactiveCommand<Unit, Unit> AllowCommand { get; }
     public ReactiveCommand<Unit, Unit> AllowAlwaysCommand { get; }
     public ReactiveCommand<Unit, Unit> DenyCommand { get; }
 
-    public PermissionCardViewModel(PendingPermissionRequest entry, IPermissionService permissions, IObservable<string?> root) {
+    public PermissionCardViewModel(PendingPermissionRequest entry, IPermissionService permissions, IObservable<string?> root) : base(entry) {
         _entry = entry;
         _permissions = permissions;
         ToolName = entry.ToolName.Length == 0 ? "Tool call" : entry.ToolName;
-        ShowsAllowAlways = entry.Vendor == "claude";
+        ShowsAllowAlways = entry.Vendor == "claude" && entry.ToolName != ClaudeElicitation.ToolName;
 
         _detail = root
             .Select(r => entry.ToolInputOmitted ? "Input too large to show" : ToolDetail.From(entry.ToolInputJson, r))
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .ToProperty(this, x => x.Detail, entry.ToolInputOmitted ? "Input too large to show" : ToolDetail.From(entry.ToolInputJson, null))
-            .DisposeWith(_disposables);
+            .DisposeWith(Disposables);
 
-        var idle = _busy.Select(b => !b);
+        var idle = Busy.Select(b => !b);
         AllowCommand       = ReactiveCommand.CreateFromTask(() => AnswerAsync(PermissionAnswer.Allow), idle);
         AllowAlwaysCommand = ReactiveCommand.CreateFromTask(() => AnswerAsync(PermissionAnswer.AllowAlways), idle);
         DenyCommand        = ReactiveCommand.CreateFromTask(() => AnswerAsync(PermissionAnswer.Deny), idle);
-        _disposables.Add(AllowCommand);
-        _disposables.Add(AllowAlwaysCommand);
-        _disposables.Add(DenyCommand);
-        _disposables.Add(_busy);
+        Disposables.Add(AllowCommand);
+        Disposables.Add(AllowAlwaysCommand);
+        Disposables.Add(DenyCommand);
     }
 
     async Task AnswerAsync(PermissionAnswer answer) {
@@ -79,6 +54,4 @@ public sealed class PermissionCardViewModel : ReactiveObject, IDisposable {
             IsBusy = false;
         }
     }
-
-    public void Dispose() => _disposables.Dispose();
 }

--- a/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
+++ b/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
@@ -1,0 +1,154 @@
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+public sealed class QuestionOptionViewModel : ReactiveObject {
+    readonly Action _selectionChanged;
+    bool _isSelected;
+
+    public string Label { get; }
+    public string? Description { get; }
+    public bool IsMulti { get; }
+    public ReactiveCommand<Unit, Unit> PickCommand { get; }
+
+    public bool IsSelected {
+        get => _isSelected;
+        set {
+            if (_isSelected == value) return;
+            this.RaiseAndSetIfChanged(ref _isSelected, value);
+            _selectionChanged();
+        }
+    }
+
+    // Notifies the owning group directly rather than via this.WhenAnyValue: that call routes
+    // through ReactiveUI's ObservableForProperty/RxAppBuilder global init, only reliably primed
+    // once some other test has already pumped the headless dispatcher first (see
+    // SessionRailViewModel and RailWorktreeViewModel for the same avoidance).
+    internal QuestionOptionViewModel(ElicitationOption option, bool isMulti, Func<QuestionOptionViewModel, Task> pick, IObservable<bool> idle, Action selectionChanged) {
+        Label = option.Label;
+        Description = option.Description;
+        IsMulti = isMulti;
+        _selectionChanged = selectionChanged;
+        PickCommand = ReactiveCommand.CreateFromTask(() => pick(this), idle);
+    }
+}
+
+public sealed class QuestionGroupViewModel : ReactiveObject {
+    readonly BehaviorSubject<bool> _answered = new(false);
+    string _otherText = "";
+
+    public string? Header { get; }
+    public string Text { get; }
+    public bool MultiSelect { get; }
+    public IReadOnlyList<QuestionOptionViewModel> Options { get; }
+    public int MaxOtherLength => ClaudeElicitation.MaxOtherTextChars;
+    public ReactiveCommand<Unit, Unit> EnterCommand { get; }
+    internal IObservable<bool> Answered => _answered;
+
+    public string OtherText {
+        get => _otherText;
+        set {
+            this.RaiseAndSetIfChanged(ref _otherText, value);
+            // Single-select: typing Other displaces a picked option.
+            if (!MultiSelect && !string.IsNullOrWhiteSpace(value))
+                foreach (var option in Options) option.IsSelected = false;
+            Refresh();
+        }
+    }
+
+    public bool IsAnswered => Options.Any(o => o.IsSelected) || !string.IsNullOrWhiteSpace(OtherText);
+    public bool ShowsOtherAnswer => !string.IsNullOrWhiteSpace(OtherText);
+
+    internal QuestionGroupViewModel(ElicitationQuestion question, Func<QuestionOptionViewModel, QuestionGroupViewModel, Task> pick,
+            Func<QuestionGroupViewModel, Task> enter, IObservable<bool> idle) {
+        Header = question.Header;
+        Text = question.Question;
+        MultiSelect = question.MultiSelect;
+        Options = question.Options.Select(o => new QuestionOptionViewModel(o, question.MultiSelect, opt => pick(opt, this), idle, Refresh)).ToList();
+        EnterCommand = ReactiveCommand.CreateFromTask(() => enter(this), idle);
+    }
+
+    internal void SelectExclusively(QuestionOptionViewModel picked) {
+        foreach (var option in Options) option.IsSelected = ReferenceEquals(option, picked);
+        if (OtherText.Length != 0) { _otherText = ""; this.RaisePropertyChanged(nameof(OtherText)); }
+        Refresh();
+    }
+
+    internal ElicitationAnswer ToAnswer() => new(
+        Text,
+        Options.Where(o => o.IsSelected).Select(o => o.Label).ToList(),
+        string.IsNullOrWhiteSpace(OtherText) ? null : OtherText.Trim());
+
+    void Refresh() {
+        _answered.OnNext(IsAnswered);
+        this.RaisePropertyChanged(nameof(IsAnswered));
+        this.RaisePropertyChanged(nameof(ShowsOtherAnswer));
+    }
+}
+
+/// The NEEDS YOU question card: renders every question of an AskUserQuestion payload and answers
+/// them all in one resolve. No Deny and no Allow always by design.
+public sealed class QuestionCardViewModel : PendingCardViewModel {
+    readonly PendingPermissionRequest _entry;
+    readonly IPermissionService _permissions;
+    readonly CancellationTokenSource _lifetime = new();
+
+    public IReadOnlyList<QuestionGroupViewModel> Questions { get; }
+    public bool IsFastPath { get; }
+    public bool ShowsSubmit => !IsFastPath;
+    public ReactiveCommand<Unit, Unit> SubmitCommand { get; }
+
+    public QuestionCardViewModel(PendingPermissionRequest entry, IPermissionService permissions) : base(entry) {
+        _entry = entry;
+        _permissions = permissions;
+        var parsed = entry.Questions ?? throw new ArgumentException("not an elicitation entry", nameof(entry));
+
+        var idle = Busy.Select(b => !b);
+        Questions = parsed.Questions.Select(q => new QuestionGroupViewModel(q, PickAsync, EnterAsync, idle)).ToList();
+        IsFastPath = Questions.Count == 1 && !Questions[0].MultiSelect && Questions[0].Options.Count > 0;
+
+        var allAnswered = Questions.Select(q => q.Answered).CombineLatest(states => states.All(x => x));
+        SubmitCommand = ReactiveCommand.CreateFromTask(SubmitAsync, allAnswered.CombineLatest(idle, (a, i) => a && i));
+
+        Disposables.Add(SubmitCommand);
+        // Dispose() runs Disposables in order: cancel _lifetime BEFORE disposing it, so the
+        // token passed to AnswerAsync observes cancellation rather than firing on a disposed CTS.
+        Disposables.Add(Disposable.Create(() => { try { _lifetime.Cancel(); } catch (ObjectDisposedException) { } }));
+        Disposables.Add(_lifetime);
+    }
+
+    Task PickAsync(QuestionOptionViewModel option, QuestionGroupViewModel group) {
+        if (group.MultiSelect) { option.IsSelected = !option.IsSelected; return Task.CompletedTask; }
+        group.SelectExclusively(option);
+        return IsFastPath ? SubmitAsync() : Task.CompletedTask;
+    }
+
+    Task EnterAsync(QuestionGroupViewModel group) {
+        if (IsFastPath) return group.ShowsOtherAnswer ? SubmitAsync() : Task.CompletedTask;
+        return Questions.All(q => q.IsAnswered) ? SubmitAsync() : Task.CompletedTask;
+    }
+
+    async Task SubmitAsync() {
+        if (IsBusy || IsDisposed) return;
+        IsBusy = true;
+        ErrorText = null;
+        try {
+            var answers = Questions.Select(q => q.ToAnswer()).ToList();
+            var outcome = await _permissions.AnswerAsync(_entry, answers, _lifetime.Token);
+            if (outcome.Kind == PermissionResolveKind.TransportFailure)
+                ErrorText = outcome.Error == "daemon_unreachable" ? "Daemon unreachable — try again" : $"Could not answer ({outcome.Error}) — try again";
+        } catch (OperationCanceledException) {
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: question submit failed unexpectedly: {ex.Message}");
+            ErrorText = "Something went wrong — try again";
+        } finally {
+            IsBusy = false;
+        }
+    }
+}

--- a/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
+++ b/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
@@ -149,7 +149,7 @@ public sealed class QuestionCardViewModel : PendingCardViewModel {
             var outcome = await _permissions.AnswerAsync(_entry, answers, _lifetime.Token);
             if (outcome.Kind == PermissionResolveKind.TransportFailure)
                 ErrorText = outcome.Error == "daemon_unreachable" ? "Daemon unreachable — try again" : $"Could not answer ({outcome.Error}) — try again";
-        } catch (OperationCanceledException) {
+        } catch (OperationCanceledException) when (_lifetime.IsCancellationRequested) {
         } catch (Exception ex) {
             Console.Error.WriteLine($"kcap: question submit failed unexpectedly: {ex.Message}");
             ErrorText = "Something went wrong — try again";

--- a/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
+++ b/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
@@ -42,6 +42,7 @@ public sealed class QuestionOptionViewModel : ReactiveObject {
 public sealed class QuestionGroupViewModel : ReactiveObject {
     readonly BehaviorSubject<bool> _answered = new(false);
     string _otherText = "";
+    bool _inFastPath;
 
     public string? Header { get; }
     public string Text { get; }
@@ -50,6 +51,10 @@ public sealed class QuestionGroupViewModel : ReactiveObject {
     public int MaxOtherLength => ClaudeElicitation.MaxOtherTextChars;
     public ReactiveCommand<Unit, Unit> EnterCommand { get; }
     internal IObservable<bool> Answered => _answered;
+    internal bool InFastPath {
+        get => _inFastPath;
+        set => this.RaiseAndSetIfChanged(ref _inFastPath, value);
+    }
 
     public string OtherText {
         get => _otherText;
@@ -63,7 +68,7 @@ public sealed class QuestionGroupViewModel : ReactiveObject {
     }
 
     public bool IsAnswered => Options.Any(o => o.IsSelected) || !string.IsNullOrWhiteSpace(OtherText);
-    public bool ShowsOtherAnswer => !string.IsNullOrWhiteSpace(OtherText);
+    public bool ShowsOtherAnswer => InFastPath && !string.IsNullOrWhiteSpace(OtherText);
 
     internal QuestionGroupViewModel(ElicitationQuestion question, Func<QuestionOptionViewModel, QuestionGroupViewModel, Task> pick,
             Func<QuestionGroupViewModel, Task> enter, IObservable<bool> idle) {
@@ -112,6 +117,7 @@ public sealed class QuestionCardViewModel : PendingCardViewModel {
         var idle = Busy.Select(b => !b);
         Questions = parsed.Questions.Select(q => new QuestionGroupViewModel(q, PickAsync, EnterAsync, idle)).ToList();
         IsFastPath = Questions.Count == 1 && !Questions[0].MultiSelect && Questions[0].Options.Count > 0;
+        foreach (var q in Questions) q.InFastPath = IsFastPath;
 
         var allAnswered = Questions.Select(q => q.Answered).CombineLatest(states => states.All(x => x));
         SubmitCommand = ReactiveCommand.CreateFromTask(SubmitAsync, allAnswered.CombineLatest(idle, (a, i) => a && i));

--- a/src/Capacitor.App/ViewModels/TrayViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TrayViewModel.cs
@@ -130,12 +130,13 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
                 "IPauseController.State, IConsentService.PendingCount, and IPermissionService.Summary must replay a value on subscribe."))
             .DisposeWith(_disposables);
 
-        // Edge-triggered passive refresh (spec §6): fired once on the attach-state transition
-        // INTO Connected, not on every snapshot/state emission that follows — so the toggle is
+        // Edge-triggered passive refresh: fired once on the attach-state transition INTO
+        // Connected, not on every snapshot/state emission that follows — so the toggle is
         // usually verified before the FIRST menu open instead of waiting for the adapter's
         // NeedsUpdate kick on the second. DistinctUntilChanged means a later Connected push with
-        // no real state change (or a snapshot-only update) is a no-op here; the §6 lane drops a
-        // redundant refresh while busy, so this can never race the NeedsUpdate-triggered one.
+        // no real state change (or a snapshot-only update) is a no-op here; the refresh path
+        // itself drops a redundant refresh while busy, so this can never race the
+        // NeedsUpdate-triggered one.
         service.Status
             .Select(s => s.State)
             .DistinctUntilChanged()
@@ -154,7 +155,7 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
             string daemonName, AttachStatus status, DaemonStatusDto? snap, PauseState pauseState,
             IReadOnlySet<string> stopsInFlight, int pendingConsent, string? lifecycleAttention, PendingSummary pendingSummary) {
         var (state, count) = Project(status, snap);
-        var baseState = state; // the row's own verdict (rows 1-10), before either upgrade below
+        var baseState = state; // the connection/agent-count verdict, before either upgrade below
 
         // Pending consent, a pending permission request, or a pending question asserts Attention
         // only while Connected — the owner has something waiting. Judged against baseState (not
@@ -166,15 +167,13 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
             && baseState is TrayState.Idle or TrayState.Running;
         if (pendingAttention) state = TrayState.Attention;
 
-        // spec §6: a lifecycle Attention call (e.g. a restore-verification failure, an orphan
-        // label repair affordance) only ever upgrades a GENUINELY fine row (Idle/Running) — judged
-        // against baseState, never against the already-Attention state a connection-trouble row
-        // (2, 5, 6, 9, 10) produced on its own. A `state is ... or
-        // TrayState.Attention` check would let ANY co-occurring Attention row hand its header line to a
-        // stale/unrelated lifecycle message, masking exactly the text the comment claimed to
-        // protect (e.g. "reconnecting to server" swallowed by a leftover repair-affordance line).
-        // When active it also wins the header body over pendingAttention's generic text in
-        // HeaderText — both are judged off the same baseState, so either or both can be active.
+        // A lifecycle attention message (e.g. a restore-verification failure, an orphan label
+        // repair affordance) only ever upgrades a state that is genuinely fine (Idle/Running),
+        // judged against baseState — never a state a connection-trouble mapping already set.
+        // Judging against the live `state` instead would let a stale, unrelated repair-affordance
+        // line replace the connection text in the header (e.g. "reconnecting to server"). When
+        // active it also wins the header body over pendingAttention's generic text in HeaderText
+        // — both are judged off the same baseState, so either or both can be active.
         var lifecycleAttentionActive = !string.IsNullOrEmpty(lifecycleAttention)
             && baseState is TrayState.Idle or TrayState.Running;
         if (lifecycleAttentionActive) state = TrayState.Attention;

--- a/src/Capacitor.App/ViewModels/TrayViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TrayViewModel.cs
@@ -156,12 +156,12 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
         var (state, count) = Project(status, snap);
         var baseState = state; // the row's own verdict (rows 1-10), before either upgrade below
 
-        // Row 11: pending consent, a pending permission request, or a pending question asserts
-        // Attention only while Connected — the owner has something waiting. Judged against
-        // baseState (not state) so a later independent upgrade can never make this fire
-        // retroactively; connection-trouble rows above already left baseState at something other
-        // than Idle/Running, so they keep precedence for free, and the running-count badge (count)
-        // keeps the agent count regardless.
+        // Pending consent, a pending permission request, or a pending question asserts Attention
+        // only while Connected — the owner has something waiting. Judged against baseState (not
+        // state) so a later independent upgrade can never make this fire retroactively;
+        // connection-trouble rows above already left baseState non-Idle/Running and keep
+        // precedence for free, and the running-count badge (count) keeps the agent count
+        // regardless.
         var pendingAttention = status.State == AttachState.Connected && (pendingConsent > 0 || pendingSummary.Total > 0)
             && baseState is TrayState.Idle or TrayState.Running;
         if (pendingAttention) state = TrayState.Attention;

--- a/src/Capacitor.App/ViewModels/TrayViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TrayViewModel.cs
@@ -91,21 +91,20 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
             .Select(s => (DaemonStatusDto?)s)
             .StartWith((DaemonStatusDto?)null);
 
-        // consent.PendingCount and IPermissionService.PendingCount are DynamicData's CountChanged,
-        // which seeds the current count on subscribe (decompile-verified) — deliberately NOT
-        // StartWith(0)'d, which would inject a spurious extra 0 ahead of that seed and could
-        // flicker Attention at startup. A null lifecycleAttention (no live lifecycle controller)
-        // becomes Observable.Return(null): it emits synchronously on subscribe and then completes,
-        // which is exactly the seed CombineLatest needs — Rx.CombineLatest only completes once
-        // EVERY source has, so a completed source just freezes at its last (here: only) value
-        // forever. A null permissions service (no live IPermissionService) uses the same
-        // Observable.Return shape for its count.
+        // consent.PendingCount is DynamicData's CountChanged, which seeds the current count on
+        // subscribe (decompile-verified) — deliberately NOT StartWith(0)'d, which would inject a
+        // spurious extra 0 ahead of that seed and could flicker Attention at startup. A null
+        // lifecycleAttention (no live lifecycle controller) becomes Observable.Return(null): it
+        // emits synchronously on subscribe and then completes, which is exactly the seed
+        // CombineLatest needs — Rx.CombineLatest only completes once EVERY source has, so a
+        // completed source just freezes at its last (here: only) value forever. A null permissions
+        // service (no live IPermissionService) uses the same Observable.Return shape for its summary.
         var attention = lifecycleAttention ?? Observable.Return((string?)null);
         var shim = shimOfferable ?? Observable.Return(false);
-        var permissionCount = permissions?.PendingCount ?? Observable.Return(0);
-        var projected = service.Status.CombineLatest(snapshots, pause.State, actions.StopsInFlight, consent.PendingCount, attention, permissionCount,
-            (status, snap, pauseState, inFlight, pending, lifecycleMsg, permissionPending) =>
-                Build(service.DaemonName, status, snap, pauseState, inFlight, pending, lifecycleMsg, permissionPending));
+        var pendingSummary = permissions?.Summary ?? Observable.Return(default(PendingSummary));
+        var projected = service.Status.CombineLatest(snapshots, pause.State, actions.StopsInFlight, consent.PendingCount, attention, pendingSummary,
+            (status, snap, pauseState, inFlight, pending, lifecycleMsg, summary) =>
+                Build(service.DaemonName, status, snap, pauseState, inFlight, pending, lifecycleMsg, summary));
 
         // A second, narrower CombineLatest rather than folding `shim` into the six-source one
         // above: it keeps Build's signature untouched (Build already reads awkwardly with six
@@ -115,21 +114,20 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
         var withShim = projected.CombineLatest(shim, (model, visible) => model with { ShimInstallVisible = visible });
 
         // Status, snapshots (seeded above), pause.State, consent.PendingCount, attention,
-        // permissionCount, and shim are all replay-1-shaped (seed on subscribe), so CombineLatest
+        // pendingSummary, and shim are all replay-1-shaped (seed on subscribe), so CombineLatest
         // emits synchronously on subscribe — captured here as the OAPH's initial value so
         // MenuModel is never default(TrayMenuModel) (null) before RxSchedulers.MainThreadScheduler
         // delivers the ObserveOn'd copy below. The synchronous-emission assumption rests on
-        // IPauseController.State's, IConsentService.PendingCount's, and
-        // IPermissionService.PendingCount's documented replay-on-subscribe contracts, which a
-        // future implementation could violate — defended below rather than left to surface as an
-        // unexplained NRE on first MenuModel access.
+        // IPauseController.State's, IConsentService.PendingCount's, and IPermissionService.Summary's
+        // documented replay-on-subscribe contracts, which a future implementation could violate —
+        // defended below rather than left to surface as an unexplained NRE on first MenuModel access.
         TrayMenuModel? seed = null;
         using (withShim.Subscribe(v => seed = v)) { }
 
         _menuModel = withShim
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .ToProperty(this, x => x.MenuModel, seed ?? throw new InvalidOperationException(
-                "IPauseController.State, IConsentService.PendingCount, and IPermissionService.PendingCount must replay a value on subscribe."))
+                "IPauseController.State, IConsentService.PendingCount, and IPermissionService.Summary must replay a value on subscribe."))
             .DisposeWith(_disposables);
 
         // Edge-triggered passive refresh (spec §6): fired once on the attach-state transition
@@ -154,16 +152,17 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
 
     static TrayMenuModel Build(
             string daemonName, AttachStatus status, DaemonStatusDto? snap, PauseState pauseState,
-            IReadOnlySet<string> stopsInFlight, int pendingConsent, string? lifecycleAttention, int pendingPermissions) {
+            IReadOnlySet<string> stopsInFlight, int pendingConsent, string? lifecycleAttention, PendingSummary pendingSummary) {
         var (state, count) = Project(status, snap);
         var baseState = state; // the row's own verdict (rows 1-10), before either upgrade below
 
-        // Row 11: pending consent or a pending permission request asserts Attention only
-        // while Connected — the owner has something waiting. Judged against baseState (not state)
-        // so a later independent upgrade can never make this fire retroactively; connection-trouble
-        // rows above already left baseState at something other than Idle/Running, so they keep
-        // precedence for free, and the running-count badge (count) keeps the agent count regardless.
-        var pendingAttention = status.State == AttachState.Connected && (pendingConsent > 0 || pendingPermissions > 0)
+        // Row 11: pending consent, a pending permission request, or a pending question asserts
+        // Attention only while Connected — the owner has something waiting. Judged against
+        // baseState (not state) so a later independent upgrade can never make this fire
+        // retroactively; connection-trouble rows above already left baseState at something other
+        // than Idle/Running, so they keep precedence for free, and the running-count badge (count)
+        // keeps the agent count regardless.
+        var pendingAttention = status.State == AttachState.Connected && (pendingConsent > 0 || pendingSummary.Total > 0)
             && baseState is TrayState.Idle or TrayState.Running;
         if (pendingAttention) state = TrayState.Attention;
 
@@ -183,7 +182,7 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
         return new TrayMenuModel(
             state, count,
             HeaderText(daemonName, status, snap, state, count, pendingAttention, pendingConsent,
-                lifecycleAttentionActive ? lifecycleAttention : null, pendingPermissions),
+                lifecycleAttentionActive ? lifecycleAttention : null, pendingSummary),
             BuildEntries(status, snap, stopsInFlight), BuildPause(status, pauseState), pendingConsent);
     }
 
@@ -218,14 +217,14 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
 
     static string HeaderText(
             string daemonName, AttachStatus status, DaemonStatusDto? snap, TrayState state, int count,
-            bool pendingAttention, int pendingConsent, string? lifecycleAttentionText, int pendingPermissions) {
+            bool pendingAttention, int pendingConsent, string? lifecycleAttentionText, PendingSummary pendingSummary) {
         if (state == TrayState.Attention && status.State == AttachState.Unreachable && status.Reason == IncompatibleReason)
             return SkewMessage; // no daemon-name prefix
 
         if (lifecycleAttentionText is not null) return $"{daemonName}: {lifecycleAttentionText}";
 
         var body = pendingAttention
-            ? PendingBody(pendingPermissions, pendingConsent)
+            ? PendingBody(pendingSummary, pendingConsent)
             : state switch {
                 TrayState.Stopped    => "not running",
                 TrayState.Connecting => "connecting…",
@@ -237,9 +236,10 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
         return $"{daemonName}: {body}";
     }
 
-    static string PendingBody(int permissions, int consent) {
-        var parts = new List<string>(2);
-        if (permissions > 0) parts.Add($"{permissions} permission request{(permissions == 1 ? "" : "s")} waiting");
+    static string PendingBody(PendingSummary summary, int consent) {
+        var parts = new List<string>(3);
+        if (summary.Questions > 0) parts.Add($"{summary.Questions} question{(summary.Questions == 1 ? "" : "s")} waiting");
+        if (summary.Permissions > 0) parts.Add($"{summary.Permissions} permission request{(summary.Permissions == 1 ? "" : "s")} waiting");
         if (consent > 0) parts.Add($"{consent} launch{(consent == 1 ? "" : "es")} awaiting approval");
         return string.Join(", ", parts);
     }

--- a/src/Capacitor.App/ViewModels/TrayViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TrayViewModel.cs
@@ -92,8 +92,8 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
             .StartWith((DaemonStatusDto?)null);
 
         // consent.PendingCount is DynamicData's CountChanged, which seeds the current count on
-        // subscribe (decompile-verified) — deliberately NOT StartWith(0)'d, which would inject a
-        // spurious extra 0 ahead of that seed and could flicker Attention at startup. A null
+        // subscribe — deliberately NOT StartWith(0)'d, which would inject a spurious extra 0
+        // ahead of that seed and could flicker Attention at startup. A null
         // lifecycleAttention (no live lifecycle controller) becomes Observable.Return(null): it
         // emits synchronously on subscribe and then completes, which is exactly the seed
         // CombineLatest needs — Rx.CombineLatest only completes once EVERY source has, so a

--- a/src/Capacitor.App/ViewModels/TrayViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TrayViewModel.cs
@@ -145,8 +145,8 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
             .DisposeWith(_disposables);
     }
 
-    /// Adapter's NeedsUpdate hook (spec §5) — trivially delegating; the drop-while-busy rule lives
-    /// in the IPauseController implementation (spec §6).
+    /// Adapter's NeedsUpdate hook — trivially delegating; the drop-while-busy rule lives
+    /// in the IPauseController implementation.
     public void RequestPauseRefresh() => _pause.RequestRefresh();
 
     public void Dispose() => _disposables.Dispose();

--- a/src/Capacitor.App/ViewModels/TrayViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TrayViewModel.cs
@@ -145,8 +145,7 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
             .DisposeWith(_disposables);
     }
 
-    /// Adapter's NeedsUpdate hook — trivially delegating; the drop-while-busy rule lives
-    /// in the IPauseController implementation.
+    /// IPauseController owns the drop-while-busy rule.
     public void RequestPauseRefresh() => _pause.RequestRefresh();
 
     public void Dispose() => _disposables.Dispose();

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -101,7 +101,7 @@
                                                         <Border Background="{StaticResource KcapSurfaceBrush}" CornerRadius="4" Padding="5,1" HorizontalAlignment="Left"
                                                                 IsVisible="{Binding Header, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
                                                             <TextBlock Text="{Binding Header}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}"
-                                                                       TextTrimming="CharacterEllipsis" />
+                                                                       TextTrimming="CharacterEllipsis" MaxLines="1" />
                                                         </Border>
                                                         <TextBlock Text="{Binding Text}" FontWeight="SemiBold" FontSize="13" TextWrapping="Wrap"
                                                                    Foreground="{StaticResource KcapTextBrush}" />

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -93,13 +93,16 @@
                                             <Setter Property="BorderBrush" Value="{StaticResource KcapAccentBrush}" />
                                         </Style>
                                     </Border.Styles>
-                                    <StackPanel Spacing="8">
+                                    <StackPanel Spacing="8" IsEnabled="{Binding !IsBusy}">
                                         <ItemsControl ItemsSource="{Binding Questions}">
                                             <ItemsControl.ItemTemplate>
                                                 <DataTemplate x:DataType="vm:QuestionGroupViewModel">
                                                     <StackPanel Spacing="5" Margin="0,0,0,4">
-                                                        <TextBlock Text="{Binding Header}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}"
-                                                                   IsVisible="{Binding Header, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                                        <Border Background="{StaticResource KcapSurfaceBrush}" CornerRadius="4" Padding="5,1" HorizontalAlignment="Left"
+                                                                IsVisible="{Binding Header, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                                                            <TextBlock Text="{Binding Header}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}"
+                                                                       TextTrimming="CharacterEllipsis" />
+                                                        </Border>
                                                         <TextBlock Text="{Binding Text}" FontWeight="SemiBold" FontSize="13" TextWrapping="Wrap"
                                                                    Foreground="{StaticResource KcapTextBrush}" />
                                                         <ItemsControl ItemsSource="{Binding Options}">
@@ -114,7 +117,7 @@
                                                                             <StackPanel>
                                                                                 <TextBlock Text="{Binding Label}" Foreground="{StaticResource KcapTextBrush}" />
                                                                                 <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
-                                                                                           TextWrapping="Wrap"
+                                                                                           TextWrapping="Wrap" MaxLines="3" TextTrimming="CharacterEllipsis"
                                                                                            IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                                                             </StackPanel>
                                                                         </Button>
@@ -122,7 +125,7 @@
                                                                             <StackPanel>
                                                                                 <TextBlock Text="{Binding Label}" Foreground="{StaticResource KcapTextBrush}" />
                                                                                 <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
-                                                                                           TextWrapping="Wrap"
+                                                                                           TextWrapping="Wrap" MaxLines="3" TextTrimming="CharacterEllipsis"
                                                                                            IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                                                             </StackPanel>
                                                                         </CheckBox>

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -60,7 +60,7 @@
                    Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5"
                    HorizontalAlignment="Center" VerticalAlignment="Center" />
 
-        <Border x:Name="PermissionRow" Grid.Row="1" Margin="22,0,22,4" IsVisible="{Binding HasPendingCards}">
+        <Border x:Name="NeedsYouRow" Grid.Row="1" Margin="22,0,22,4" IsVisible="{Binding HasPendingCards}">
             <StackPanel Spacing="6">
                 <TextBlock Text="NEEDS YOU" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}" />
                 <ScrollViewer MaxHeight="260" VerticalScrollBarVisibility="Auto">

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -65,7 +65,7 @@
                 <TextBlock Text="NEEDS YOU" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}" />
                 <ScrollViewer MaxHeight="260" VerticalScrollBarVisibility="Auto">
                     <ItemsControl ItemsSource="{Binding PendingPermissions}">
-                        <ItemsControl.ItemTemplate>
+                        <ItemsControl.DataTemplates>
                             <DataTemplate x:DataType="vm:PermissionCardViewModel">
                                 <Border Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapAccentBrush}"
                                         BorderThickness="1" CornerRadius="10" Padding="13,10" Margin="0,0,0,6">
@@ -85,7 +85,76 @@
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>
-                        </ItemsControl.ItemTemplate>
+                            <DataTemplate x:DataType="vm:QuestionCardViewModel">
+                                <Border Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapAccentBrush}"
+                                        BorderThickness="1" CornerRadius="10" Padding="13,10" Margin="0,0,0,6">
+                                    <Border.Styles>
+                                        <Style Selector="Button.selected">
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapAccentBrush}" />
+                                        </Style>
+                                    </Border.Styles>
+                                    <StackPanel Spacing="8">
+                                        <ItemsControl ItemsSource="{Binding Questions}">
+                                            <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:QuestionGroupViewModel">
+                                                    <StackPanel Spacing="5" Margin="0,0,0,4">
+                                                        <TextBlock Text="{Binding Header}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}"
+                                                                   IsVisible="{Binding Header, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                                        <TextBlock Text="{Binding Text}" FontWeight="SemiBold" FontSize="13" TextWrapping="Wrap"
+                                                                   Foreground="{StaticResource KcapTextBrush}" />
+                                                        <ItemsControl ItemsSource="{Binding Options}">
+                                                            <ItemsControl.ItemTemplate>
+                                                                <DataTemplate x:DataType="vm:QuestionOptionViewModel">
+                                                                    <StackPanel Margin="0,0,0,2">
+                                                                        <Button IsVisible="{Binding !IsMulti}" Command="{Binding PickCommand}"
+                                                                                Classes.selected="{Binding IsSelected}"
+                                                                                HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
+                                                                                Padding="10,5" FontSize="12" CornerRadius="7"
+                                                                                Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1">
+                                                                            <StackPanel>
+                                                                                <TextBlock Text="{Binding Label}" Foreground="{StaticResource KcapTextBrush}" />
+                                                                                <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
+                                                                                           TextWrapping="Wrap"
+                                                                                           IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                                                            </StackPanel>
+                                                                        </Button>
+                                                                        <CheckBox IsVisible="{Binding IsMulti}" IsChecked="{Binding IsSelected}" FontSize="12">
+                                                                            <StackPanel>
+                                                                                <TextBlock Text="{Binding Label}" Foreground="{StaticResource KcapTextBrush}" />
+                                                                                <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
+                                                                                           TextWrapping="Wrap"
+                                                                                           IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                                                            </StackPanel>
+                                                                        </CheckBox>
+                                                                    </StackPanel>
+                                                                </DataTemplate>
+                                                            </ItemsControl.ItemTemplate>
+                                                        </ItemsControl>
+                                                        <DockPanel>
+                                                            <Button DockPanel.Dock="Right" Content="Answer" Command="{Binding EnterCommand}"
+                                                                    IsVisible="{Binding ShowsOtherAnswer}" Margin="6,0,0,0"
+                                                                    Padding="10,4" FontSize="12" CornerRadius="7"
+                                                                    Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                                                            <TextBox Text="{Binding OtherText}" PlaceholderText="Other…" MaxLength="{Binding MaxOtherLength}"
+                                                                     AcceptsReturn="False" FontSize="12" MinHeight="30">
+                                                                <TextBox.KeyBindings>
+                                                                    <KeyBinding Gesture="Enter" Command="{Binding EnterCommand}" />
+                                                                </TextBox.KeyBindings>
+                                                            </TextBox>
+                                                        </DockPanel>
+                                                    </StackPanel>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                        <TextBlock Text="{Binding ErrorText}" FontSize="11" Foreground="{StaticResource KcapDangerBrush}"
+                                                   IsVisible="{Binding ErrorText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                        <Button Content="Submit" Command="{Binding SubmitCommand}" IsVisible="{Binding ShowsSubmit}"
+                                                HorizontalAlignment="Right" Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
+                                                Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                                    </StackPanel>
+                                </Border>
+                            </DataTemplate>
+                        </ItemsControl.DataTemplates>
                     </ItemsControl>
                 </ScrollViewer>
             </StackPanel>

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -60,11 +60,11 @@
                    Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5"
                    HorizontalAlignment="Center" VerticalAlignment="Center" />
 
-        <Border x:Name="PermissionRow" Grid.Row="1" Margin="22,0,22,4" IsVisible="{Binding HasPendingPermissions}">
+        <Border x:Name="PermissionRow" Grid.Row="1" Margin="22,0,22,4" IsVisible="{Binding HasPendingCards}">
             <StackPanel Spacing="6">
                 <TextBlock Text="NEEDS YOU" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}" />
                 <ScrollViewer MaxHeight="260" VerticalScrollBarVisibility="Auto">
-                    <ItemsControl ItemsSource="{Binding PendingPermissions}">
+                    <ItemsControl ItemsSource="{Binding PendingCards}">
                         <ItemsControl.DataTemplates>
                             <DataTemplate x:DataType="vm:PermissionCardViewModel">
                                 <Border Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapAccentBrush}"

--- a/src/Capacitor.Cli.Core/ClaudeElicitation.cs
+++ b/src/Capacitor.Cli.Core/ClaudeElicitation.cs
@@ -31,7 +31,7 @@ public sealed class ElicitationQuestions {
 }
 
 /// The Claude AskUserQuestion contract: parsing the hook's tool_input and composing the
-/// updatedInput answer. Caps bound the composed resolve payload (spec decision 6); a payload
+/// updatedInput answer. Caps bound the composed resolve payload; a payload
 /// over any cap is unparseable and falls back to the plain permission card.
 public static class ClaudeElicitation {
     public const string ToolName = "AskUserQuestion";

--- a/src/Capacitor.Cli.Core/ClaudeElicitation.cs
+++ b/src/Capacitor.Cli.Core/ClaudeElicitation.cs
@@ -77,7 +77,6 @@ public static class ClaudeElicitation {
         return s is not null && s.Length <= maxChars && s.AsSpan().Trim().Length > 0 ? s : null;
     }
 
-    // Display field: a non-blank string is used; wrong type or whitespace reads as absent.
     static string? DisplayString(JsonElement obj, string name) {
         var s = obj.Str(name)?.Trim();
         return s is { Length: > 0 } ? s : null;

--- a/src/Capacitor.Cli.Core/ClaudeElicitation.cs
+++ b/src/Capacitor.Cli.Core/ClaudeElicitation.cs
@@ -68,11 +68,13 @@ public static class ClaudeElicitation {
         }
     }
 
-    // Protocol field: must be a non-blank string within the cap; anything else is null → fatal.
+    // Protocol field: the ORIGINAL string is the protocol value — ComposeAnswers keys the answers
+    // map by it and replays QuestionsJson verbatim, so a trimmed copy would no longer match the
+    // replayed array. Trimming is used only to test blankness; the cap applies to the raw length.
     static string? ProtocolString(JsonElement obj, string name, int maxChars) {
         if (obj.Prop(name) is null) return null;
-        var s = obj.Str(name)?.Trim();
-        return s is { Length: > 0 } && s.Length <= maxChars ? s : null;
+        var s = obj.Str(name);
+        return s is not null && s.Length <= maxChars && s.AsSpan().Trim().Length > 0 ? s : null;
     }
 
     // Display field: a non-blank string is used; wrong type or whitespace reads as absent.

--- a/src/Capacitor.Cli.Core/ClaudeElicitation.cs
+++ b/src/Capacitor.Cli.Core/ClaudeElicitation.cs
@@ -1,5 +1,6 @@
 using System.Collections.Immutable;
 using System.Text.Json;
+using System.Text.Json.Nodes;
 
 namespace Capacitor.Cli.Core;
 
@@ -29,6 +30,8 @@ public sealed class ElicitationQuestions {
     public JsonElement QuestionsJson { get; }
     public ImmutableArray<ElicitationQuestion> Questions { get; }
 }
+
+public sealed record ElicitationAnswer(string Question, IReadOnlyList<string> SelectedLabels, string? OtherText);
 
 /// The Claude AskUserQuestion contract: parsing the hook's tool_input and composing the
 /// updatedInput answer. Caps bound the composed resolve payload; a payload
@@ -106,5 +109,73 @@ public static class ClaudeElicitation {
         }
         options = builder.ToImmutable();
         return true;
+    }
+
+    /// Validates against the parsed questions — every question answered, labels from the parsed
+    /// options only, Other text bounded — and builds the answer updatedInput. ArgumentException
+    /// here is a programming error in the caller, never a user state.
+    public static JsonElement ComposeAnswers(ElicitationQuestions questions, IReadOnlyList<ElicitationAnswer> answers) {
+        ArgumentNullException.ThrowIfNull(questions);
+        ArgumentNullException.ThrowIfNull(answers);
+        if (answers.Count != questions.Questions.Length)
+            throw new ArgumentException($"expected {questions.Questions.Length} answer(s), got {answers.Count}", nameof(answers));
+
+        var byQuestion = new Dictionary<string, ElicitationAnswer>(StringComparer.Ordinal);
+        foreach (var answer in answers)
+            if (!byQuestion.TryAdd(answer.Question, answer))
+                throw new ArgumentException($"duplicate answer for \"{answer.Question}\"", nameof(answers));
+
+        var answersObj = new JsonObject();
+        foreach (var question in questions.Questions) {
+            if (!byQuestion.TryGetValue(question.Question, out var answer))
+                throw new ArgumentException($"missing answer for \"{question.Question}\"", nameof(answers));
+            answersObj[question.Question] = ComposeValue(question, answer);
+        }
+
+        var payload = new JsonObject {
+            ["questions"] = JsonNode.Parse(questions.QuestionsJson.GetRawText()),
+            ["answers"] = answersObj,
+        };
+        using var doc = JsonDocument.Parse(payload.ToJsonString());
+        return doc.RootElement.Clone();
+    }
+
+    static JsonNode ComposeValue(ElicitationQuestion question, ElicitationAnswer answer) {
+        var selected = new List<string>();
+        foreach (var label in answer.SelectedLabels) {
+            if (!question.Options.Any(o => string.Equals(o.Label, label, StringComparison.Ordinal)))
+                throw new ArgumentException($"\"{label}\" is not an option of \"{question.Question}\"", nameof(answer));
+            if (selected.Contains(label))
+                throw new ArgumentException($"\"{label}\" selected twice for \"{question.Question}\"", nameof(answer));
+            selected.Add(label);
+        }
+
+        var other = answer.OtherText?.Trim();
+        if (other is not null) {
+            if (other.Length == 0)
+                throw new ArgumentException($"blank Other text for \"{question.Question}\"", nameof(answer));
+            if (other.Length > MaxOtherTextChars)
+                throw new ArgumentException($"Other text over {MaxOtherTextChars} chars for \"{question.Question}\"", nameof(answer));
+            // An option label typed as Other IS that option — never a duplicate wire value.
+            if (question.Options.Any(o => string.Equals(o.Label, other, StringComparison.Ordinal))) {
+                if (!selected.Contains(other)) selected.Add(other);
+                other = null;
+            }
+        }
+
+        if (!question.MultiSelect) {
+            if (selected.Count + (other is null ? 0 : 1) != 1)
+                throw new ArgumentException($"single-select \"{question.Question}\" needs exactly one value", nameof(answer));
+            return JsonValue.Create(other ?? selected[0]);
+        }
+
+        if (selected.Count == 0 && other is null)
+            throw new ArgumentException($"multi-select \"{question.Question}\" needs at least one value", nameof(answer));
+
+        var array = new JsonArray();
+        foreach (var option in question.Options)
+            if (selected.Contains(option.Label)) array.Add((JsonNode)JsonValue.Create(option.Label));
+        if (other is not null) array.Add((JsonNode)JsonValue.Create(other));
+        return array;
     }
 }

--- a/src/Capacitor.Cli.Core/ClaudeElicitation.cs
+++ b/src/Capacitor.Cli.Core/ClaudeElicitation.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -134,11 +133,10 @@ public static class ClaudeElicitation {
         }
 
         using var buffer = new MemoryStream();
-        var options = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
-        using (var writer = new Utf8JsonWriter(buffer, options)) {
+        using (var writer = new Utf8JsonWriter(buffer)) {
             writer.WriteStartObject();
             writer.WritePropertyName("questions");
-            questions.QuestionsJson.WriteTo(writer);
+            writer.WriteRawValue(questions.QuestionsJson.GetRawText(), skipInputValidation: true);
             writer.WritePropertyName("answers");
             answersObj.WriteTo(writer);
             writer.WriteEndObject();

--- a/src/Capacitor.Cli.Core/ClaudeElicitation.cs
+++ b/src/Capacitor.Cli.Core/ClaudeElicitation.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Nodes;
 
@@ -132,11 +133,17 @@ public static class ClaudeElicitation {
             answersObj[question.Question] = ComposeValue(question, answer);
         }
 
-        var payload = new JsonObject {
-            ["questions"] = JsonNode.Parse(questions.QuestionsJson.GetRawText()),
-            ["answers"] = answersObj,
-        };
-        using var doc = JsonDocument.Parse(payload.ToJsonString());
+        using var buffer = new MemoryStream();
+        var options = new JsonWriterOptions { Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping };
+        using (var writer = new Utf8JsonWriter(buffer, options)) {
+            writer.WriteStartObject();
+            writer.WritePropertyName("questions");
+            questions.QuestionsJson.WriteTo(writer);
+            writer.WritePropertyName("answers");
+            answersObj.WriteTo(writer);
+            writer.WriteEndObject();
+        }
+        using var doc = JsonDocument.Parse(buffer.ToArray());
         return doc.RootElement.Clone();
     }
 
@@ -144,18 +151,18 @@ public static class ClaudeElicitation {
         var selected = new List<string>();
         foreach (var label in answer.SelectedLabels) {
             if (!question.Options.Any(o => string.Equals(o.Label, label, StringComparison.Ordinal)))
-                throw new ArgumentException($"\"{label}\" is not an option of \"{question.Question}\"", nameof(answer));
+                throw new ArgumentException($"\"{label}\" is not an option of \"{question.Question}\"");
             if (selected.Contains(label))
-                throw new ArgumentException($"\"{label}\" selected twice for \"{question.Question}\"", nameof(answer));
+                throw new ArgumentException($"\"{label}\" selected twice for \"{question.Question}\"");
             selected.Add(label);
         }
 
         var other = answer.OtherText?.Trim();
         if (other is not null) {
             if (other.Length == 0)
-                throw new ArgumentException($"blank Other text for \"{question.Question}\"", nameof(answer));
+                throw new ArgumentException($"blank Other text for \"{question.Question}\"");
             if (other.Length > MaxOtherTextChars)
-                throw new ArgumentException($"Other text over {MaxOtherTextChars} chars for \"{question.Question}\"", nameof(answer));
+                throw new ArgumentException($"Other text over {MaxOtherTextChars} chars for \"{question.Question}\"");
             // An option label typed as Other IS that option — never a duplicate wire value.
             if (question.Options.Any(o => string.Equals(o.Label, other, StringComparison.Ordinal))) {
                 if (!selected.Contains(other)) selected.Add(other);
@@ -165,12 +172,12 @@ public static class ClaudeElicitation {
 
         if (!question.MultiSelect) {
             if (selected.Count + (other is null ? 0 : 1) != 1)
-                throw new ArgumentException($"single-select \"{question.Question}\" needs exactly one value", nameof(answer));
+                throw new ArgumentException($"single-select \"{question.Question}\" needs exactly one value");
             return JsonValue.Create(other ?? selected[0]);
         }
 
         if (selected.Count == 0 && other is null)
-            throw new ArgumentException($"multi-select \"{question.Question}\" needs at least one value", nameof(answer));
+            throw new ArgumentException($"multi-select \"{question.Question}\" needs at least one value");
 
         var array = new JsonArray();
         foreach (var option in question.Options)

--- a/src/Capacitor.Cli.Core/ClaudeElicitation.cs
+++ b/src/Capacitor.Cli.Core/ClaudeElicitation.cs
@@ -1,0 +1,110 @@
+using System.Collections.Immutable;
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core;
+
+public sealed class ElicitationOption {
+    internal ElicitationOption(string label, string? description) { Label = label; Description = description; }
+    public string Label { get; }
+    public string? Description { get; }
+}
+
+public sealed class ElicitationQuestion {
+    internal ElicitationQuestion(string question, string? header, bool multiSelect, ImmutableArray<ElicitationOption> options) {
+        Question = question; Header = header; MultiSelect = multiSelect; Options = options;
+    }
+    public string Question { get; }
+    public string? Header { get; }
+    public bool MultiSelect { get; }
+    public ImmutableArray<ElicitationOption> Options { get; }
+}
+
+/// Parser-created only: internal ctor + immutable collections ground ComposeAnswers' validation
+/// in parse output, so no caller can hand it a fabricated or mutated model.
+public sealed class ElicitationQuestions {
+    internal ElicitationQuestions(JsonElement questionsJson, ImmutableArray<ElicitationQuestion> questions) {
+        QuestionsJson = questionsJson; Questions = questions;
+    }
+    /// Detached clone of the payload's questions array, replayed verbatim into the answer.
+    public JsonElement QuestionsJson { get; }
+    public ImmutableArray<ElicitationQuestion> Questions { get; }
+}
+
+/// The Claude AskUserQuestion contract: parsing the hook's tool_input and composing the
+/// updatedInput answer. Caps bound the composed resolve payload (spec decision 6); a payload
+/// over any cap is unparseable and falls back to the plain permission card.
+public static class ClaudeElicitation {
+    public const string ToolName = "AskUserQuestion";
+    public const int MaxQuestions = 8;
+    public const int MaxOptionsPerQuestion = 16;
+    public const int MaxQuestionTextChars = 4096;
+    public const int MaxOptionLabelChars = 1024;
+    public const int MaxOtherTextChars = 8192;
+
+    public static ElicitationQuestions? TryParse(string? toolInputJson) {
+        if (string.IsNullOrEmpty(toolInputJson)) return null;
+        JsonDocument doc;
+        try { doc = JsonDocument.Parse(toolInputJson); } catch (JsonException) { return null; }
+        using (doc) {
+            var root = doc.RootElement;
+            if (!root.IsObject || root.Prop("questions") is not { } arr || !arr.IsArray) return null;
+            var count = arr.GetArrayLength();
+            if (count is 0 or > MaxQuestions) return null;
+
+            var parsed = ImmutableArray.CreateBuilder<ElicitationQuestion>(count);
+            var texts = new HashSet<string>(StringComparer.Ordinal);
+            foreach (var q in arr.EnumerateArray()) {
+                if (!q.IsObject) return null;
+                var text = ProtocolString(q, "question", MaxQuestionTextChars);
+                if (text is null || !texts.Add(text)) return null;
+                if (!TryReadFlag(q, out var multi)) return null;
+                if (!TryReadOptions(q, out var options)) return null;
+                parsed.Add(new ElicitationQuestion(text, DisplayString(q, "header"), multi, options));
+            }
+            return new ElicitationQuestions(arr.Clone(), parsed.MoveToImmutable());
+        }
+    }
+
+    // Protocol field: must be a non-blank string within the cap; anything else is null → fatal.
+    static string? ProtocolString(JsonElement obj, string name, int maxChars) {
+        if (obj.Prop(name) is null) return null;
+        var s = obj.Str(name)?.Trim();
+        return s is { Length: > 0 } && s.Length <= maxChars ? s : null;
+    }
+
+    // Display field: a non-blank string is used; wrong type or whitespace reads as absent.
+    static string? DisplayString(JsonElement obj, string name) {
+        var s = obj.Str(name)?.Trim();
+        return s is { Length: > 0 } ? s : null;
+    }
+
+    // Both spellings accepted; a present non-boolean or a disagreement is fatal — the flag
+    // decides string-versus-array in the answer, so guessing changes the answer type.
+    static bool TryReadFlag(JsonElement q, out bool multi) {
+        multi = false;
+        bool? camel = null, snake = null;
+        if (q.Prop("multiSelect") is not null && (camel = q.Bool("multiSelect")) is null) return false;
+        if (q.Prop("multi_select") is not null && (snake = q.Bool("multi_select")) is null) return false;
+        if (camel is not null && snake is not null && camel != snake) return false;
+        multi = camel ?? snake ?? false;
+        return true;
+    }
+
+    static bool TryReadOptions(JsonElement q, out ImmutableArray<ElicitationOption> options) {
+        options = ImmutableArray<ElicitationOption>.Empty;
+        if (q.Prop("options") is not { } el) return true;
+        if (!el.IsArray || el.GetArrayLength() > MaxOptionsPerQuestion) return false;
+
+        var builder = ImmutableArray.CreateBuilder<ElicitationOption>();
+        var labels = new HashSet<string>(StringComparer.Ordinal);
+        foreach (var o in el.EnumerateArray()) {
+            if (!o.IsObject) return false;
+            var label = ProtocolString(o, "label", MaxOptionLabelChars);
+            if (label is null) return false;
+            // Duplicate labels collapse to the first: the label IS the answer value.
+            if (labels.Add(label)) builder.Add(new ElicitationOption(label, DisplayString(o, "description")));
+        }
+        options = builder.ToImmutable();
+        return true;
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -291,9 +291,28 @@ public class ChatTabViewModelTests {
             var h = Claude();
             h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolName: "Read", toolInputJson: """{"file_path":"/repo/x/src/a.cs"}"""));
             await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 1, what: "the card");
-            await Assert.That(h.Chat.PendingPermissions[0].Detail).IsEqualTo("/repo/x/src/a.cs");
+            await Assert.That(((PermissionCardViewModel)h.Chat.PendingPermissions[0]).Detail).IsEqualTo("/repo/x/src/a.cs");
             await h.PushAsync(Dto(transcriptPath: null));
-            await WaitUntilAsync(() => h.Chat.PendingPermissions[0].Detail == "src/a.cs", what: "relative once the root lands");
+            await WaitUntilAsync(() => ((PermissionCardViewModel)h.Chat.PendingPermissions[0]).Detail == "src/a.cs", what: "relative once the root lands");
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Question_entries_become_question_cards_beside_permission_cards() {
+        await RunOnUiAsync(async () => {
+            var h = Claude(p => {
+                p.Add(PermissionEntries.Entry("r1", requestedAt: "2026-08-28T10:00:00.0000000+00:00"));
+                p.Add(PermissionEntries.Question("q1", requestedAt: "2026-08-28T10:00:01.0000000+00:00"));
+            });
+            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 2, what: "both cards");
+            await Assert.That(h.Chat.PendingPermissions[0]).IsTypeOf<PermissionCardViewModel>();
+            await Assert.That(h.Chat.PendingPermissions[1]).IsTypeOf<QuestionCardViewModel>();
+
+            h.Permissions.Remove("q1");
+            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 1, what: "question card removed");
+            await Assert.That(h.Chat.PendingPermissions[0].RequestId).IsEqualTo("r1");
             await h.TeardownAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -65,8 +65,8 @@ public class ChatTabViewModelTests {
     public async Task A_request_already_cached_when_the_tab_opens_lights_the_row_at_once() {
         await RunOnUiAsync(async () => {
             var h = Claude(seed: p => p.Add(PermissionEntries.Entry("r1", "a1")));
-            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 1, what: "the replayed card");
-            await Assert.That(h.Chat.HasPendingPermissions).IsTrue();
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "the replayed card");
+            await Assert.That(h.Chat.HasPendingCards).IsTrue();
             await h.TeardownAsync();
         });
     }
@@ -273,13 +273,13 @@ public class ChatTabViewModelTests {
             h.Permissions.Add(PermissionEntries.Entry("r2", "a1", requestedAt: "2026-08-28T10:00:02.0000000+00:00"));
             h.Permissions.Add(PermissionEntries.Entry("r1", "a1", requestedAt: "2026-08-28T10:00:01.0000000+00:00"));
             h.Permissions.Add(PermissionEntries.Entry("rX", "other", requestedAt: "2026-08-28T10:00:00.0000000+00:00"));
-            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 2, what: "two cards");
-            await Assert.That(h.Chat.PendingPermissions.Select(c => c.RequestId).ToArray()).IsEquivalentTo(new[] { "r1", "r2" }, CollectionOrdering.Matching);
-            await Assert.That(h.Chat.HasPendingPermissions).IsTrue();
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 2, what: "two cards");
+            await Assert.That(h.Chat.PendingCards.Select(c => c.RequestId).ToArray()).IsEquivalentTo(new[] { "r1", "r2" }, CollectionOrdering.Matching);
+            await Assert.That(h.Chat.HasPendingCards).IsTrue();
 
             h.Permissions.Remove("r1");
-            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 1, what: "one card left");
-            await Assert.That(h.Chat.PendingPermissions[0].RequestId).IsEqualTo("r2");
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "one card left");
+            await Assert.That(h.Chat.PendingCards[0].RequestId).IsEqualTo("r2");
             await h.TeardownAsync();
         });
     }
@@ -290,10 +290,10 @@ public class ChatTabViewModelTests {
         await RunOnUiAsync(async () => {
             var h = Claude();
             h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolName: "Read", toolInputJson: """{"file_path":"/repo/x/src/a.cs"}"""));
-            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 1, what: "the card");
-            await Assert.That(((PermissionCardViewModel)h.Chat.PendingPermissions[0]).Detail).IsEqualTo("/repo/x/src/a.cs");
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "the card");
+            await Assert.That(((PermissionCardViewModel)h.Chat.PendingCards[0]).Detail).IsEqualTo("/repo/x/src/a.cs");
             await h.PushAsync(Dto(transcriptPath: null));
-            await WaitUntilAsync(() => ((PermissionCardViewModel)h.Chat.PendingPermissions[0]).Detail == "src/a.cs", what: "relative once the root lands");
+            await WaitUntilAsync(() => ((PermissionCardViewModel)h.Chat.PendingCards[0]).Detail == "src/a.cs", what: "relative once the root lands");
             await h.TeardownAsync();
         });
     }
@@ -306,13 +306,13 @@ public class ChatTabViewModelTests {
                 p.Add(PermissionEntries.Entry("r1", requestedAt: "2026-08-28T10:00:00.0000000+00:00"));
                 p.Add(PermissionEntries.Question("q1", requestedAt: "2026-08-28T10:00:01.0000000+00:00"));
             });
-            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 2, what: "both cards");
-            await Assert.That(h.Chat.PendingPermissions[0]).IsTypeOf<PermissionCardViewModel>();
-            await Assert.That(h.Chat.PendingPermissions[1]).IsTypeOf<QuestionCardViewModel>();
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 2, what: "both cards");
+            await Assert.That(h.Chat.PendingCards[0]).IsTypeOf<PermissionCardViewModel>();
+            await Assert.That(h.Chat.PendingCards[1]).IsTypeOf<QuestionCardViewModel>();
 
             h.Permissions.Remove("q1");
-            await WaitUntilAsync(() => h.Chat.PendingPermissions.Count == 1, what: "question card removed");
-            await Assert.That(h.Chat.PendingPermissions[0].RequestId).IsEqualTo("r1");
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "question card removed");
+            await Assert.That(h.Chat.PendingCards[0].RequestId).IsEqualTo("r1");
             await h.TeardownAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -464,14 +464,14 @@ public class ChatTabViewSmokeTests {
             await Assert.That(row.IsVisible).IsFalse();
 
             host.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolName: "Bash"));
-            await WaitUntilAsync(() => host.Chat.PendingPermissions.Count == 1, what: "the card");
+            await WaitUntilAsync(() => host.Chat.PendingCards.Count == 1, what: "the card");
             Dispatcher.UIThread.RunJobs();
             await Assert.That(row.IsVisible).IsTrue();
             var buttons = row.GetVisualDescendants().OfType<Button>().Select(b => b.Content?.ToString() ?? "").ToArray();
             await Assert.That(buttons).IsEquivalentTo(new[] { "Deny", "Allow always", "Allow" });
 
             host.Permissions.Remove("r1");
-            await WaitUntilAsync(() => host.Chat.PendingPermissions.Count == 0, what: "cleared");
+            await WaitUntilAsync(() => host.Chat.PendingCards.Count == 0, what: "cleared");
             Dispatcher.UIThread.RunJobs();
             await Assert.That(row.IsVisible).IsFalse();
         });

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -460,7 +460,7 @@ public class ChatTabViewSmokeTests {
     public async Task Card_renders_with_its_buttons_and_the_row_collapses_when_empty() {
         await RunOnUiAsync(async () => {
             var host = new Host();
-            var row = host.View.FindControl<Border>("PermissionRow")!;
+            var row = host.View.FindControl<Border>("NeedsYouRow")!;
             await Assert.That(row.IsVisible).IsFalse();
 
             host.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolName: "Bash"));

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -491,8 +491,8 @@ public class ChatTabViewSmokeTests {
             var buttons = host.View.GetVisualDescendants().OfType<Button>()
                 .Select(b => b.Content as string ?? b.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault()?.Text)
                 .ToList();
-            await Assert.That(buttons).Contains("Allow");           // the permission card
-            await Assert.That(buttons).Contains("A");               // a question option button
+            await Assert.That(buttons).Contains("Allow");
+            await Assert.That(buttons).Contains("A");
             var otherBoxes = host.View.GetVisualDescendants().OfType<TextBox>()
                 .Where(t => t.PlaceholderText == "Other…").ToList();
             await Assert.That(otherBoxes.Count).IsEqualTo(1);

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -476,4 +476,27 @@ public class ChatTabViewSmokeTests {
             await Assert.That(row.IsVisible).IsFalse();
         });
     }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Question_card_renders_options_other_and_coexists_with_a_permission_card() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            host.Permissions.Add(PermissionEntries.Entry("r1"));
+            host.Permissions.Add(PermissionEntries.Question("q1"));
+            host.Settle();
+
+            // A plain-text button (Allow, Deny, Submit…) yields its Content directly; an option
+            // button's Content is the Label/Description StackPanel, so its first TextBlock stands in.
+            var buttons = host.View.GetVisualDescendants().OfType<Button>()
+                .Select(b => b.Content as string ?? b.GetVisualDescendants().OfType<TextBlock>().FirstOrDefault()?.Text)
+                .ToList();
+            await Assert.That(buttons).Contains("Allow");           // the permission card
+            await Assert.That(buttons).Contains("A");               // a question option button
+            var otherBoxes = host.View.GetVisualDescendants().OfType<TextBox>()
+                .Where(t => t.PlaceholderText == "Other…").ToList();
+            await Assert.That(otherBoxes.Count).IsEqualTo(1);
+            await Assert.That(host.View.GetVisualDescendants().OfType<TextBlock>().Any(t => t.Text == "Pick")).IsTrue();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/FakePermissionService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakePermissionService.cs
@@ -38,14 +38,8 @@ sealed class FakePermissionService : IPermissionService {
             .StartWith((IReadOnlySet<string>)new HashSet<string>());
     public IObservable<PendingSummary> Summary =>
         Cache.Connect()
-            .QueryWhenChanged(q => Summarize(q.Items))
+            .QueryWhenChanged(q => PendingSummary.From(q.Items))
             .StartWith(new PendingSummary(0, 0));
-
-    static PendingSummary Summarize(IEnumerable<PendingPermissionRequest> items) {
-        int permissions = 0, questions = 0;
-        foreach (var item in items) { if (item.Questions is null) permissions++; else questions++; }
-        return new PendingSummary(permissions, questions);
-    }
 
     public void Add(PendingPermissionRequest entry) => Cache.AddOrUpdate(entry);
     public void Remove(string requestId) => Cache.Remove(requestId);

--- a/test/Capacitor.App.Tests.Unit/FakePermissionService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakePermissionService.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using Capacitor.App.Services;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 
@@ -13,6 +14,12 @@ static class PermissionEntries {
         if (toolInputJson is not null) { using var d = System.Text.Json.JsonDocument.Parse(toolInputJson); input = d.RootElement.Clone(); }
         return new PendingPermissionRequest(new PermissionPendingDto(requestId, agentId, "s1", vendor, toolName, input, null, omitted, false, requestedAt));
     }
+
+    public static PendingPermissionRequest Question(
+            string requestId = "q1", string agentId = "a1",
+            string toolInputJson = """{"questions":[{"question":"Pick","options":[{"label":"A"},{"label":"B"}]}]}""",
+            string requestedAt = "2026-08-28T10:00:00.0000000+00:00") =>
+        Entry(requestId, agentId, "claude", ClaudeElicitation.ToolName, toolInputJson, false, requestedAt);
 }
 
 /// Scripted IPermissionService: a real SourceCache plus a per-call outcome queue, like
@@ -22,12 +29,23 @@ sealed class FakePermissionService : IPermissionService {
     public readonly SourceCache<PendingPermissionRequest, string> Cache = new(p => p.RequestId);
     readonly Queue<TaskCompletionSource<PermissionResolveOutcome>> _outcomes = new();
     public readonly List<(string RequestId, PermissionAnswer Answer)> Resolved = [];
+    public readonly List<(string RequestId, IReadOnlyList<ElicitationAnswer> Answers)> Answered = [];
 
     public IObservable<IChangeSet<PendingPermissionRequest, string>> Pending => Cache.Connect();
     public IObservable<int> PendingCount => Cache.CountChanged;
     public IObservable<IReadOnlySet<string>> AgentsWithPending =>
         Cache.Connect().QueryWhenChanged(q => (IReadOnlySet<string>)q.Items.Select(p => p.AgentId).ToHashSet(StringComparer.Ordinal))
             .StartWith((IReadOnlySet<string>)new HashSet<string>());
+    public IObservable<PendingSummary> Summary =>
+        Cache.Connect()
+            .QueryWhenChanged(q => Summarize(q.Items))
+            .StartWith(new PendingSummary(0, 0));
+
+    static PendingSummary Summarize(IEnumerable<PendingPermissionRequest> items) {
+        int permissions = 0, questions = 0;
+        foreach (var item in items) { if (item.Questions is null) permissions++; else questions++; }
+        return new PendingSummary(permissions, questions);
+    }
 
     public void Add(PendingPermissionRequest entry) => Cache.AddOrUpdate(entry);
     public void Remove(string requestId) => Cache.Remove(requestId);
@@ -42,6 +60,15 @@ sealed class FakePermissionService : IPermissionService {
     public async Task<PermissionResolveOutcome> ResolveAsync(PendingPermissionRequest target, PermissionAnswer answer, CancellationToken ct) {
         Resolved.Add((target.RequestId, answer));
         if (_outcomes.Count == 0) throw new InvalidOperationException("FakePermissionService: unscripted resolve call");
+        var outcome = await _outcomes.Dequeue().Task;
+        if (outcome.Kind != PermissionResolveKind.TransportFailure) Cache.Remove(target.RequestId);
+        return outcome;
+    }
+
+    public async Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target, IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct) {
+        if (target.Questions is null) throw new ArgumentException("not an elicitation entry", nameof(target));
+        Answered.Add((target.RequestId, answers));
+        if (_outcomes.Count == 0) throw new InvalidOperationException("FakePermissionService: unscripted answer call");
         var outcome = await _outcomes.Dequeue().Task;
         if (outcome.Kind != PermissionResolveKind.TransportFailure) Cache.Remove(target.RequestId);
         return outcome;

--- a/test/Capacitor.App.Tests.Unit/PermissionCardViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PermissionCardViewModelTests.cs
@@ -68,4 +68,17 @@ public class PermissionCardViewModelTests {
             await Assert.That(svc.Cache.Count).IsEqualTo(0);
         });
     }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Allow_always_hides_for_the_ask_user_question_fallback_card() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var svc = new FakePermissionService();
+            // Oversized questions payload: still ToolName AskUserQuestion, but unclassified.
+            using var fallback = new PermissionCardViewModel(
+                PermissionEntries.Entry(toolName: Capacitor.Cli.Core.ClaudeElicitation.ToolName, toolInputJson: null, omitted: true),
+                svc, new System.Reactive.Subjects.BehaviorSubject<string?>(null));
+            await Assert.That(fallback.ShowsAllowAlways).IsFalse();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/PermissionServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PermissionServiceTests.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Capacitor.App.Services;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 using Microsoft.Extensions.Time.Testing;
@@ -143,5 +144,115 @@ public class PermissionServiceTests {
         await Assert.That(h.View.Count).IsEqualTo(1);
         h.Stream.EmitSubscribed();
         await WaitUntilAsync(() => h.View.Count == 0, what: "cleared at Subscribed");
+    }
+
+    static PermissionPendingDto Dto2(string id, string agent, string vendor, string toolName, string? toolInputJson, bool omitted = false) {
+        System.Text.Json.JsonElement? input = null;
+        if (toolInputJson is not null) { using var d = System.Text.Json.JsonDocument.Parse(toolInputJson); input = d.RootElement.Clone(); }
+        return new PermissionPendingDto(id, agent, "s1", vendor, toolName, input, null, omitted, false, "2026-08-28T10:00:00.0000000+00:00");
+    }
+
+    const string QuestionInput = """{"questions":[{"question":"Pick","options":[{"label":"A"},{"label":"B"}]}]}""";
+
+    [Test]
+    public async Task Classification_requires_claude_the_tool_name_present_input_and_a_parse() {
+        using var h = new Harness();
+        await h.StartAsync();
+        var yes = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        await Assert.That(yes.Questions).IsNotNull();
+        var codex = await h.EmitAsync(Dto2("q2", "a1", "codex", ClaudeElicitation.ToolName, QuestionInput));
+        var wrongTool = await h.EmitAsync(Dto2("q3", "a1", "claude", "Bash", QuestionInput));
+        var omitted = await h.EmitAsync(Dto2("q4", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput, omitted: true));
+        var nullInput = await h.EmitAsync(Dto2("q5", "a1", "claude", ClaudeElicitation.ToolName, null));
+        var unparseable = await h.EmitAsync(Dto2("q6", "a1", "claude", ClaudeElicitation.ToolName, """{"questions":[]}"""));
+        foreach (var entry in new[] { codex, wrongTool, omitted, nullInput, unparseable })
+            await Assert.That(entry.Questions).IsNull();
+    }
+
+    [Test]
+    public async Task Answer_sends_allow_with_updated_input_and_concludes_on_either_ack() {
+        using var h = new Harness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+
+        h.Ops.QueuePermissionResolve(true);
+        var applied = await h.Service.AnswerAsync(entry, [new ElicitationAnswer("Pick", ["B"], null)], CancellationToken.None);
+        await Assert.That(applied.Kind).IsEqualTo(PermissionResolveKind.Applied);
+        var payload = h.Ops.PermissionResolvePayloads[0];
+        await Assert.That(payload.Decision).IsEqualTo("allow");
+        await Assert.That(payload.ApplyPermissions).IsNull();
+        await Assert.That(payload.UpdatedInput!.Value.Prop("answers")!.Value.Str("Pick")).IsEqualTo("B");
+        await Assert.That(h.View.Count).IsEqualTo(0);
+
+        var second = await h.EmitAsync(Dto2("q2", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        h.Ops.QueuePermissionResolve(false, "no pending permission request with that id");
+        var already = await h.Service.AnswerAsync(second, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None);
+        await Assert.That(already.Kind).IsEqualTo(PermissionResolveKind.AlreadyDecided);
+        await Assert.That(h.View.Count).IsEqualTo(0);
+
+        var third = await h.EmitAsync(Dto2("q3", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        h.Ops.QueuePermissionResolveFailure("daemon_unreachable");
+        var failed = await h.Service.AnswerAsync(third, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None);
+        await Assert.That(failed.Kind).IsEqualTo(PermissionResolveKind.TransportFailure);
+        await Assert.That(h.View.Count).IsEqualTo(1);
+
+        // A Resolved push after the failed send clears the survivor; a ghost replay stays dropped.
+        h.Stream.EmitResolved("q3", "server");
+        await WaitUntilAsync(() => h.View.Count == 0, what: "push cleared the survivor");
+    }
+
+    [Test]
+    public async Task Answer_rejects_an_unclassified_target_and_a_bad_answer_set_without_sending() {
+        using var h = new Harness();
+        await h.StartAsync();
+        var plain = await h.EmitAsync(Dto2("p1", "a1", "claude", "Bash", """{"command":"ls"}"""));
+        await Assert.That(async () => await h.Service.AnswerAsync(plain, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None))
+            .Throws<ArgumentException>();
+
+        var entry = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        await Assert.That(async () => await h.Service.AnswerAsync(entry, [], CancellationToken.None)).Throws<ArgumentException>();
+        await Assert.That(h.Ops.PermissionResolveCalls).IsEqualTo(0);
+        await Assert.That(h.View.Count).IsEqualTo(2);
+    }
+
+    [Test]
+    public async Task A_resolved_push_landing_before_the_ack_ends_in_the_same_state() {
+        using var h = new Harness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+
+        var gate = h.Ops.ArmPermissionResolve();
+        var run = h.Service.AnswerAsync(entry, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None);
+        h.Stream.EmitResolved("q1", "server");
+        await WaitUntilAsync(() => h.View.Count == 0, what: "push evicted while the ack is in flight");
+        gate.SetResult(new PermissionAckDto(false, "no pending permission request with that id"));
+        var outcome = await run;
+        await Assert.That(outcome.Kind).IsEqualTo(PermissionResolveKind.AlreadyDecided);
+        await Assert.That(h.View.Count).IsEqualTo(0);
+
+        // The tombstoned id stays dead against a ghost replay.
+        h.Stream.EmitPending(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        await Task.Delay(50);
+        await Assert.That(h.View.Count).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Summary_seeds_and_stays_a_consistent_pair() {
+        using var h = new Harness();
+        var summaries = new List<PendingSummary>();
+        using var sub = h.Service.Summary.Subscribe(summaries.Add);
+        await Assert.That(summaries[0]).IsEqualTo(new PendingSummary(0, 0));
+
+        await h.StartAsync();
+        await h.EmitAsync(Dto2("p1", "a1", "claude", "Bash", """{"command":"ls"}"""));
+        await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        await WaitUntilAsync(() => summaries[^1] == new PendingSummary(1, 1), what: "one of each");
+
+        h.Stream.EmitResolved("q1", "server");
+        await WaitUntilAsync(() => summaries[^1] == new PendingSummary(1, 0), what: "question settled");
+        foreach (var s in summaries) {
+            await Assert.That(s.Permissions).IsGreaterThanOrEqualTo(0);
+            await Assert.That(s.Questions).IsGreaterThanOrEqualTo(0);
+        }
     }
 }

--- a/test/Capacitor.App.Tests.Unit/PermissionServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PermissionServiceTests.cs
@@ -146,7 +146,7 @@ public class PermissionServiceTests {
         await WaitUntilAsync(() => h.View.Count == 0, what: "cleared at Subscribed");
     }
 
-    static PermissionPendingDto Dto2(string id, string agent, string vendor, string toolName, string? toolInputJson, bool omitted = false) {
+    static PermissionPendingDto PendingDto(string id, string agent, string vendor, string toolName, string? toolInputJson, bool omitted = false) {
         System.Text.Json.JsonElement? input = null;
         if (toolInputJson is not null) { using var d = System.Text.Json.JsonDocument.Parse(toolInputJson); input = d.RootElement.Clone(); }
         return new PermissionPendingDto(id, agent, "s1", vendor, toolName, input, null, omitted, false, "2026-08-28T10:00:00.0000000+00:00");
@@ -158,13 +158,13 @@ public class PermissionServiceTests {
     public async Task Classification_requires_claude_the_tool_name_present_input_and_a_parse() {
         using var h = new Harness();
         await h.StartAsync();
-        var yes = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        var yes = await h.EmitAsync(PendingDto("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
         await Assert.That(yes.Questions).IsNotNull();
-        var codex = await h.EmitAsync(Dto2("q2", "a1", "codex", ClaudeElicitation.ToolName, QuestionInput));
-        var wrongTool = await h.EmitAsync(Dto2("q3", "a1", "claude", "Bash", QuestionInput));
-        var omitted = await h.EmitAsync(Dto2("q4", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput, omitted: true));
-        var nullInput = await h.EmitAsync(Dto2("q5", "a1", "claude", ClaudeElicitation.ToolName, null));
-        var unparseable = await h.EmitAsync(Dto2("q6", "a1", "claude", ClaudeElicitation.ToolName, """{"questions":[]}"""));
+        var codex = await h.EmitAsync(PendingDto("q2", "a1", "codex", ClaudeElicitation.ToolName, QuestionInput));
+        var wrongTool = await h.EmitAsync(PendingDto("q3", "a1", "claude", "Bash", QuestionInput));
+        var omitted = await h.EmitAsync(PendingDto("q4", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput, omitted: true));
+        var nullInput = await h.EmitAsync(PendingDto("q5", "a1", "claude", ClaudeElicitation.ToolName, null));
+        var unparseable = await h.EmitAsync(PendingDto("q6", "a1", "claude", ClaudeElicitation.ToolName, """{"questions":[]}"""));
         foreach (var entry in new[] { codex, wrongTool, omitted, nullInput, unparseable })
             await Assert.That(entry.Questions).IsNull();
     }
@@ -173,7 +173,7 @@ public class PermissionServiceTests {
     public async Task Answer_sends_allow_with_updated_input_and_concludes_on_either_ack() {
         using var h = new Harness();
         await h.StartAsync();
-        var entry = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        var entry = await h.EmitAsync(PendingDto("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
 
         h.Ops.QueuePermissionResolve(true);
         var applied = await h.Service.AnswerAsync(entry, [new ElicitationAnswer("Pick", ["B"], null)], CancellationToken.None);
@@ -184,13 +184,13 @@ public class PermissionServiceTests {
         await Assert.That(payload.UpdatedInput!.Value.Prop("answers")!.Value.Str("Pick")).IsEqualTo("B");
         await Assert.That(h.View.Count).IsEqualTo(0);
 
-        var second = await h.EmitAsync(Dto2("q2", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        var second = await h.EmitAsync(PendingDto("q2", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
         h.Ops.QueuePermissionResolve(false, "no pending permission request with that id");
         var already = await h.Service.AnswerAsync(second, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None);
         await Assert.That(already.Kind).IsEqualTo(PermissionResolveKind.AlreadyDecided);
         await Assert.That(h.View.Count).IsEqualTo(0);
 
-        var third = await h.EmitAsync(Dto2("q3", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        var third = await h.EmitAsync(PendingDto("q3", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
         h.Ops.QueuePermissionResolveFailure("daemon_unreachable");
         var failed = await h.Service.AnswerAsync(third, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None);
         await Assert.That(failed.Kind).IsEqualTo(PermissionResolveKind.TransportFailure);
@@ -205,11 +205,11 @@ public class PermissionServiceTests {
     public async Task Answer_rejects_an_unclassified_target_and_a_bad_answer_set_without_sending() {
         using var h = new Harness();
         await h.StartAsync();
-        var plain = await h.EmitAsync(Dto2("p1", "a1", "claude", "Bash", """{"command":"ls"}"""));
+        var plain = await h.EmitAsync(PendingDto("p1", "a1", "claude", "Bash", """{"command":"ls"}"""));
         await Assert.That(async () => await h.Service.AnswerAsync(plain, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None))
             .Throws<ArgumentException>();
 
-        var entry = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        var entry = await h.EmitAsync(PendingDto("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
         await Assert.That(async () => await h.Service.AnswerAsync(entry, [], CancellationToken.None)).Throws<ArgumentException>();
         await Assert.That(h.Ops.PermissionResolveCalls).IsEqualTo(0);
         await Assert.That(h.View.Count).IsEqualTo(2);
@@ -219,7 +219,7 @@ public class PermissionServiceTests {
     public async Task A_resolved_push_landing_before_the_ack_ends_in_the_same_state() {
         using var h = new Harness();
         await h.StartAsync();
-        var entry = await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        var entry = await h.EmitAsync(PendingDto("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
 
         var gate = h.Ops.ArmPermissionResolve();
         var run = h.Service.AnswerAsync(entry, [new ElicitationAnswer("Pick", ["A"], null)], CancellationToken.None);
@@ -231,7 +231,7 @@ public class PermissionServiceTests {
         await Assert.That(h.View.Count).IsEqualTo(0);
 
         // The tombstoned id stays dead against a ghost replay.
-        h.Stream.EmitPending(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        h.Stream.EmitPending(PendingDto("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
         await Task.Delay(50);
         await Assert.That(h.View.Count).IsEqualTo(0);
     }
@@ -244,8 +244,8 @@ public class PermissionServiceTests {
         await Assert.That(summaries[0]).IsEqualTo(new PendingSummary(0, 0));
 
         await h.StartAsync();
-        await h.EmitAsync(Dto2("p1", "a1", "claude", "Bash", """{"command":"ls"}"""));
-        await h.EmitAsync(Dto2("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
+        await h.EmitAsync(PendingDto("p1", "a1", "claude", "Bash", """{"command":"ls"}"""));
+        await h.EmitAsync(PendingDto("q1", "a1", "claude", ClaudeElicitation.ToolName, QuestionInput));
         await WaitUntilAsync(() => summaries[^1] == new PendingSummary(1, 1), what: "one of each");
 
         h.Stream.EmitResolved("q1", "server");

--- a/test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs
@@ -62,8 +62,10 @@ public class QuestionCardViewModelTests {
                 await Assert.That(card.ShowsSubmit).IsTrue();
                 card.Questions[0].OtherText = "   ";
                 await Assert.That(card.Questions[0].IsAnswered).IsFalse();
+                await Assert.That(card.Questions[0].ShowsOtherAnswer).IsFalse();
                 card.Questions[0].OtherText = "hello";
                 await Assert.That(card.Questions[0].IsAnswered).IsTrue();
+                await Assert.That(card.Questions[0].ShowsOtherAnswer).IsFalse();
             }
         });
     }

--- a/test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs
@@ -1,0 +1,163 @@
+using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class QuestionCardViewModelTests {
+    const string SingleSelect = """{"questions":[{"question":"Pick","header":"Choice","options":[{"label":"A","description":"first"},{"label":"B"}]}]}""";
+    const string FreeTextOnly = """{"questions":[{"question":"Say"}]}""";
+    const string MultiAndSingle = """{"questions":[{"question":"Pick","options":[{"label":"A"},{"label":"B"}]},{"question":"Tags","multiSelect":true,"options":[{"label":"X"},{"label":"Y"}]}]}""";
+
+    static (FakePermissionService Svc, QuestionCardViewModel Card) Make(string input, string requestId = "q1") {
+        var svc = new FakePermissionService();
+        var entry = PermissionEntries.Question(requestId, toolInputJson: input);
+        svc.Add(entry);
+        return (svc, new QuestionCardViewModel(entry, svc));
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Fast_path_submits_on_option_click() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) using (card) {
+                await Assert.That(card.IsFastPath).IsTrue();
+                await Assert.That(card.ShowsSubmit).IsFalse();
+                svc.Queue(PermissionResolveKind.Applied);
+                await card.Questions[0].Options[1].PickCommand.Execute().ToTask();
+                await Assert.That(svc.Answered[0].Answers[0].SelectedLabels).IsEquivalentTo(["B"]);
+                await Assert.That(svc.Answered[0].Answers[0].OtherText).IsNull();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Fast_path_other_text_submits_on_enter_and_shows_the_inline_answer() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) using (card) {
+                var group = card.Questions[0];
+                await Assert.That(group.ShowsOtherAnswer).IsFalse();
+                group.OtherText = "my own";
+                await Assert.That(group.ShowsOtherAnswer).IsTrue();
+                svc.Queue(PermissionResolveKind.Applied);
+                await group.EnterCommand.Execute().ToTask();
+                await Assert.That(svc.Answered[0].Answers[0].OtherText).IsEqualTo("my own");
+                await Assert.That(svc.Answered[0].Answers[0].SelectedLabels.Count).IsEqualTo(0);
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Free_text_only_is_not_the_fast_path_and_whitespace_does_not_answer() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(FreeTextOnly);
+            using (svc) using (card) {
+                await Assert.That(card.IsFastPath).IsFalse();
+                await Assert.That(card.ShowsSubmit).IsTrue();
+                card.Questions[0].OtherText = "   ";
+                await Assert.That(card.Questions[0].IsAnswered).IsFalse();
+                card.Questions[0].OtherText = "hello";
+                await Assert.That(card.Questions[0].IsAnswered).IsTrue();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Submit_gates_on_every_question_and_sends_all_answers() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(MultiAndSingle);
+            using (svc) using (card) {
+                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsFalse();
+                card.Questions[0].Options[0].IsSelected = true;
+                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsFalse();
+                card.Questions[1].Options[0].IsSelected = true;
+                card.Questions[1].Options[1].IsSelected = true;
+                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsTrue();
+
+                svc.Queue(PermissionResolveKind.Applied);
+                await card.SubmitCommand.Execute().ToTask();
+                var answers = svc.Answered[0].Answers;
+                await Assert.That(answers[0].SelectedLabels).IsEquivalentTo(["A"]);
+                await Assert.That(answers[1].SelectedLabels).IsEquivalentTo(["X", "Y"]);
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Single_select_pick_and_other_text_displace_each_other() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(MultiAndSingle);
+            using (svc) using (card) {
+                var group = card.Questions[0];
+                group.Options[0].IsSelected = true;
+                group.OtherText = "custom";
+                await Assert.That(group.Options[0].IsSelected).IsFalse();
+                await group.Options[1].PickCommand.Execute().ToTask();
+                await Assert.That(group.OtherText).IsEqualTo("");
+                await Assert.That(group.Options[1].IsSelected).IsTrue();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Double_activation_sends_once_and_transport_failure_re_enables() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) using (card) {
+                var gate = svc.Arm();
+                var first = card.Questions[0].Options[0].PickCommand.Execute().ToTask();
+                await WaitUntilAsync(() => card.IsBusy, what: "busy in flight");
+                await card.Questions[0].Options[1].PickCommand.Execute().ToTask();
+                gate.SetResult(new PermissionResolveOutcome(PermissionResolveKind.TransportFailure, "daemon_unreachable"));
+                await first;
+                await Assert.That(svc.Answered.Count).IsEqualTo(1);
+                await Assert.That(card.IsBusy).IsFalse();
+                await Assert.That(card.ErrorText).IsEqualTo("Daemon unreachable — try again");
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Eviction_mid_flight_leaves_no_error_and_no_post_disposal_notification() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) {
+                var gate = svc.Arm();
+                var run = card.Questions[0].Options[0].PickCommand.Execute().ToTask();
+                await WaitUntilAsync(() => card.IsBusy, what: "busy in flight");
+
+                var notified = new List<string>();
+                card.PropertyChanged += (_, e) => notified.Add(e.PropertyName ?? "");
+                card.Dispose();
+                gate.SetResult(new PermissionResolveOutcome(PermissionResolveKind.TransportFailure, "daemon_unreachable"));
+                await run;
+                await Assert.That(notified).IsEmpty();
+                await Assert.That(card.ErrorText).IsNull();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_throwing_service_clears_busy_and_shows_the_generic_line() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) using (card) {
+                svc.Arm().SetException(new ArgumentException("composer rejected"));
+                await card.Questions[0].Options[0].PickCommand.Execute().ToTask();
+                await Assert.That(card.IsBusy).IsFalse();
+                await Assert.That(card.ErrorText).IsEqualTo("Something went wrong — try again");
+            }
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs
@@ -162,4 +162,18 @@ public class QuestionCardViewModelTests {
             }
         });
     }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_cancellation_not_from_disposal_shows_the_generic_line() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(SingleSelect);
+            using (svc) using (card) {
+                svc.Arm().SetException(new OperationCanceledException());
+                await card.Questions[0].Options[0].PickCommand.Execute().ToTask();
+                await Assert.That(card.IsBusy).IsFalse();
+                await Assert.That(card.ErrorText).IsEqualTo("Something went wrong — try again");
+            }
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
@@ -1062,4 +1062,32 @@ public class TrayViewModelTests {
             await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Running);
         });
     }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Pending_questions_split_the_header_wording() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var pause = new FakePauseController();
+            var actions = NewActions(service);
+            var consent = new FakeConsentService();
+            using var permissions = new FakePermissionService();
+            using var vm = new TrayViewModel(service, pause, actions, consent, permissions: permissions);
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, ["permission/1"]));
+            service.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(active: 1));
+            await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Running);
+
+            permissions.Add(PermissionEntries.Question("q1"));
+            await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Attention);
+            await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: 1 question waiting");
+
+            permissions.Add(PermissionEntries.Entry("r1"));
+            await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: 1 question waiting, 1 permission request waiting");
+
+            permissions.Remove("q1");
+            permissions.Remove("r1");
+            await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Running);
+        });
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
@@ -1,4 +1,6 @@
 using System.Collections.Immutable;
+using Capacitor.Cli.Core.LocalIpc;
+using TUnit.Assertions.Enums;
 
 namespace Capacitor.Cli.Core.Tests.Unit;
 
@@ -112,5 +114,110 @@ public class ClaudeElicitationTests {
         await Assert.That(parsed!.Questions is ImmutableArray<ElicitationQuestion>).IsTrue();
         await Assert.That(parsed.Questions[0].Options is ImmutableArray<ElicitationOption>).IsTrue();
 #pragma warning restore CS0183
+    }
+
+    static ElicitationQuestions Parsed(string json) => ClaudeElicitation.TryParse(json)!;
+
+    const string MixedPayload =
+        """{"questions":[{"question":"Q1","options":[{"label":"A"},{"label":"B"}]},{"question":"Q2","multiSelect":true,"options":[{"label":"X"},{"label":"Y"},{"label":"Z"}]}]}""";
+
+    [Test]
+    public async Task Composes_the_documented_shape_with_passthrough_and_ordered_values() {
+        var q = Parsed(MixedPayload);
+        var composed = ClaudeElicitation.ComposeAnswers(q, [
+            new ElicitationAnswer("Q1", ["B"], null),
+            new ElicitationAnswer("Q2", ["Z", "X"], "custom"),
+        ]);
+        await Assert.That(composed.Prop("questions")!.Value.GetRawText()).IsEqualTo(q.QuestionsJson.GetRawText());
+        var answers = composed.Prop("answers")!.Value;
+        await Assert.That(answers.Str("Q1")).IsEqualTo("B");
+        // Multi-select: option order first, the genuine Other text last. Ordering.Matching —
+        // the default equivalence ignores order and would let the ordering rule regress.
+        await Assert.That(answers.Prop("Q2")!.Value.EnumerateArray().Select(v => v.GetString()!))
+            .IsEquivalentTo(["X", "Z", "custom"], CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Single_select_accepts_other_text_as_the_one_value() {
+        var q = Parsed("""{"questions":[{"question":"Q","options":[{"label":"A"}]}]}""");
+        var composed = ClaudeElicitation.ComposeAnswers(q, [new ElicitationAnswer("Q", [], "  my own  ")]);
+        await Assert.That(composed.Prop("answers")!.Value.Str("Q")).IsEqualTo("my own");
+    }
+
+    [Test]
+    public async Task Other_text_equal_to_a_label_normalizes_into_the_selection() {
+        var q = Parsed("""{"questions":[{"question":"Q","multiSelect":true,"options":[{"label":"A"},{"label":"B"}]}]}""");
+        var fresh = ClaudeElicitation.ComposeAnswers(q, [new ElicitationAnswer("Q", ["B"], "A")]);
+        await Assert.That(fresh.Prop("answers")!.Value.Prop("Q")!.Value.EnumerateArray().Select(v => v.GetString()!))
+            .IsEquivalentTo(["A", "B"], CollectionOrdering.Matching);
+        var already = ClaudeElicitation.ComposeAnswers(q, [new ElicitationAnswer("Q", ["A"], "A")]);
+        await Assert.That(already.Prop("answers")!.Value.Prop("Q")!.Value.EnumerateArray().Select(v => v.GetString()!))
+            .IsEquivalentTo(["A"]);
+        // Single-select: the normalized pair collapses to one value instead of throwing.
+        var single = Parsed("""{"questions":[{"question":"S","options":[{"label":"A"}]}]}""");
+        var collapsed = ClaudeElicitation.ComposeAnswers(single, [new ElicitationAnswer("S", ["A"], "A")]);
+        await Assert.That(collapsed.Prop("answers")!.Value.Str("S")).IsEqualTo("A");
+    }
+
+    [Test]
+    public async Task Invalid_answer_sets_throw() {
+        var q = Parsed(MixedPayload);
+        List<IReadOnlyList<ElicitationAnswer>> bad = [
+            [new ElicitationAnswer("Q1", ["A"], null)],                                                 // missing Q2
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q1", ["B"], null)],       // duplicate key
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Nope", ["X"], null)],     // unknown key
+            [new ElicitationAnswer("Q1", ["C"], null), new ElicitationAnswer("Q2", ["X"], null)],       // label not an option
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", ["X", "X"], null)],  // label twice
+            [new ElicitationAnswer("Q1", ["A", "B"], null), new ElicitationAnswer("Q2", ["X"], null)],  // two for single-select
+            [new ElicitationAnswer("Q1", ["A"], "extra"), new ElicitationAnswer("Q2", ["X"], null)],    // label AND other for single-select
+            [new ElicitationAnswer("Q1", [], null), new ElicitationAnswer("Q2", ["X"], null)],          // neither for single-select
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", [], null)],          // empty multi-select
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", [], "   ")],         // blank other
+            [new ElicitationAnswer("Q1", ["A"], null),
+             new ElicitationAnswer("Q2", [], new string('x', ClaudeElicitation.MaxOtherTextChars + 1))], // over-cap other
+        ];
+        foreach (var answers in bad)
+            await Assert.That(() => ClaudeElicitation.ComposeAnswers(q, answers)).Throws<ArgumentException>();
+    }
+
+    [Test]
+    public async Task Composed_element_outlives_every_composer_local_owner() {
+        var composed = ClaudeElicitation.ComposeAnswers(
+            Parsed("""{"questions":[{"question":"Q","options":[{"label":"A"}]}]}"""),
+            [new ElicitationAnswer("Q", ["A"], null)]);
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        await Assert.That(composed.GetRawText()).Contains("\"answers\"");
+    }
+
+    [Test]
+    public async Task Maximal_composed_payload_fits_the_frame_codec() {
+        var esc = new string('', 1);
+        string Chars(int n) => string.Concat(Enumerable.Repeat(esc, n));
+        var questions = string.Join(",", Enumerable.Range(0, ClaudeElicitation.MaxQuestions).Select(i => {
+            var text = System.Text.Json.JsonEncodedText.Encode(Chars(ClaudeElicitation.MaxQuestionTextChars - 2) + i.ToString("00", System.Globalization.CultureInfo.InvariantCulture));
+            var options = string.Join(",", Enumerable.Range(0, ClaudeElicitation.MaxOptionsPerQuestion).Select(j => {
+                var label = System.Text.Json.JsonEncodedText.Encode(Chars(ClaudeElicitation.MaxOptionLabelChars - 2) + j.ToString("00", System.Globalization.CultureInfo.InvariantCulture));
+                return $$"""{"label":"{{label}}"}""";
+            }));
+            return $$"""{"question":"{{text}}","multiSelect":true,"options":[{{options}}]}""";
+        }));
+        var parsed = ClaudeElicitation.TryParse($$"""{"questions":[{{questions}}]}""");
+        await Assert.That(parsed).IsNotNull();
+
+        var answers = parsed!.Questions
+            .Select(q => new ElicitationAnswer(q.Question, q.Options.Select(o => o.Label).ToList(),
+                Chars(ClaudeElicitation.MaxOtherTextChars)))
+            .ToList();
+        var updated = ClaudeElicitation.ComposeAnswers(parsed, answers);
+
+        var dto = new PermissionResolveDto("r", "allow", null, updated);
+        var json = System.Text.Json.JsonSerializer.Serialize(dto, PermissionIpcJsonContext.Default.PermissionResolveDto);
+        var frame = LocalFrame.PermissionJson(FrameType.PermissionResolve, json);
+        using var stream = new MemoryStream();
+        await FrameCodec.WriteAsync(stream, frame, CancellationToken.None);
+        stream.Position = 0;
+        var read = await FrameCodec.ReadAsync(stream, CancellationToken.None);
+        await Assert.That(read!.Type).IsEqualTo(FrameType.PermissionResolve);
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
@@ -219,7 +219,7 @@ public class ClaudeElicitationTests {
 
     [Test]
     public async Task Maximal_composed_payload_fits_the_frame_codec() {
-        var esc = new string('', 1);
+        var esc = new string('\u0001', 1);
         string Chars(int n) => string.Concat(Enumerable.Repeat(esc, n));
         var questions = string.Join(",", Enumerable.Range(0, ClaudeElicitation.MaxQuestions).Select(i => {
             var text = System.Text.Json.JsonEncodedText.Encode(Chars(ClaudeElicitation.MaxQuestionTextChars - 2) + i.ToString("00", System.Globalization.CultureInfo.InvariantCulture));

--- a/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
@@ -31,22 +31,22 @@ public class ClaudeElicitationTests {
     }
 
     [Test]
-    [Arguments("""{"questions":[]}""")]                                              // empty array
-    [Arguments("""{"questions":{}}""")]                                              // not an array
-    [Arguments("""{"noquestions":true}""")]                                          // missing
-    [Arguments("""[1,2]""")]                                                         // input not an object
-    [Arguments("""{"questions":["notanobject"]}""")]                                 // entry not an object
-    [Arguments("""{"questions":[{"question":""}]}""")]                               // blank text
-    [Arguments("""{"questions":[{"question":"   "}]}""")]                            // whitespace text
-    [Arguments("""{"questions":[{"header":"h"}]}""")]                                // missing text
-    [Arguments("""{"questions":[{"question":42}]}""")]                               // wrong-typed text
-    [Arguments("""{"questions":[{"question":"Q"},{"question":"Q"}]}""")]             // duplicate texts
-    [Arguments("""{"questions":[{"question":"Q","multiSelect":"yes"}]}""")]          // non-boolean flag
-    [Arguments("""{"questions":[{"question":"Q","multiSelect":true,"multi_select":false}]}""")] // conflicting spellings
-    [Arguments("""{"questions":[{"question":"Q","options":{}}]}""")]                 // options not an array
-    [Arguments("""{"questions":[{"question":"Q","options":["x"]}]}""")]              // option not an object
-    [Arguments("""{"questions":[{"question":"Q","options":[{"label":""}]}]}""")]     // blank label
-    [Arguments("""{"questions":[{"question":"Q","options":[{"nolabel":1}]}]}""")]    // missing label
+    [Arguments("""{"questions":[]}""")]
+    [Arguments("""{"questions":{}}""")]
+    [Arguments("""{"noquestions":true}""")]
+    [Arguments("""[1,2]""")]
+    [Arguments("""{"questions":["notanobject"]}""")]
+    [Arguments("""{"questions":[{"question":""}]}""")]
+    [Arguments("""{"questions":[{"question":"   "}]}""")]
+    [Arguments("""{"questions":[{"header":"h"}]}""")]
+    [Arguments("""{"questions":[{"question":42}]}""")]
+    [Arguments("""{"questions":[{"question":"Q"},{"question":"Q"}]}""")]
+    [Arguments("""{"questions":[{"question":"Q","multiSelect":"yes"}]}""")]
+    [Arguments("""{"questions":[{"question":"Q","multiSelect":true,"multi_select":false}]}""")]
+    [Arguments("""{"questions":[{"question":"Q","options":{}}]}""")]
+    [Arguments("""{"questions":[{"question":"Q","options":["x"]}]}""")]
+    [Arguments("""{"questions":[{"question":"Q","options":[{"label":""}]}]}""")]
+    [Arguments("""{"questions":[{"question":"Q","options":[{"nolabel":1}]}]}""")]
     [Arguments("not json")]
     [Arguments(null)]
     public async Task Malformed_protocol_fields_fail_the_parse(string? payload) {
@@ -107,7 +107,6 @@ public class ClaudeElicitationTests {
         var overCap = $$"""{"questions":[{"question":"{{padded}}"}]}""";
         await Assert.That(ClaudeElicitation.TryParse(overCap)).IsNull();
 
-        // Exactly the cap INCLUDING padding passes.
         var atCap = " " + new string('q', ClaudeElicitation.MaxQuestionTextChars - 1);
         var underCap = $$"""{"questions":[{"question":"{{atCap}}"}]}""";
         var parsed = ClaudeElicitation.TryParse(underCap);
@@ -218,18 +217,18 @@ public class ClaudeElicitationTests {
     public async Task Invalid_answer_sets_throw() {
         var q = Parsed(MixedPayload);
         List<IReadOnlyList<ElicitationAnswer>> bad = [
-            [new ElicitationAnswer("Q1", ["A"], null)],                                                 // missing Q2
-            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q1", ["B"], null)],       // duplicate key
-            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Nope", ["X"], null)],     // unknown key
-            [new ElicitationAnswer("Q1", ["C"], null), new ElicitationAnswer("Q2", ["X"], null)],       // label not an option
-            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", ["X", "X"], null)],  // label twice
-            [new ElicitationAnswer("Q1", ["A", "B"], null), new ElicitationAnswer("Q2", ["X"], null)],  // two for single-select
-            [new ElicitationAnswer("Q1", ["A"], "extra"), new ElicitationAnswer("Q2", ["X"], null)],    // label AND other for single-select
-            [new ElicitationAnswer("Q1", [], null), new ElicitationAnswer("Q2", ["X"], null)],          // neither for single-select
-            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", [], null)],          // empty multi-select
-            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", [], "   ")],         // blank other
+            [new ElicitationAnswer("Q1", ["A"], null)],
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q1", ["B"], null)],
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Nope", ["X"], null)],
+            [new ElicitationAnswer("Q1", ["C"], null), new ElicitationAnswer("Q2", ["X"], null)],
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", ["X", "X"], null)],
+            [new ElicitationAnswer("Q1", ["A", "B"], null), new ElicitationAnswer("Q2", ["X"], null)],
+            [new ElicitationAnswer("Q1", ["A"], "extra"), new ElicitationAnswer("Q2", ["X"], null)],
+            [new ElicitationAnswer("Q1", [], null), new ElicitationAnswer("Q2", ["X"], null)],
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", [], null)],
+            [new ElicitationAnswer("Q1", ["A"], null), new ElicitationAnswer("Q2", [], "   ")],
             [new ElicitationAnswer("Q1", ["A"], null),
-             new ElicitationAnswer("Q2", [], new string('x', ClaudeElicitation.MaxOtherTextChars + 1))], // over-cap other
+             new ElicitationAnswer("Q2", [], new string('x', ClaudeElicitation.MaxOtherTextChars + 1))],
         ];
         foreach (var answers in bad)
             await Assert.That(() => ClaudeElicitation.ComposeAnswers(q, answers)).Throws<ArgumentException>();

--- a/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
@@ -1,0 +1,116 @@
+using System.Collections.Immutable;
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class ClaudeElicitationTests {
+    static string OneQuestion(string extra = "") =>
+        $$"""{"questions":[{"question":"Pick one","header":"Choice","options":[{"label":"A","description":"first"},{"label":"B"}]{{extra}}}]}""";
+
+    [Test]
+    public async Task Parses_every_question_in_payload_order() {
+        var parsed = ClaudeElicitation.TryParse(
+            """{"questions":[{"question":"Q1","options":[{"label":"A"}]},{"question":"Q2","multiSelect":true,"options":[{"label":"X"},{"label":"Y"}]}]}""");
+        await Assert.That(parsed).IsNotNull();
+        await Assert.That(parsed!.Questions.Length).IsEqualTo(2);
+        await Assert.That(parsed.Questions[0].Question).IsEqualTo("Q1");
+        await Assert.That(parsed.Questions[0].MultiSelect).IsFalse();
+        await Assert.That(parsed.Questions[1].Question).IsEqualTo("Q2");
+        await Assert.That(parsed.Questions[1].MultiSelect).IsTrue();
+        await Assert.That(parsed.Questions[1].Options.Select(o => o.Label)).IsEquivalentTo(["X", "Y"]);
+    }
+
+    [Test]
+    public async Task Header_and_description_carry_through_and_snake_case_flag_is_honored() {
+        var parsed = ClaudeElicitation.TryParse(
+            """{"questions":[{"question":"Q","header":"Scope","multi_select":true,"options":[{"label":"A","description":"first"}]}]}""");
+        await Assert.That(parsed!.Questions[0].Header).IsEqualTo("Scope");
+        await Assert.That(parsed.Questions[0].MultiSelect).IsTrue();
+        await Assert.That(parsed.Questions[0].Options[0].Description).IsEqualTo("first");
+    }
+
+    [Test]
+    [Arguments("""{"questions":[]}""")]                                              // empty array
+    [Arguments("""{"questions":{}}""")]                                              // not an array
+    [Arguments("""{"noquestions":true}""")]                                          // missing
+    [Arguments("""[1,2]""")]                                                         // input not an object
+    [Arguments("""{"questions":["notanobject"]}""")]                                 // entry not an object
+    [Arguments("""{"questions":[{"question":""}]}""")]                               // blank text
+    [Arguments("""{"questions":[{"question":"   "}]}""")]                            // whitespace text
+    [Arguments("""{"questions":[{"header":"h"}]}""")]                                // missing text
+    [Arguments("""{"questions":[{"question":42}]}""")]                               // wrong-typed text
+    [Arguments("""{"questions":[{"question":"Q"},{"question":"Q"}]}""")]             // duplicate texts
+    [Arguments("""{"questions":[{"question":"Q","multiSelect":"yes"}]}""")]          // non-boolean flag
+    [Arguments("""{"questions":[{"question":"Q","multiSelect":true,"multi_select":false}]}""")] // conflicting spellings
+    [Arguments("""{"questions":[{"question":"Q","options":{}}]}""")]                 // options not an array
+    [Arguments("""{"questions":[{"question":"Q","options":["x"]}]}""")]              // option not an object
+    [Arguments("""{"questions":[{"question":"Q","options":[{"label":""}]}]}""")]     // blank label
+    [Arguments("""{"questions":[{"question":"Q","options":[{"nolabel":1}]}]}""")]    // missing label
+    [Arguments("not json")]
+    [Arguments(null)]
+    public async Task Malformed_protocol_fields_fail_the_parse(string? payload) {
+        await Assert.That(ClaudeElicitation.TryParse(payload)).IsNull();
+    }
+
+    [Test]
+    public async Task Agreeing_flag_spellings_and_absent_options_are_fine() {
+        var both = ClaudeElicitation.TryParse("""{"questions":[{"question":"Q","multiSelect":true,"multi_select":true}]}""");
+        await Assert.That(both!.Questions[0].MultiSelect).IsTrue();
+        await Assert.That(both.Questions[0].Options.Length).IsEqualTo(0);
+        var empty = ClaudeElicitation.TryParse("""{"questions":[{"question":"Q","options":[]}]}""");
+        await Assert.That(empty!.Questions[0].Options.Length).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Display_fields_with_wrong_types_or_whitespace_read_as_absent() {
+        var parsed = ClaudeElicitation.TryParse(
+            """{"questions":[{"question":"Q","header":42,"options":[{"label":"A","description":"  "}]}]}""");
+        await Assert.That(parsed!.Questions[0].Header).IsNull();
+        await Assert.That(parsed.Questions[0].Options[0].Description).IsNull();
+    }
+
+    [Test]
+    public async Task Duplicate_option_labels_keep_the_first() {
+        var parsed = ClaudeElicitation.TryParse(
+            """{"questions":[{"question":"Q","options":[{"label":"A","description":"one"},{"label":"A","description":"two"},{"label":"B"}]}]}""");
+        await Assert.That(parsed!.Questions[0].Options.Select(o => o.Label)).IsEquivalentTo(["A", "B"]);
+        await Assert.That(parsed.Questions[0].Options[0].Description).IsEqualTo("one");
+    }
+
+    [Test]
+    public async Task Caps_pass_at_the_boundary_and_fail_one_over() {
+        static string Questions(int n) =>
+            $$"""{"questions":[{{string.Join(",", Enumerable.Range(0, n).Select(i => $$"""{"question":"Q{{i}}"}"""))}}]}""";
+        await Assert.That(ClaudeElicitation.TryParse(Questions(ClaudeElicitation.MaxQuestions))).IsNotNull();
+        await Assert.That(ClaudeElicitation.TryParse(Questions(ClaudeElicitation.MaxQuestions + 1))).IsNull();
+
+        static string Options(int n) =>
+            $$"""{"questions":[{"question":"Q","options":[{{string.Join(",", Enumerable.Range(0, n).Select(i => $$"""{"label":"L{{i}}"}"""))}}]}]}""";
+        await Assert.That(ClaudeElicitation.TryParse(Options(ClaudeElicitation.MaxOptionsPerQuestion))).IsNotNull();
+        await Assert.That(ClaudeElicitation.TryParse(Options(ClaudeElicitation.MaxOptionsPerQuestion + 1))).IsNull();
+
+        static string Text(int chars) => $$"""{"questions":[{"question":"{{new string('q', chars)}}"}]}""";
+        await Assert.That(ClaudeElicitation.TryParse(Text(ClaudeElicitation.MaxQuestionTextChars))).IsNotNull();
+        await Assert.That(ClaudeElicitation.TryParse(Text(ClaudeElicitation.MaxQuestionTextChars + 1))).IsNull();
+
+        static string Label(int chars) => $$"""{"questions":[{"question":"Q","options":[{"label":"{{new string('l', chars)}}"}]}]}""";
+        await Assert.That(ClaudeElicitation.TryParse(Label(ClaudeElicitation.MaxOptionLabelChars))).IsNotNull();
+        await Assert.That(ClaudeElicitation.TryParse(Label(ClaudeElicitation.MaxOptionLabelChars + 1))).IsNull();
+    }
+
+    [Test]
+    public async Task Retained_questions_element_outlives_the_parse() {
+        var parsed = ClaudeElicitation.TryParse(OneQuestion());
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        await Assert.That(parsed!.QuestionsJson.GetRawText()).Contains("Pick one");
+    }
+
+    [Test]
+    public async Task Model_collections_are_immutable() {
+        var parsed = ClaudeElicitation.TryParse(OneQuestion());
+#pragma warning disable CS0183
+        await Assert.That(parsed!.Questions is ImmutableArray<ElicitationQuestion>).IsTrue();
+        await Assert.That(parsed.Questions[0].Options is ImmutableArray<ElicitationOption>).IsTrue();
+#pragma warning restore CS0183
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
@@ -147,6 +147,24 @@ public class ClaudeElicitationTests {
     }
 
     [Test]
+    public async Task Preserves_pre_escaped_sequences_in_questions() {
+        var q = Parsed("""{"questions":[{"question":"café","options":[{"label":"A"}]}]}""");
+        var composed = ClaudeElicitation.ComposeAnswers(q, [
+            new ElicitationAnswer("café", ["A"], null),
+        ]);
+        await Assert.That(composed.Prop("questions")!.Value.GetRawText()).IsEqualTo(q.QuestionsJson.GetRawText());
+    }
+
+    [Test]
+    public async Task Preserves_astral_characters_in_questions() {
+        var q = Parsed("""{"questions":[{"question":"😀","options":[{"label":"B"}]}]}""");
+        var composed = ClaudeElicitation.ComposeAnswers(q, [
+            new ElicitationAnswer("😀", ["B"], null),
+        ]);
+        await Assert.That(composed.Prop("questions")!.Value.GetRawText()).IsEqualTo(q.QuestionsJson.GetRawText());
+    }
+
+    [Test]
     public async Task Single_select_accepts_other_text_as_the_one_value() {
         var q = Parsed("""{"questions":[{"question":"Q","options":[{"label":"A"}]}]}""");
         var composed = ClaudeElicitation.ComposeAnswers(q, [new ElicitationAnswer("Q", [], "  my own  ")]);

--- a/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
@@ -138,6 +138,15 @@ public class ClaudeElicitationTests {
     }
 
     [Test]
+    public async Task Preserves_the_questions_bytes_with_non_ascii_content() {
+        var q = Parsed("""{"questions":[{"question":"Café — décider?","options":[{"label":"Oui"},{"label":"Non"}]}]}""");
+        var composed = ClaudeElicitation.ComposeAnswers(q, [
+            new ElicitationAnswer("Café — décider?", ["Oui"], null),
+        ]);
+        await Assert.That(composed.Prop("questions")!.Value.GetRawText()).IsEqualTo(q.QuestionsJson.GetRawText());
+    }
+
+    [Test]
     public async Task Single_select_accepts_other_text_as_the_one_value() {
         var q = Parsed("""{"questions":[{"question":"Q","options":[{"label":"A"}]}]}""");
         var composed = ClaudeElicitation.ComposeAnswers(q, [new ElicitationAnswer("Q", [], "  my own  ")]);

--- a/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/ClaudeElicitationTests.cs
@@ -100,6 +100,22 @@ public class ClaudeElicitationTests {
     }
 
     [Test]
+    public async Task Question_text_cap_is_measured_on_the_raw_untrimmed_string() {
+        // Cap-length content plus one leading space: trimmed length is under the cap, but the raw
+        // (protocol) length is one over — must still fail.
+        var padded = " " + new string('q', ClaudeElicitation.MaxQuestionTextChars);
+        var overCap = $$"""{"questions":[{"question":"{{padded}}"}]}""";
+        await Assert.That(ClaudeElicitation.TryParse(overCap)).IsNull();
+
+        // Exactly the cap INCLUDING padding passes.
+        var atCap = " " + new string('q', ClaudeElicitation.MaxQuestionTextChars - 1);
+        var underCap = $$"""{"questions":[{"question":"{{atCap}}"}]}""";
+        var parsed = ClaudeElicitation.TryParse(underCap);
+        await Assert.That(parsed).IsNotNull();
+        await Assert.That(parsed!.Questions[0].Question).IsEqualTo(atCap);
+    }
+
+    [Test]
     public async Task Retained_questions_element_outlives_the_parse() {
         var parsed = ClaudeElicitation.TryParse(OneQuestion());
         GC.Collect();
@@ -144,6 +160,18 @@ public class ClaudeElicitationTests {
             new ElicitationAnswer("Café — décider?", ["Oui"], null),
         ]);
         await Assert.That(composed.Prop("questions")!.Value.GetRawText()).IsEqualTo(q.QuestionsJson.GetRawText());
+    }
+
+    [Test]
+    public async Task Padded_question_and_label_text_round_trips_untrimmed() {
+        var q = Parsed("""{"questions":[{"question":"  Pick one  ","options":[{"label":" A "},{"label":"B"}]}]}""");
+        await Assert.That(q.Questions[0].Question).IsEqualTo("  Pick one  ");
+        await Assert.That(q.Questions[0].Options[0].Label).IsEqualTo(" A ");
+
+        var composed = ClaudeElicitation.ComposeAnswers(q, [new ElicitationAnswer("  Pick one  ", [" A "], null)]);
+        var answers = composed.Prop("answers")!.Value;
+        await Assert.That(answers.Prop("  Pick one  ")).IsNotNull();
+        await Assert.That(answers.Str("  Pick one  ")).IsEqualTo(" A ");
     }
 
     [Test]


### PR DESCRIPTION
AI-2361 — no GitHub issue exists for this one, so the closing half is dropped.

## What & why

A PTY Claude session blocked on `AskUserQuestion` showed a useless Allow / Allow always / Deny card in the desktop app, even though the request already rides the permission lane end to end (the `PermissionRequest` hook payload reaches the app as a pending permission entry, and the web answers it with `allow` plus `updatedInput.answers`). The app now classifies those entries and renders a question card — every question in the payload, option buttons or checkboxes, an Other free-text per question, click-to-answer for a single single-select — answering over the existing `permission/1` wire. No daemon, CLI, or wire change, so it works against any daemon already advertising `permission/1`; the tray splits its wording ("1 question waiting"), and a settlement from any surface clears card, pips and tray as before.

## Where to look

`ClaudeElicitation` in Core owns the whole contract: a strict, capped, parser-created immutable model plus a composer that validates every answer against it — that pairing is what bounds the composed resolve frame. Anything unparseable or over-cap falls back to the plain permission card, with "Allow always" hidden for the question tool. The spec riding this PR records the decisions, including why the questions passthrough is byte-faithful in the composer but semantic at the wire.

## Verification

- `dotnet test --solution Capacitor.slnx`: 10762 total, 10695 passed, 66 skipped, 1 failed — `Installed_codex_schema_matches_the_vendored_pin`, a machine-local codex 0.150.1 vs vendored 0.147.0 pin drift, unrelated to this diff.
- `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` → no output.
- New coverage: 35 `ClaudeElicitationTests` (parse, compose, caps at their boundaries, JSON-element ownership past GC, a maximal worst-case-escaped payload round-tripped through `FrameCodec`); service classification matrix, answer/ack/push interleavings and single-snapshot summary; question-card fast path, single flight and dispose-mid-flight; mixed NEEDS YOU row headless smoke; tray wording variants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)