### PR TITLE
Scope a terminal outcome's send-gate invalidation to its own attempt

### DIFF
--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -199,9 +199,13 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         // token -- which DeliverAsync's own check then reads as current, sending the submit CR
         // into the client being disposed.
         var token = Volatile.Read(ref _openingToken);
+        var inFlight = Volatile.Read(ref _sendInFlightToken);
         if (!CanAcceptText || _client is not { } client) return false;
         if (Volatile.Read(ref _openingToken) != token) return false;
-        Volatile.Write(ref _sendInFlightToken, token);
+        // Claim, rather than assign: CanAcceptText's in-flight half and the write that satisfies
+        // it are otherwise two steps, so two acceptances could both pass and the first delivery's
+        // clear would release the second while it is still writing.
+        if (Interlocked.CompareExchange(ref _sendInFlightToken, token, inFlight) != inFlight) return false;
         RaiseSendProjections();
         _delivery = DeliverAsync(client, token, TerminalInputEncoder.Paste(text));
         return true;

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -34,8 +34,10 @@ namespace Capacitor.App.ViewModels;
 ///   A call that loses the try-enter is a clean no-op, not a queued retry.
 /// * Send gate (_openingToken): who may accept composer text. BeginAttempt and Invalidate are its
 ///   only advances; an attempt may open the gate only while the token it carries is still current,
-///   and every publish that is not an attempt's own Connecting/Attached invalidates. State has one
-///   assignment site, Publish, which applies both rules.
+///   and a publish that is not an attempt's own Connecting/Attached invalidates -- a terminal
+///   outcome only while its OWN attempt still holds the token, since a reattach takes its token
+///   before it disposes the client whose outcome it is retiring. State has one assignment site,
+///   Publish, which applies both rules.
 ///
 /// UI affinity: the resolve gate mutates State after ObserveOn(RxSchedulers.MainThreadScheduler)
 /// or RxSchedulers.MainThreadScheduler.Schedule(...) (the TimeProvider timer fires off-thread in
@@ -152,7 +154,15 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     }
 
     /// The one place State is assigned. An attempt-owned publish (Connecting, Attached) carries
-    /// its token and is discarded when that token is stale; every other state is an invalidation.
+    /// its token and is discarded when that token is stale.
+    ///
+    /// A terminal state renders whether or not its token is still current -- an explicit detach
+    /// invalidates BEFORE the Detached outcome it asked for arrives -- but invalidates only while
+    /// its own attempt still holds the token. A reattach takes its token before it disposes the
+    /// client whose outcome this is, so bumping past a stale one would retire the replacement
+    /// attempt that already owns it, silently discarding its Connecting and Attached. `null` is
+    /// the unconditional form, for the invalidations no attempt owns (a removal, the resolve
+    /// gate's verdicts).
     void Publish(TerminalSessionState state, int? ownerToken) {
         if (state.Phase is TerminalSessionPhase.Connecting or TerminalSessionPhase.Attached) {
             if (ownerToken != Volatile.Read(ref _openingToken)) return;
@@ -164,7 +174,8 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         // State first: Invalidate raises the projections, and they must not be read against the
         // state this publish is replacing.
         State = state;
-        Invalidate();
+        if (ownerToken is null || ownerToken == Volatile.Read(ref _openingToken)) Invalidate();
+        else RaiseSendProjections(); // the owning attempt closed the gate already; only State moved
     }
 
     /// Synchronous acceptance on the UI thread: true means the text is on its way through the
@@ -454,7 +465,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
 
             _client = client;
             WireSurface(surface, client, generation);
-            _runTask = RunAttemptAsync(generation, client, surface, decoder, cols, rows, token);
+            _runTask = RunAttemptAsync(generation, openingToken, client, surface, decoder, cols, rows, token);
         } catch (OperationCanceledException) {
             // Retired before the swap even finished (e.g. TeardownAsync raced this call) --
             // expected, not an error.
@@ -499,17 +510,17 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         }, DispatcherPriority.Default, ct);
     }
 
-    async Task RunAttemptAsync(int generation, ITerminalAttachClient client, ITerminalSurface surface, Utf8StreamDecoder decoder, int cols, int rows, CancellationToken ct) {
+    async Task RunAttemptAsync(int generation, int openingToken, ITerminalAttachClient client, ITerminalSurface surface, Utf8StreamDecoder decoder, int cols, int rows, CancellationToken ct) {
         AttachOutcome outcome;
         try {
             outcome = await client.RunAsync(cols, rows, ct).ConfigureAwait(false);
         } catch (OperationCanceledException) {
             return; // retired attempt's own cancellation -- silent, never an error
         } catch (AttachCallbackException ex) {
-            await FinishAttemptAsync(generation, surface, decoder, TerminalSessionState.Failed(Describe(ex))).ConfigureAwait(false);
+            await FinishAttemptAsync(generation, openingToken, surface, decoder, TerminalSessionState.Failed(Describe(ex))).ConfigureAwait(false);
             return;
         } catch (Exception ex) {
-            await FinishAttemptAsync(generation, surface, decoder, TerminalSessionState.Failed(ex.Message)).ConfigureAwait(false);
+            await FinishAttemptAsync(generation, openingToken, surface, decoder, TerminalSessionState.Failed(ex.Message)).ConfigureAwait(false);
             return;
         }
 
@@ -520,7 +531,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
             AttachOutcome.ConnectionLost    => TerminalSessionState.Failed("the terminal lost connection to the daemon"),
             _                                => TerminalSessionState.Failed("unknown attach outcome"),
         };
-        await FinishAttemptAsync(generation, surface, decoder, mapped).ConfigureAwait(false);
+        await FinishAttemptAsync(generation, openingToken, surface, decoder, mapped).ConfigureAwait(false);
     }
 
     static string Describe(AttachCallbackException ex) => ex.InnerException?.Message ?? ex.Message;
@@ -536,12 +547,12 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     // nothing else in this VM ever calls Flush -- without it, that trailing partial sequence is
     // silently dropped instead of rendering (typically as U+FFFD, same as any other genuinely
     // truncated stream).
-    Task FinishAttemptAsync(int generation, ITerminalSurface surface, Utf8StreamDecoder decoder, TerminalSessionState state) =>
+    Task FinishAttemptAsync(int generation, int openingToken, ITerminalSurface surface, Utf8StreamDecoder decoder, TerminalSessionState state) =>
         Dispatcher.UIThread.InvokeAsync(() => {
             if (generation != _attemptGeneration) return;
             var remainder = decoder.Flush();
             if (remainder.Length > 0) surface.Feed(remainder);
-            Publish(state, null);
+            Publish(state, openingToken);
         }, DispatcherPriority.Default, CancellationToken.None).GetTask();
 
     async Task RunDetachAsync() {

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -33,9 +33,9 @@ namespace Capacitor.App.ViewModels;
 ///   real clients.
 ///   A call that loses the try-enter is a clean no-op, not a queued retry.
 /// * Send gate (_openingToken): who may accept composer text. BeginAttempt and Invalidate are its
-///   only advances, and the gate is DERIVED from ownership (_gateOpenToken == _openingToken), so
-///   an advance closes it with nothing to remember and no window in which a passed token check
-///   still opens one. A publish that is not an attempt's own Connecting/Attached invalidates -- a
+///   only advances, and both the gate and the in-flight flag are DERIVED from ownership
+///   (_gateOpenToken / _sendInFlightToken == _openingToken), so an advance settles them with
+///   nothing to remember and no window in which a passed token check still sets one. A publish that is not an attempt's own Connecting/Attached invalidates -- a
 ///   terminal outcome only while its OWN attempt still holds the token, since a reattach takes
 ///   its token before it disposes the client whose outcome it is retiring. State has one
 ///   assignment site, Publish, which applies both rules.
@@ -97,19 +97,14 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     // BeginAttempt opens nothing, and no invalidation path has to remember to close it. Starts at
     // a value no token takes, since Interlocked.Increment hands out 1 upwards.
     int _gateOpenToken = -1;
-    bool _sendInFlight;
+    // Whose send is in flight, on the same derived footing as _gateOpenToken: a check-then-set
+    // flag could be set by an acceptance that raced a claim and then never cleared, since a
+    // delivery only clears a flag it still owns -- wedging the composer for the tab's whole life.
+    int _sendInFlightToken = -1;
     Task? _delivery;
 
     /// Bound; true from a send's acceptance until its delivery ends.
-    public bool SendInFlight {
-        get => Volatile.Read(ref _sendInFlight);
-        private set {
-            if (Volatile.Read(ref _sendInFlight) == value) return;
-            Volatile.Write(ref _sendInFlight, value);
-            this.RaisePropertyChanged();
-            RaiseSendProjections();
-        }
-    }
+    public bool SendInFlight => Volatile.Read(ref _sendInFlightToken) == Volatile.Read(ref _openingToken);
 
     /// The gate itself: the attempt that opened it still owns the token.
     bool GateOpen => Volatile.Read(ref _gateOpenToken) == Volatile.Read(ref _openingToken);
@@ -139,6 +134,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     internal Task? PendingDeliveryForTesting => _delivery;
 
     void RaiseSendProjections() {
+        this.RaisePropertyChanged(nameof(SendInFlight));
         this.RaisePropertyChanged(nameof(CanAcceptText));
         this.RaisePropertyChanged(nameof(SendAvailability));
     }
@@ -146,7 +142,6 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// Closes the gate and hands the caller a fresh token, which that attempt carries for its
     /// whole life.
     int BeginAttempt() {
-        SendInFlight = false;
         var token = Interlocked.Increment(ref _openingToken);
         RaiseSendProjections();
         return token;
@@ -155,7 +150,6 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// Advances ownership past every attempt alive: an already-closed gate still allocates, since
     /// a callback queued mid-Connecting must lose its right to open.
     void Invalidate() {
-        SendInFlight = false;
         Interlocked.Increment(ref _openingToken);
         RaiseSendProjections();
     }
@@ -166,7 +160,6 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// them would be advanced past by the increment that follows: the replacement attempt
     /// retired by the very outcome this guard exists to keep out of its way.
     void InvalidateOwner(int ownerToken) {
-        SendInFlight = false;
         Interlocked.CompareExchange(ref _openingToken, ownerToken + 1, ownerToken);
         RaiseSendProjections();
     }
@@ -208,7 +201,8 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         var token = Volatile.Read(ref _openingToken);
         if (!CanAcceptText || _client is not { } client) return false;
         if (Volatile.Read(ref _openingToken) != token) return false;
-        SendInFlight = true;
+        Volatile.Write(ref _sendInFlightToken, token);
+        RaiseSendProjections();
         _delivery = DeliverAsync(client, token, TerminalInputEncoder.Paste(text));
         return true;
     }
@@ -230,7 +224,8 @@ public sealed class TerminalTabViewModel : ReactiveObject {
                 await Dispatcher.UIThread.InvokeAsync(() => {
                     if (Volatile.Read(ref _resolveState) == ResolveDisposed) return;
                     if (Volatile.Read(ref _openingToken) != token) return;
-                    SendInFlight = false;
+                    Interlocked.CompareExchange(ref _sendInFlightToken, -1, token);
+                    RaiseSendProjections();
                 });
             }
         }

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -153,16 +153,28 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         RaiseSendProjections();
     }
 
+    /// Invalidate, but only while `ownerToken` is still the current one -- as a SINGLE atomic
+    /// step. Compare-then-Invalidate would be two, and BeginAttempt runs on whatever thread
+    /// called ReattachCommand.Execute (not necessarily the UI one), so a claim landing between
+    /// them would be advanced past by the increment that follows: the replacement attempt
+    /// retired by the very outcome this guard exists to keep out of its way.
+    void InvalidateOwner(int ownerToken) {
+        _gateOpen = false;
+        SendInFlight = false;
+        Interlocked.CompareExchange(ref _openingToken, ownerToken + 1, ownerToken);
+        RaiseSendProjections();
+    }
+
     /// The one place State is assigned. An attempt-owned publish (Connecting, Attached) carries
     /// its token and is discarded when that token is stale.
     ///
     /// A terminal state renders whether or not its token is still current -- an explicit detach
-    /// invalidates BEFORE the Detached outcome it asked for arrives -- but invalidates only while
-    /// its own attempt still holds the token. A reattach takes its token before it disposes the
-    /// client whose outcome this is, so bumping past a stale one would retire the replacement
-    /// attempt that already owns it, silently discarding its Connecting and Attached. `null` is
-    /// the unconditional form, for the invalidations no attempt owns (a removal, the resolve
-    /// gate's verdicts).
+    /// invalidates BEFORE the Detached outcome it asked for arrives -- but advances the token
+    /// only while its own attempt still holds it. A reattach takes its token before it disposes
+    /// the client whose outcome this is, so advancing past a stale one would retire the
+    /// replacement attempt that already owns it, silently discarding its Connecting and Attached.
+    /// `null` is the unconditional form, for the invalidations no attempt owns (a removal, the
+    /// resolve gate's verdicts).
     void Publish(TerminalSessionState state, int? ownerToken) {
         if (state.Phase is TerminalSessionPhase.Connecting or TerminalSessionPhase.Attached) {
             if (ownerToken != Volatile.Read(ref _openingToken)) return;
@@ -174,8 +186,8 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         // State first: Invalidate raises the projections, and they must not be read against the
         // state this publish is replacing.
         State = state;
-        if (ownerToken is null || ownerToken == Volatile.Read(ref _openingToken)) Invalidate();
-        else RaiseSendProjections(); // the owning attempt closed the gate already; only State moved
+        if (ownerToken is { } owner) InvalidateOwner(owner);
+        else Invalidate();
     }
 
     /// Synchronous acceptance on the UI thread: true means the text is on its way through the

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -33,11 +33,12 @@ namespace Capacitor.App.ViewModels;
 ///   real clients.
 ///   A call that loses the try-enter is a clean no-op, not a queued retry.
 /// * Send gate (_openingToken): who may accept composer text. BeginAttempt and Invalidate are its
-///   only advances; an attempt may open the gate only while the token it carries is still current,
-///   and a publish that is not an attempt's own Connecting/Attached invalidates -- a terminal
-///   outcome only while its OWN attempt still holds the token, since a reattach takes its token
-///   before it disposes the client whose outcome it is retiring. State has one assignment site,
-///   Publish, which applies both rules.
+///   only advances, and the gate is DERIVED from ownership (_gateOpenToken == _openingToken), so
+///   an advance closes it with nothing to remember and no window in which a passed token check
+///   still opens one. A publish that is not an attempt's own Connecting/Attached invalidates -- a
+///   terminal outcome only while its OWN attempt still holds the token, since a reattach takes
+///   its token before it disposes the client whose outcome it is retiring. State has one
+///   assignment site, Publish, which applies both rules.
 ///
 /// UI affinity: the resolve gate mutates State after ObserveOn(RxSchedulers.MainThreadScheduler)
 /// or RxSchedulers.MainThreadScheduler.Schedule(...) (the TimeProvider timer fires off-thread in
@@ -90,7 +91,12 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     // live while it awaits the old client's disposal, and a detach leaves both unchanged while it
     // awaits the detach write.
     int _openingToken;
-    bool _gateOpen;
+    // Which attempt's Attached opened the gate, rather than a flag any of them may set. Open is
+    // then DERIVED from ownership, so advancing the token is itself what closes the gate: an
+    // attempt whose token check passed and whose gate-opening write lands after a concurrent
+    // BeginAttempt opens nothing, and no invalidation path has to remember to close it. Starts at
+    // a value no token takes, since Interlocked.Increment hands out 1 upwards.
+    int _gateOpenToken = -1;
     bool _sendInFlight;
     Task? _delivery;
 
@@ -105,16 +111,19 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         }
     }
 
+    /// The gate itself: the attempt that opened it still owns the token.
+    bool GateOpen => Volatile.Read(ref _gateOpenToken) == Volatile.Read(ref _openingToken);
+
     /// Bound; the one authority TrySendText itself consults, so can-execute and acceptance can
     /// never disagree.
-    public bool CanAcceptText => _gateOpen && !_sendInFlight;
+    public bool CanAcceptText => GateOpen && !_sendInFlight;
 
     /// Bound; the gate folded into the state, so a hint built from it is true in every window.
     public SendAvailability SendAvailability {
         get {
             if (_sendInFlight) return SendAvailability.Sending;
             if (State is { Phase: TerminalSessionPhase.Attached, ReadOnly: false })
-                return _gateOpen ? SendAvailability.Ready : SendAvailability.Transitioning;
+                return GateOpen ? SendAvailability.Ready : SendAvailability.Transitioning;
             return State.Phase switch {
                 TerminalSessionPhase.Attached => SendAvailability.ReadOnly,
                 TerminalSessionPhase.Resolving or TerminalSessionPhase.Connecting => SendAvailability.Connecting,
@@ -126,7 +135,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     }
 
     internal int OpeningTokenForTesting => Volatile.Read(ref _openingToken);
-    internal bool SendGateOpenForTesting => _gateOpen;
+    internal bool SendGateOpenForTesting => GateOpen;
     internal Task? PendingDeliveryForTesting => _delivery;
 
     void RaiseSendProjections() {
@@ -137,7 +146,6 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// Closes the gate and hands the caller a fresh token, which that attempt carries for its
     /// whole life.
     int BeginAttempt() {
-        _gateOpen = false;
         SendInFlight = false;
         var token = Interlocked.Increment(ref _openingToken);
         RaiseSendProjections();
@@ -147,7 +155,6 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// Advances ownership past every attempt alive: an already-closed gate still allocates, since
     /// a callback queued mid-Connecting must lose its right to open.
     void Invalidate() {
-        _gateOpen = false;
         SendInFlight = false;
         Interlocked.Increment(ref _openingToken);
         RaiseSendProjections();
@@ -159,7 +166,6 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// them would be advanced past by the increment that follows: the replacement attempt
     /// retired by the very outcome this guard exists to keep out of its way.
     void InvalidateOwner(int ownerToken) {
-        _gateOpen = false;
         SendInFlight = false;
         Interlocked.CompareExchange(ref _openingToken, ownerToken + 1, ownerToken);
         RaiseSendProjections();
@@ -179,7 +185,8 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         if (state.Phase is TerminalSessionPhase.Connecting or TerminalSessionPhase.Attached) {
             if (ownerToken != Volatile.Read(ref _openingToken)) return;
             State = state;
-            if (state is { Phase: TerminalSessionPhase.Attached, ReadOnly: false }) _gateOpen = true;
+            if (state is { Phase: TerminalSessionPhase.Attached, ReadOnly: false })
+                Volatile.Write(ref _gateOpenToken, ownerToken.Value);
             RaiseSendProjections();
             return;
         }

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -102,10 +102,10 @@ public sealed class TerminalTabViewModel : ReactiveObject {
 
     /// Bound; true from a send's acceptance until its delivery ends.
     public bool SendInFlight {
-        get => _sendInFlight;
+        get => Volatile.Read(ref _sendInFlight);
         private set {
-            if (_sendInFlight == value) return;
-            _sendInFlight = value;
+            if (Volatile.Read(ref _sendInFlight) == value) return;
+            Volatile.Write(ref _sendInFlight, value);
             this.RaisePropertyChanged();
             RaiseSendProjections();
         }
@@ -116,12 +116,12 @@ public sealed class TerminalTabViewModel : ReactiveObject {
 
     /// Bound; the one authority TrySendText itself consults, so can-execute and acceptance can
     /// never disagree.
-    public bool CanAcceptText => GateOpen && !_sendInFlight;
+    public bool CanAcceptText => GateOpen && !SendInFlight;
 
     /// Bound; the gate folded into the state, so a hint built from it is true in every window.
     public SendAvailability SendAvailability {
         get {
-            if (_sendInFlight) return SendAvailability.Sending;
+            if (SendInFlight) return SendAvailability.Sending;
             if (State is { Phase: TerminalSessionPhase.Attached, ReadOnly: false })
                 return GateOpen ? SendAvailability.Ready : SendAvailability.Transitioning;
             return State.Phase switch {
@@ -200,8 +200,14 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// Synchronous acceptance on the UI thread: true means the text is on its way through the
     /// current client and the composer may clear; false means nothing was written.
     public bool TrySendText(string text) {
-        if (!CanAcceptText || _client is not { } client) return false;
+        // Token, then client, then token again: _client is only ever replaced (or nulled) AFTER an
+        // advance, so an unmoved token across the read proves this client is the one that token
+        // owns. Reading the client first instead pairs a retired client with its replacement's
+        // token -- which DeliverAsync's own check then reads as current, sending the submit CR
+        // into the client being disposed.
         var token = Volatile.Read(ref _openingToken);
+        if (!CanAcceptText || _client is not { } client) return false;
+        if (Volatile.Read(ref _openingToken) != token) return false;
         SendInFlight = true;
         _delivery = DeliverAsync(client, token, TerminalInputEncoder.Paste(text));
         return true;
@@ -497,17 +503,18 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     /// retired the one identified by `generation` (0 means "no attempt identity yet" -- only the
     /// disposal half applies). See TryStartAttemptAsync's doc comment for why both are checked.
     bool Retired(int generation) =>
-        Volatile.Read(ref _resolveState) == ResolveDisposed || (generation != 0 && generation != _attemptGeneration);
+        Volatile.Read(ref _resolveState) == ResolveDisposed
+        || (generation != 0 && generation != Volatile.Read(ref _attemptGeneration));
 
     void WireSurface(ITerminalSurface surface, ITerminalAttachClient client, int generation) {
         // Read-only is belt and braces: the client itself also guards SendInputAsync/ResizeAsync,
         // but suppressing here means a read-only attach never even attempts the round trip.
         surface.InputProduced += bytes => {
-            if (generation != _attemptGeneration || State.ReadOnly) return;
+            if (Retired(generation) || State.ReadOnly) return;
             _ = client.SendInputAsync(bytes);
         };
         surface.Resized += (cols, rows) => {
-            if (generation != _attemptGeneration || State.ReadOnly) return;
+            if (Retired(generation) || State.ReadOnly) return;
             _ = client.ResizeAsync(cols, rows);
         };
     }
@@ -515,7 +522,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     async Task OnAttachedAsync(int generation, int openingToken, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] snapshot, string? reason, CancellationToken ct) {
         var text = decoder.Decode(snapshot);
         await Dispatcher.UIThread.InvokeAsync(() => {
-            if (generation != _attemptGeneration) return;
+            if (Retired(generation)) return;
             surface.Feed(text);
             Publish(TerminalSessionState.Attached(reason), openingToken);
         }, DispatcherPriority.Default, ct);
@@ -524,7 +531,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     async Task OnOutputAsync(int generation, ITerminalSurface surface, Utf8StreamDecoder decoder, byte[] bytes, CancellationToken ct) {
         var text = decoder.Decode(bytes);
         await Dispatcher.UIThread.InvokeAsync(() => {
-            if (generation != _attemptGeneration) return;
+            if (Retired(generation)) return;
             surface.Feed(text);
         }, DispatcherPriority.Default, ct);
     }
@@ -555,10 +562,10 @@ public sealed class TerminalTabViewModel : ReactiveObject {
 
     static string Describe(AttachCallbackException ex) => ex.InnerException?.Message ?? ex.Message;
 
-    // CancellationToken.None deliberately: a retired attempt's generation check (inside the
-    // dispatched action) already guards correctness, and the outcome must still apply when the
-    // attempt's own token is cancelled but the generation is still current (e.g. a graceful
-    // Detached racing TeardownAsync's early cts.Cancel()).
+    // CancellationToken.None deliberately: the Retired check inside the dispatched action already
+    // guards correctness, and the outcome must still apply when the attempt's own token is
+    // cancelled but the attempt is not yet retired (e.g. a graceful Detached racing
+    // TeardownAsync's early cts.Cancel(), which lands before its generation bump).
     //
     // Flushes the decoder here too, not just on every live frame: a terminal completion (Exited,
     // ConnectionLost, a mapped Failed) can land with a multibyte code point still buffered inside
@@ -568,7 +575,7 @@ public sealed class TerminalTabViewModel : ReactiveObject {
     // truncated stream).
     Task FinishAttemptAsync(int generation, int openingToken, ITerminalSurface surface, Utf8StreamDecoder decoder, TerminalSessionState state) =>
         Dispatcher.UIThread.InvokeAsync(() => {
-            if (generation != _attemptGeneration) return;
+            if (Retired(generation)) return;
             var remainder = decoder.Flush();
             if (remainder.Length > 0) surface.Feed(remainder);
             Publish(state, openingToken);

--- a/test/Capacitor.App.Tests.Unit/TerminalSendGateTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalSendGateTests.cs
@@ -116,7 +116,10 @@ public class TerminalSendGateTests {
             await vm.CurrentRunForTesting!;
             gate.SetResult();
             await reattach;
-            await Assert.That(factory.Created.Count).IsEqualTo(1); // the drained outcome retired the attempt
+            // The outcome retires nothing here: reattach took the opening token before it disposed
+            // the client whose outcome that is, so its own attempt survives and swaps in.
+            await Assert.That(factory.Created.Count).IsEqualTo(2);
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
 
             await vm.ReattachCommand.Execute();
             var client2 = factory.Created[^1];

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -421,12 +421,12 @@ public class TerminalTabViewModelTests {
         });
     }
 
-    /// The deterministic half of Cancel_dispose_orderings above: the retired attempt's own
-    /// outcome rendering while the reattach that retired it is parked on its dispose. Reattach
-    /// takes its opening token BEFORE that dispose, so if the outcome invalidates unconditionally
-    /// it retires the very attempt that is mid-flight -- either aborting it at the post-dispose
-    /// token check (no second client at all) or, a few instructions later, leaving its Connecting
-    /// discarded on a token that is already stale.
+    /// A retired attempt's own terminal outcome, rendering while the reattach that retired it is
+    /// parked on its dispose, leaves that reattach intact: it still swaps in its own client and
+    /// settles on Connecting. Parking the dispose is what makes the ordering deterministic rather
+    /// than a race -- the reattach holds its opening token across that whole window, which is
+    /// precisely the stretch in which the generation guard does not yet distinguish the two
+    /// attempts, so the token is the only thing keeping them apart.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task An_outcome_landing_inside_the_reattach_dispose_window_leaves_the_reattach_alone() {

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -389,11 +389,13 @@ public class TerminalTabViewModelTests {
     public async Task Cancel_dispose_orderings_each_yield_one_recorded_state() {
         await RunOnUiAsync(async () => {
             // Three interleavings of "the retired attempt's own outcome" racing "reattach's
-            // retire step" (immediate completion, yielded completion, and a bare TrySetResult
-            // fired from its own background Task) -- regardless of ordering, the VM settles on
-            // exactly one coherent State (attempt 2's Connecting; the generation check makes
-            // attempt 1's outcome a no-op whichever side of the retiring increment it lands on)
-            // and the client is disposed exactly once.
+            // retire step": immediate completion, one yield later, and one scheduler tick later
+            // (late enough that the retiring generation bump has typically already happened).
+            // Regardless of ordering the VM settles on exactly one coherent State -- attempt 2's
+            // Connecting -- and the client is disposed exactly once. Two guards get it there and
+            // NEITHER covers the other's window: past the retiring increment the generation check
+            // makes attempt 1's outcome a no-op, and before it the outcome renders but leaves the
+            // opening token attempt 2 already holds alone, so attempt 2's Connecting still lands.
             for (var i = 0; i < 3; i++) {
                 var (_, factory, _, vm, client1) = await BuildConnectingAsync(agentId: $"race{i}");
                 var run1 = vm.CurrentRunForTesting!;
@@ -405,7 +407,10 @@ public class TerminalTabViewModelTests {
                         await Task.Yield();
                         client1.Result.TrySetResult(new AttachOutcome.Exited(1));
                     }),
-                    _ => Task.Run(() => client1.Result.TrySetResult(new AttachOutcome.Exited(1))),
+                    _ => Task.Run(async () => {
+                        await Task.Delay(1);
+                        client1.Result.TrySetResult(new AttachOutcome.Exited(1));
+                    }),
                 };
                 await Task.WhenAll(reattach, raceOther, run1);
 
@@ -413,6 +418,36 @@ public class TerminalTabViewModelTests {
                 await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
                 await Assert.That(factory.Created.Count).IsEqualTo(2);
             }
+        });
+    }
+
+    /// The deterministic half of Cancel_dispose_orderings above: the retired attempt's own
+    /// outcome rendering while the reattach that retired it is parked on its dispose. Reattach
+    /// takes its opening token BEFORE that dispose, so if the outcome invalidates unconditionally
+    /// it retires the very attempt that is mid-flight -- either aborting it at the post-dispose
+    /// token check (no second client at all) or, a few instructions later, leaving its Connecting
+    /// discarded on a token that is already stale.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_outcome_landing_inside_the_reattach_dispose_window_leaves_the_reattach_alone() {
+        await RunOnUiAsync(async () => {
+            var gate = new TaskCompletionSource();
+            var (_, factory, _, vm, client1) = await BuildConnectingAsync(configureNext: c => c.DisposeGate = gate);
+            var run1 = vm.CurrentRunForTesting!;
+
+            var reattach = Task.Run(() => vm.ReattachCommand.Execute().ToTask());
+            await WaitUntilAsync(() => client1.DisposeCalls == 1, what: "reattach parked on the old client's dispose");
+
+            // The fake terminalizes the run it retires (Detached), exactly as the real client's
+            // own eager terminalizer does; awaiting run1 lands that publish before the gate opens.
+            await run1;
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Detached);
+
+            gate.SetResult();
+            await reattach;
+
+            await Assert.That(factory.Created.Count).IsEqualTo(2);
+            await Assert.That(vm.State.Phase).IsEqualTo(TerminalSessionPhase.Connecting);
         });
     }
 


### PR DESCRIPTION
Closes #698 — AI-2355

## What & why

`TerminalTabViewModel` holds two attempt identities and takes them at different points in a reattach: `BeginAttempt()` claims the opening token *before* `await prevClient.DisposeAsync()` (it must, so an in-flight composer delivery stops writing to the client about to die), and the generation bump lands *after*. In that window the retired attempt is still current by generation while the replacement already owns the token — and `Publish` invalidated the token on every terminal state, so the retired attempt's own outcome retired its replacement. Symptoms: the reattach aborts at its post-dispose token check (no second client at all), or its `Connecting` and later `Attached` are discarded on a stale token and the tab renders Exited over a live, attached client with the send gate shut. Not a fake-only path — `AgentAttachClient.RunAsync` returns the claimed cause, so a daemon exit frame that beats the reattach's cancel comes back as `Exited(code)`, not an `OperationCanceledException`.

The fix scopes that invalidation to the attempt that owns it, as a single compare-and-advance. Review then surfaced three more instances of the same shape — a check on one thread and the write that satisfies it on another — so the gate and the in-flight flag are now **derived from token ownership** rather than flags anyone may set, and send acceptance claims its slot atomically. An advance now settles all of it, with no path left needing to remember to close anything.

## Where to look

`TerminalSendGateTests` asserted the defect in this exact scenario (`Created.Count == 1`, "the drained outcome retired the attempt"). Its sibling covering the case that *must* abort a reattach — an external invalidation, an agent removal, which publishes with a `null` owner and so still invalidates unconditionally — is unchanged and green. The two now distinguish cases they were conflating.

## Verification

New `An_outcome_landing_inside_the_reattach_dispose_window_leaves_the_reattach_alone` parks the reattach on its dispose via `DisposeGate`, so the ordering is deterministic rather than raced. On the unpatched view model it fails `Expected to be 2 but found 1`.

The derived gate and derived in-flight flag were mutation-tested rather than assumed: breaking each fails existing tests (2 and 1 respectively), so both are load-bearing.

```
Capacitor.App.Tests.Unit      1266/1266 passed
--treenode-filter Terminal*      45/45 passed
```

Race stress on macOS arm64: 100+ consecutive clean runs of the Terminal set. A ~1-in-30 SIGSEGV of the Avalonia headless host reproduces identically on `origin/main`, so it is pre-existing and unrelated.

The CAS and derived-ownership windows are single interleavings across two threads with no seam to park between them; they are closed by construction, not by coverage, and no test claims otherwise.

Known follow-up, pre-existing and untouched here: the reattach path awaits `prevClient.DisposeAsync()` unbounded, so a hanging dispose leaves the last terminal state up until it completes. This branch strictly improves that case (the reattach now survives it) but does not bound it.
