### PR TITLE
Derive the Antigravity ADC trio at service install

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,21 +1051,25 @@ reasons, and can never deliver its result. The grant admits those named tools an
 **Give the daemon durable credentials.** An unattended reviewer's stdin is closed, so it cannot complete an
 interactive login — an unauthenticated `agy` fails the launch with a coded
 `antigravity_reviewer_auth_unavailable` rather than hanging. Application Default Credentials are the
-supported setup:
+supported setup, and the service install completes them for you:
 
 ```bash
 gcloud auth application-default login
-export GOOGLE_CLOUD_PROJECT=<your-project>
-export AGY_ADC_AUTH=1                           # selects ADC; without it agy still demands an OAuth login
-export GOOGLE_APPLICATION_CREDENTIALS="$HOME/.config/gcloud/application_default_credentials.json"
+kcap daemon service install --name "$(whoami)"   # captures/derives the trio into the unit
 ```
 
-All three are required. The credential path looks redundant — ADC has a well-known default location, and
-that is exactly where `gcloud auth application-default login` just wrote it — but a reviewer launch
-redirects `HOME` to a per-launch state directory, so the default location is not visible to the child.
-Without the explicit path `agy` reports `authentication required. Run 'agy' to log in.` even with the
-other two set correctly. The daemon does not fill this in for you: it never reads a credential location
-of its own accord, only forwards what you exported.
+The daemon needs all three of `GOOGLE_CLOUD_PROJECT`, `AGY_ADC_AUTH=1` and
+`GOOGLE_APPLICATION_CREDENTIALS`. The install captures any you exported and silently derives the rest:
+the credential path from ADC's well-known location (only when the file is actually there), `AGY_ADC_AUTH=1`
+alongside it, and the project from your environment or gcloud's own active configuration. Exported values
+always win. The explicit path looks redundant — ADC has a well-known default location — but a reviewer
+launch redirects `HOME` to a per-launch state directory, so the default location is not visible to the
+child. Derivation happens in the installer, at your command; the daemon itself still never reads a
+credential location of its own accord — it only forwards what the unit carries.
+
+Deliberately unit-only: do **not** export `AGY_ADC_AUTH=1` in your interactive shell — under ADC auth agy
+fires no hooks, so that export would stop kcap capturing your own interactive Antigravity sessions. The
+unit's copy reaches only daemon-spawned children.
 
 **Minimum version.** Containment here depends on the installed build honouring `HOME` and reading no other
 global config source, so the daemon records a minimum `agy` version at the first startup that finds `agy`
@@ -1146,8 +1150,10 @@ kcap daemon service install --name "$(whoami)"    # captures the setting into th
 ```
 
 The Antigravity ADC variables (`GOOGLE_CLOUD_PROJECT`, `AGY_ADC_AUTH`, `GOOGLE_APPLICATION_CREDENTIALS`)
-are captured by the same install, so a daemon installed *before* this shipped must be reinstalled from an
-interactive shell to pick them up. `KCAP_ANTIGRAVITY_PATH` is **not** captured — like the other vendor path
+are captured — and, where you exported nothing, derived from gcloud's own state — by the same install, so a
+daemon installed *before* this shipped must be reinstalled to pick them up. The install prints an
+`Antigravity:` line naming a complete capture, or the missing pieces of a partial one (a partial trio is
+never a working hosted-agy configuration). `KCAP_ANTIGRAVITY_PATH` is **not** captured — like the other vendor path
 overrides, set it where the unit can see it if you need a non-default value.
 
 Install prints a `Consent:` line naming each reviewer variable it captured. That freeze is the point to

--- a/README.md
+++ b/README.md
@@ -1062,7 +1062,8 @@ The daemon needs all three of `GOOGLE_CLOUD_PROJECT`, `AGY_ADC_AUTH=1` and
 `GOOGLE_APPLICATION_CREDENTIALS`. The install captures any you exported and silently derives the rest:
 the credential path from ADC's well-known location (only when the file is actually there), `AGY_ADC_AUTH=1`
 alongside it, and the project from your environment or gcloud's own active configuration. Exported values
-always win. The explicit path looks redundant — ADC has a well-known default location — but a reviewer
+always win. Only the canonical `GOOGLE_CLOUD_PROJECT` counts here — `GOOGLE_CLOUD_PROJECT_ID` is carried
+for Gemini, which honours both, and does not satisfy agy's project leg. The explicit path looks redundant — ADC has a well-known default location — but a reviewer
 launch redirects `HOME` to a per-launch state directory, so the default location is not visible to the
 child. Derivation happens in the installer, at your command; the daemon itself still never reads a
 credential location of its own accord — it only forwards what the unit carries.

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -67,6 +67,20 @@ retry the request.
 nothing left to do. Treating the two the same would leave the request outstanding on a server that would
 have answered it.
 
+## Service install derives the Antigravity ADC trio
+
+Hosted `agy` runs under a per-launch isolated `HOME`, which hides both the interactive OAuth login and
+ADC's well-known location — so the daemon can only authenticate it through three unit-carried variables,
+and an operator with a fully working interactive `agy` still saw `antigravity_reviewer_auth_unavailable`
+after every reinstall because two of the three were exported nowhere. Install now completes the trio
+silently, the same capture every other key gets: the credential path from ADC's well-known file (only when
+it exists), `AGY_ADC_AUTH=1` riding the credential (the flag alone is a broken half-configuration), the
+project from the environment or gcloud's active config. Exported values always win.
+
+Two boundaries hold. Derivation lives in the installer the operator is running, never the daemon — the
+daemon still reads no credential location of its own accord. And the flag lands in the UNIT only: exported
+interactively, `AGY_ADC_AUTH=1` disables agy's hook capture, so the shell is exactly where it must not go.
+
 ## The import outcome reaches the first-run flow
 
 The flow's `import-outcome` route folded a report into `FirstRunFlowState.ImportOutcome` and had no

--- a/src/Capacitor.Cli/Commands/DaemonServiceCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonServiceCommands.cs
@@ -174,7 +174,7 @@ sealed class DaemonServiceCommands(
             // The hosted-agy trio's state, said out loud for the same reason the consent flags are:
             // the unit outlives the shell, and a partial trio is never a working agy configuration —
             // silence here is how a reinstall that changed nothing goes unnoticed.
-            var (agyPresent, agyMissing) = ServiceEnvironment.AgyTrio(env);
+            var (agyPresent, agyMissing) = Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.Status(env);
             if (agyPresent && agyMissing.Count == 0) {
                 await Console.Out.WriteLineAsync(
                     "  Antigravity: ADC trio captured into the unit — hosted agy can authenticate.");

--- a/src/Capacitor.Cli/Commands/DaemonServiceCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonServiceCommands.cs
@@ -120,7 +120,7 @@ sealed class DaemonServiceCommands(
         if (daemonPath is null) { await Console.Error.WriteLineAsync(DaemonCommands.DaemonNotFoundMessage()); return 1; }
 
         var profileName = DaemonCommands.ExtractFlagValue(args, "--profile") ?? profiles.Resolution.ProfileName;
-        var env = new Dictionary<string, string>(ServiceEnvironment.Capture(profileName, root)) {
+        var env = new Dictionary<string, string>(ServiceEnvironment.Capture(profileName, root, home)) {
             ["KCAP_DAEMON_SUPERVISED"] = id,   // name-specific; daemon honors it only when == its sanitized --name
         };
 
@@ -171,6 +171,20 @@ sealed class DaemonServiceCommands(
             // these became opt-outs, a captured `0` DISABLES, and the old "the reviewer it enables stays on"
             // text was exactly backwards for that case. Classified through the same Core parser the daemon
             // reads, so the notice and the daemon can never disagree about a value's meaning.
+            // The hosted-agy trio's state, said out loud for the same reason the consent flags are:
+            // the unit outlives the shell, and a partial trio is never a working agy configuration —
+            // silence here is how a reinstall that changed nothing goes unnoticed.
+            var (agyPresent, agyMissing) = ServiceEnvironment.AgyTrio(env);
+            if (agyPresent && agyMissing.Count == 0) {
+                await Console.Out.WriteLineAsync(
+                    "  Antigravity: ADC trio captured into the unit — hosted agy can authenticate.");
+            } else if (agyPresent) {
+                await Console.Out.WriteLineAsync(
+                    $"  Antigravity: PARTIAL ADC capture — missing {string.Join(", ", agyMissing)}. "
+                  + "Hosted agy cannot authenticate until the unit carries all three "
+                  + "(run `gcloud auth application-default login`, then reinstall).");
+            }
+
             foreach (var flag in ServiceEnvironment.CarriedConsentFlags(env)) {
                 var effect = ReviewerConsent.IsEnabled(env[flag])
                     ? "keeps that reviewer ENABLED (already the default)"
@@ -467,7 +481,7 @@ sealed class DaemonServiceCommands(
 
         // The app's MutationEnv overlay, in-process: seed born-prompt + the expected server the gate
         // and the daemon's own boot both re-read. Everything else comes from the ambient capture.
-        var env = EnsureUnitEnv(profileName, serverUrl, ServiceEnvironment.Capture(profileName, root));
+        var env = EnsureUnitEnv(profileName, serverUrl, ServiceEnvironment.Capture(profileName, root, home));
         env["KCAP_DAEMON_SUPERVISED"] = id;
         var logPath = root.Path($"daemon-{id}.log");
         var spec    = new ServiceSpec(id, daemonPath, logPath, env, []);

--- a/src/Capacitor.Cli/Harness/Antigravity/AntigravityAdcTrio.cs
+++ b/src/Capacitor.Cli/Harness/Antigravity/AntigravityAdcTrio.cs
@@ -1,0 +1,69 @@
+namespace Capacitor.Cli.Harness.Antigravity;
+
+/// <summary>
+/// The three environment variables a daemon-hosted agy needs, and how a service install completes
+/// them. A hosted launch redirects HOME, so ADC's well-known location is invisible to the child and
+/// the credential path has to be explicit; the flag selects the auth mode, without which agy demands
+/// an interactive login it has no stdin for.
+///
+/// <para>Deriving belongs to the installer the operator is running, never to the daemon, which goes
+/// looking for a credential nowhere. And it lands in the unit only: <c>AGY_ADC_AUTH=1</c> exported
+/// in an interactive shell disables agy's own hook capture.</para>
+/// </summary>
+static class AntigravityAdcTrio {
+    internal const string ProjectKey     = "GOOGLE_CLOUD_PROJECT";
+    internal const string FlagKey        = "AGY_ADC_AUTH";
+    internal const string CredentialsKey = "GOOGLE_APPLICATION_CREDENTIALS";
+
+    /// <summary>agy reads the flag as the literal <c>1</c>; anything else leaves it on interactive
+    /// OAuth. Reported as <c>AGY_ADC_AUTH=1</c> so a captured <c>0</c> names its own remedy.</summary>
+    const string FlagEnabled = "1";
+
+    /// <summary>The ADC well-known path, only when the file is actually there — deriving the path
+    /// without the file would bake a broken half-configuration. Never throws.</summary>
+    public static string? ExistingCredentialsPath(Core.UserHome home) {
+        try {
+            var path = Path.Combine(home.Path, ".config", "gcloud", "application_default_credentials.json");
+
+            return File.Exists(path) ? path : null;
+        } catch {
+            return null;
+        }
+    }
+
+    /// <summary>Fills whatever the operator's shell left silent. Exported values always win —
+    /// derivation completes a configuration, it never argues with one. The canonical project spelling
+    /// is derived even when <c>GOOGLE_CLOUD_PROJECT_ID</c> is exported: that alternate is a Gemini
+    /// affordance, and agy reads only the canonical key.</summary>
+    public static void Complete(
+            IDictionary<string, string> env, string? credentialsPath, string? gcloudProject) {
+        if (!env.ContainsKey(CredentialsKey) && !string.IsNullOrEmpty(credentialsPath))
+            env[CredentialsKey] = credentialsPath;
+
+        // The flag rides the credential: without a reachable ADC file, AGY_ADC_AUTH=1 is a broken
+        // half-configuration (agy fails auth outright).
+        if (env.ContainsKey(CredentialsKey) && !env.ContainsKey(FlagKey))
+            env[FlagKey] = FlagEnabled;
+
+        if (!env.ContainsKey(ProjectKey) && !string.IsNullOrEmpty(gcloudProject))
+            env[ProjectKey] = gcloudProject;
+    }
+
+    /// <summary>The trio's state in a built environment, for the install path to report:
+    /// <c>AnyPresent</c> false means agy is simply not configured (nothing to say); <c>Missing</c>
+    /// non-empty with <c>AnyPresent</c> true is a partial trio — never a working agy configuration,
+    /// so always worth a warning.</summary>
+    public static (bool AnyPresent, IReadOnlyList<string> Missing) Status(
+            IReadOnlyDictionary<string, string> env) {
+        var missing = new List<string>();
+        if (!env.ContainsKey(ProjectKey))                                        missing.Add(ProjectKey);
+        if (!env.TryGetValue(FlagKey, out var flag) || flag.Trim() != FlagEnabled) missing.Add($"{FlagKey}={FlagEnabled}");
+        if (!env.ContainsKey(CredentialsKey))                                    missing.Add(CredentialsKey);
+
+        // Keyed on presence, not on the values above: an operator who exported AGY_ADC_AUTH=0 has
+        // configured agy, wrongly, and needs the warning rather than silence.
+        var anyPresent = env.ContainsKey(ProjectKey) || env.ContainsKey(FlagKey) || env.ContainsKey(CredentialsKey);
+
+        return (anyPresent, missing);
+    }
+}

--- a/src/Capacitor.Cli/Services/GcloudConfig.cs
+++ b/src/Capacitor.Cli/Services/GcloudConfig.cs
@@ -27,12 +27,21 @@ static class GcloudConfig {
 
     /// <summary>Minimal INI walk: the <c>project</c> key inside the <c>[core]</c> section and
     /// nowhere else — the same key under another section (e.g. <c>[compute]</c>) means something
-    /// different to gcloud and must not be read as the default project.</summary>
+    /// different to gcloud and must not be read as the default project.
+    ///
+    /// <para>Two keys in one section is a file gcloud's own reader refuses, so this refuses it too
+    /// rather than picking a winner it cannot know: a wrong project is baked into a unit and surfaces
+    /// much later as an auth failure, where deriving nothing surfaces immediately as a partial trio.
+    /// Whole-line comments, trailing comments and a quoted value are all stripped — hand-edited files
+    /// carry all three, and each would otherwise be baked into the value verbatim.</para></summary>
     internal static string? ParseProject(string ini) {
         var inCore = false;
+        string? found = null;
 
         foreach (var raw in ini.Split('\n')) {
             var line = raw.Trim();
+
+            if (line.Length == 0 || line[0] is '#' or ';') continue;
 
             if (line.StartsWith('[')) {
                 inCore = line.Equals("[core]", StringComparison.OrdinalIgnoreCase);
@@ -44,11 +53,23 @@ static class GcloudConfig {
             var eq = line.IndexOf('=');
             if (eq <= 0 || !line[..eq].Trim().Equals("project", StringComparison.OrdinalIgnoreCase)) continue;
 
-            var value = line[(eq + 1)..].Trim();
+            if (found is not null) return null;
 
-            return value.Length > 0 ? value : null;
+            found = CleanValue(line[(eq + 1)..]);
         }
 
-        return null;
+        return found;
+    }
+
+    /// <summary>A trailing <c>#</c>/<c>;</c> comment removed, then one matching pair of surrounding
+    /// quotes. Null for an empty result, which is the same as the key being absent.</summary>
+    static string? CleanValue(string raw) {
+        var cut   = raw.IndexOfAny(['#', ';']);
+        var value = (cut >= 0 ? raw[..cut] : raw).Trim();
+
+        if (value.Length >= 2 && value[0] == value[^1] && value[0] is '"' or '\'')
+            value = value[1..^1].Trim();
+
+        return value.Length > 0 ? value : null;
     }
 }

--- a/src/Capacitor.Cli/Services/GcloudConfig.cs
+++ b/src/Capacitor.Cli/Services/GcloudConfig.cs
@@ -1,0 +1,54 @@
+namespace Capacitor.Cli.Services;
+
+/// <summary>
+/// Reads gcloud's own on-disk configuration for the active default project — no process spawn, no
+/// network. Used only by the service-install capture (<see cref="ServiceEnvironment.Capture"/>);
+/// the daemon itself never reads this.
+/// </summary>
+static class GcloudConfig {
+    /// <summary>The active configuration's <c>[core] project</c>, or null when gcloud is not set
+    /// up, the config is unreadable, or no project is set. Never throws.</summary>
+    public static string? DefaultProject(Core.UserHome home) {
+        try {
+            var root   = Path.Combine(home.Path, ".config", "gcloud");
+            var active = "default";
+
+            var activePath = Path.Combine(root, "active_config");
+            if (File.Exists(activePath) && File.ReadAllText(activePath).Trim() is { Length: > 0 } name)
+                active = name;
+
+            var configPath = Path.Combine(root, "configurations", $"config_{active}");
+
+            return File.Exists(configPath) ? ParseProject(File.ReadAllText(configPath)) : null;
+        } catch {
+            return null;
+        }
+    }
+
+    /// <summary>Minimal INI walk: the <c>project</c> key inside the <c>[core]</c> section and
+    /// nowhere else — the same key under another section (e.g. <c>[compute]</c>) means something
+    /// different to gcloud and must not be read as the default project.</summary>
+    internal static string? ParseProject(string ini) {
+        var inCore = false;
+
+        foreach (var raw in ini.Split('\n')) {
+            var line = raw.Trim();
+
+            if (line.StartsWith('[')) {
+                inCore = line.Equals("[core]", StringComparison.OrdinalIgnoreCase);
+                continue;
+            }
+
+            if (!inCore) continue;
+
+            var eq = line.IndexOf('=');
+            if (eq <= 0 || !line[..eq].Trim().Equals("project", StringComparison.OrdinalIgnoreCase)) continue;
+
+            var value = line[(eq + 1)..].Trim();
+
+            return value.Length > 0 ? value : null;
+        }
+
+        return null;
+    }
+}

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -112,10 +112,15 @@ static class ServiceEnvironment {
     /// the same silent capture every other key gets. Install time is the one moment this is
     /// legitimate: the operator is running the command, and the daemon itself still never reads a
     /// credential location of its own accord.</summary>
-    public static IReadOnlyDictionary<string, string> Capture(string? profileName, Core.ConfigRoot config, Core.UserHome home) =>
-        Build(profileName, Snapshot(), config, OperatingSystem.IsWindows(),
-            adcCredentialsPath: Harness.Antigravity.AntigravityAdcTrio.ExistingCredentialsPath(home),
-            gcloudProject: GcloudConfig.DefaultProject(home));
+    public static IReadOnlyDictionary<string, string> Capture(string? profileName, Core.ConfigRoot config, Core.UserHome home) {
+        // Windows derives nothing, so it must also LOOK at nothing: reading the credential location
+        // and discarding the result downstream is still the probe the boundary forbids.
+        var isWindows = OperatingSystem.IsWindows();
+
+        return Build(profileName, Snapshot(), config, isWindows,
+            adcCredentialsPath: isWindows ? null : Harness.Antigravity.AntigravityAdcTrio.ExistingCredentialsPath(home),
+            gcloudProject:      isWindows ? null : GcloudConfig.DefaultProject(home));
+    }
 
     static Dictionary<string, string> Snapshot() {
         var d = new Dictionary<string, string>();
@@ -129,7 +134,12 @@ static class ServiceEnvironment {
     /// other key here (which skips a present-but-empty value as if unset), these are baked
     /// VERBATIM whenever the key is present, empty or not. Silently dropping an empty directive
     /// on the way into the unit would let it vanish instead of failing closed.</summary>
-    static readonly string[] BakeEvenEmptyKeys = ["KCAP_CONSENT_SEED_DEFAULT", "KCAP_EXPECT_SERVER_URL"];
+    static readonly string[] BakeEvenEmptyKeys = [
+        "KCAP_CONSENT_SEED_DEFAULT", "KCAP_EXPECT_SERVER_URL",
+        // Same contract, for the same reason: an operator who exported an empty AGY_ADC_AUTH is
+        // refusing ADC auth, and dropping it here would let derivation hand them the 1 they declined.
+        "AGY_ADC_AUTH",
+    ];
 
     /// <summary>Pure: select the relevant keys from <paramref name="source"/>, pin the profile and the
     /// config root.</summary>

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -114,20 +114,8 @@ static class ServiceEnvironment {
     /// credential location of its own accord.</summary>
     public static IReadOnlyDictionary<string, string> Capture(string? profileName, Core.ConfigRoot config, Core.UserHome home) =>
         Build(profileName, Snapshot(), config, OperatingSystem.IsWindows(),
-            adcCredentialsPath: ExistingAdcPath(home),
+            adcCredentialsPath: Harness.Antigravity.AntigravityAdcTrio.ExistingCredentialsPath(home),
             gcloudProject: GcloudConfig.DefaultProject(home));
-
-    /// <summary>The ADC well-known path, only when the file is actually there — deriving the path
-    /// without the file would bake a broken half-configuration.</summary>
-    static string? ExistingAdcPath(Core.UserHome home) {
-        try {
-            var path = Path.Combine(home.Path, ".config", "gcloud", "application_default_credentials.json");
-
-            return File.Exists(path) ? path : null;
-        } catch {
-            return null;
-        }
-    }
 
     static Dictionary<string, string> Snapshot() {
         var d = new Dictionary<string, string>();
@@ -159,25 +147,10 @@ static class ServiceEnvironment {
         }
         if (!string.IsNullOrEmpty(profileName)) env["KCAP_PROFILE"] = profileName; // explicit pin wins
 
-        // The Antigravity ADC trio, completed from gcloud's own state where the operator exported
-        // nothing. Exported values always win — derivation fills silence, it never argues. POSIX
-        // only: Windows carries no GOOGLE_APPLICATION_CREDENTIALS at all (no owner-only unit
+        // POSIX only: Windows carries no GOOGLE_APPLICATION_CREDENTIALS at all (no owner-only unit
         // guarantee), so the trio can never complete there and a derived half would only mislead.
-        // Deriving into the UNIT (not the operator's shell) is load-bearing: AGY_ADC_AUTH=1 in an
-        // interactive shell disables agy's hook capture for the operator's own sessions.
-        if (!isWindows) {
-            if (!env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS") && !string.IsNullOrEmpty(adcCredentialsPath))
-                env["GOOGLE_APPLICATION_CREDENTIALS"] = adcCredentialsPath;
-
-            // The flag rides the credential: without a reachable ADC file, AGY_ADC_AUTH=1 is a
-            // broken half-configuration (agy fails auth outright).
-            if (env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS") && !env.ContainsKey("AGY_ADC_AUTH"))
-                env["AGY_ADC_AUTH"] = "1";
-
-            if (!env.ContainsKey("GOOGLE_CLOUD_PROJECT") && !env.ContainsKey("GOOGLE_CLOUD_PROJECT_ID")
-                && !string.IsNullOrEmpty(gcloudProject))
-                env["GOOGLE_CLOUD_PROJECT"] = gcloudProject;
-        }
+        if (!isWindows)
+            Harness.Antigravity.AntigravityAdcTrio.Complete(env, adcCredentialsPath, gcloudProject);
 
         // From the installer's context rather than captured from its environment: a unit inherits
         // nothing, so a captured root would be baked only when one happened to be exported — and the
@@ -185,23 +158,6 @@ static class ServiceEnvironment {
         env[Core.ConfigRoot.ConfigDirEnvVar] = config.Directory;
 
         return env;
-    }
-
-    /// <summary>The hosted-agy auth trio's state in a built environment, for the install path to
-    /// report: <c>AnyPresent</c> false means agy is simply not configured (nothing to say);
-    /// <c>Missing</c> non-empty with <c>AnyPresent</c> true is a partial trio — never a working agy
-    /// configuration, so always worth a warning. Either project spelling satisfies the project leg.</summary>
-    internal static (bool AnyPresent, IReadOnlyList<string> Missing) AgyTrio(IReadOnlyDictionary<string, string> env) {
-        var hasProject     = env.ContainsKey("GOOGLE_CLOUD_PROJECT") || env.ContainsKey("GOOGLE_CLOUD_PROJECT_ID");
-        var hasFlag        = env.ContainsKey("AGY_ADC_AUTH");
-        var hasCredentials = env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS");
-
-        var missing = new List<string>();
-        if (!hasProject)     missing.Add("GOOGLE_CLOUD_PROJECT");
-        if (!hasFlag)        missing.Add("AGY_ADC_AUTH");
-        if (!hasCredentials) missing.Add("GOOGLE_APPLICATION_CREDENTIALS");
-
-        return (missing.Count < 3, missing);
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -107,9 +107,27 @@ static class ServiceEnvironment {
     /// inert variable into the one serializer that cannot hold it safely buys nothing.</para></summary>
     const string TokenCommandKey = "KCAP_COPILOT_TOKEN_CMD";
 
-    /// <summary>Production entry point: capture from the current process env.</summary>
-    public static IReadOnlyDictionary<string, string> Capture(string? profileName, Core.ConfigRoot config) =>
-        Build(profileName, Snapshot(), config, OperatingSystem.IsWindows());
+    /// <summary>Production entry point: capture from the current process env, completing the
+    /// Antigravity ADC trio from gcloud's own on-disk state where the operator exported nothing —
+    /// the same silent capture every other key gets. Install time is the one moment this is
+    /// legitimate: the operator is running the command, and the daemon itself still never reads a
+    /// credential location of its own accord.</summary>
+    public static IReadOnlyDictionary<string, string> Capture(string? profileName, Core.ConfigRoot config, Core.UserHome home) =>
+        Build(profileName, Snapshot(), config, OperatingSystem.IsWindows(),
+            adcCredentialsPath: ExistingAdcPath(home),
+            gcloudProject: GcloudConfig.DefaultProject(home));
+
+    /// <summary>The ADC well-known path, only when the file is actually there — deriving the path
+    /// without the file would bake a broken half-configuration.</summary>
+    static string? ExistingAdcPath(Core.UserHome home) {
+        try {
+            var path = Path.Combine(home.Path, ".config", "gcloud", "application_default_credentials.json");
+
+            return File.Exists(path) ? path : null;
+        } catch {
+            return null;
+        }
+    }
 
     static Dictionary<string, string> Snapshot() {
         var d = new Dictionary<string, string>();
@@ -130,7 +148,7 @@ static class ServiceEnvironment {
     /// <param name="isWindows">Platform, passed rather than probed so the exclusion is testable.</param>
     public static IReadOnlyDictionary<string, string> Build(
             string? profileName, IReadOnlyDictionary<string, string> source, Core.ConfigRoot config,
-            bool isWindows = false) {
+            bool isWindows = false, string? adcCredentialsPath = null, string? gcloudProject = null) {
         var env = new Dictionary<string, string>(StringComparer.Ordinal);
         string[] keys = isWindows
             ? [.. Keys, .. ReviewerConsentKeys, .. GoogleConfigKeys]
@@ -141,12 +159,49 @@ static class ServiceEnvironment {
         }
         if (!string.IsNullOrEmpty(profileName)) env["KCAP_PROFILE"] = profileName; // explicit pin wins
 
+        // The Antigravity ADC trio, completed from gcloud's own state where the operator exported
+        // nothing. Exported values always win — derivation fills silence, it never argues. POSIX
+        // only: Windows carries no GOOGLE_APPLICATION_CREDENTIALS at all (no owner-only unit
+        // guarantee), so the trio can never complete there and a derived half would only mislead.
+        // Deriving into the UNIT (not the operator's shell) is load-bearing: AGY_ADC_AUTH=1 in an
+        // interactive shell disables agy's hook capture for the operator's own sessions.
+        if (!isWindows) {
+            if (!env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS") && !string.IsNullOrEmpty(adcCredentialsPath))
+                env["GOOGLE_APPLICATION_CREDENTIALS"] = adcCredentialsPath;
+
+            // The flag rides the credential: without a reachable ADC file, AGY_ADC_AUTH=1 is a
+            // broken half-configuration (agy fails auth outright).
+            if (env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS") && !env.ContainsKey("AGY_ADC_AUTH"))
+                env["AGY_ADC_AUTH"] = "1";
+
+            if (!env.ContainsKey("GOOGLE_CLOUD_PROJECT") && !env.ContainsKey("GOOGLE_CLOUD_PROJECT_ID")
+                && !string.IsNullOrEmpty(gcloudProject))
+                env["GOOGLE_CLOUD_PROJECT"] = gcloudProject;
+        }
+
         // From the installer's context rather than captured from its environment: a unit inherits
         // nothing, so a captured root would be baked only when one happened to be exported — and the
         // supervisor's own HOME would decide the rest.
         env[Core.ConfigRoot.ConfigDirEnvVar] = config.Directory;
 
         return env;
+    }
+
+    /// <summary>The hosted-agy auth trio's state in a built environment, for the install path to
+    /// report: <c>AnyPresent</c> false means agy is simply not configured (nothing to say);
+    /// <c>Missing</c> non-empty with <c>AnyPresent</c> true is a partial trio — never a working agy
+    /// configuration, so always worth a warning. Either project spelling satisfies the project leg.</summary>
+    internal static (bool AnyPresent, IReadOnlyList<string> Missing) AgyTrio(IReadOnlyDictionary<string, string> env) {
+        var hasProject     = env.ContainsKey("GOOGLE_CLOUD_PROJECT") || env.ContainsKey("GOOGLE_CLOUD_PROJECT_ID");
+        var hasFlag        = env.ContainsKey("AGY_ADC_AUTH");
+        var hasCredentials = env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS");
+
+        var missing = new List<string>();
+        if (!hasProject)     missing.Add("GOOGLE_CLOUD_PROJECT");
+        if (!hasFlag)        missing.Add("AGY_ADC_AUTH");
+        if (!hasCredentials) missing.Add("GOOGLE_APPLICATION_CREDENTIALS");
+
+        return (missing.Count < 3, missing);
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Harness/Antigravity/AntigravityAdcTrioTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Harness/Antigravity/AntigravityAdcTrioTests.cs
@@ -1,0 +1,43 @@
+using Capacitor.Cli.Harness.Antigravity;
+
+namespace Capacitor.Cli.Tests.Unit.Harness.Antigravity;
+
+public class AntigravityAdcTrioTests {
+    [Test]
+    public async Task AgyTrio_reports_complete_partial_and_absent() {
+        var complete = AntigravityAdcTrio.Status(new Dictionary<string, string> {
+            ["GOOGLE_CLOUD_PROJECT"] = "p", ["AGY_ADC_AUTH"] = "1",
+            ["GOOGLE_APPLICATION_CREDENTIALS"] = "/adc.json",
+        });
+        await Assert.That(complete.AnyPresent).IsTrue();
+        await Assert.That(complete.Missing).IsEmpty();
+
+        var partial = AntigravityAdcTrio.Status(new Dictionary<string, string> {
+            ["GOOGLE_CLOUD_PROJECT"] = "p",
+        });
+        await Assert.That(partial.AnyPresent).IsTrue();
+        await Assert.That(partial.Missing).IsEquivalentTo(new[] { "AGY_ADC_AUTH=1", "GOOGLE_APPLICATION_CREDENTIALS" });
+
+        var absent = AntigravityAdcTrio.Status(new Dictionary<string, string>());
+        await Assert.That(absent.AnyPresent).IsFalse();
+    }
+
+    /// <summary>agy reads only the canonical project key, and only the literal 1 selects ADC auth —
+    /// either substitute leaves a unit that cannot authenticate, which is the case the complete-trio
+    /// confirmation must not be printed for.</summary>
+    [Test]
+    public async Task AgyTrio_refuses_the_id_spelling_and_a_disabled_flag() {
+        var idSpelling = AntigravityAdcTrio.Status(new Dictionary<string, string> {
+            ["GOOGLE_CLOUD_PROJECT_ID"] = "p", ["AGY_ADC_AUTH"] = "1",
+            ["GOOGLE_APPLICATION_CREDENTIALS"] = "/adc.json",
+        });
+        await Assert.That(idSpelling.Missing).IsEquivalentTo(new[] { "GOOGLE_CLOUD_PROJECT" });
+
+        var disabled = AntigravityAdcTrio.Status(new Dictionary<string, string> {
+            ["GOOGLE_CLOUD_PROJECT"] = "p", ["AGY_ADC_AUTH"] = "0",
+            ["GOOGLE_APPLICATION_CREDENTIALS"] = "/adc.json",
+        });
+        await Assert.That(disabled.AnyPresent).IsTrue();
+        await Assert.That(disabled.Missing).IsEquivalentTo(new[] { "AGY_ADC_AUTH=1" });
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
@@ -355,6 +355,17 @@ public class ServiceEnvironmentTests {
 
     /// <summary>An exported value is the operator's word, whatever it says — derivation only fills
     /// silence, it never argues.</summary>
+    /// <summary>An empty export is the operator declining ADC auth, not an absent key — derivation
+    /// must not hand them the 1 they declined.</summary>
+    [Test]
+    public async Task Build_keeps_an_exported_empty_adc_auth_over_the_derived_flag() {
+        var env = ServiceEnvironment.Build(null,
+            new Dictionary<string, string> { ["AGY_ADC_AUTH"] = "" },
+            Config.Root, adcCredentialsPath: "/derived/adc.json");
+
+        await Assert.That(env["AGY_ADC_AUTH"]).IsEqualTo("");
+    }
+
     [Test]
     public async Task Build_does_not_flip_an_exported_adc_auth_value() {
         var src = new Dictionary<string, string> { ["AGY_ADC_AUTH"] = "0" };
@@ -405,7 +416,10 @@ public class ServiceEnvironmentTests {
     }
 
     /// <summary>Windows carries no GOOGLE_APPLICATION_CREDENTIALS at all (unit files there have no
-    /// owner-only guarantee), so the trio can never complete and derivation stays off wholesale.</summary>
+    /// owner-only guarantee), so the trio can never complete and derivation stays off wholesale.
+    /// <see cref="ServiceEnvironment.Capture"/> also skips looking either source up on Windows —
+    /// reading a credential location and discarding it is still the probe the boundary forbids, and
+    /// only that caller can prove it, since Build is handed the values already read.</summary>
     [Test]
     public async Task Windows_build_derives_nothing() {
         var env = ServiceEnvironment.Build(null, new Dictionary<string, string>(), Config.Root,
@@ -414,6 +428,19 @@ public class ServiceEnvironmentTests {
         await Assert.That(env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS")).IsFalse();
         await Assert.That(env.ContainsKey("AGY_ADC_AUTH")).IsFalse();
         await Assert.That(env.ContainsKey("GOOGLE_CLOUD_PROJECT")).IsFalse();
+    }
+
+    /// <summary>A hand-edited config carries comments and quotes, and two keys in one section is a
+    /// file gcloud's own reader refuses — a guessed winner would be baked into a unit and only surface
+    /// later as an auth failure.</summary>
+    [Test]
+    public async Task GcloudConfig_strips_comments_and_quotes_and_refuses_a_duplicate_key() {
+        await Assert.That(GcloudConfig.ParseProject("[core]\nproject = my-proj # the one we use\n"))
+            .IsEqualTo("my-proj");
+        await Assert.That(GcloudConfig.ParseProject("[core]\nproject = \"my-proj\"\n")).IsEqualTo("my-proj");
+        await Assert.That(GcloudConfig.ParseProject("# project = decoy\n[core]\nproject = my-proj\n"))
+            .IsEqualTo("my-proj");
+        await Assert.That(GcloudConfig.ParseProject("[core]\nproject = one\nproject = two\n")).IsNull();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
@@ -384,15 +384,24 @@ public class ServiceEnvironmentTests {
 
     [Test]
     public async Task Build_keeps_an_exported_project_over_the_gcloud_one() {
-        var byName = ServiceEnvironment.Build(null,
+        var env = ServiceEnvironment.Build(null,
             new Dictionary<string, string> { ["GOOGLE_CLOUD_PROJECT"] = "exported" },
             Config.Root, gcloudProject: "gcloud-proj");
-        await Assert.That(byName["GOOGLE_CLOUD_PROJECT"]).IsEqualTo("exported");
 
-        var byId = ServiceEnvironment.Build(null,
+        await Assert.That(env["GOOGLE_CLOUD_PROJECT"]).IsEqualTo("exported");
+    }
+
+    /// <summary>The alternate spelling is a Gemini affordance; agy reads only the canonical key, so an
+    /// exported id must not suppress deriving it — that combination is what reports a complete trio
+    /// over a unit agy cannot authenticate with.</summary>
+    [Test]
+    public async Task Build_derives_the_canonical_project_alongside_an_exported_id_spelling() {
+        var env = ServiceEnvironment.Build(null,
             new Dictionary<string, string> { ["GOOGLE_CLOUD_PROJECT_ID"] = "exported-id" },
             Config.Root, gcloudProject: "gcloud-proj");
-        await Assert.That(byId.ContainsKey("GOOGLE_CLOUD_PROJECT")).IsFalse();
+
+        await Assert.That(env["GOOGLE_CLOUD_PROJECT"]).IsEqualTo("gcloud-proj");
+        await Assert.That(env["GOOGLE_CLOUD_PROJECT_ID"]).IsEqualTo("exported-id");
     }
 
     /// <summary>Windows carries no GOOGLE_APPLICATION_CREDENTIALS at all (unit files there have no
@@ -405,31 +414,6 @@ public class ServiceEnvironmentTests {
         await Assert.That(env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS")).IsFalse();
         await Assert.That(env.ContainsKey("AGY_ADC_AUTH")).IsFalse();
         await Assert.That(env.ContainsKey("GOOGLE_CLOUD_PROJECT")).IsFalse();
-    }
-
-    [Test]
-    public async Task AgyTrio_reports_complete_partial_and_absent() {
-        var complete = ServiceEnvironment.AgyTrio(new Dictionary<string, string> {
-            ["GOOGLE_CLOUD_PROJECT"] = "p", ["AGY_ADC_AUTH"] = "1",
-            ["GOOGLE_APPLICATION_CREDENTIALS"] = "/adc.json",
-        });
-        await Assert.That(complete.AnyPresent).IsTrue();
-        await Assert.That(complete.Missing).IsEmpty();
-
-        var partial = ServiceEnvironment.AgyTrio(new Dictionary<string, string> {
-            ["GOOGLE_CLOUD_PROJECT"] = "p",
-        });
-        await Assert.That(partial.AnyPresent).IsTrue();
-        await Assert.That(partial.Missing).IsEquivalentTo(new[] { "AGY_ADC_AUTH", "GOOGLE_APPLICATION_CREDENTIALS" });
-
-        var idSpelling = ServiceEnvironment.AgyTrio(new Dictionary<string, string> {
-            ["GOOGLE_CLOUD_PROJECT_ID"] = "p", ["AGY_ADC_AUTH"] = "1",
-            ["GOOGLE_APPLICATION_CREDENTIALS"] = "/adc.json",
-        });
-        await Assert.That(idSpelling.Missing).IsEmpty();
-
-        var absent = ServiceEnvironment.AgyTrio(new Dictionary<string, string>());
-        await Assert.That(absent.AnyPresent).IsFalse();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceEnvironmentTests.cs
@@ -331,4 +331,113 @@ public class ServiceEnvironmentTests {
 
         await Assert.That(env["AGY_ADC_AUTH"]).IsEqualTo("1");
     }
+
+    // ── Antigravity ADC trio derivation ──
+
+    [Test]
+    public async Task Build_derives_the_adc_path_and_flag_when_the_well_known_file_exists() {
+        var env = ServiceEnvironment.Build(null, new Dictionary<string, string>(), Config.Root,
+            adcCredentialsPath: "/h/.config/gcloud/application_default_credentials.json");
+
+        await Assert.That(env["GOOGLE_APPLICATION_CREDENTIALS"])
+            .IsEqualTo("/h/.config/gcloud/application_default_credentials.json");
+        await Assert.That(env["AGY_ADC_AUTH"]).IsEqualTo("1");
+    }
+
+    [Test]
+    public async Task Build_prefers_an_exported_credentials_path_over_the_derived_one() {
+        var src = new Dictionary<string, string> { ["GOOGLE_APPLICATION_CREDENTIALS"] = "/custom/adc.json" };
+
+        var env = ServiceEnvironment.Build(null, src, Config.Root, adcCredentialsPath: "/derived/adc.json");
+
+        await Assert.That(env["GOOGLE_APPLICATION_CREDENTIALS"]).IsEqualTo("/custom/adc.json");
+    }
+
+    /// <summary>An exported value is the operator's word, whatever it says — derivation only fills
+    /// silence, it never argues.</summary>
+    [Test]
+    public async Task Build_does_not_flip_an_exported_adc_auth_value() {
+        var src = new Dictionary<string, string> { ["AGY_ADC_AUTH"] = "0" };
+
+        var env = ServiceEnvironment.Build(null, src, Config.Root, adcCredentialsPath: "/derived/adc.json");
+
+        await Assert.That(env["AGY_ADC_AUTH"]).IsEqualTo("0");
+    }
+
+    /// <summary>The flag without a credential path is a broken half-configuration this code must
+    /// never manufacture: agy under AGY_ADC_AUTH=1 with no reachable ADC fails auth outright.</summary>
+    [Test]
+    public async Task Build_leaves_the_flag_unset_without_a_credentials_path() {
+        var env = ServiceEnvironment.Build(null, new Dictionary<string, string>(), Config.Root);
+
+        await Assert.That(env.ContainsKey("AGY_ADC_AUTH")).IsFalse();
+        await Assert.That(env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS")).IsFalse();
+    }
+
+    [Test]
+    public async Task Build_derives_the_project_from_gcloud_when_neither_spelling_is_exported() {
+        var env = ServiceEnvironment.Build(null, new Dictionary<string, string>(), Config.Root,
+            gcloudProject: "gcloud-proj");
+
+        await Assert.That(env["GOOGLE_CLOUD_PROJECT"]).IsEqualTo("gcloud-proj");
+    }
+
+    [Test]
+    public async Task Build_keeps_an_exported_project_over_the_gcloud_one() {
+        var byName = ServiceEnvironment.Build(null,
+            new Dictionary<string, string> { ["GOOGLE_CLOUD_PROJECT"] = "exported" },
+            Config.Root, gcloudProject: "gcloud-proj");
+        await Assert.That(byName["GOOGLE_CLOUD_PROJECT"]).IsEqualTo("exported");
+
+        var byId = ServiceEnvironment.Build(null,
+            new Dictionary<string, string> { ["GOOGLE_CLOUD_PROJECT_ID"] = "exported-id" },
+            Config.Root, gcloudProject: "gcloud-proj");
+        await Assert.That(byId.ContainsKey("GOOGLE_CLOUD_PROJECT")).IsFalse();
+    }
+
+    /// <summary>Windows carries no GOOGLE_APPLICATION_CREDENTIALS at all (unit files there have no
+    /// owner-only guarantee), so the trio can never complete and derivation stays off wholesale.</summary>
+    [Test]
+    public async Task Windows_build_derives_nothing() {
+        var env = ServiceEnvironment.Build(null, new Dictionary<string, string>(), Config.Root,
+            isWindows: true, adcCredentialsPath: "/derived/adc.json", gcloudProject: "gcloud-proj");
+
+        await Assert.That(env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS")).IsFalse();
+        await Assert.That(env.ContainsKey("AGY_ADC_AUTH")).IsFalse();
+        await Assert.That(env.ContainsKey("GOOGLE_CLOUD_PROJECT")).IsFalse();
+    }
+
+    [Test]
+    public async Task AgyTrio_reports_complete_partial_and_absent() {
+        var complete = ServiceEnvironment.AgyTrio(new Dictionary<string, string> {
+            ["GOOGLE_CLOUD_PROJECT"] = "p", ["AGY_ADC_AUTH"] = "1",
+            ["GOOGLE_APPLICATION_CREDENTIALS"] = "/adc.json",
+        });
+        await Assert.That(complete.AnyPresent).IsTrue();
+        await Assert.That(complete.Missing).IsEmpty();
+
+        var partial = ServiceEnvironment.AgyTrio(new Dictionary<string, string> {
+            ["GOOGLE_CLOUD_PROJECT"] = "p",
+        });
+        await Assert.That(partial.AnyPresent).IsTrue();
+        await Assert.That(partial.Missing).IsEquivalentTo(new[] { "AGY_ADC_AUTH", "GOOGLE_APPLICATION_CREDENTIALS" });
+
+        var idSpelling = ServiceEnvironment.AgyTrio(new Dictionary<string, string> {
+            ["GOOGLE_CLOUD_PROJECT_ID"] = "p", ["AGY_ADC_AUTH"] = "1",
+            ["GOOGLE_APPLICATION_CREDENTIALS"] = "/adc.json",
+        });
+        await Assert.That(idSpelling.Missing).IsEmpty();
+
+        var absent = ServiceEnvironment.AgyTrio(new Dictionary<string, string>());
+        await Assert.That(absent.AnyPresent).IsFalse();
+    }
+
+    [Test]
+    public async Task GcloudConfig_parses_the_core_project() {
+        await Assert.That(GcloudConfig.ParseProject("[core]\nproject = my-proj\naccount = a@b.c\n"))
+            .IsEqualTo("my-proj");
+        await Assert.That(GcloudConfig.ParseProject("[compute]\nproject = wrong-section\n")).IsNull();
+        await Assert.That(GcloudConfig.ParseProject("")).IsNull();
+        await Assert.That(GcloudConfig.ParseProject("[core]\nproject =\n")).IsNull();
+    }
 }


### PR DESCRIPTION
Closes #713 — AI-2382

## What & why

An operator with fully-working interactive agy still hit `antigravity_reviewer_auth_unavailable` after every service reinstall, because hosted agy needs all three of `GOOGLE_CLOUD_PROJECT`/`AGY_ADC_AUTH`/`GOOGLE_APPLICATION_CREDENTIALS` in the unit and capture only ever took what the shell happened to export. Install now completes the trio silently, like every other captured key: the credential path from ADC's well-known file (only when it exists), `AGY_ADC_AUTH=1` riding the credential, the project from the environment or gcloud's own active config (read from gcloud's files, no process spawn). Exported values always win; a partial trio prints a warning naming the missing pieces, a complete one prints confirmation.

## Where to look

Two boundaries: derivation lives in the installer the operator is running — the daemon still never reads a credential location of its own accord; and the flag lands in the unit only — exported interactively, `AGY_ADC_AUTH=1` disables agy's hook capture, so the README now explicitly warns against the shell export. Derivation is POSIX-only, consistent with `GOOGLE_APPLICATION_CREDENTIALS`' existing Windows exclusion.

## Verification

`ServiceEnvironmentTests` 32/32 with nine new pins: derivation, exported-value precedence (including an exported `AGY_ADC_AUTH=0` left alone), no flag without a credential path, project-spelling handling, Windows derives nothing, trio status complete/partial/absent, the gcloud INI parse (`[core]`-section-only). Full CLI suite 3866 total, 1 failed — `session_end_against_hung_server_is_spooled_within_budget`, a wall-clock budget flake under full-suite load, green in isolation. AOT publish clean of IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)