### PR TITLE
Block chat messaging to a flow participant in the desktop app

### DIFF
--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -101,6 +101,29 @@ public sealed class ChatTabViewModel : ReactiveObject {
     string _statusText = "";
     public string StatusText { get => _statusText; private set => this.RaiseAndSetIfChanged(ref _statusText, value); }
 
+    bool _isReadOnlyParticipant;
+    /// True for a flow participant (any kind other than "agent"): the view swaps the composer
+    /// input for the read-only banner, and the send gate refuses regardless of the terminal
+    /// attach — the kind, not the handshake, is what makes the session unmessageable.
+    public bool IsReadOnlyParticipant {
+        get => _isReadOnlyParticipant;
+        private set => this.RaiseAndSetIfChanged(ref _isReadOnlyParticipant, value);
+    }
+
+    string _readOnlyNotice = "";
+    public string ReadOnlyNotice { get => _readOnlyNotice; private set => this.RaiseAndSetIfChanged(ref _readOnlyNotice, value); }
+
+    /// Why this session cannot be messaged, or "" for an ordinary agent. Mirrors the wording of
+    /// the daemon's attach-time ProtectionReason so the chat banner and the terminal banner name
+    /// the same block identically; an unrecognised kind fails safe as protected, like
+    /// AgentActionService.IsProtectedKind.
+    internal static string ParticipantNotice(AgentStatusDto dto) {
+        if (!AgentActionService.IsProtectedKind(dto.Kind)) return "";
+        var role = string.IsNullOrEmpty(dto.FlowRole) ? "" : $", role {dto.FlowRole}";
+        var flow = string.IsNullOrEmpty(dto.FlowRunId) ? "" : $" (flow {dto.FlowRunId}{role})";
+        return $"{dto.Kind} agent{flow}";
+    }
+
     IBrush _statusDot = SessionStatusDots.For("");
     public IBrush StatusDot { get => _statusDot; private set => this.RaiseAndSetIfChanged(ref _statusDot, value); }
 
@@ -176,17 +199,21 @@ public sealed class ChatTabViewModel : ReactiveObject {
             })
             .DisposeWith(_disposables);
 
+        // The banner carries the read-only explanation for a flow participant, so the hint
+        // goes blank there instead of offering a reply that can never be sent.
         _composerHint = Observable.CombineLatest(
                 terminal.WhenAnyValue(t => t.SendAvailability, t => t.State, (availability, state) => (availability, state)),
                 this.WhenAnyValue(x => x.VendorLabel),
-                (t, label) => HintFor(t.availability, t.state, label))
+                this.WhenAnyValue(x => x.IsReadOnlyParticipant),
+                (t, label, readOnly) => readOnly ? "" : HintFor(t.availability, t.state, label))
             .ToProperty(this, x => x.ComposerHint, HintFor(terminal.SendAvailability, terminal.State, ""))
             .DisposeWith(_disposables);
 
         var canSend = Observable.CombineLatest(
             this.WhenAnyValue(x => x.ComposerText),
             terminal.WhenAnyValue(t => t.CanAcceptText),
-            (text, can) => can && !string.IsNullOrWhiteSpace(text));
+            this.WhenAnyValue(x => x.IsReadOnlyParticipant),
+            (text, can, readOnly) => can && !readOnly && !string.IsNullOrWhiteSpace(text));
         SendCommand = ReactiveCommand.Create(() => {
             if (_terminal.TrySendText(ComposerText)) ComposerText = "";
         }, canSend);
@@ -208,6 +235,9 @@ public sealed class ChatTabViewModel : ReactiveObject {
     }
 
     void OnDto(AgentStatusDto dto) {
+        var notice = ParticipantNotice(dto);
+        ReadOnlyNotice = notice;
+        IsReadOnlyParticipant = notice.Length > 0;
         _vendor = dto.Vendor;
         _root = dto.RepoPath;
         _rootSubject.OnNext(dto.RepoPath);

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -97,7 +97,15 @@
             <StackPanel Spacing="6">
                 <TextBox x:Name="ComposerInput" Classes="kcapEmbedded" Text="{Binding ComposerText}" AcceptsReturn="True" TextWrapping="Wrap"
                          MinHeight="38" MaxHeight="160" Background="Transparent" BorderThickness="0"
-                         PlaceholderText="Write a message" />
+                         PlaceholderText="Write a message" IsVisible="{Binding !IsReadOnlyParticipant}" />
+                <!-- A flow participant is addressed through the flow protocol, never messaged
+                     directly, so the banner replaces the input rather than overlaying a dead one. -->
+                <Border x:Name="ReadOnlyBanner" IsVisible="{Binding IsReadOnlyParticipant}"
+                        Background="{StaticResource KcapWarningDimBrush}" BorderBrush="{StaticResource KcapWarningBrush}"
+                        BorderThickness="1" CornerRadius="8" Padding="12,7">
+                    <TextBlock Text="{Binding ReadOnlyNotice, StringFormat='Read-only: {0}'}"
+                               Foreground="{StaticResource KcapWarningBrush}" TextWrapping="Wrap" />
+                </Border>
                 <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto">
                     <TextBlock Text="{Binding ComposerHint}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
                                VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
@@ -108,7 +116,8 @@
                                VerticalAlignment="Center" />
                     <Button x:Name="SendButton" Grid.Column="4" Content="Send" Command="{Binding SendCommand}" Margin="12,0,0,0"
                             Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
-                            Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                            Background="{StaticResource KcapAccentBrush}" Foreground="#07120E"
+                            IsVisible="{Binding !IsReadOnlyParticipant}" />
                 </Grid>
             </StackPanel>
         </Border>

--- a/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
@@ -113,6 +113,42 @@ public class ChatComposerTests {
         });
     }
 
+    /// A flow participant is unmessageable by kind, not by handshake: even a read-write attach
+    /// (an older daemon that doesn't flag protected attaches) must leave the composer closed.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_flow_participant_chat_never_sends_even_over_a_writable_attach() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var factory = new FakeTerminalAttachClientFactory();
+            var time = new FakeTimeProvider();
+            var terminal = new TerminalTabViewModel("r1", daemon, factory.Factory, () => new FakeTerminalSurface(), time);
+            var chat = new ChatTabViewModel(
+                "r1", daemon, terminal, TranscriptProjection.For("claude"), new RecordingOpener(), time, new FakePermissionService());
+            daemon.Agents.AddOrUpdate(
+                Agent("r1", "claude", hasTerminal: true, kind: "review-flow") with { FlowRunId = "f1", FlowRole = "reviewer" });
+            await (terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await factory.Created.Single().TriggerAttached([]);
+
+            await Assert.That(terminal.CanAcceptText).IsTrue();
+            await Assert.That(chat.IsReadOnlyParticipant).IsTrue();
+            await Assert.That(chat.ReadOnlyNotice).IsEqualTo("review-flow agent (flow f1, role reviewer)");
+            chat.ComposerText = "hello";
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsFalse();
+            await Assert.That(chat.ComposerHint).IsEqualTo("");
+            await chat.TeardownAsync();
+        });
+    }
+
+    [Test]
+    public async Task Participant_notice_mirrors_the_daemon_protection_reason() {
+        await Assert.That(ChatTabViewModel.ParticipantNotice(Agent("a", "claude", true))).IsEqualTo("");
+        await Assert.That(ChatTabViewModel.ParticipantNotice(Agent("a", "claude", true, kind: "review"))).IsEqualTo("review agent");
+        await Assert.That(ChatTabViewModel.ParticipantNotice(
+            Agent("a", "claude", true, kind: "review-flow") with { FlowRunId = "f1" })).IsEqualTo("review-flow agent (flow f1)");
+        await Assert.That(ChatTabViewModel.ParticipantNotice(Agent("a", "claude", true, kind: "sidekick"))).IsEqualTo("sidekick agent");
+    }
+
     /// Thread identity: the hint's own change lands on the UI thread even when the terminal's
     /// state flips from a pool thread.
     [Test]


### PR DESCRIPTION
Closes #705 — AI-2368

## What & why

A review-flow participant's workspace shows the read-only banner on the terminal tab, but the chat tab shows nothing and its composer gate rides the terminal attach handshake alone — the pane never consults the agent's kind. The web UI does not allow talking to a reviewer; the app's chat now matches: any kind other than exactly `agent` swaps the composer input and Send button for a read-only banner and refuses the send command, regardless of how the attach came up. The banner text mirrors the daemon's attach-time ProtectionReason wording, so chat and terminal name the same block identically.

## Where to look

The new test pins the load-bearing case: the kind blocks the composer even over a *writable* attach — the handshake alone must never decide.

## Verification

`dotnet run --project test/Capacitor.App.Tests.Unit/...` — 1247 total, 0 failed (2 new: flow-participant send refusal over a writable attach; notice wording vs the daemon's).

🤖 Generated with [Claude Code](https://claude.com/claude-code)