### PR TITLE
Exclude the Cursor telemetry spawn test from the whole assembly

### DIFF
--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CursorHookCommandTests.cs
@@ -144,7 +144,9 @@ public class CursorHookCommandTests {
     // is still stuck undelivered. Simulates: sessionStart is already spooled from a prior failed
     // invocation; this invocation's top-of-method drain retries it and hits a transient failure
     // (503) so it stays queued, while postToolUse's own POST succeeds.
-    [Test]
+    // Bare NotInParallel: the spawn override is process-wide, so any concurrent peer's spawn lands
+    // in this list. The class key is not enough — its cohort excludes only the env-override readers.
+    [Test, NotInParallel]
     public async Task telemetry_hook_does_not_recovery_spawn_while_an_earlier_canonical_event_is_still_stuck() {
         var sid = Guid.NewGuid().ToString("N");
         var spool = new HookSpool(Config.PathTo("spool"));

--- a/test/Capacitor.Cli.Tests.Unit/Commands/UnusableUrlGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/UnusableUrlGuardTests.cs
@@ -13,6 +13,10 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 /// catch-all every one of these paths already has, so an effect-only assertion passes with the guard
 /// deleted; six review rounds found exactly that, repeatedly.</para>
 /// </summary>
+// The two spawn guards below install WatcherManager.ProcessStarterForTesting and Dispose nulls it,
+// both process-global: a concurrent peer's spawn lands in this class's counter, and its own override
+// is cleared under it. Bare, as every other writer of that seam already carries.
+[NotInParallel]
 public class UnusableUrlGuardTests : IDisposable {
     [TempHome] public required TempHome Home { get; init; }
 


### PR DESCRIPTION
Closes #720 — AI-2387

## What & why

`telemetry_hook_does_not_recovery_spawn_while_an_earlier_canonical_event_is_still_stuck` installs `WatcherManager.SpawnOverrideForTesting`, a process-wide static, while its class carries only the keyed `[NotInParallel("VendorEnvOverrides")]` — a cohort of env-override readers, not of every test that can trigger a watcher spawn. A concurrent peer's spawn therefore lands in this test's `spawned` list and the emptiness assertion fails. Bare `[NotInParallel]` on the method makes it assembly-exclusive, matching what every other override mutator already carries.

## Where to look

The method-level attribute shadows the class-level key rather than adding to it. That loses nothing: assembly-exclusive is strictly stronger than the env-override cohort the class key buys.

## Verification

The red run's evidence is the key it saw — `9dc2775376454e4691ecc2d69973c152` is `ClaudeHookCommandTests.Sid`, a constant this test (fresh `Guid.NewGuid()`) cannot produce. Full CLI unit suite on this branch: 3857 total, 0 failed. Test-only change, so AOT publish is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)