### PR TITLE
Say when an interactive turn has gone silent, and keep the child's stderr

### DIFF
--- a/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using System.Text;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Acp;
@@ -26,8 +27,20 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
     readonly string                  _vendor;
     readonly CancellationTokenSource _stderrDrainCts = new();
     readonly Task                    _stderrDrainTask;
+    readonly Lock                    _diagnosticsGate = new();
+    readonly StringBuilder           _diagnostics     = new();
 
     int _disposed;
+
+    /// <summary>Enough to carry a startup/auth error or a retry banner and the context around it, and
+    /// small enough that a chatty long-lived child cannot grow the daemon's heap over a whole
+    /// session. Over-cap output is dropped, never rotated — this exists to explain a failed launch or
+    /// a stalled turn, and that explanation is at the start.</summary>
+    const int DiagnosticsCap = 4096;
+
+    public string? Diagnostics {
+        get { lock (_diagnosticsGate) return _diagnostics.Length == 0 ? null : _diagnostics.ToString(); }
+    }
 
     /// <param name="debugFrames">
     /// <c>KCAP_ACP_DEBUG_FRAMES</c> (<see cref="DaemonConfig.DebugFrames"/>) — off by default. When
@@ -63,6 +76,12 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
 
                 if (line.Length == 0) continue;
 
+                // Retained whatever the log level does: the operator opts into per-line logging, not
+                // into being able to explain a stall after the fact, and the vendor writes its whole
+                // diagnosis here (gemini's "Attempt N failed: RATE_LIMIT_EXCEEDED … Retrying after
+                // 70650ms" reached a live daemon and was thrown away). Daemon-local only.
+                Capture(line);
+
                 // KCAP_ACP_DEBUG_FRAMES gate (Off by default) — stderr can carry paths, prompt
                 // fragments, or error detail, so it is only logged verbatim when explicitly opted in;
                 // otherwise only its length is logged.
@@ -77,6 +96,14 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
             // Pipe torn down (process killed mid-read) — expected on teardown.
         } catch (ObjectDisposedException) {
             // Stream disposed out from under us (process.Dispose() raced the read) — expected.
+        }
+    }
+
+    void Capture(string line) {
+        lock (_diagnosticsGate) {
+            if (_diagnostics.Length >= DiagnosticsCap) return;
+
+            _diagnostics.Append(line).Append('\n');
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
@@ -101,9 +101,13 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
 
     void Capture(string line) {
         lock (_diagnosticsGate) {
-            if (_diagnostics.Length >= DiagnosticsCap) return;
+            var room = DiagnosticsCap - _diagnostics.Length;
+            if (room <= 0) return;
 
-            _diagnostics.Append(line).Append('\n');
+            // Truncated per append, not merely gated on it: a vendor that writes one enormous line —
+            // a stack trace, a base64 payload — would otherwise store all of it and carry it into a
+            // Warning, which is the bound this cap exists to hold.
+            _diagnostics.Append(line.AsSpan(0, Math.Min(line.Length, room - 1))).Append('\n');
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
@@ -1,5 +1,4 @@
 using System.Diagnostics;
-using System.Text;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Acp;
@@ -28,18 +27,22 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
     readonly CancellationTokenSource _stderrDrainCts = new();
     readonly Task                    _stderrDrainTask;
     readonly Lock                    _diagnosticsGate = new();
-    readonly StringBuilder           _diagnostics     = new();
+    readonly Queue<string>           _diagnostics     = new();
 
     int _disposed;
+    int _diagnosticsLength;
 
     /// <summary>Enough to carry a startup/auth error or a retry banner and the context around it, and
     /// small enough that a chatty long-lived child cannot grow the daemon's heap over a whole
-    /// session. Over-cap output is dropped, never rotated — this exists to explain a failed launch or
-    /// a stalled turn, and that explanation is at the start.</summary>
+    /// session.</summary>
     const int DiagnosticsCap = 4096;
 
+    /// <summary>The most recent stderr within the cap, oldest lines evicted first. Recency rather
+    /// than a first-N buffer because the two readers want different moments and only recency serves
+    /// both: a failed launch has written nothing else yet, while a turn that goes silent an hour in
+    /// would otherwise be explained by startup chatter that filled the buffer and never left.</summary>
     public string? Diagnostics {
-        get { lock (_diagnosticsGate) return _diagnostics.Length == 0 ? null : _diagnostics.ToString(); }
+        get { lock (_diagnosticsGate) return _diagnostics.Count == 0 ? null : string.Join('\n', _diagnostics); }
     }
 
     /// <param name="debugFrames">
@@ -100,14 +103,16 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
     }
 
     void Capture(string line) {
-        lock (_diagnosticsGate) {
-            var room = DiagnosticsCap - _diagnostics.Length;
-            if (room <= 0) return;
+        // Truncated before it is stored, not merely gated on the running total: one enormous line —
+        // a stack trace, a base64 payload — would otherwise blow the cap on its own.
+        var kept = line.Length > DiagnosticsCap ? line[..DiagnosticsCap] : line;
 
-            // Truncated per append, not merely gated on it: a vendor that writes one enormous line —
-            // a stack trace, a base64 payload — would otherwise store all of it and carry it into a
-            // Warning, which is the bound this cap exists to hold.
-            _diagnostics.Append(line.AsSpan(0, Math.Min(line.Length, room - 1))).Append('\n');
+        lock (_diagnosticsGate) {
+            _diagnostics.Enqueue(kept);
+            _diagnosticsLength += kept.Length + 1;
+
+            while (_diagnosticsLength > DiagnosticsCap && _diagnostics.Count > 1)
+                _diagnosticsLength -= _diagnostics.Dequeue().Length + 1;
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
@@ -77,9 +77,9 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
                 if (line.Length == 0) continue;
 
                 // Retained whatever the log level does: the operator opts into per-line logging, not
-                // into being able to explain a stall after the fact, and the vendor writes its whole
-                // diagnosis here (gemini's "Attempt N failed: RATE_LIMIT_EXCEEDED … Retrying after
-                // 70650ms" reached a live daemon and was thrown away). Daemon-local only.
+                // into being able to explain a stall afterwards, and a vendor that goes silent on the
+                // wire writes its whole diagnosis here — a rate-limit retry banner reaches stderr and
+                // nowhere else. Daemon-local; never forwarded.
                 Capture(line);
 
                 // KCAP_ACP_DEBUG_FRAMES gate (Off by default) — stderr can carry paths, prompt

--- a/src/Capacitor.Cli.Daemon/Acp/IAcpProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/IAcpProcess.cs
@@ -22,4 +22,10 @@ internal interface IAcpProcess : IAsyncDisposable {
 
     /// <summary>Terminate the process (SIGTERM then SIGKILL) within <paramref name="timeout"/>.</summary>
     Task TerminateAsync(TimeSpan? timeout = null);
+
+    /// <summary>A bounded capture of whatever the child wrote to stderr, or null if it wrote nothing.
+    /// Read when a launch fails or a turn goes silent, to turn "the agent did nothing" into a reason:
+    /// a vendor waiting out a rate limit or an expired credential explains itself here and nowhere
+    /// else on the wire. Null for a double with no real child. Mirrors <c>IPiRpcProcess</c>.</summary>
+    string? Diagnostics => null;
 }

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -455,6 +455,10 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// </summary>
     readonly TimeSpan? _firstOutputDeadline;
 
+    /// <summary>Whether this launch's transcript is review output rather than a conversation someone
+    /// is watching. Decides who a silent turn is worth telling.</summary>
+    readonly bool _isReviewFlow;
+
     /// <summary>The <c>@server/tool</c> identities this launch injected — the set
     /// <see cref="AcpUnattendedInteractionPolicy.AllowlistedAutoApprove"/> approves. Null for every
     /// other policy.</summary>
@@ -612,12 +616,14 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             KiroMcpSurfaceMonitor?                                                          mcpSurfaceMonitor = null,
             Action?                                                                         onDisposed = null,
             TimeSpan?                                                                       firstOutputDeadline = null,
+            bool                                                                            isReviewFlow = false,
             IReadOnlySet<string>?                                                           admittedToolIds = null,
             AcpLaunchPermissionPreset?                                                      acpPermissionPreset = null,
             Action<AcpAutoApprovalNotice>?                                                  notifyAutoApproval = null
         ) {
         _admittedToolIds = admittedToolIds;
         _firstOutputDeadline = firstOutputDeadline;
+        _isReviewFlow        = isReviewFlow;
         _mcpSurfaceMonitor = mcpSurfaceMonitor;
         _onDisposed        = onDisposed;
         _reconnect     = reconnect;
@@ -1281,6 +1287,8 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // or chunk).
             LogTurnStarted(_agentId, _vendor);
 
+            using var silenceNotice = ArmTurnSilenceNotice();
+
             try {
                 await SendPromptAsync(connection, turn, ct).ConfigureAwait(false);
             } catch (Exception ex) when (ex is not OperationCanceledException) {
@@ -1780,6 +1788,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // below: the content was genuinely produced, and by the time the channel is completed nothing
         // downstream is reading idle state for this agent anyway.
         ActivityClock?.Advance();
+        Interlocked.Increment(ref _envelopesEmitted);
 
         lock (_aggregationLock) {
             if (_transcript.Reader.Count >= _transcriptCapacity) {
@@ -2401,6 +2410,59 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         }
     }
 
+    /// <summary>Every envelope this runtime has emitted. Read only as a difference across a silence
+    /// window — the absolute value means nothing.</summary>
+    long _envelopesEmitted;
+
+    /// <summary>How long an interactive turn may produce nothing before the user is told. Long enough
+    /// that an ordinary slow first token stays quiet (a rate-limited gemini backs off ~70s per
+    /// attempt, so a shorter window would fire mid-wave on a turn that recovers).</summary>
+    internal static readonly TimeSpan TurnSilenceWindow = TimeSpan.FromMinutes(3);
+
+    /// <summary>Watches one turn for total wire silence and, once, says so. Never reaps: a silent turn
+    /// is usually a vendor waiting out a retry it will win, and killing it would lose work the user
+    /// cannot see is coming. Armed only where nothing else bounds the turn — a reviewer launch has
+    /// <see cref="_firstOutputDeadline"/>, which does reap, and two voices on one silence would
+    /// contradict each other. Nor into a review flow's transcript, which is consumed as the round's
+    /// output — not every reviewer vendor carries that deadline, so the two conditions are separate.</summary>
+    IDisposable ArmTurnSilenceNotice() {
+        if (_isReviewFlow || _firstOutputDeadline is not null) return NullDisposable.Instance;
+
+        var cts = new CancellationTokenSource();
+        _ = WatchForTurnSilenceAsync(cts.Token);
+
+        return cts;
+    }
+
+    async Task WatchForTurnSilenceAsync(CancellationToken ct) {
+        var before = Interlocked.Read(ref _envelopesEmitted);
+
+        try {
+            await Task.Delay(TurnSilenceWindow, _timeProvider, ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            return; // the turn ended inside the window — nothing to report
+        }
+
+        if (Interlocked.Read(ref _envelopesEmitted) != before) return;
+
+        var diagnostics = _installed.Process.Diagnostics;
+
+        LogTurnSilent(_agentId, _vendor, TurnSilenceWindow.TotalMinutes, diagnostics ?? "(the child wrote nothing to stderr)");
+
+        EmitEnvelope(new AcpEventEnvelope(
+            Seq: 0,
+            Kind: AcpEventKind.SystemNote,
+            Text: $"No output from {_vendor} for {TurnSilenceWindow.TotalMinutes:0} minutes. The agent is still "
+                + "running — vendors go quiet like this while retrying a rate-limited or unauthenticated model "
+                + "call. The daemon log carries whatever the child reported.",
+            TimestampIso: NowIso()));
+    }
+
+    sealed class NullDisposable : IDisposable {
+        public static readonly NullDisposable Instance = new();
+        public void Dispose() { }
+    }
+
     /// <summary>Tells the user, in the transcript itself, that the model they picked is not the one
     /// answering. Worded for every reason the selector returns null — no match in the published list,
     /// a list published in no shape it reads, or the agent refusing the selection RPC — since which
@@ -2709,6 +2771,9 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     [LoggerMessage(Level = LogLevel.Information, Message = "ACP turn ended for agent {AgentId} (vendor={Vendor})")]
     partial void LogTurnEnded(string agentId, string vendor);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ACP turn for agent {AgentId} (vendor={Vendor}) has produced nothing for {Minutes} minutes; the child is still running. Its stderr so far: {Diagnostics}")]
+    partial void LogTurnSilent(string agentId, string vendor, double minutes, string diagnostics);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "ACP launch handshake wedged at stage '{Stage}': agentId={AgentId} did not advance within {CapSeconds}s — terminating the child.")]
     partial void LogLaunchStageTimeout(string agentId, string stage, double capSeconds);

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -2470,9 +2470,15 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
         if (Interlocked.Read(ref _turnOutputEnvelopes) != before) return;
 
+        // Behind the same gate the per-line drain uses: stderr can carry paths and prompt fragments,
+        // and a stall is not a reason to widen a privacy decision made about the same bytes. Its
+        // SIZE goes unconditionally, so an operator knows there is something to opt into.
         var diagnostics = _installed.Process.Diagnostics;
 
-        LogTurnSilent(_agentId, _vendor, TurnSilenceWindow.TotalMinutes, diagnostics ?? "(the child wrote nothing to stderr)");
+        if (_debugFrames && diagnostics is { Length: > 0 })
+            LogTurnSilentWithStderr(_agentId, _vendor, TurnSilenceWindow.TotalMinutes, AcpDebugFrameLog.Cap(diagnostics));
+        else
+            LogTurnSilent(_agentId, _vendor, TurnSilenceWindow.TotalMinutes, diagnostics?.Length ?? 0);
 
         EmitEnvelope(new AcpEventEnvelope(
             Seq: 0,
@@ -2797,8 +2803,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     [LoggerMessage(Level = LogLevel.Information, Message = "ACP turn ended for agent {AgentId} (vendor={Vendor})")]
     partial void LogTurnEnded(string agentId, string vendor);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "ACP turn for agent {AgentId} (vendor={Vendor}) has produced nothing for {Minutes} minutes; the child is still running. Its stderr so far: {Diagnostics}")]
-    partial void LogTurnSilent(string agentId, string vendor, double minutes, string diagnostics);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ACP turn for agent {AgentId} (vendor={Vendor}) has produced nothing for {Minutes} minutes; the child is still running and has written {StderrChars} chars to stderr (set KCAP_ACP_DEBUG_FRAMES=1 to log it).")]
+    partial void LogTurnSilent(string agentId, string vendor, double minutes, int stderrChars);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "ACP turn for agent {AgentId} (vendor={Vendor}) has produced nothing for {Minutes} minutes; the child is still running. Its recent stderr: {Diagnostics}")]
+    partial void LogTurnSilentWithStderr(string agentId, string vendor, double minutes, string diagnostics);
 
     [LoggerMessage(Level = LogLevel.Error, Message = "ACP launch handshake wedged at stage '{Stage}': agentId={AgentId} did not advance within {CapSeconds}s — terminating the child.")]
     partial void LogLaunchStageTimeout(string agentId, string stage, double capSeconds);

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -1789,8 +1789,8 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // downstream is reading idle state for this agent anyway.
         ActivityClock?.Advance();
 
-        // Named positively, so a metadata kind added later cannot accidentally count as the agent
-        // speaking: usage and session-info envelopes reach here with no turn in flight at all, and a
+        // Named positively, so a metadata kind added later cannot count as the agent speaking by
+        // accident: usage and session-info envelopes reach here with no turn in flight at all, and a
         // vendor that pings usage while producing nothing would otherwise read as a healthy turn.
         if (envelope.Kind is AcpEventKind.AssistantText or AcpEventKind.AssistantThinking
                           or AcpEventKind.ToolCall or AcpEventKind.ToolResult or AcpEventKind.Plan)
@@ -2437,7 +2437,17 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         var cts = new CancellationTokenSource();
         _ = WatchForTurnSilenceAsync(turn, cts.Token);
 
-        return cts;
+        // Cancel, then dispose: disposing a CancellationTokenSource does not cancel its token, so
+        // returning it directly would leave the watcher holding its delay for the whole window after
+        // every turn.
+        return new CancelOnDispose(cts);
+    }
+
+    sealed class CancelOnDispose(CancellationTokenSource cts) : IDisposable {
+        public void Dispose() {
+            cts.Cancel();
+            cts.Dispose();
+        }
     }
 
     async Task WatchForTurnSilenceAsync(PendingTurn turn, CancellationToken ct) {

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -1287,7 +1287,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // or chunk).
             LogTurnStarted(_agentId, _vendor);
 
-            using var silenceNotice = ArmTurnSilenceNotice();
+            using var silenceNotice = ArmTurnSilenceNotice(turn);
 
             try {
                 await SendPromptAsync(connection, turn, ct).ConfigureAwait(false);
@@ -1788,7 +1788,13 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // below: the content was genuinely produced, and by the time the channel is completed nothing
         // downstream is reading idle state for this agent anyway.
         ActivityClock?.Advance();
-        Interlocked.Increment(ref _envelopesEmitted);
+
+        // Named positively, so a metadata kind added later cannot accidentally count as the agent
+        // speaking: usage and session-info envelopes reach here with no turn in flight at all, and a
+        // vendor that pings usage while producing nothing would otherwise read as a healthy turn.
+        if (envelope.Kind is AcpEventKind.AssistantText or AcpEventKind.AssistantThinking
+                          or AcpEventKind.ToolCall or AcpEventKind.ToolResult or AcpEventKind.Plan)
+            Interlocked.Increment(ref _turnOutputEnvelopes);
 
         lock (_aggregationLock) {
             if (_transcript.Reader.Count >= _transcriptCapacity) {
@@ -2410,9 +2416,9 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         }
     }
 
-    /// <summary>Every envelope this runtime has emitted. Read only as a difference across a silence
-    /// window — the absolute value means nothing.</summary>
-    long _envelopesEmitted;
+    /// <summary>Envelopes that represent the agent actually saying something. Read only as a
+    /// difference across a silence window — the absolute value means nothing.</summary>
+    long _turnOutputEnvelopes;
 
     /// <summary>How long an interactive turn may produce nothing before the user is told. Long enough
     /// that an ordinary slow first token stays quiet (a rate-limited gemini backs off ~70s per
@@ -2425,17 +2431,17 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// <see cref="_firstOutputDeadline"/>, which does reap, and two voices on one silence would
     /// contradict each other. Nor into a review flow's transcript, which is consumed as the round's
     /// output — not every reviewer vendor carries that deadline, so the two conditions are separate.</summary>
-    IDisposable ArmTurnSilenceNotice() {
+    IDisposable ArmTurnSilenceNotice(PendingTurn turn) {
         if (_isReviewFlow || _firstOutputDeadline is not null) return NullDisposable.Instance;
 
         var cts = new CancellationTokenSource();
-        _ = WatchForTurnSilenceAsync(cts.Token);
+        _ = WatchForTurnSilenceAsync(turn, cts.Token);
 
         return cts;
     }
 
-    async Task WatchForTurnSilenceAsync(CancellationToken ct) {
-        var before = Interlocked.Read(ref _envelopesEmitted);
+    async Task WatchForTurnSilenceAsync(PendingTurn turn, CancellationToken ct) {
+        var before = Interlocked.Read(ref _turnOutputEnvelopes);
 
         try {
             await Task.Delay(TurnSilenceWindow, _timeProvider, ct).ConfigureAwait(false);
@@ -2443,7 +2449,16 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             return; // the turn ended inside the window — nothing to report
         }
 
-        if (Interlocked.Read(ref _envelopesEmitted) != before) return;
+        // The delay can complete and queue its continuation while the turn is ending, so neither the
+        // token nor the counter alone proves the turn is still running: a note published after the
+        // agent answered would be a lie about the state it describes. The registration is the truth.
+        lock (_reconnectLock) {
+            if (_inFlight is not { } f || !ReferenceEquals(f.Turn, turn)) return;
+        }
+
+        if (ct.IsCancellationRequested) return;
+
+        if (Interlocked.Read(ref _turnOutputEnvelopes) != before) return;
 
         var diagnostics = _installed.Process.Diagnostics;
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -230,6 +230,10 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
                 firstOutputDeadline: ReviewerLaunchTimeoutSeconds(descriptor, config, ctx) is { } firstOutputSeconds
                     ? TimeSpan.FromSeconds(firstOutputSeconds)
                     : null,
+                // Whether a silent turn has a person watching it. Not derivable from the deadline
+                // above: only some vendors carry one, so a reviewer without it would otherwise be
+                // told, in a transcript that is consumed as review output, to keep waiting.
+                isReviewFlow: ctx.IsReviewFlow,
                 // The set AllowlistedAutoApprove admits, built from the SAME injected specs and identity
                 // the trust argv is built from. Two derivations would let the reviewer be TRUSTED to call
                 // a tool the policy then refuses to approve — a round that dies on its own result call.

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpTurnSilenceNoticeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpTurnSilenceNoticeTests.cs
@@ -1,0 +1,157 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Acp;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// An interactive turn that produces nothing says so in the transcript, once, and keeps running. A
+/// reviewer launch does not: its first-output deadline already reaps, and two voices on one silence
+/// would contradict each other.
+/// </summary>
+public class AcpTurnSilenceNoticeTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(10);
+
+    /// <summary>Answers session/prompt only when a test releases it, so a turn can be held silent for
+    /// as long as the fake clock is advanced.</summary>
+    sealed class SilentProcess : IAcpProcess {
+        readonly TaskCompletionSource _exited = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        public int     Pid         { get; } = 4242;
+        public bool    HasExited   { get; private set; }
+        public int?    ExitCode    { get; private set; }
+        public string? Diagnostics { get; init; }
+
+        public Task WaitForExitAsync(TimeSpan? timeout = null) => _exited.Task;
+
+        public Task TerminateAsync(TimeSpan? timeout = null) {
+            HasExited = true;
+            ExitCode  = 0;
+            _exited.TrySetResult();
+            return Task.CompletedTask;
+        }
+
+        public ValueTask DisposeAsync() => ValueTask.CompletedTask;
+    }
+
+    static RuntimeStartContext MakeContext(string agentId, bool isReviewFlow) => new(
+        AgentId: agentId, Vendor: "cursor", SourceRepoPath: "/repo",
+        Worktree: new WorktreeInfo(Path: "/abs/worktree", Branch: "b", SourceRepo: "/repo"),
+        Prompt: "do the thing",
+        Model: null, Effort: null, Tools: null,
+        IsReview: isReviewFlow, IsReviewFlow: isReviewFlow, Review: null,
+        // A review-flow launch builds its result channel from these, and refuses without them.
+        Cols: 80, Rows: 24, ServerUrl: "http://kcap.test", DaemonBridgeUrl: null,
+        CapacitorPath: "/usr/local/bin/kcap");
+
+    sealed class Harness : IAsyncDisposable {
+        public FakeAcpAgent                 Fake    { get; }
+        public FakeTimeProvider             Time    { get; } = new();
+        public AcpHostedAgentRuntimeFactory Factory { get; }
+        public CancellationTokenSource      Cts     { get; } = new();
+
+        Task _fakeRunTask = Task.CompletedTask;
+
+        public Harness(string? stderr = null) {
+            Fake = new FakeAcpAgent();
+
+            var connection = new ServerConnection(
+                new DaemonConfig { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+                NullLoggerFactory.Instance,
+                NullLogger<ServerConnection>.Instance);
+
+            Factory = new AcpHostedAgentRuntimeFactory(
+                descriptor: AcpVendorDescriptors.Cursor,
+                config: new DaemonConfig { CursorPath = "cursor-agent" },
+                loggerFactory: NullLoggerFactory.Instance,
+                connection: connection,
+                connectionSource: _ => (Fake.ClientWriteStream, Fake.ClientReadStream,
+                                        new SilentProcess { Diagnostics = stderr }),
+                timeProvider: Time);
+        }
+
+        public void StartFakeAgentLoop() => _fakeRunTask = Fake.RunAsync(Cts.Token);
+
+        public async ValueTask DisposeAsync() {
+            Cts.Cancel();
+            try { await _fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+            await Fake.DisposeAsync();
+            Cts.Dispose();
+        }
+    }
+
+    static async Task<string?> WaitForSilenceNoteAsync(IAcpTranscriptSource transcript, FakeTimeProvider time) {
+        var deadline = DateTime.UtcNow + HangGuard;
+
+        while (DateTime.UtcNow < deadline) {
+            while (transcript.Envelopes.TryRead(out var envelope))
+                if (envelope.Kind == AcpEventKind.SystemNote && envelope.Text?.Contains("No output") == true)
+                    return envelope.Text;
+
+            time.Advance(TimeSpan.FromSeconds(30));
+            await Task.Delay(10);
+        }
+
+        return null;
+    }
+
+    [Test]
+    public async Task An_interactive_turn_that_produces_nothing_says_so_and_keeps_running() {
+        await using var h = new Harness(stderr: "Attempt 1 failed: RATE_LIMIT_EXCEEDED\n");
+        h.Fake.HoldPromptResponses = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        h.StartFakeAgentLoop();
+
+        var start = await h.Factory.StartAsync(MakeContext("agent-silent", isReviewFlow: false), h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        var note = await WaitForSilenceNoteAsync(start.Transcript!, h.Time);
+
+        await Assert.That(note).IsNotNull();
+        await Assert.That(note!).Contains("3 minutes");
+        await Assert.That(start.Runtime.HasExited).IsFalse();
+
+        // Once per turn: the watcher retires on the note, so advancing well past a second window
+        // must not produce another. A repeating one would bury the transcript it is trying to explain.
+        for (var i = 0; i < 20; i++) {
+            h.Time.Advance(TimeSpan.FromSeconds(30));
+            await Task.Delay(5);
+        }
+
+        var extra = 0;
+        while (start.Transcript!.Envelopes.TryRead(out var envelope))
+            if (envelope.Kind == AcpEventKind.SystemNote && envelope.Text?.Contains("No output") == true)
+                extra++;
+
+        await Assert.That(extra).IsEqualTo(0);
+
+        h.Fake.HoldPromptResponses.TrySetResult();
+    }
+
+    /// A reviewer launch carries a first-output deadline that reaps on the same silence — a note
+    /// beside it would promise the run continues while the reaper ends it.
+    [Test]
+    public async Task A_reviewer_turn_is_left_to_its_own_deadline() {
+        await using var h = new Harness();
+        h.Fake.HoldPromptResponses = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        h.StartFakeAgentLoop();
+
+        var start = await h.Factory.StartAsync(MakeContext("agent-reviewer", isReviewFlow: true), h.Cts.Token)
+            .WaitAsync(HangGuard);
+
+        for (var i = 0; i < 20; i++) {
+            h.Time.Advance(TimeSpan.FromSeconds(30));
+            await Task.Delay(5);
+        }
+
+        var notes = 0;
+        while (start.Transcript!.Envelopes.TryRead(out var envelope))
+            if (envelope.Kind == AcpEventKind.SystemNote && envelope.Text?.Contains("No output") == true)
+                notes++;
+
+        await Assert.That(notes).IsEqualTo(0);
+
+        h.Fake.HoldPromptResponses.TrySetResult();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpTurnSilenceNoticeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpTurnSilenceNoticeTests.cs
@@ -2,6 +2,8 @@ using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Capacitor.Cli.Daemon.Tests.Unit.Acp;
+using System.Diagnostics;
+using System.Runtime.Versioning;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
 
@@ -95,6 +97,30 @@ public class AcpTurnSilenceNoticeTests {
         }
 
         return null;
+    }
+
+    /// A line longer than the cap must not ride into the retained buffer whole — the bound is what
+    /// keeps a malformed child from leaving a large string resident for the session.
+    [Test]
+    [UnsupportedOSPlatform("windows")]
+    public async Task Retained_stderr_stays_within_its_cap_for_a_single_enormous_line() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Spawns a POSIX shell.");
+
+        var psi = new ProcessStartInfo("/bin/sh") {
+            RedirectStandardError = true, RedirectStandardOutput = true, RedirectStandardInput = true,
+        };
+        psi.ArgumentList.Add("-c");
+        psi.ArgumentList.Add("awk 'BEGIN { while (i++ < 20000) printf \"x\"; print \"\" }' 1>&2");
+
+        await using var child = new AcpChildProcess(Process.Start(psi)!, NullLogger.Instance);
+
+        await child.WaitForExitAsync(TimeSpan.FromSeconds(10));
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (child.Diagnostics is null && DateTime.UtcNow < deadline) await Task.Delay(10);
+
+        await Assert.That(child.Diagnostics).IsNotNull();
+        await Assert.That(child.Diagnostics!.Length).IsLessThanOrEqualTo(4096);
     }
 
     [Test]


### PR DESCRIPTION
Closes #715 — AI-2384

## What & why

A hosted Gemini turn ran 11m43s producing no transcript events and no error: the CLI was silently retrying a rate-limited model call in ~70s waves, writing the whole diagnosis to stderr while the ACP wire carried nothing. From the launcher it reads as a hang from launch. Two gaps made it invisible, and both are ours:

- `AcpChildProcess` drained stderr for deadlock safety and logged only line *lengths* unless the operator had opted into frame debugging, so the vendor's own explanation was thrown away. It now retains a bounded copy (4KB, dropped over cap, daemon-local) the way `PiRpcProcess` already does.
- Nothing bounded an interactive turn. After three minutes of zero envelopes the runtime now emits one `system_note` saying the agent is still running and that vendors go quiet this way, and logs a Warning carrying the retained stderr.

## Where to look

The note never reaps — a silent turn is usually a retry the vendor wins, and killing it would lose work the user cannot see coming. It is withheld from review flows for a different reason than from reviewer launches with a first-output deadline, and the two conditions are separate on purpose: only some vendors carry that deadline, so deriving one from the other would put a "keep waiting" note into a transcript that is consumed as review output.

## Verification

`AcpTurnSilenceNoticeTests` drives the real factory against `FakeAcpAgent` with the prompt response held open and a `FakeTimeProvider`: the note arrives, names the window, the runtime is still alive, a second window produces no second note, and a review-flow launch gets none at all. Daemon unit suite 2884 total, 0 failed. AOT publish of the daemon clean of IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)