### PR TITLE
Answer a refused permission with the agent's reject option

### DIFF
--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -557,52 +557,17 @@ internal sealed partial class AcpInteractionBridge(
     partial void LogUnattendedPermissionFrameForbidden(string agentId, string toolTitle, string toolKind);
 
     /// <summary>
-    /// Maps a resolved <see cref="AcpInteractionDecision"/> to the ACP outcome result shape.
+    /// Maps a resolved <see cref="AcpInteractionDecision"/> to the ACP outcome result shape, by two
+    /// allowlists and no fallthrough: an outcome on neither list is <c>cancelled</c>, so a typo, a
+    /// corrupted decision, or a vocabulary the daemon has not been taught cannot grant or refuse
+    /// anything. Both lists are literal copies of the server's canonical values — the daemon does not
+    /// reference the server-only <c>InterruptOutcomes</c> type, per the AOT/trim constraints.
     ///
-    /// <b>Spec-review Finding 2 (security-critical, fail-safe-by-default):</b> this method uses
-    /// an EXPLICIT ALLOWLIST of recognized affirmative outcome strings (<c>"allow"</c>/
-    /// <c>"allow_once"</c>/<c>"allow_always"</c>/<c>"answered"</c> — the daemon does not reference
-    /// the server-only <c>InterruptOutcomes</c> type per this plan's AOT/trim Global Constraints, so
-    /// these are the literal string values of the SAME canonical vocabulary Task A2 documents, kept
-    /// in sync by the <c>AffirmativeOutcomes</c> constant below) rather than a denylist of recognized
-    /// negative outcomes with an "everything else selects" fallthrough. The PRIOR shape
-    /// (<c>decision.Outcome is "deny" or "cancel" ? cancelled : selected</c>) meant ANY unrecognized
-    /// outcome string — a typo (the canonical negative outcome is <c>"cancel"</c>, NOT
-    /// <c>"cancelled"</c> — see Task A2's Interfaces note for exactly this drift happening once
-    /// already in this plan), a future outcome vocabulary addition the daemon hasn't been updated
-    /// for, or a malformed/corrupted decision — fell through to <c>selected</c>/<c>options[0]</c>,
-    /// i.e. GRANTED permission for an outcome nobody explicitly asked to grant. Fail-safe now means:
-    /// not on the allowlist → always <see cref="CancelledResult"/>, full stop, regardless of how many
-    /// options were offered.
-    ///
-    /// <b>Fresh-review finding (this revision): a null <see cref="AcpInteractionDecision.SelectedOptionId"/>
-    /// used to STILL fall back to the first offered option even for a recognized affirmative
-    /// outcome</b> — an earlier draft of this fix treated "no id supplied" as "assume the human meant
-    /// the first option," which is exactly the same class of bug spec-review Finding 2 exists to
-    /// close: an ACP options request with two-or-more offered options (e.g. "Allow once" / "Deny")
-    /// resolved via a decision-submit path that (for whatever reason — a bug, a stale client, a
-    /// future code path that forgets to thread the id) omits <see cref="AcpInteractionDecision.SelectedOptionId"/>
-    /// would silently grant `options[0]` — often "Allow" — regardless of what the human actually
-    /// intended, or even whether the human ever saw the request. This method now FAILS CLOSED for
-    /// that case too: for an ACP interaction that offered ANY options, an affirmative outcome with
-    /// a null/unknown/unresolvable <see cref="AcpInteractionDecision.SelectedOptionId"/> ALWAYS maps
-    /// to <c>cancelled</c> — there is NO first-option fallback anywhere in this method, full stop.
-    /// The only way to get a <c>selected</c> result is an explicit, resolvable <c>SelectedOptionId</c>
-    /// matching one of the offered <see cref="PermissionOptionDto.OptionId"/>s.
-    ///
-    /// For a recognized affirmative outcome (spec-review Finding 6): selects the option whose
-    /// <see cref="PermissionOptionDto.OptionId"/> matches <see cref="AcpInteractionDecision.SelectedOptionId"/> —
-    /// NEVER by re-matching <see cref="PermissionOptionDto.Name"/>/<see cref="AcpInteractionDecision.SelectedOptionLabel"/>,
-    /// since duplicate or reordered option labels (which the ACP wire shape does not forbid) would
-    /// otherwise resolve to the wrong option. Two cases, both fail-closed: a
-    /// <see cref="AcpInteractionDecision.SelectedOptionId"/> that matches an offered
-    /// <see cref="PermissionOptionDto.OptionId"/> → that option, <c>selected</c>; ANYTHING else — no
-    /// id supplied at all (<see langword="null"/>), or an id that matches NONE of the offered
-    /// options — → <c>cancelled</c> (an absent or unresolvable id, whether from a decision-submit
-    /// path that forgot to echo one back or a correlation bug/stale/replayed decision, must never
-    /// silently grant an arbitrary option instead).
-    /// <c>"deny"</c>/<c>"cancel"</c>, no options offered at all, or ANY other outcome string not on
-    /// the allowlist above, map to <c>cancelled</c>.
+    /// <para>Selection is by <see cref="AcpInteractionDecision.SelectedOptionId"/> against the
+    /// OFFERED options, never by name or label, which the wire shape lets repeat or reorder. An
+    /// affirmative outcome with no id, or an id matching none of them, is <c>cancelled</c>: there is
+    /// no first-option fallback anywhere here, because "no specific option chosen" must never resolve
+    /// to whichever one the agent happened to list first — usually the allow.</para>
     /// </summary>
     static readonly HashSet<string> AffirmativeOutcomes = ["allow", "allow_once", "allow_always", "answered"];
 

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -606,11 +606,30 @@ internal sealed partial class AcpInteractionBridge(
     /// </summary>
     static readonly HashSet<string> AffirmativeOutcomes = ["allow", "allow_once", "allow_always", "answered"];
 
+    /// <summary>Outcomes that mean the user said no to THIS tool call, as opposed to abandoning the
+    /// turn. The distinction is the agent's to act on: <c>cancelled</c> tells it the prompt turn went
+    /// away, while a selected reject option tells it this call was refused and the turn continues.
+    /// Recognized ones only — an unknown string still falls through to <c>cancelled</c>.</summary>
+    static readonly HashSet<string> NegativeOutcomes = ["deny", "deny_once", "deny_always", "reject", "reject_once", "reject_always"];
+
+    static readonly HashSet<string> RejectKinds = ["reject_once", "reject_always"];
+
     static JsonElement MapPermissionDecision(AcpInteractionDecision decision, IReadOnlyList<PermissionOptionDto> options) {
-        // Fail-safe allowlist: only a RECOGNIZED affirmative outcome can ever produce "selected".
-        // Everything else — deny, cancel, an unrecognized/typo'd string, or no options offered —
-        // maps to cancelled. There is deliberately no "default: selected" path anywhere below.
-        if (options.Count == 0 || !AffirmativeOutcomes.Contains(decision.Outcome))
+        if (options.Count == 0)
+            return CancelledResult()!.Value;
+
+        // A refusal is answered with the agent's own reject option where it offered one. Answering
+        // `cancelled` instead tells the agent the prompt turn was cancelled — a different thing, and
+        // one an agent may respond to by tearing the session down rather than moving on.
+        if (NegativeOutcomes.Contains(decision.Outcome))
+            return TrySelectReject(decision, options) is { } rejection
+                ? SelectedResult(rejection)
+                : CancelledResult()!.Value;
+
+        // Fail-safe allowlist: only a RECOGNIZED affirmative outcome can ever produce an allow
+        // "selected". An unrecognized/typo'd string maps to cancelled. There is deliberately no
+        // "default: selected" path anywhere below.
+        if (!AffirmativeOutcomes.Contains(decision.Outcome))
             return CancelledResult()!.Value;
 
         // Fresh-review fix: resolve by OptionId ONLY, and FAIL CLOSED with no first-option
@@ -632,6 +651,31 @@ internal sealed partial class AcpInteractionBridge(
         var matched = options.FirstOrDefault(o => o.OptionId == optionId);
 
         return matched is not null ? SelectedResult(matched) : CancelledResult()!.Value;
+    }
+
+    /// <summary>The reject option to answer a refusal with, or null when the agent offered none (the
+    /// caller then falls back to <c>cancelled</c> — with no way to say no, saying nothing is honest).
+    /// An explicitly chosen id wins, but ONLY when it resolves to a reject-kind option: a refusal must
+    /// never be able to select an allow, whatever id came back with it. Otherwise the least-privilege
+    /// reject, preferring <c>reject_once</c> over <c>reject_always</c>, and never guessing between two
+    /// of the same kind — the standing-refusal case is exactly where a wrong pick persists.</summary>
+    static PermissionOptionDto? TrySelectReject(
+            AcpInteractionDecision decision, IReadOnlyList<PermissionOptionDto> options) {
+        var rejects = options.Where(o => o.Kind is { } k && RejectKinds.Contains(k)).ToArray();
+
+        if (decision.SelectedOptionId is { } optionId)
+            return rejects.FirstOrDefault(o => o.OptionId == optionId);
+
+        var once   = rejects.Where(o => o.Kind == "reject_once").ToArray();
+        var always = rejects.Where(o => o.Kind == "reject_always").ToArray();
+
+        var chosen = once.Length == 1 ? once[0] : always.Length == 1 ? always[0] : null;
+
+        return chosen is not null
+            && !string.IsNullOrWhiteSpace(chosen.OptionId)
+            && rejects.Count(o => o.OptionId == chosen.OptionId) == 1
+                ? chosen
+                : null;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -609,8 +609,11 @@ internal sealed partial class AcpInteractionBridge(
     /// <summary>Outcomes that mean the user said no to THIS tool call, as opposed to abandoning the
     /// turn. The distinction is the agent's to act on: <c>cancelled</c> tells it the prompt turn went
     /// away, while a selected reject option tells it this call was refused and the turn continues.
-    /// Recognized ones only — an unknown string still falls through to <c>cancelled</c>.</summary>
-    static readonly HashSet<string> NegativeOutcomes = ["deny", "deny_once", "deny_always", "reject", "reject_once", "reject_always"];
+    /// One entry because the canonical vocabulary has one — the literal value of the same
+    /// server-side constant <see cref="AffirmativeOutcomes"/> mirrors, kept as a copy for the same
+    /// AOT/trim reason. <c>cancel</c> and <c>timeout</c> are deliberately absent: they really are the
+    /// turn going away, and an unrecognized string falls through to <c>cancelled</c> too.</summary>
+    static readonly HashSet<string> NegativeOutcomes = ["deny"];
 
     static readonly HashSet<string> RejectKinds = ["reject_once", "reject_always"];
 
@@ -664,18 +667,22 @@ internal sealed partial class AcpInteractionBridge(
         var rejects = options.Where(o => o.Kind is { } k && RejectKinds.Contains(k)).ToArray();
 
         if (decision.SelectedOptionId is { } optionId)
-            return rejects.FirstOrDefault(o => o.OptionId == optionId);
+            return Addressable(rejects.FirstOrDefault(o => o.OptionId == optionId), options);
 
         var once   = rejects.Where(o => o.Kind == "reject_once").ToArray();
         var always = rejects.Where(o => o.Kind == "reject_always").ToArray();
 
-        var chosen = once.Length == 1 ? once[0] : always.Length == 1 ? always[0] : null;
+        return Addressable(once.Length == 1 ? once[0] : always.Length == 1 ? always[0] : null, options);
+    }
 
-        return chosen is not null
-            && !string.IsNullOrWhiteSpace(chosen.OptionId)
-            && rejects.Count(o => o.OptionId == chosen.OptionId) == 1
-                ? chosen
-                : null;
+    /// <summary>The option, or null when its id cannot address exactly it. The wire deserializer
+    /// enforces neither non-blank nor unique ids, so an echoed id that is blank or shared with
+    /// another offered option — a second reject, or an allow — names no single option: the agent
+    /// resolves it by its own rule, and one of the answers is not the one refused.</summary>
+    static PermissionOptionDto? Addressable(PermissionOptionDto? chosen, IReadOnlyList<PermissionOptionDto> options) {
+        if (chosen is null || string.IsNullOrWhiteSpace(chosen.OptionId)) return null;
+
+        return options.Count(o => o.OptionId == chosen.OptionId) == 1 ? chosen : null;
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -21,6 +21,14 @@ public class AcpInteractionBridgeTests {
     const string AgentId      = "agent-1";
     const string AcpSessionId = "fc2e09cf-f4b0-4463-9dc1-bda11268896b";
 
+    static JsonElement KindedPermissionParams(params (string Id, string Kind)[] options) {
+        var optionsJson = string.Join(",", options.Select(o =>
+            $$"""{"optionId":"{{o.Id}}","name":"{{o.Id}}","kind":"{{o.Kind}}"}"""));
+        var json = $$"""{"sessionId":"{{AcpSessionId}}","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":[{{optionsJson}}]}""";
+
+        return JsonDocument.Parse(json).RootElement.Clone();
+    }
+
     static JsonElement PermissionRequestParams(string[] optionIds) {
         var optionsJson = string.Join(",", optionIds.Select(id => $$"""{"optionId":"{{id}}","name":"{{id}}","kind":"allow_once"}"""));
         var json = $$"""{"sessionId":"{{AcpSessionId}}","toolCall":{"toolCallId":"call-1","title":"Run ls"},"options":[{{optionsJson}}]}""";
@@ -57,19 +65,91 @@ public class AcpInteractionBridgeTests {
         await Assert.That(outcome.GetProperty("optionId").GetString()).IsEqualTo("allow-once");
     }
 
+    /// <summary>A refusal is the agent's own reject option, not a cancelled turn: the two mean
+    /// different things to the agent, and only one of them says this call was refused.</summary>
     [Test]
-    public async Task RequestPermission_DenyOutcome_ReturnsCancelledResult() {
+    public async Task RequestPermission_DenyOutcome_SelectsTheAgentsRejectOption() {
         var bridge = new AcpInteractionBridge(
             requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("deny", null, null, null, null, null)),
             agentId: AgentId,
             logger: NullLogger.Instance);
 
-        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+        var request = new AcpRequest(1, "session/request_permission", KindedPermissionParams(
+            ("allow-once", "allow_once"), ("no", "reject_once")));
 
         var result = await bridge.HandleAsync(request, CancellationToken.None);
 
         var outcome = result!.Value.GetProperty("outcome");
-        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("selected");
+        await Assert.That(outcome.GetProperty("optionId").GetString()).IsEqualTo("no");
+    }
+
+    /// <summary>With no way to say no, saying nothing is the honest answer — and the one thing a
+    /// refusal must never do is select an allow.</summary>
+    [Test]
+    public async Task RequestPermission_DenyOutcome_WithNoRejectOptionOffered_ReturnsCancelled() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("deny", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "allow-always"]));
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>An id that resolves to an ALLOW cannot ride in on a refusal, whatever sent it.</summary>
+    [Test]
+    public async Task RequestPermission_DenyOutcome_NamingAnAllowOptionId_ReturnsCancelled() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("deny", "allow-once", null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", KindedPermissionParams(
+            ("allow-once", "allow_once"), ("no", "reject_once")));
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>Two rejects of the same kind is an ambiguous refusal; a standing one is exactly where
+    /// a guessed pick persists past this call.</summary>
+    [Test]
+    public async Task RequestPermission_DenyOutcome_WithTwoRejectAlwaysAndNoChoice_ReturnsCancelled() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("deny", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", KindedPermissionParams(
+            ("no-a", "reject_always"), ("no-b", "reject_always")));
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>reject_once over reject_always: a refusal of one call must not silently become a
+    /// standing one.</summary>
+    [Test]
+    public async Task RequestPermission_DenyOutcome_PrefersRejectOnceOverRejectAlways() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("deny", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", KindedPermissionParams(
+            ("never", "reject_always"), ("not-now", "reject_once")));
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        var outcome = result!.Value.GetProperty("outcome");
+        await Assert.That(outcome.GetProperty("outcome").GetString()).IsEqualTo("selected");
+        await Assert.That(outcome.GetProperty("optionId").GetString()).IsEqualTo("not-now");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -133,6 +133,40 @@ public class AcpInteractionBridgeTests {
         await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
     }
 
+    /// <summary>An echoed id that two options share addresses neither: the agent resolves it by its
+    /// own rule, and one of the answers is not the refusal that was made.</summary>
+    [Test]
+    public async Task RequestPermission_DenyOutcome_WithADuplicatedOptionId_ReturnsCancelled() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("deny", "no", null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", KindedPermissionParams(
+            ("no", "reject_always"), ("no", "reject_once")));
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
+    /// <summary>Sharing an id with an ALLOW makes it just as unaddressable, and the wrong resolution
+    /// there grants what was refused.</summary>
+    [Test]
+    public async Task RequestPermission_DenyOutcome_WithAnIdSharedWithAnAllow_ReturnsCancelled() {
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("deny", null, null, null, null, null)),
+            agentId: AgentId,
+            logger: NullLogger.Instance);
+
+        var request = new AcpRequest(1, "session/request_permission", KindedPermissionParams(
+            ("same", "allow_once"), ("same", "reject_once")));
+
+        var result = await bridge.HandleAsync(request, CancellationToken.None);
+
+        await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+    }
+
     /// <summary>reject_once over reject_always: a refusal of one call must not silently become a
     /// standing one.</summary>
     [Test]


### PR DESCRIPTION
Closes #732 — AI-2383 (part)

## What & why

A user's Deny reached the agent as ACP `cancelled`. That says the prompt turn went away, not that this call was refused, and an agent can reasonably respond to the first by stopping — the cursor session in #714 ended silently three minutes after a pair of cancelled permission requests. A refusal now selects the agent's own reject option, and `cancelled` is kept for the case where no reject option was offered.

## Where to look

The fail-safe property is the part worth checking. A negative outcome resolves only among reject-kind options, so an allow id arriving on a refusal resolves to nothing and falls back to `cancelled`; `reject_once` is preferred over `reject_always`, and two of the same kind with no explicit choice is left ambiguous rather than guessed — a standing refusal is where a wrong pick outlives the call.

## Verification

Five new pins in `AcpInteractionBridgeTests`: the reject option is selected, no reject offered gives `cancelled`, a deny naming an allow id gives `cancelled`, two `reject_always` with no choice gives `cancelled`, and `reject_once` wins over `reject_always`. Daemon unit suite 2898 total, 0 failed. AOT publish of the daemon clean of IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)