### PR TITLE
Tell the user when a picked model is not the one answering

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -2401,13 +2401,14 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     }
 
     /// <summary>Tells the user, in the transcript itself, that the model they picked is not the one
-    /// answering — the daemon's own warning reaches only the daemon log, which the launching surface
-    /// never shows.</summary>
+    /// answering. Worded for every reason the selector returns null — no match in the published list,
+    /// a list published in no shape it reads, or the agent refusing the selection RPC — since which
+    /// one it was does not reach here.</summary>
     void EmitModelFallbackNote(string requestedModel) =>
         EmitEnvelope(new AcpEventEnvelope(
             Seq: 0,
             Kind: AcpEventKind.SystemNote,
-            Text: $"{_vendor} does not offer the model '{requestedModel}'; this session is running {_vendor}'s default model instead.",
+            Text: $"{_vendor} could not apply the model '{requestedModel}'; this session is running {_vendor}'s default model instead.",
             TimestampIso: NowIso()));
 
     /// <summary>The §8 surfacing envelope — emitted after commit and settlement, before reopen,

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -904,7 +904,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// </summary>
     public async Task StartAsync(
             string cwd, string? initialPrompt, CancellationToken ct, string? requestedModel = null,
-            IReadOnlyList<AcpMcpServerSpec>? mcpServers = null, bool modelWasPickedForThisLaunch = false) {
+            IReadOnlyList<AcpMcpServerSpec>? mcpServers = null, string? modelOwedAnExplanation = null) {
         _cwd            = cwd;
         _requestedModel = requestedModel;
         // Captured for session/load: a resume must hand the agent the SAME server list the
@@ -1033,9 +1033,10 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
         // A dropped model is only knowable after session/new publishes the vendor's list, so nothing
         // upstream can refuse the launch over it: the agent runs, answering as a model the user did
-        // not pick. Emitted before the initial turn is enqueued, so it precedes that turn's output.
-        if (modelWasPickedForThisLaunch && !string.IsNullOrWhiteSpace(requestedModel) && _resolvedModel is null)
-            EmitModelFallbackNote(requestedModel);
+        // not pick. Names the model the LAUNCH asked for, which is not always the one that reached
+        // the selector. Emitted before the initial turn is enqueued, so it precedes that turn's output.
+        if (modelOwedAnExplanation is { Length: > 0 } owed && _resolvedModel is null)
+            EmitModelFallbackNote(owed);
 
         // The session is established (initialize + session/new both completed) — the caller
         // (orchestrator) can now treat this agent as live. Enqueue the initial turn without

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -904,7 +904,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// </summary>
     public async Task StartAsync(
             string cwd, string? initialPrompt, CancellationToken ct, string? requestedModel = null,
-            IReadOnlyList<AcpMcpServerSpec>? mcpServers = null) {
+            IReadOnlyList<AcpMcpServerSpec>? mcpServers = null, bool modelWasPickedForThisLaunch = false) {
         _cwd            = cwd;
         _requestedModel = requestedModel;
         // Captured for session/load: a resume must hand the agent the SAME server list the
@@ -1030,6 +1030,12 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // one consolidated Info log carrying the negotiated protocol version, loadSession, and the
         // resolved model (null if none was requested/matched).
         LogHandshakeOk(_agentId, _negotiatedProtocolVersion, _negotiatedCapabilities.LoadSession, _resolvedModel);
+
+        // A dropped model is only knowable after session/new publishes the vendor's list, so nothing
+        // upstream can refuse the launch over it: the agent runs, answering as a model the user did
+        // not pick. Emitted before the initial turn is enqueued, so it precedes that turn's output.
+        if (modelWasPickedForThisLaunch && !string.IsNullOrWhiteSpace(requestedModel) && _resolvedModel is null)
+            EmitModelFallbackNote(requestedModel);
 
         // The session is established (initialize + session/new both completed) — the caller
         // (orchestrator) can now treat this agent as live. Enqueue the initial turn without
@@ -2393,6 +2399,16 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             return true;
         }
     }
+
+    /// <summary>Tells the user, in the transcript itself, that the model they picked is not the one
+    /// answering — the daemon's own warning reaches only the daemon log, which the launching surface
+    /// never shows.</summary>
+    void EmitModelFallbackNote(string requestedModel) =>
+        EmitEnvelope(new AcpEventEnvelope(
+            Seq: 0,
+            Kind: AcpEventKind.SystemNote,
+            Text: $"{_vendor} does not offer the model '{requestedModel}'; this session is running {_vendor}'s default model instead.",
+            TimestampIso: NowIso()));
 
     /// <summary>The §8 surfacing envelope — emitted after commit and settlement, before reopen,
     /// while the worker is still parked, so it deterministically precedes every resumed envelope.

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -332,7 +332,8 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
                 ctx.Prompt,
                 launchDeadline?.Token ?? ct,
                 ResolveRequestedModel(descriptor, config, ctx),
-                mcpServers
+                mcpServers,
+                LaunchPickedTheModel(ctx)
             ).ConfigureAwait(false);
         } catch (OperationCanceledException ex) when (launchDeadline is { IsCancellationRequested: true }
                                                 && !ct.IsCancellationRequested) {
@@ -690,21 +691,26 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     internal static bool UsesMcpNameAllowlistArgv(AcpVendorDescriptor descriptor) =>
         descriptor.Vendor == AcpVendorDescriptors.Gemini.Vendor;
 
+    /// <summary>Whether the model reaching the runtime is the launch's own pick rather than the
+    /// daemon-wide default. Only the pick is worth telling the user about when the vendor drops it —
+    /// a default the vendor does not publish would otherwise nag on every launch. The UI dispatches
+    /// the literal string <c>"default"</c>, not an empty one, when the user picked nothing (the same
+    /// sentinel convention <c>CodexLauncher.AddModelArg</c> reads).</summary>
+    static bool LaunchPickedTheModel(RuntimeStartContext ctx) =>
+        !string.IsNullOrEmpty(ctx.Model) && !string.Equals(ctx.Model, "default", StringComparison.OrdinalIgnoreCase);
+
     /// <summary>
     /// Merges the per-launch model override with the daemon-wide default —
-    /// <paramref name="ctx"/>'s own <c>Model</c> takes precedence when the launch specifies one,
-    /// else falls back to <paramref name="descriptor"/>'s <c>ResolveDefaultModel</c>. Mirrors the
-    /// existing <c>"default"</c>-sentinel convention <c>CodexLauncher.AddModelArg</c> already uses
-    /// for "no override requested" (the UI dispatches the literal string <c>"default"</c>, not an
-    /// empty string, when the user hasn't picked a model). The merged value is still a bare family
-    /// prefix or an exact <c>modelId</c> — final resolution against the session's
+    /// <paramref name="ctx"/>'s own <c>Model</c> takes precedence when the launch picked one, else
+    /// <paramref name="descriptor"/>'s <c>ResolveDefaultModel</c>. Shares
+    /// <see cref="LaunchPickedTheModel"/> with the fallback notice, so which value won here and
+    /// whether the user is told it was dropped cannot disagree. The merged value is still a bare
+    /// family prefix or an exact <c>modelId</c> — final resolution against the session's
     /// <c>availableModels</c> happens in <see cref="AcpHostedAgentRuntime"/> via
     /// <see cref="Capacitor.Cli.Core.Acp.AcpModelResolver"/>.
     /// </summary>
     static string? ResolveRequestedModel(AcpVendorDescriptor descriptor, DaemonConfig config, RuntimeStartContext ctx) =>
-        !string.IsNullOrEmpty(ctx.Model) && !string.Equals(ctx.Model, "default", StringComparison.OrdinalIgnoreCase)
-            ? ctx.Model
-            : descriptor.ResolveDefaultModel(config);
+        LaunchPickedTheModel(ctx) ? ctx.Model : descriptor.ResolveDefaultModel(config);
 
     /// <summary>
     /// PURE builder for a real launch's spawn shape — no process side effects. StartRealProcess is

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -333,7 +333,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
                 launchDeadline?.Token ?? ct,
                 ResolveRequestedModel(descriptor, config, ctx),
                 mcpServers,
-                LaunchPickedTheModel(ctx)
+                ModelOwedAnExplanation(ctx)
             ).ConfigureAwait(false);
         } catch (OperationCanceledException ex) when (launchDeadline is { IsCancellationRequested: true }
                                                 && !ct.IsCancellationRequested) {
@@ -692,12 +692,21 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         descriptor.Vendor == AcpVendorDescriptors.Gemini.Vendor;
 
     /// <summary>Whether the model reaching the runtime is the launch's own pick rather than the
-    /// daemon-wide default. Only the pick is worth telling the user about when the vendor drops it —
-    /// a default the vendor does not publish would otherwise nag on every launch. The UI dispatches
-    /// the literal string <c>"default"</c>, not an empty one, when the user picked nothing (the same
-    /// sentinel convention <c>CodexLauncher.AddModelArg</c> reads).</summary>
+    /// daemon-wide default. The UI dispatches the literal string <c>"default"</c>, not an empty one,
+    /// when the user picked nothing (the same sentinel convention <c>CodexLauncher.AddModelArg</c>
+    /// reads).</summary>
     static bool LaunchPickedTheModel(RuntimeStartContext ctx) =>
         !string.IsNullOrEmpty(ctx.Model) && !string.Equals(ctx.Model, "default", StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>The model the user is owed an explanation for if selection does not apply it, or null
+    /// when nothing was picked. A default the vendor does not publish is deliberately not disclosed —
+    /// nobody asked for it, and a note on every launch trains the user to ignore it. A pick the
+    /// orchestrator already cleared is still disclosed: that path drops it precisely because the
+    /// vendor cannot apply one, so it is the case most in need of saying so.</summary>
+    static string? ModelOwedAnExplanation(RuntimeStartContext ctx) =>
+        ctx.DroppedModelPick is { Length: > 0 } dropped ? dropped
+            : LaunchPickedTheModel(ctx) ? ctx.Model
+            : null;
 
     /// <summary>The merged value is a bare family prefix or an exact <c>modelId</c>; resolution
     /// against the session's <c>availableModels</c> happens in <see cref="AcpHostedAgentRuntime"/>

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -699,16 +699,9 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     static bool LaunchPickedTheModel(RuntimeStartContext ctx) =>
         !string.IsNullOrEmpty(ctx.Model) && !string.Equals(ctx.Model, "default", StringComparison.OrdinalIgnoreCase);
 
-    /// <summary>
-    /// Merges the per-launch model override with the daemon-wide default —
-    /// <paramref name="ctx"/>'s own <c>Model</c> takes precedence when the launch picked one, else
-    /// <paramref name="descriptor"/>'s <c>ResolveDefaultModel</c>. Shares
-    /// <see cref="LaunchPickedTheModel"/> with the fallback notice, so which value won here and
-    /// whether the user is told it was dropped cannot disagree. The merged value is still a bare
-    /// family prefix or an exact <c>modelId</c> — final resolution against the session's
-    /// <c>availableModels</c> happens in <see cref="AcpHostedAgentRuntime"/> via
-    /// <see cref="Capacitor.Cli.Core.Acp.AcpModelResolver"/>.
-    /// </summary>
+    /// <summary>The merged value is a bare family prefix or an exact <c>modelId</c>; resolution
+    /// against the session's <c>availableModels</c> happens in <see cref="AcpHostedAgentRuntime"/>
+    /// via <see cref="Capacitor.Cli.Core.Acp.AcpModelResolver"/>.</summary>
     static string? ResolveRequestedModel(AcpVendorDescriptor descriptor, DaemonConfig config, RuntimeStartContext ctx) =>
         LaunchPickedTheModel(ctx) ? ctx.Model : descriptor.ResolveDefaultModel(config);
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1960,7 +1960,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
             }
 
-            LogLaunching(agentId, repoPath, effort ?? "default", effectiveModel);
+            LogLaunching(agentId, repoPath, cmd.Vendor, effort ?? "default", effectiveModel);
 
             // Review launches base the worktree on the PR head ref so the agent
             // works against the PR's actual state, not the local HEAD.
@@ -4808,8 +4808,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     // ── LoggerMessage source-generated methods ────────────────────────────
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Launching agent {AgentId} for {Repo} (effort={Effort}, model={Model})")]
-    partial void LogLaunching(string agentId, string repo, string effort, string? model);
+    // Vendor belongs on the same line as the model: without it, a model that does not belong to the
+    // launched vendor is only visible by correlating with a later runtime line, and PTY vendors emit
+    // no such line at all.
+    [LoggerMessage(Level = LogLevel.Information, Message = "Launching agent {AgentId} for {Repo} (vendor={Vendor}, effort={Effort}, model={Model})")]
+    partial void LogLaunching(string agentId, string repo, string vendor, string effort, string? model);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "Vendor '{Vendor}' cannot apply a requested model; launching with its default and reporting no model instead of '{RequestedModel}', so the dashboard and analytics are not told a model is live that isn't.")]
     partial void LogModelSelectionUnsupported(string vendor, string requestedModel);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1802,6 +1802,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         var modelDisposition = ModelSelectionLaunchPolicy.Evaluate(
             effectiveModel, runtimeFactory.SupportsModelSelection, cmd.ExplicitReviewerModel is not null);
 
+        string? droppedModelPick = null;
+
         if (modelDisposition != ModelSelectionDisposition.Honor) {
             // Non-null by construction: Evaluate returns Honor whenever the requested model is
             // null/blank, so reaching here means a model really was asked for. Captured before the
@@ -1817,7 +1819,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             }
 
             LogModelSelectionUnsupported(cmd.Vendor, unhonorableModel);
-            effectiveModel = null;
+            droppedModelPick = unhonorableModel;
+            effectiveModel   = null;
         }
 
         if (isReviewFlow && cmd.Borrowed && !runtimeFactory.SupportsBorrowedReviewFlow) {
@@ -2104,6 +2107,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 // runtime instead registers the handshake-confirmed model (see registeredModel),
                 // which can only narrow this request, never substitute a different one.
                 Model: effectiveModel,
+                DroppedModelPick: droppedModelPick,
                 Effort: effort,
                 Tools: tools,
                 IsReview: isReview,

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -206,6 +206,11 @@ internal sealed record RuntimeStartContext(
         // .ReviewFlowRedirectsHome is the other. The ONE thing AcpReviewFlowMcp reads, so the two
         // causes cannot end up expressed differently at the two ends of the same launch.
         bool               RequiresBrokeredResultDelivery = false,
+        // The model this launch asked for and did not get, when ModelSelectionLaunchPolicy cleared
+        // Model above so the dashboard is not told a model is live that isn't. Carried separately
+        // because the two answer different questions: Model is what the process runs, this is what
+        // the user is owed an explanation for.
+        string?            DroppedModelPick = null,
         // Caller-selected Codex sandbox/approval posture, carried verbatim from
         // LaunchAgentCommand.CodexPosture through to LauncherContext.CodexPosture. Non-null only for
         // an interactive daemon-owned-worktree Codex launch that passed the orchestrator's guard.

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpModelFallbackNoticeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpModelFallbackNoticeTests.cs
@@ -1,0 +1,138 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Acp;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// A requested model the vendor does not publish is dropped for the vendor's default — correct, and
+/// until now visible only in the daemon log, so the launcher kept showing the model the user picked
+/// while another one answered. These pin the note that tells them, and pin that a model which WAS
+/// applied stays silent (a note on every launch would train the user to ignore it).
+/// </summary>
+public class AcpModelFallbackNoticeTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(10);
+
+    sealed class FakeAcpProcess : IAcpProcess {
+        readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int  Pid       { get; } = 4242;
+        public bool HasExited { get; private set; }
+        public int? ExitCode  { get; private set; }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => _exited.Task;
+
+        public Task TerminateAsync(TimeSpan? timeout = null) {
+            HasExited = true;
+            ExitCode  = 0;
+            _exited.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    static RuntimeStartContext MakeContext(string agentId, string? model) => new(
+        AgentId: agentId, Vendor: "cursor", SourceRepoPath: "/repo",
+        Worktree: new WorktreeInfo(Path: "/abs/worktree", Branch: "branch-name", SourceRepo: "/repo"), Prompt: "",
+        Model: model, Effort: null, Tools: null,
+        IsReview: false, IsReviewFlow: false, Review: null,
+        Cols: 80, Rows: 24, ServerUrl: null, DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap",
+        ActivityClock: null);
+
+    sealed class Harness : IAsyncDisposable {
+        public FakeAcpAgent                 Fake    { get; }
+        public AcpHostedAgentRuntimeFactory Factory { get; }
+        public CancellationTokenSource      Cts     { get; } = new();
+
+        Task _fakeRunTask = Task.CompletedTask;
+
+        public Harness() {
+            Fake = new FakeAcpAgent();
+
+            var connection = new ServerConnection(
+                new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+                NullLoggerFactory.Instance,
+                NullLogger<ServerConnection>.Instance);
+
+            Factory = new AcpHostedAgentRuntimeFactory(
+                descriptor: AcpVendorDescriptors.Cursor,
+                config: new DaemonConfig { CursorPath = "cursor-agent" },
+                loggerFactory: NullLoggerFactory.Instance,
+                connection: connection,
+                connectionSource: _ => (Fake.ClientWriteStream, Fake.ClientReadStream, new FakeAcpProcess()),
+                timeProvider: new FakeTimeProvider());
+        }
+
+        public void PublishModels(params string[] modelIds) =>
+            Fake.SetSessionNewResult(FakeAcpAgent.BuildSessionNewResult(
+                FakeAcpAgent.FixedSessionId, modelIds[0], modelIds.Select(m => (m, m))));
+
+        public void StartFakeAgentLoop() => _fakeRunTask = Fake.RunAsync(Cts.Token);
+
+        public async ValueTask DisposeAsync() {
+            Cts.Cancel();
+            try { await _fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+            await Fake.DisposeAsync();
+            Cts.Dispose();
+        }
+    }
+
+    static List<AcpEventEnvelope> Drain(IAcpTranscriptSource transcript) {
+        var envelopes = new List<AcpEventEnvelope>();
+        while (transcript.Envelopes.TryRead(out var envelope)) envelopes.Add(envelope);
+        return envelopes;
+    }
+
+    static IEnumerable<string> SystemNotes(IAcpTranscriptSource transcript) =>
+        Drain(transcript).Where(e => e.Kind == AcpEventKind.SystemNote).Select(e => e.Text ?? "");
+
+    [Test]
+    public async Task A_requested_model_the_vendor_does_not_publish_is_reported_as_a_system_note() {
+        await using var h = new Harness();
+        h.PublishModels("cursor-fast", "cursor-smart");
+        h.StartFakeAgentLoop();
+
+        var start = await h.Factory
+            .StartAsync(MakeContext("agent-mismatch", model: "gemini-3.7-flash"), h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        var notes = SystemNotes(start.Transcript!).ToList();
+        await Assert.That(notes.Count).IsEqualTo(1);
+        await Assert.That(notes[0]).Contains("gemini-3.7-flash");
+        await Assert.That(notes[0]).Contains("cursor");
+    }
+
+    [Test]
+    public async Task An_applied_model_emits_no_system_note() {
+        await using var h = new Harness();
+        h.PublishModels("cursor-fast", "cursor-smart");
+        h.StartFakeAgentLoop();
+
+        var start = await h.Factory
+            .StartAsync(MakeContext("agent-applied", model: "cursor-smart"), h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(start.Transcript!.ResolvedModel).IsEqualTo("cursor-smart");
+        await Assert.That(SystemNotes(start.Transcript!)).IsEmpty();
+    }
+
+    /// A launch that picked nothing still carries the daemon-wide default down to the selector, and
+    /// the models published here deliberately exclude it — so the drop really does happen and the
+    /// silence is the gate doing its job, not the absence of anything to report.
+    [Test]
+    public async Task A_daemon_default_the_vendor_does_not_publish_is_dropped_silently() {
+        await using var h = new Harness();
+        h.PublishModels("cursor-fast", "cursor-smart");
+        h.StartFakeAgentLoop();
+
+        var start = await h.Factory
+            .StartAsync(MakeContext("agent-default", model: null), h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        await Assert.That(start.Transcript!.ResolvedModel).IsNull();
+        await Assert.That(SystemNotes(start.Transcript!)).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpModelFallbackNoticeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpModelFallbackNoticeTests.cs
@@ -8,10 +8,9 @@ using Microsoft.Extensions.Time.Testing;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
 /// <summary>
-/// A requested model the vendor does not publish is dropped for the vendor's default — correct, and
-/// until now visible only in the daemon log, so the launcher kept showing the model the user picked
-/// while another one answered. These pin the note that tells them, and pin that a model which WAS
-/// applied stays silent (a note on every launch would train the user to ignore it).
+/// A model the launch picked but the vendor drops is disclosed in the transcript; a model that was
+/// applied, and a daemon-wide default the vendor drops, are not (a note on every launch would train
+/// the user to ignore it).
 /// </summary>
 public class AcpModelFallbackNoticeTests {
     static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(10);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpModelFallbackNoticeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpModelFallbackNoticeTests.cs
@@ -33,10 +33,10 @@ public class AcpModelFallbackNoticeTests {
         public ValueTask DisposeAsync() => ValueTask.CompletedTask;
     }
 
-    static RuntimeStartContext MakeContext(string agentId, string? model) => new(
+    static RuntimeStartContext MakeContext(string agentId, string? model, string? droppedPick = null) => new(
         AgentId: agentId, Vendor: "cursor", SourceRepoPath: "/repo",
         Worktree: new WorktreeInfo(Path: "/abs/worktree", Branch: "branch-name", SourceRepo: "/repo"), Prompt: "",
-        Model: model, Effort: null, Tools: null,
+        Model: model, DroppedModelPick: droppedPick, Effort: null, Tools: null,
         IsReview: false, IsReviewFlow: false, Review: null,
         Cols: 80, Rows: 24, ServerUrl: null, DaemonBridgeUrl: null, CapacitorPath: "/usr/local/bin/kcap",
         ActivityClock: null);
@@ -102,6 +102,24 @@ public class AcpModelFallbackNoticeTests {
         await Assert.That(notes.Count).IsEqualTo(1);
         await Assert.That(notes[0]).Contains("gemini-3.7-flash");
         await Assert.That(notes[0]).Contains("cursor");
+    }
+
+    /// The orchestrator clears the model for a vendor whose selector cannot apply one, so the pick
+    /// never reaches the selector at all — the note has to come from what the launch asked for, not
+    /// from what the handshake was handed.
+    [Test]
+    public async Task A_pick_the_orchestrator_cleared_is_still_reported() {
+        await using var h = new Harness();
+        h.PublishModels("cursor-fast", "cursor-smart");
+        h.StartFakeAgentLoop();
+
+        var start = await h.Factory
+            .StartAsync(MakeContext("agent-cleared", model: null, droppedPick: "gemini-3.7-flash"), h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        var notes = SystemNotes(start.Transcript!).ToList();
+        await Assert.That(notes.Count).IsEqualTo(1);
+        await Assert.That(notes[0]).Contains("gemini-3.7-flash");
     }
 
     [Test]


### PR DESCRIPTION
Closes #716 — AI-2385

## What & why

A launch carrying a model the vendor does not publish runs the vendor's default instead. That is correct — the model list only arrives with `session/new`, so no upstream gate can refuse the launch over it — but the only trace was a daemon-log warning, and the launcher went on showing the model the user picked while a different one answered. The runtime now puts one `system_note` on the transcript naming the dropped model and the vendor whose default is running.

Both launcher surfaces already clear the model when the vendor changes, so this closes the half of the issue that was still open. The `Launching agent` log line now also carries the vendor, so a future requested-vs-running mismatch is attributable from one line rather than by correlating with a later runtime line — which PTY vendors never emit.

## Where to look

The note is gated on the launch having *picked* a model, not merely on one reaching the selector: `ResolveRequestedModel` substitutes the daemon-wide default, and a default the vendor omits would otherwise produce this note on every launch. That gate and the substitution share one predicate so they cannot disagree.

## Verification

Three new pins in `AcpModelFallbackNoticeTests`, driving the real factory against `FakeAcpAgent`: the mismatch note, silence when the model is applied, and silence for a daemon default the vendor does not publish (asserting `ResolvedModel` is null, so the drop really happens). Daemon unit suite 2869 total, 0 failed. AOT publish of the daemon clean of IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)