### PR TITLE
Surface an errored Pi turn as a system note instead of silence

### DIFF
--- a/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpc.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpc.cs
@@ -99,9 +99,12 @@ internal static class PiRpc {
     ///
     /// <list type="bullet">
     /// <item><description><c>message_end</c> with an assistant message maps each content item, IN
-    /// ORDER, to <c>assistant_text</c> / <c>assistant_thinking</c> / <c>tool_call</c>, then appends
-    /// ONE trailing <c>usage</c> envelope when the message carries a <c>usage</c> block. Every
-    /// envelope's <see cref="AcpEventEnvelope.Model"/> is the message's own <c>"model"</c> field, else
+    /// ORDER, to <c>assistant_text</c> / <c>assistant_thinking</c> / <c>tool_call</c>; a
+    /// <c>stopReason</c> of <c>"error"</c> then appends ONE <c>system_note</c> carrying the
+    /// message's <c>errorMessage</c> (capped at <see cref="ExtensionNoteTextCap"/>) — a failed turn
+    /// usually has EMPTY content, so this note is its only visible trace; finally ONE trailing
+    /// <c>usage</c> envelope when the message carries a <c>usage</c> block. Every envelope's
+    /// <see cref="AcpEventEnvelope.Model"/> is the message's own <c>"model"</c> field, else
     /// <paramref name="fallbackModel"/>.</description></item>
     /// <item><description><c>message_end</c> with a user message maps to ONE <c>user_message</c>
     /// envelope carrying the concatenated text — content may be a plain string or a content-part
@@ -193,6 +196,19 @@ internal static class PiRpc {
                         break;
                 }
             }
+        }
+
+        // A provider-side turn failure arrives as stopReason "error" with the detail in
+        // errorMessage — usually alongside EMPTY content, so without this arm the failure
+        // translates to nothing and the hosted session reads as hung. "aborted" is excluded:
+        // the daemon's own graceful stop sends the abort, so it is not a failure to report.
+        if (message.Str("stopReason") == "error") {
+            (envelopes ??= []).Add(new AcpEventEnvelope(
+                Kind: AcpEventKind.SystemNote,
+                Text: message.Str("errorMessage") is { Length: > 0 } error
+                    ? Cap($"Pi turn failed: {error}")
+                    : "Pi turn failed (no error detail from Pi).",
+                Model: model));
         }
 
         if (message.Obj("usage") is { } usage) {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiHostedRuntimeLiveCertTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiHostedRuntimeLiveCertTests.cs
@@ -117,11 +117,16 @@ public class PiHostedRuntimeLiveCertTests {
 
             // (b) The prompted turn's assistant_text reply must carry the nonce, observed over the
             // SAME channel the daemon forwards to the server.
-            var (sawNonce, collected) = await CollectUntilNonceAsync(runtime.Envelopes, nonce, TurnTimeout);
+            var (sawNonce, turnError, collected) = await CollectUntilNonceAsync(runtime.Envelopes, nonce, TurnTimeout);
 
             Console.WriteLine($"[pi-hosted-live] observed {collected.Count} transcript envelope(s):");
             foreach (var env in collected)
                 Console.WriteLine($"[pi-hosted-live]   kind={env.Kind} text={env.Text}");
+
+            await Assert.That(turnError).IsNull()
+                .Because("the prompted turn failed on the Pi/provider side — an ENVIRONMENT fault "
+                       + "(check the provider auth/usage this machine's `pi` runs under), not a "
+                       + $"runtime defect: {turnError}");
 
             await Assert.That(sawNonce).IsTrue()
                 .Because($"expected an assistant_text envelope containing '{nonce}' within {TurnTimeout} "
@@ -142,9 +147,11 @@ public class PiHostedRuntimeLiveCertTests {
     }
 
     /// <summary>Drains <paramref name="envelopes"/> until an <c>assistant_text</c> envelope's
-    /// <see cref="AcpEventEnvelope.Text"/> contains <paramref name="nonce"/> (ordinal), or
-    /// <paramref name="timeout"/> elapses.</summary>
-    static async Task<(bool SawNonce, List<AcpEventEnvelope> Collected)> CollectUntilNonceAsync(
+    /// <see cref="AcpEventEnvelope.Text"/> contains <paramref name="nonce"/> (ordinal), a turn-failed
+    /// <c>system_note</c> arrives (an environment fault — provider auth/usage — that would otherwise
+    /// burn the whole timeout and report as opaque dead air), or <paramref name="timeout"/>
+    /// elapses.</summary>
+    static async Task<(bool SawNonce, string? TurnError, List<AcpEventEnvelope> Collected)> CollectUntilNonceAsync(
             ChannelReader<AcpEventEnvelope> envelopes, string nonce, TimeSpan timeout) {
         var collected = new List<AcpEventEnvelope>();
 
@@ -158,7 +165,12 @@ public class PiHostedRuntimeLiveCertTests {
                     if (env.Kind == AcpEventKind.AssistantText
                             && env.Text is { Length: > 0 } text
                             && text.Contains(nonce, StringComparison.Ordinal))
-                        return (true, collected);
+                        return (true, null, collected);
+
+                    if (env.Kind == AcpEventKind.SystemNote
+                            && env.Text is { } note
+                            && note.StartsWith("Pi turn failed", StringComparison.Ordinal))
+                        return (false, note, collected);
                 }
             }
         } catch (OperationCanceledException) {
@@ -166,7 +178,7 @@ public class PiHostedRuntimeLiveCertTests {
             // observed either way.
         }
 
-        return (false, collected);
+        return (false, null, collected);
     }
 
     /// <summary>Best-effort <c>pi --version</c> capture for the test log — never asserted on, purely

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcTests.cs
@@ -132,6 +132,96 @@ public class PiRpcTests {
         await Assert.That(envelopes[0].Model).IsEqualTo("fallback-model");
     }
 
+    // ---- ToEnvelopes: errored assistant message_end ----
+    //
+    // Pi reports a provider-side turn failure as an assistant message_end with empty content,
+    // stopReason "error" and the detail in errorMessage. Without a translation arm for it, the
+    // failure reaches no surface at all: the hosted session just goes silent (#709).
+
+    [Test]
+    public async Task Errored_assistant_message_end_yields_a_system_note_with_the_error() {
+        const string line = """
+            {"type":"message_end","message":{"role":"assistant","content":[],"model":"pi-large",
+                "usage":{"input":0,"output":0},"stopReason":"error",
+                "errorMessage":"400 rate limited"}}
+            """;
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(2);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(envelopes[0].Text).IsEqualTo("Pi turn failed: 400 rate limited");
+        await Assert.That(envelopes[0].Model).IsEqualTo("pi-large");
+        await Assert.That(envelopes[1].Kind).IsEqualTo(AcpEventKind.Usage);
+    }
+
+    [Test]
+    public async Task Errored_assistant_message_end_without_errorMessage_still_yields_a_note() {
+        const string line = """
+            {"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"error"}}
+            """;
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(envelopes[0].Text).IsEqualTo("Pi turn failed (no error detail from Pi).");
+    }
+
+    [Test]
+    public async Task Errored_assistant_message_end_error_text_is_capped_at_500_characters() {
+        var longError = new string('x', 800);
+        var line = $$$"""
+            {"type":"message_end","message":{"role":"assistant","content":[],"stopReason":"error",
+                "errorMessage":"{{{longError}}}"}}
+            """;
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(envelopes[0].Text!.Length).IsEqualTo(500);
+    }
+
+    [Test]
+    public async Task Errored_assistant_message_end_keeps_partial_content_and_usage_stays_trailing() {
+        const string line = """
+            {"type":"message_end","message":{"role":"assistant","content":[
+                {"type":"text","text":"partial"}
+            ],"usage":{"input":7,"output":0},"stopReason":"error","errorMessage":"boom"}}
+            """;
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(3);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(envelopes[0].Text).IsEqualTo("partial");
+        await Assert.That(envelopes[1].Kind).IsEqualTo(AcpEventKind.SystemNote);
+        await Assert.That(envelopes[1].Text).IsEqualTo("Pi turn failed: boom");
+        await Assert.That(envelopes[2].Kind).IsEqualTo(AcpEventKind.Usage);
+    }
+
+    /// <summary>An aborted turn is a stop somebody asked for — the daemon's own graceful stop
+    /// sends the abort — so it must not read as a failure note on every wind-down.</summary>
+    [Test]
+    public async Task Aborted_assistant_message_end_yields_no_note() {
+        const string line = """
+            {"type":"message_end","message":{"role":"assistant","content":[
+                {"type":"text","text":"cut short"}
+            ],"stopReason":"aborted"}}
+            """;
+
+        var frame = PiRpc.TryParseLine(line);
+        var envelopes = PiRpc.ToEnvelopes(frame!, fallbackModel: null);
+
+        await Assert.That(envelopes.Count).IsEqualTo(1);
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.AssistantText);
+    }
+
     // ---- ToEnvelopes: user message_end ----
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcTests.cs
@@ -135,8 +135,8 @@ public class PiRpcTests {
     // ---- ToEnvelopes: errored assistant message_end ----
     //
     // Pi reports a provider-side turn failure as an assistant message_end with empty content,
-    // stopReason "error" and the detail in errorMessage. Without a translation arm for it, the
-    // failure reaches no surface at all: the hosted session just goes silent (#709).
+    // stopReason "error" and the detail in errorMessage. The system note is that failure's only
+    // visible trace — untranslated, the hosted session reads as hung.
 
     [Test]
     public async Task Errored_assistant_message_end_yields_a_system_note_with_the_error() {


### PR DESCRIPTION
Closes #709 — AI-2374

## What & why

A hosted Pi turn that fails on the provider side (auth, rate limit, usage exhausted) arrives as an assistant `message_end` with empty content, `stopReason: "error"` and the detail in `errorMessage` — a shape with no translation arm, so the failure produced no envelope at all and the hosted session read as hung. The errored message now appends one `system_note` carrying the error, capped the same way as `extension_error`'s, after any partial content and before the trailing `usage` envelope.

## Where to look

`stopReason: "aborted"` is deliberately not translated: the daemon's own graceful stop sends the abort, so a note there would stamp every wind-down as a failure.

## Verification

- `PiRpcTests`: 30/30 green, five of them new (note text, no-detail fallback, 500-char cap, ordering around partial content and trailing usage, aborted excluded).
- `KCAP_PI_HOSTED_LIVE=1` live cert against `pi` 0.83.0 with a provider in an error state: the real spawned child's failed turn now reaches the transcript channel as `system_note text=Pi turn failed: 400 …`, and the cert reports that fault in 5.6s where it previously burned a 60s timeout and reported dead air.
- Daemon suite: 2866 total, 0 failed. AOT publish: no IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)