### PR TITLE
Probe the binary the factory would launch, not one a map remembers

### DIFF
--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1380,10 +1380,9 @@ public static partial class DaemonRunner {
         foreach (var vendor in unattended) {
             var factory = factories.First(f => string.Equals(f.Vendor, vendor, StringComparison.Ordinal));
             // The binary comes from the factory that would launch it, never from a vendor-keyed map
-            // here: the map form shipped twice with a vendor missing, and each time the daemon told
-            // the operator "CLI version unknown" for a vendor the gate had just admitted on a
-            // resolved version — the wrong one of two answers about one build, in the first place
-            // anyone looks when a reviewer misbehaves. Only the policy version is genuinely per
+            // here: a map is a second answer about one build, and the vendor it forgets is advertised
+            // as "CLI version unknown" while the admission gate resolves it fine — the wrong answer
+            // reaching the operator's log and the server. Only the policy version is genuinely per
             // vendor, and a missing arm there is a wrong string rather than a silent nothing.
             var cliPath = factory.CliPath;
             var policyVersion = vendor switch {

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1379,26 +1379,24 @@ public static partial class DaemonRunner {
         var capabilities = new List<UnattendedVendorCapability>();
         foreach (var vendor in unattended) {
             var factory = factories.First(f => string.Equals(f.Vendor, vendor, StringComparison.Ordinal));
-            var (cliPath, policyVersion) = vendor switch {
-                "claude"  => (config.ClaudePath, ClaudeLauncherPolicyVersion),
-                "cursor"  => (config.CursorPath, CursorLauncherPolicyVersion),
-                // The advertised codex policy version is chosen from the SAME resolved field the
-                // launch router uses (config.CodexAppServerActive), so the certified policy and the
-                // transport actually launched can never diverge.
-                "codex"   => (config.CodexPath,
-                              config.CodexAppServerActive ? CodexAppServerLauncherPolicyVersion : CodexLauncherPolicyVersion),
-                "copilot" => (config.CopilotPath, CopilotLauncherPolicyVersion),
-                // Named rather than left to the generic arm, which advertises CliVersion: null — there
-                // is a real configured path here to probe, and the floor is stated in that version.
-                AntigravityVendor => (config.AntigravityPath, AntigravityLauncherPolicyVersion),
-                // Named for the same reason as Antigravity above, and found the same way: a live dev
-                // daemon logged "Unattended vendor 'opencode': CLI version unknown" while the gate had
-                // just admitted it on a resolved version, because the gate probes
-                // descriptor.ResolveBinaryPath and this map did not know the vendor. Two answers about
-                // one build, and the WRONG one is what reaches the server and the operator's log — the
-                // first place anyone looks when a reviewer misbehaves.
-                "opencode" => (config.OpenCodePath, OpenCodeLauncherPolicyVersion),
-                _         => ("", $"{vendor}-unattended-v1")
+            // The binary comes from the factory that would launch it, never from a vendor-keyed map
+            // here: the map form shipped twice with a vendor missing, and each time the daemon told
+            // the operator "CLI version unknown" for a vendor the gate had just admitted on a
+            // resolved version — the wrong one of two answers about one build, in the first place
+            // anyone looks when a reviewer misbehaves. Only the policy version is genuinely per
+            // vendor, and a missing arm there is a wrong string rather than a silent nothing.
+            var cliPath = factory.CliPath;
+            var policyVersion = vendor switch {
+                "claude"  => ClaudeLauncherPolicyVersion,
+                "cursor"  => CursorLauncherPolicyVersion,
+                // Chosen from the SAME resolved field the launch router uses
+                // (config.CodexAppServerActive), so the certified policy and the transport actually
+                // launched can never diverge.
+                "codex"   => config.CodexAppServerActive ? CodexAppServerLauncherPolicyVersion : CodexLauncherPolicyVersion,
+                "copilot" => CopilotLauncherPolicyVersion,
+                AntigravityVendor => AntigravityLauncherPolicyVersion,
+                "opencode" => OpenCodeLauncherPolicyVersion,
+                _         => $"{vendor}-unattended-v1"
             };
             // Trust-by-default: a vendor's borrowed-review capability is a property of its FACTORY,
             // never of the installed build's identity. Gating this on an exact-build match made an

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
@@ -114,6 +114,8 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// capture side already knows <c>antigravity</c>. <c>agy</c> is only ever a binary name.</summary>
     public string Vendor => "antigravity";
 
+    public string CliPath => config.AntigravityPath;
+
     public bool IsAvailable() => _binaryExists(config.AntigravityPath);
 
     public bool SupportsUnattended => DescribeUnattendedSupport().Supported;

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -55,6 +55,7 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
     public string Vendor => "codex";
 
     // Capability advertisement is transport-independent — delegate every member to the PTY factory.
+    public string           CliPath                                    => _pty.CliPath;
     public bool             IsAvailable()                              => _pty.IsAvailable();
     public bool             SupportsUnattended                          => _pty.SupportsUnattended;
     public UnattendedSupport DescribeUnattendedSupport()               => _pty.DescribeUnattendedSupport();

--- a/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntimeFactory.cs
@@ -64,6 +64,8 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
 
     public string Vendor => "pi";
 
+    public string CliPath => config.PiPath;
+
     public bool IsAvailable() => _binaryExists(config.PiPath);
 
     /// <summary>PR-1 only — the reviewer lane is not implemented yet. Pi never claimed unattended

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -115,7 +115,9 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// implementation, or a test double, is equally valid and would defeat one.</summary>
     public bool SupportsModelSelection => descriptor.ModelSelector.CanSelectModel;
 
-    public bool IsAvailable() => CliResolver.Exists(descriptor.ResolveBinaryPath(config));
+    public string CliPath => descriptor.ResolveBinaryPath(config);
+
+    public bool IsAvailable() => CliResolver.Exists(CliPath);
 
     public async Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
         LogLaunching(ctx.AgentId, Vendor, ctx.Worktree.Path);

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -35,6 +35,13 @@ internal interface IHostedAgentRuntimeFactory {
     /// </summary>
     bool IsAvailable();
 
+    /// <summary>The binary this factory would launch — the one whose <c>--version</c> identifies the
+    /// build a launch actually gets. Every factory already resolves it to answer
+    /// <see cref="IsAvailable"/>, so asking here is what keeps the advertised version and the admitted
+    /// build one answer: a vendor-keyed map beside them drifts, and the drift is silent (the operator
+    /// reads "CLI version unknown" for a vendor the gate just admitted on a resolved version).</summary>
+    string CliPath { get; }
+
     /// <summary>
     /// Whether this vendor can host a fully UNATTENDED agent (<see cref="LaunchKind.ReviewFlow"/>).
     /// The orchestrator refuses an unattended launch for a vendor that returns <c>false</c>.

--- a/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
@@ -35,6 +35,8 @@ internal sealed partial class PtyHostedAgentRuntimeFactory(
     /// launcher (Claude, Codex) owns its accepted aliases/ids and canonical/equivalence behavior.</summary>
     public IReviewerModelResolver? ReviewerModelResolver => launcher.ReviewerModelResolver;
 
+    public string CliPath => launcher.CliPath;
+
     public bool IsAvailable() => launcher.IsAvailable();
 
     /// <remarks>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerAntigravityFloorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerAntigravityFloorTests.cs
@@ -303,9 +303,9 @@ public class DaemonRunnerAntigravityFloorTests {
     }
 
     /// <summary>The version comes from the factory that would launch the binary, so a vendor the
-    /// policy-version switch has no arm for still advertises the build it would run. That switch is
-    /// the recurring hazard: gemini and kiro reached a live daemon reported as "CLI version unknown"
-    /// while the gate had just admitted them on a resolved version.</summary>
+    /// policy-version switch has no arm for still advertises the build it would run. The stub is a
+    /// real executable because that is the only thing separating a derived path from a fixed one —
+    /// the policy version is identical either way.</summary>
     [Test]
     [UnsupportedOSPlatform("windows")]
     public async Task AVendorThePolicySwitchDoesNotNameStillAdvertisesItsProbedVersion() {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerAntigravityFloorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerAntigravityFloorTests.cs
@@ -18,7 +18,8 @@ public class DaemonRunnerAntigravityFloorTests {
 
     [TempDaemonPaths] public required TempDaemonStore Daemons { get; init; }
 
-    sealed class FakeFactory(string vendor, bool advertised) : IHostedAgentRuntimeFactory {
+    sealed class FakeFactory(string vendor, bool advertised, string cliPath = "") : IHostedAgentRuntimeFactory {
+        public string CliPath            { get; } = cliPath;
         public string Vendor             { get; } = vendor;
         public bool   SupportsUnattended { get; } = advertised;
 
@@ -290,16 +291,34 @@ public class DaemonRunnerAntigravityFloorTests {
 
         using var stubDir = StubAgy("1.1.10", out var stub);
 
-        var config = Config();
-        config.AntigravityPath = stub;
-
         var capabilities = DaemonRunner.ComputeUnattendedVendorCapabilities(
-            [new FakeFactory("antigravity", advertised: true)], config, advertised: ["antigravity"]);
+            [new FakeFactory("antigravity", advertised: true, cliPath: stub)], Config(),
+            advertised: ["antigravity"]);
 
         var antigravity = capabilities.Single();
 
         await Assert.That(antigravity.CliVersion).IsEqualTo("1.1.10");
         await Assert.That(antigravity.LauncherPolicyVersion)
             .IsEqualTo(DaemonRunner.AntigravityLauncherPolicyVersion);
+    }
+
+    /// <summary>The version comes from the factory that would launch the binary, so a vendor the
+    /// policy-version switch has no arm for still advertises the build it would run. That switch is
+    /// the recurring hazard: gemini and kiro reached a live daemon reported as "CLI version unknown"
+    /// while the gate had just admitted them on a resolved version.</summary>
+    [Test]
+    [UnsupportedOSPlatform("windows")]
+    public async Task AVendorThePolicySwitchDoesNotNameStillAdvertisesItsProbedVersion() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary below is a POSIX shell script.");
+
+        using var stubDir = StubAgy("0.56.0", out var stub);
+
+        var capabilities = DaemonRunner.ComputeUnattendedVendorCapabilities(
+            [new FakeFactory("gemini", advertised: true, cliPath: stub)], Config(), advertised: ["gemini"]);
+
+        var gemini = capabilities.Single();
+
+        await Assert.That(gemini.CliVersion).IsEqualTo("0.56.0");
+        await Assert.That(gemini.LauncherPolicyVersion).IsEqualTo("gemini-unattended-v1");
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCursorAvailabilityTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCursorAvailabilityTests.cs
@@ -23,6 +23,7 @@ public class DaemonRunnerCursorAvailabilityTests {
             bool supportsBorrowedReviewFlow = false,
             IReviewerModelResolver? reviewerModelResolver = null,
             string? borrowedReviewContainment = null) : IHostedAgentRuntimeFactory {
+        public string CliPath => "unused-by-this-double";
         public string Vendor             { get; } = vendor;
         public bool   SupportsUnattended { get; } = supportsUnattended;
         public bool   SupportsBorrowedReviewFlow { get; } = supportsBorrowedReviewFlow;
@@ -137,6 +138,7 @@ public class DaemonRunnerCursorAvailabilityTests {
     /// answering it spawns the vendor binary for the gated reviewers.</summary>
     sealed class WithholdingRuntimeFactory(string vendor, string? withheldReason, bool isAvailable = true)
             : IHostedAgentRuntimeFactory {
+        public string CliPath => "unused-by-this-double";
         public int Describes { get; private set; }
 
         public string Vendor             { get; } = vendor;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityReviewerReapingTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityReviewerReapingTests.cs
@@ -166,6 +166,7 @@ public class AntigravityReviewerReapingTests {
     /// exactly as a real first turn would. Mirrors the real factory's one load-bearing ordering: the
     /// conversation id is resolved before control returns.</summary>
     sealed class AntigravityRuntimeSpyFactory : IHostedAgentRuntimeFactory {
+    public string CliPath => "unused-by-this-double";
         public string Vendor             => "antigravity";
         public bool   SupportsUnattended => true;
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -19,6 +19,7 @@ public class CodexHostedAgentRuntimeFactoryTests {
 
     // ── Test doubles ─────────────────────────────────────────────────────────────────────────
     sealed class RecordingPtyFactory : IHostedAgentRuntimeFactory {
+    public string CliPath => "unused-by-this-double";
         public int StartCalls;
         public string Vendor => "codex";
         public bool IsAvailable() => true;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpLaunchStageTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpLaunchStageTests.cs
@@ -452,6 +452,7 @@ public class AcpLaunchStageOrchestratorTests {
     /// was ever wired, and only the Running-flip's own Clear bumped the seq" — verified by mutation
     /// below. Object-identity plus a same-instance read-back closes that gap.</summary>
     sealed class StageStampingAcpRuntimeFactory(string vendor = "cursor") : IHostedAgentRuntimeFactory {
+    public string CliPath => "unused-by-this-double";
         public string Vendor             { get; } = vendor;
         public bool   SupportsUnattended => false;
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorBorrowLaunchTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorBorrowLaunchTests.cs
@@ -816,6 +816,7 @@ public class AgentOrchestratorBorrowLaunchTests {
     /// (non-<see cref="CodexHooksNotInstalledException"/>) failure, driving the launch into the
     /// main failed-launch cleanup path AFTER the worktree is assigned.</summary>
     sealed class ThrowingHostedAgentRuntimeFactory(string vendor, string message) : IHostedAgentRuntimeFactory {
+    public string CliPath => "unused-by-this-double";
         public string  Vendor            { get; }              = vendor;
         public bool    SupportsUnattended                       => true;
         public string? LastWorktreePath  { get; private set; }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LaunchStageEvidenceLaneTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LaunchStageEvidenceLaneTests.cs
@@ -36,6 +36,7 @@ public class LaunchStageEvidenceLaneTests {
     /// failed-handshake cleanup path.</summary>
     sealed class FourStageAcpRuntimeFactory(
             CaptureServerConnection server, bool throwAfterFirstStage = false) : IHostedAgentRuntimeFactory {
+        public string CliPath => "unused-by-this-double";
         public static readonly string[] Stages = ["spawned", "initialized", "session_created", "model_set"];
 
         public string Vendor             => "cursor";

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpyAcpHostedAgentRuntimeFactory.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpyAcpHostedAgentRuntimeFactory.cs
@@ -9,6 +9,7 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 /// wiring, where the runtime IS its own transcript source.
 /// </summary>
 internal sealed class SpyAcpHostedAgentRuntimeFactory(string vendor = "cursor") : IHostedAgentRuntimeFactory {
+    public string CliPath => "unused-by-this-double";
     public string Vendor             { get; } = vendor;
     public bool   SupportsUnattended => false;
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpyHostedAgentRuntimeFactory.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpyHostedAgentRuntimeFactory.cs
@@ -9,6 +9,7 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 /// <see cref="IHostedAgentRuntimeFactory"/> by vendor.
 /// </summary>
 sealed class SpyHostedAgentRuntimeFactory(string vendor) : IHostedAgentRuntimeFactory {
+    public string CliPath => "unused-by-this-double";
     public string Vendor                                    { get; } = vendor;
     public bool   SupportsUnattended                        { get; init; }
     public bool   SupportsBorrowedReviewFlow                { get; init; }


### PR DESCRIPTION
Closes #725 — AI-2384 (part)

## What & why

`ComputeUnattendedVendorCapabilities` resolved each vendor's binary from a hand-maintained `switch`, so a vendor with no arm advertised `CliVersion: null` — a live daemon reported `gemini` and `kiro` as "CLI version unknown" and withheld the reviewer lane, while the admission gate that had just run probed `descriptor.ResolveBinaryPath` and resolved them fine. Two answers about one build, and the wrong one reaches the server and the operator's log. The comment on the `opencode` arm records the previous recurrence and warns about this one.

`IHostedAgentRuntimeFactory` now carries `CliPath`, which every factory already resolves to answer `IsAvailable()`. The switch keeps only the launcher-policy version, where a missing arm yields a wrong string rather than a silent nothing.

## Where to look

The member is required, not defaulted. That costs a line in each test double, and buys the guarantee a default would give away: a new vendor cannot reach the advertisement without saying what it would launch.

## Verification

`AVendorThePolicySwitchDoesNotNameStillAdvertisesItsProbedVersion` probes a real stub binary under a vendor token the switch has no arm for and asserts the version arrives — the assertion that can tell a fixed map from a derived one, since the policy version is identical either way. Daemon unit suite 2883 total, 0 failed. AOT publish clean of IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)