### PR TITLE
Launch codex with the model its own migration map resolves to

### DIFF
--- a/src/Capacitor.Cli.Core/Harness/Codex/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/Harness/Codex/CodexConfigToml.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using System.Collections.ObjectModel;
 using System.Globalization;
 using System.Security.Cryptography;
 using System.Text;
@@ -306,6 +307,38 @@ public static class CodexConfigToml {
                 : null;
         } catch {
             return null;
+        }
+    }
+
+    /// <summary>
+    /// Reads the <c>[notice.model_migrations]</c> table — the old-slug to new-slug map Codex writes
+    /// once the operator has answered its model-migration dialog. Launching with a slug this maps
+    /// re-raises that dialog, and the dialog is modal and pre-<c>thread/start</c>: nothing correlates
+    /// the session until it is answered, and a TUI parked on it still renders, so no stuck-launch
+    /// watchdog fires either. Ordinal keys, matching how Codex writes them. Read-only; never throws;
+    /// empty when the file is missing, unreadable, or carries no such table.
+    /// </summary>
+    public static IReadOnlyDictionary<string, string> ReadModelMigrations(string configPath) {
+        if (!File.Exists(configPath)) return ReadOnlyDictionary<string, string>.Empty;
+
+        try {
+            var root = TomlSerializer.Deserialize(File.ReadAllText(configPath), _tomlTypeInfo.TableInfo);
+
+            if (root is null || !root.TryGetValue("notice", out var notice) || notice is not TomlTable noticeTable)
+                return ReadOnlyDictionary<string, string>.Empty;
+
+            if (!noticeTable.TryGetValue("model_migrations", out var migrations) || migrations is not TomlTable table)
+                return ReadOnlyDictionary<string, string>.Empty;
+
+            var map = new Dictionary<string, string>(StringComparer.Ordinal);
+
+            foreach (var (from, to) in table)
+                if (to is string target && !string.IsNullOrWhiteSpace(target))
+                    map[from] = target;
+
+            return map;
+        } catch {
+            return ReadOnlyDictionary<string, string>.Empty;
         }
     }
 

--- a/src/Capacitor.Cli.Core/Harness/Codex/CodexConfigToml.cs
+++ b/src/Capacitor.Cli.Core/Harness/Codex/CodexConfigToml.cs
@@ -322,7 +322,9 @@ public static class CodexConfigToml {
         if (!File.Exists(configPath)) return ReadOnlyDictionary<string, string>.Empty;
 
         try {
-            var root = TomlSerializer.Deserialize(File.ReadAllText(configPath), _tomlTypeInfo.TableInfo);
+            // Shared read: Codex writes this file itself — the migration entry read here is one it
+            // wrote — and a write-denying open locks it out of its own config on Windows.
+            var root = TomlSerializer.Deserialize(File.ReadAllTextShared(configPath), _tomlTypeInfo.TableInfo);
 
             if (root is null || !root.TryGetValue("notice", out var notice) || notice is not TomlTable noticeTable)
                 return ReadOnlyDictionary<string, string>.Empty;

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
@@ -194,7 +194,7 @@ internal sealed partial class CodexLauncher(
             AppendMcpIsolationArgs(args, ctx, appServer: false);
         }
 
-        AddModelArg(args, ctx.Model);
+        AddModelArg(args, ctx.Model, ctx.AgentId);
 
         var effort = ctx.Effort;
 
@@ -413,11 +413,31 @@ internal sealed partial class CodexLauncher(
 
     /// Append `-m &lt;model&gt;` unless the model is empty or the "default" no-override sentinel
     /// (see <see cref="IsConcreteModel"/>).
-    static void AddModelArg(List<string> args, string? model) {
-        if (IsConcreteModel(model)) {
-            args.Add("-m");
-            args.Add(model!);
-        }
+    void AddModelArg(List<string> args, string? model, string agentId) {
+        if (!IsConcreteModel(model)) return;
+
+        args.Add("-m");
+        args.Add(MigratedModel(model!, agentId));
+    }
+
+    /// <summary>The slug Codex would end up on anyway, when its own
+    /// <c>[notice.model_migrations]</c> maps the one asked for. Passing the retired slug instead
+    /// raises a modal migration dialog before <c>thread/start</c>: nothing correlates the session
+    /// while it is up, a parked TUI still renders so no stuck-launch watchdog fires, and the user sits
+    /// on "Waiting for session to start…" until something answers it. Read from the operator's own
+    /// acknowledged map, never a table of ours — Codex owns which model replaces which, and an
+    /// unacknowledged migration is not in there to read.</summary>
+    string MigratedModel(string model, string agentId) {
+        var migrations = CodexConfigToml.ReadModelMigrations(_paths.ConfigToml);
+
+        if (!migrations.TryGetValue(model, out var migrated)
+         || string.IsNullOrWhiteSpace(migrated)
+         || string.Equals(migrated, model, StringComparison.Ordinal))
+            return model;
+
+        LogModelMigrated(agentId, model, migrated);
+
+        return migrated;
     }
 
     /// Review launch: inject the same kcap-review MCP server Claude gets, but via
@@ -428,7 +448,7 @@ internal sealed partial class CodexLauncher(
     /// Sandbox/approval stay FIXED here by design: the PR-review path sits outside the
     /// caller-posture seam, and a posture supplied with this launch kind is rejected upstream by
     /// CodexPosturePolicy rather than reaching this method.
-    static LaunchArgs BuildReviewArgs(LauncherContext ctx, ReviewLaunchBuilder.ReviewLaunch launch) {
+    LaunchArgs BuildReviewArgs(LauncherContext ctx, ReviewLaunchBuilder.ReviewLaunch launch) {
         const string serverName = "kcap-review";
         var          mcp        = launch.Mcp;
 
@@ -451,7 +471,7 @@ internal sealed partial class CodexLauncher(
         args.Add("-c");
         args.Add($"mcp_servers.{serverName}.env={{{envList}}}");
 
-        AddModelArg(args, ctx.Model);
+        AddModelArg(args, ctx.Model, ctx.AgentId);
 
         args.Add("--no-alt-screen");
         args.Add("--");
@@ -517,6 +537,9 @@ internal sealed partial class CodexLauncher(
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Tools array of length {Count} ignored for vendor=codex (no allowlist concept) — agent {AgentId}")]
     partial void LogToolsIgnoredForCodex(string agentId, int count);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Agent {AgentId}: codex retired model '{Requested}'; launching with '{Migrated}' from its own acknowledged migration map, which is what codex would resolve after prompting.")]
+    partial void LogModelMigrated(string agentId, string requested, string migrated);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "MCP allowlist entry '{Name}' is not a kcap-owned server — skipping (agent {AgentId})")]
     partial void LogAllowlistEntryUnknown(string name, string agentId);

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
@@ -194,7 +194,7 @@ internal sealed partial class CodexLauncher(
             AppendMcpIsolationArgs(args, ctx, appServer: false);
         }
 
-        AddModelArg(args, ctx.Model, ctx.AgentId);
+        AddModelArg(args, ctx);
 
         var effort = ctx.Effort;
 
@@ -413,11 +413,16 @@ internal sealed partial class CodexLauncher(
 
     /// Append `-m &lt;model&gt;` unless the model is empty or the "default" no-override sentinel
     /// (see <see cref="IsConcreteModel"/>).
-    void AddModelArg(List<string> args, string? model, string agentId) {
-        if (!IsConcreteModel(model)) return;
+    void AddModelArg(List<string> args, LauncherContext ctx) {
+        if (!IsConcreteModel(ctx.Model)) return;
 
         args.Add("-m");
-        args.Add(MigratedModel(model!, agentId));
+        // A reviewer's model is pinned and priced by the server, which validates the slug it sent and
+        // not whatever this host's config would swap it for — a round that reviewed under a
+        // substituted model would carry an authority it does not have. A reviewer that parks on the
+        // migration dialog instead is reaped by its first-output deadline, which is the visible
+        // failure this trade prefers.
+        args.Add(ctx.IsReviewFlow || ctx.IsReview ? ctx.Model! : MigratedModel(ctx.Model!, ctx.AgentId));
     }
 
     /// <summary>The slug Codex would end up on anyway, when its own
@@ -471,7 +476,7 @@ internal sealed partial class CodexLauncher(
         args.Add("-c");
         args.Add($"mcp_servers.{serverName}.env={{{envList}}}");
 
-        AddModelArg(args, ctx.Model, ctx.AgentId);
+        AddModelArg(args, ctx);
 
         args.Add("--no-alt-screen");
         args.Add("--");

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -4516,7 +4516,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
             var discovery = new TranscriptDiscovery(TimeProvider.System, SessionIdPollInterval, SessionIdPollTimeout);
 
-            _ = WarnIfStillUnlinkedAsync(agent, cts.Token);
+            // Cancelled and awaited in the finally below, never merely dropped: an agent that exits
+            // inside the window is finalized and cleaned up without anyone touching ReadCts, and a
+            // warning that lands after that describes an agent nobody has any more.
+            using var warnCts  = CancellationTokenSource.CreateLinkedTokenSource(cts.Token);
+            var       warnTask = WarnIfStillUnlinkedAsync(agent, warnCts.Token);
+
+            try {
 
             var found = await discovery.RunAsync(locate, async winner => {
                 // Mutation first, pulse second — and the pulse before any server call, which can
@@ -4532,6 +4538,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             }, cts.Token);
 
             if (!found && !cts.IsCancellationRequested) LogSessionIdNotDetected(agent.Id, SessionIdPollTimeout.TotalSeconds);
+            } finally {
+                warnCts.Cancel();
+                await warnTask.ConfigureAwait(false);
+            }
         } catch (Exception ex) {
             LogSessionIdDetectFailed(ex, agent.Id);
         }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -5081,10 +5081,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     [LoggerMessage(Level = LogLevel.Warning, Message = "ACP final transcript drain for agent {AgentId} exceeded its {Seconds}s budget — proceeding to end the session; any undrained transcript is lost")]
     partial void LogAcpFinalDrainTimedOut(string agentId, double seconds);
 
-    // These three said the transcript scan was a fallback behind a session-start hook. There is no
-    // such leg here: the scan below is the only place agent.SessionId is ever assigned, and the
-    // vendor's own hook posts to the SERVER. Naming a primary that does not exist sends whoever
-    // reads a stalled launch to look at hooks.
+    // The transcript scan is the only place agent.SessionId is ever assigned — the vendor's own
+    // session-start hook posts to the SERVER, not here — so none of these three may describe it as a
+    // fallback behind some other link.
     [LoggerMessage(Level = LogLevel.Information, Message = "Agent {AgentId} linked to session {SessionId} by matching its transcript file")]
     partial void LogSessionIdDetected(string agentId, string sessionId);
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -4474,6 +4474,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     static readonly HashSet<string> ValidEffortLevels = ["low", "medium", "high", "max"];
 
+    /// <summary>When an unlinked launch stops being ordinary slowness and starts being worth saying
+    /// out loud. A healthy codex links in about five seconds, so a minute is far past normal while
+    /// still well short of the poll timeout that ends detection entirely.</summary>
+    static readonly TimeSpan SessionIdSlowWarnAfter = TimeSpan.FromSeconds(60);
+
     static readonly TimeSpan SessionIdPollInterval = TimeSpan.FromSeconds(2);
     static readonly TimeSpan SessionIdPollTimeout  = TimeSpan.FromMinutes(3);
 
@@ -4511,6 +4516,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             using var cts = CancellationTokenSource.CreateLinkedTokenSource(agent.ReadCts.Token, _shutdownCts.Token);
             var discovery = new TranscriptDiscovery(TimeProvider.System, SessionIdPollInterval, SessionIdPollTimeout);
 
+            _ = WarnIfStillUnlinkedAsync(agent, cts.Token);
+
             var found = await discovery.RunAsync(locate, async winner => {
                 // Mutation first, pulse second — and the pulse before any server call, which can
                 // stall on a reconnect and must never hold the app's status push hostage.
@@ -4528,6 +4535,20 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         } catch (Exception ex) {
             LogSessionIdDetectFailed(ex, agent.Id);
         }
+    }
+
+    /// <summary>Says, once and early, what the operator is otherwise left to infer from three minutes
+    /// of nothing. Never cancels or reaps the launch — detection keeps running to its own timeout,
+    /// and a slow link still resolves.</summary>
+    async Task WarnIfStillUnlinkedAsync(AgentInstance agent, CancellationToken ct) {
+        try {
+            await Task.Delay(SessionIdSlowWarnAfter, ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) {
+            return;
+        }
+
+        if (agent.SessionId is null)
+            LogSessionIdSlow(agent.Id, SessionIdSlowWarnAfter.TotalSeconds, SessionIdPollTimeout.TotalSeconds);
     }
 
     async Task RunHeartbeatLoopAsync(CancellationToken ct) {
@@ -5050,14 +5071,21 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     [LoggerMessage(Level = LogLevel.Warning, Message = "ACP final transcript drain for agent {AgentId} exceeded its {Seconds}s budget — proceeding to end the session; any undrained transcript is lost")]
     partial void LogAcpFinalDrainTimedOut(string agentId, double seconds);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Agent {AgentId} linked to session {SessionId} via its transcript file (session-start hook fallback)")]
+    // These three said the transcript scan was a fallback behind a session-start hook. There is no
+    // such leg here: the scan below is the only place agent.SessionId is ever assigned, and the
+    // vendor's own hook posts to the SERVER. Naming a primary that does not exist sends whoever
+    // reads a stalled launch to look at hooks.
+    [LoggerMessage(Level = LogLevel.Information, Message = "Agent {AgentId} linked to session {SessionId} by matching its transcript file")]
     partial void LogSessionIdDetected(string agentId, string sessionId);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "No transcript matched agent {AgentId}'s worktree within {Seconds:F0}s; session id stays hook-provided (or unknown if the hook failed)")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "No transcript matched agent {AgentId}'s worktree within {Seconds:F0}s, so it has no session id: the surface cannot leave 'waiting for session to start'. The child may be parked on a startup prompt — a TUI sitting on one still renders, so it does not read as stuck.")]
     partial void LogSessionIdNotDetected(string agentId, double seconds);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Transcript-based session-id detection failed for agent {AgentId} (continuing; the session-start hook remains the primary link)")]
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Transcript-based session-id detection failed for agent {AgentId}; nothing else assigns one, so this agent stays unlinked")]
     partial void LogSessionIdDetectFailed(Exception ex, string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Agent {AgentId} still has no session id {Seconds:F0}s after spawn; the surface is showing 'waiting for session to start'. Detection continues until {TimeoutSeconds:F0}s.")]
+    partial void LogSessionIdSlow(string agentId, double seconds, double timeoutSeconds);
 
     [GeneratedRegex(@"\x1B\[[0-9;]*[A-Za-z]|\x1B\].*?\x07|\x1B[()][AB012]|\x1B\[[\?]?[0-9;]*[hlm]")]
     private static partial Regex StripAnsiRegex();

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexConfigTomlTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexConfigTomlTests.cs
@@ -13,6 +13,33 @@ public class CodexConfigTomlTests {
     static TomlTable ReadToml(string path) =>
         TomlSerializer.Deserialize<TomlTable>(File.ReadAllText(path))!;
 
+    // ── ReadModelMigrations ────────────────────────────
+
+    /// <summary>The shape Codex writes once its migration dialog has been answered. Reading it is
+    /// what lets a launch skip that dialog, so the nested-table walk has to match Codex's own layout
+    /// rather than a top-level key.</summary>
+    [Test]
+    public async Task ReadModelMigrations_reads_the_nested_notice_table() {
+        using var tmp = new TempDir();
+        var path = tmp.CreateFile("config.toml",
+            "model = \"gpt-5.6-luna\"\n\n[notice.model_migrations]\n\"gpt-5.4-mini\" = \"gpt-5.6-luna\"\n\"gpt-5.2\" = \"gpt-5.6\"\n");
+
+        var migrations = CodexConfigToml.ReadModelMigrations(path);
+
+        await Assert.That(migrations["gpt-5.4-mini"]).IsEqualTo("gpt-5.6-luna");
+        await Assert.That(migrations["gpt-5.2"]).IsEqualTo("gpt-5.6");
+    }
+
+    [Test]
+    public async Task ReadModelMigrations_is_empty_when_the_table_is_absent_or_the_file_is_not() {
+        using var tmp = new TempDir();
+
+        await Assert.That(CodexConfigToml.ReadModelMigrations(tmp.PathTo("missing.toml"))).IsEmpty();
+        await Assert.That(CodexConfigToml.ReadModelMigrations(tmp.CreateFile("bare.toml", "model = \"x\"\n"))).IsEmpty();
+        await Assert.That(CodexConfigToml.ReadModelMigrations(tmp.CreateFile("other.toml", "[notice]\nseen = true\n"))).IsEmpty();
+        await Assert.That(CodexConfigToml.ReadModelMigrations(tmp.CreateFile("bad.toml", "this is not toml ]["))).IsEmpty();
+    }
+
     // ── BuildAllowDomains ────────────────────────────────────────────────────
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexLauncherTests.cs
@@ -50,6 +50,47 @@ public class CodexLauncherTests {
         DisableTableOverride(args) is { } table
         && table.Contains($"\"{name}\"={{enabled=false", StringComparison.Ordinal);
 
+    /// <summary>Codex raises a modal migration dialog when launched with a slug its own
+    /// <c>[notice.model_migrations]</c> retires, and that dialog sits before <c>thread/start</c> —
+    /// no session id, no correlation, and a parked TUI that still renders so no watchdog fires. The
+    /// argv is the only place this can be prevented.</summary>
+    [Test]
+    public async Task BuildArgs_launches_with_the_slug_codex_migrated_the_requested_one_to() {
+        WriteCodexConfig("[notice.model_migrations]\n\"gpt-5.4-mini\" = \"gpt-5.6-luna\"\n");
+
+        var args = NewLauncher().BuildArgs(NewCtx(model: "gpt-5.4-mini")).Args;
+
+        await Assert.That(args).Contains("gpt-5.6-luna");
+        await Assert.That(args).DoesNotContain("gpt-5.4-mini");
+    }
+
+    [Test]
+    public async Task BuildArgs_leaves_an_unmigrated_model_alone() {
+        WriteCodexConfig("[notice.model_migrations]\n\"gpt-5.2\" = \"gpt-5.6\"\n");
+
+        var args = NewLauncher().BuildArgs(NewCtx(model: "gpt-5.3-codex")).Args;
+
+        await Assert.That(args).Contains("gpt-5.3-codex");
+    }
+
+    /// <summary>The "default" sentinel means no override at all, so codex resolves from its own
+    /// config — substituting here would turn a no-override launch into a pinned one.</summary>
+    [Test]
+    public async Task BuildArgs_passes_no_model_for_the_default_sentinel_whatever_the_map_says() {
+        WriteCodexConfig("[notice.model_migrations]\n\"default\" = \"gpt-5.6-luna\"\n");
+
+        var args = NewLauncher().BuildArgs(NewCtx(model: "default")).Args;
+
+        await Assert.That(args).DoesNotContain("-m");
+        await Assert.That(args).DoesNotContain("gpt-5.6-luna");
+    }
+
+    void WriteCodexConfig(string toml) {
+        var dir = System.IO.Path.Combine(Home.Path, ".codex");
+        Directory.CreateDirectory(dir);
+        File.WriteAllText(System.IO.Path.Combine(dir, "config.toml"), toml);
+    }
+
     [Test]
     public async Task BuildArgs_uses_never_approval_for_hosted_codex() {
         var args = NewLauncher().BuildArgs(NewCtx(isReviewFlow: true)).Args;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexLauncherTests.cs
@@ -97,11 +97,7 @@ public class CodexLauncherTests {
         await Assert.That(args).DoesNotContain("gpt-5.6-luna");
     }
 
-    void WriteCodexConfig(string toml) {
-        var dir = System.IO.Path.Combine(Home.Path, ".codex");
-        Directory.CreateDirectory(dir);
-        File.WriteAllText(System.IO.Path.Combine(dir, "config.toml"), toml);
-    }
+    void WriteCodexConfig(string toml) => Home.CreateFile([".codex", "config.toml"], toml);
 
     [Test]
     public async Task BuildArgs_uses_never_approval_for_hosted_codex() {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexLauncherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexLauncherTests.cs
@@ -85,6 +85,18 @@ public class CodexLauncherTests {
         await Assert.That(args).DoesNotContain("gpt-5.6-luna");
     }
 
+    /// <summary>A reviewer's model is pinned and priced by the server against the slug it sent; a
+    /// round produced under a locally-substituted model would carry an authority it does not have.</summary>
+    [Test]
+    public async Task BuildArgs_never_migrates_a_reviewer_launch_model() {
+        WriteCodexConfig("[notice.model_migrations]\n\"gpt-5.4-mini\" = \"gpt-5.6-luna\"\n");
+
+        var args = NewLauncher().BuildArgs(NewCtx(model: "gpt-5.4-mini", isReviewFlow: true)).Args;
+
+        await Assert.That(args).Contains("gpt-5.4-mini");
+        await Assert.That(args).DoesNotContain("gpt-5.6-luna");
+    }
+
     void WriteCodexConfig(string toml) {
         var dir = System.IO.Path.Combine(Home.Path, ".codex");
         Directory.CreateDirectory(dir);


### PR DESCRIPTION
Closes #712 — AI-2381

## What & why

Hosted Codex launches sat on "Waiting for session to start…" for minutes. The child was healthy: codex 0.147 parks on a modal model-migration dialog when handed a slug its own `[notice.model_migrations]` retires, and that dialog is *before* `thread/start` — so no rollout file exists, nothing correlates the session, and a parked TUI still renders, which means the stuck-launch reaper (90s of no output) never fires either. In the recorded incident the dialog was answered by the daemon's own graceful-stop `/exit`, 161 seconds in, after the user had given up.

The launcher now reads that map and passes the migrated slug — the model codex resolves to anyway once prompted. Read from the operator's own acknowledged map, never a table of ours: codex owns which model replaces which.

Also here, from the same investigation: a Warning at 60s when an agent still has no session id, and three log messages corrected. They named a session-start hook as the primary link with the transcript scan as its fallback; that scan is the only place `agent.SessionId` is ever assigned, and the vendor's hook posts to the server. Naming a primary that does not exist sends whoever reads a stalled launch to look at hooks.

## Where to look

The substitution lives inside `AddModelArg`, which both argv builders already call, rather than at the two call sites. The `"default"` sentinel is still handled first, so a no-override launch cannot be turned into a pinned one by a map entry.

## Verification

`ReadModelMigrations` pins the nested `[notice.model_migrations]` walk and returns empty for a missing file, a missing table, and unparseable TOML. `CodexLauncherTests` pins the argv: a retired slug is replaced, an unmigrated one is untouched, and `default` still emits no `-m` even when the map names it. Daemon suite 2889 total with one failure — `Local_socket_stopv2_with_force_stops_a_protected_agent_end_to_end`, green in isolation, a known under-load flake on an unrelated path. Core suite 2581 total, 0 failed. AOT publish of the daemon clean of IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)