### PR TITLE
Stop a non-PTY hosted agent on /quit instead of forwarding it

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3499,6 +3499,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
     }
 
+    /// <summary>True only for input that IS the command — exactly <c>/quit</c> or <c>/exit</c>
+    /// after trimming — never for prose that merely mentions one.</summary>
+    internal static bool IsQuitCommand(string text) {
+        var trimmed = text.AsSpan().Trim();
+
+        return trimmed.Equals("/quit", StringComparison.OrdinalIgnoreCase)
+            || trimmed.Equals("/exit", StringComparison.OrdinalIgnoreCase);
+    }
+
     async Task HandleSendInput(SendInputCommand cmd) {
         var (agentId, text, attachmentIds) = cmd;
 
@@ -3513,6 +3522,16 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
 
         LogSendInputReceived(agentId, agent.Runtime.Vendor, text.Length, attachmentIds?.Length ?? 0);
+
+        // A quit command typed into chat: a runtime with no TUI has nothing that interprets it, so
+        // forwarding would hand the text to the model as an ordinary prompt — at best role-played
+        // ("Quitting"), never a stop. Translate it onto the same serial lane a server stop rides.
+        // PTY runtimes keep receiving the text verbatim: their TUI owns the command's meaning.
+        if (!agent.Runtime.EmitsTerminalOutput && IsQuitCommand(text)) {
+            LogSendInputQuitCommand(agentId, agent.Runtime.Vendor);
+            await HandleUnsequencedStopAgent(agentId);
+            return;
+        }
 
         // Codex turn diagnostic: whether to run the post-send rollout probe, plus this round's
         // generation and the rollout length sampled just BEFORE delivery. Declared out here so both
@@ -4858,6 +4877,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "SendInput dropped: agent {AgentId} is private — server-origin input is ignored")]
     partial void LogSendInputPrivateAgent(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "SendInput to agent {AgentId} is a quit command; {Vendor} has no TUI to interpret it, stopping the agent instead of forwarding")]
+    partial void LogSendInputQuitCommand(string agentId, string vendor);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "SendInput dropped: agent {AgentId} was already claimed by the reviewer reaper and is being stopped — the round's dispatch fails here and the server heals it on resubmit")]
     partial void LogSendInputReapClaimed(string agentId);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SendInputQuitCommandTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SendInputQuitCommandTests.cs
@@ -1,0 +1,79 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// Chat input that IS a quit command must stop a runtime that has no TUI to interpret it —
+/// forwarding it would hand the text to the model as an ordinary prompt, so the "command" at best
+/// gets role-played ("Quitting") while the agent keeps running. PTY runtimes keep receiving the
+/// text verbatim: their TUI owns the command's meaning, and intercepting there would shadow it.
+/// </summary>
+public class SendInputQuitCommandTests {
+    /// <summary>A seeded agent has no read loop, so runtime disposal (a read-loop finalizer effect)
+    /// never runs here; the stop funnel's own observable is TerminateAsync flipping HasExited.</summary>
+    static async Task EventuallyTerminated(FakeAcpRuntime runtime) {
+        for (var i = 0; i < 300; i++) {
+            if (runtime.HasExited) return;
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("Timed out waiting for the quit command to stop the agent.");
+    }
+
+    [Test]
+    [Arguments("/quit")]
+    [Arguments("/exit")]
+    [Arguments("  /quit  \n")]
+    [Arguments("/QUIT")]
+    public async Task Quit_command_to_a_non_pty_agent_stops_it_instead_of_forwarding(string text) {
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        orch.GracefulExitWait = TimeSpan.FromMilliseconds(50);
+        var runtime = new FakeAcpRuntime();
+        var agent   = AgentOrchestratorHarness.SeedAcpAgent(orch, $"quit-acp-{Guid.NewGuid():N}", runtime, activityClock: clock);
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, text, null));
+
+        await EventuallyTerminated(runtime);
+
+        // Never delivered as input: the clock still shows only the spawn advance.
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(1UL);
+    }
+
+    [Test]
+    public async Task Quit_like_text_that_is_not_exactly_the_command_is_forwarded() {
+        var time  = new FakeTimeProvider();
+        var clock = new AgentActivityClock(time);
+
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var runtime = new FakeAcpRuntime();
+        var agent   = AgentOrchestratorHarness.SeedAcpAgent(orch, "quit-acp-prose", runtime, activityClock: clock);
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "/quit the loop and try plan B", null));
+
+        // Delivered normally: spawn (1) + the delivery (2), and nothing stopped the runtime.
+        await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(2UL);
+        await Assert.That(runtime.HasExited).IsFalse();
+    }
+
+    [Test]
+    public async Task Pty_agent_receives_the_quit_text_verbatim() {
+        var pty = new RecordingPtyProcess();
+
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+        var agent = orch.SeedAgentForTest("quit-pty", pty: pty);
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "/quit", null));
+
+        await Assert.That(string.Join("", pty.Writes)).Contains("/quit");
+    }
+}


### PR DESCRIPTION
Closes #711 — AI-2380

## What & why

Typing `/quit` (or `/exit`) into a hosted agent's chat did nothing on ACP/RPC vendors — nothing in the input path interprets slash commands, so the text reached the model as an ordinary prompt (Kiro role-plays "Quitting"; Copilot answers it as a question). It only "worked" on PTY vendors by accident of their TUI. The daemon's SendInput handler — the one seam every surface routes through — now translates an exact `/quit`/`/exit` (trimmed, case-insensitive) into a stop for runtimes with no terminal, committed onto the same serial lane a server stop rides. PTY runtimes keep receiving the text verbatim: their TUI owns the command's meaning.

## Where to look

Prose that merely mentions the command (`/quit the loop and try plan B`) is deliberately still forwarded — only input that IS the command stops the agent.

## Verification

New `SendInputQuitCommandTests`: four quit variants watched fail (timeout waiting for a stop that never came), then pass — the stop funnel runs to `TerminateAsync` and the input is never delivered (activity clock unadvanced); prose-mention and PTY-verbatim pass-through pinned. Full daemon suite 2872 total, 0 failed; AOT publish clean of IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)