### PR TITLE
Tell the server its agents ended when the daemon shuts down

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -4742,6 +4742,53 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
     }
 
+    /// <summary>How long the whole shutdown report may take, across every agent. A shutdown that
+    /// waits on the server is a shutdown that can be killed mid-teardown, so this is a ceiling on the
+    /// pass rather than a per-call timeout: whatever is reported inside it is reported, and the rest
+    /// falls back to what happened before — the server learning only from the transport drop.</summary>
+    internal static readonly TimeSpan ShutdownReportBudget = TimeSpan.FromSeconds(5);
+
+    /// <summary>The reason stamped on a run this daemon ended by going away, distinct from the user
+    /// asking it to stop — the two look identical downstream otherwise.</summary>
+    internal const string DaemonShutdownStopReason = "daemon_shutdown";
+
+    /// <summary>Reports every live agent as ended, on its own budget and its own token: by the time
+    /// this runs <c>_shutdownCts</c> is cancelled, and passing that token would cancel every call
+    /// before it left. Best-effort throughout — teardown continues whatever this manages to say.</summary>
+    async Task ReportAgentsEndedForShutdownAsync() {
+        var live = _agents.Values.Where(a => !a.IsPrivate).ToList();
+
+        if (live.Count == 0) return;
+
+        using var budget = new CancellationTokenSource(ShutdownReportBudget);
+
+        LogShutdownReportStarted(live.Count, ShutdownReportBudget.TotalSeconds);
+
+        foreach (var agent in live) {
+            if (budget.IsCancellationRequested) {
+                LogShutdownReportBudgetExpired(agent.Id);
+
+                return;
+            }
+
+            try {
+                await _server.AgentStatusChangedAsync(agent.Id, "Completed", agent.SessionId).WaitAsync(budget.Token);
+                await _server.AppendAgentRunEventAsync(agent.Id, new AgentRunStopped(DaemonShutdownStopReason, agent.Runtime.ExitCode))
+                    .WaitAsync(budget.Token);
+                await _server.EndAgentSessionAsync(agent.Id, DaemonShutdownStopReason).WaitAsync(budget.Token);
+                await _server.AgentUnregisteredAsync(agent.Id).WaitAsync(budget.Token);
+
+                LogShutdownReported(agent.Id);
+            } catch (OperationCanceledException) {
+                LogShutdownReportBudgetExpired(agent.Id);
+
+                return;
+            } catch (Exception ex) {
+                LogShutdownReportFailed(ex, agent.Id);
+            }
+        }
+    }
+
     public virtual async ValueTask DisposeAsync() {
         if (Interlocked.Exchange(ref _disposeOnce, 1) != 0) return;
 
@@ -4795,6 +4842,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     /* best-effort */
                 }
             }
+
+            // Children are gone; tell the server so before the registry is torn down. Without this the
+            // daemon's whole account of a shutdown is the transport dropping, which says a daemon went
+            // away but nothing about the agents it was hosting — and a successor daemon reconnecting
+            // under the same name re-binds those retained entries onto its own connection, leaving
+            // sessions the surface still composes into and a Stop that has nothing to act on.
+            await ReportAgentsEndedForShutdownAsync();
 
             foreach (var agentId in _agents.Keys.ToList()) {
                 try {
@@ -5084,6 +5138,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // The transcript scan is the only place agent.SessionId is ever assigned — the vendor's own
     // session-start hook posts to the SERVER, not here — so none of these three may describe it as a
     // fallback behind some other link.
+    [LoggerMessage(Level = LogLevel.Information, Message = "Terminating {Count} agent(s) for daemon shutdown; reporting them ended within {Seconds:F0}s")]
+    partial void LogShutdownReportStarted(int count, double seconds);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Agent {AgentId} reported ended for daemon shutdown")]
+    partial void LogShutdownReported(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Shutdown report budget expired at agent {AgentId}; the rest of this daemon's agents end only as far as the server infers from the transport drop")]
+    partial void LogShutdownReportBudgetExpired(string agentId);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Failed to report agent {AgentId} ended for daemon shutdown")]
+    partial void LogShutdownReportFailed(Exception ex, string agentId);
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Agent {AgentId} linked to session {SessionId} by matching its transcript file")]
     partial void LogSessionIdDetected(string agentId, string sessionId);
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -4742,10 +4742,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         }
     }
 
-    /// <summary>How long the whole shutdown report may take, across every agent. A shutdown that
-    /// waits on the server is a shutdown that can be killed mid-teardown, so this is a ceiling on the
-    /// pass rather than a per-call timeout: whatever is reported inside it is reported, and the rest
-    /// falls back to what happened before — the server learning only from the transport drop.</summary>
+    /// <summary>How long the whole shutdown report may take, across every agent. A shutdown that waits
+    /// on the server is a shutdown that can be killed mid-teardown, so this bounds the pass rather
+    /// than each call: agents past the ceiling go unreported, and the server is left to infer their
+    /// ending from the transport drop.</summary>
     internal static readonly TimeSpan ShutdownReportBudget = TimeSpan.FromSeconds(5);
 
     /// <summary>The reason stamped on a run this daemon ended by going away, distinct from the user

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -4756,7 +4756,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// this runs <c>_shutdownCts</c> is cancelled, and passing that token would cancel every call
     /// before it left. Best-effort throughout — teardown continues whatever this manages to say.</summary>
     async Task ReportAgentsEndedForShutdownAsync() {
-        var live = _agents.Values.Where(a => !a.IsPrivate).ToList();
+        // Only agents this teardown still owns. One whose own finalizer already ran has reported its
+        // real ending and is waiting on cleanup; reporting it again would append a second stop event
+        // over the top of a truer one and race that finalizer's unregister.
+        var live = _agents.Values.Where(a => !a.IsPrivate && a.Status is "Starting" or "Running").ToList();
 
         if (live.Count == 0) return;
 
@@ -4771,12 +4774,15 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 return;
             }
 
+            // Not Completed: this daemon killed the child, whatever it was in the middle of, and a
+            // run reported as completed is a failure classified as success. The reason carries the
+            // distinction from a run that failed on its own.
+            SetAgentStatus(agent, "Failed");
+
             try {
-                await _server.AgentStatusChangedAsync(agent.Id, "Completed", agent.SessionId).WaitAsync(budget.Token);
-                await _server.AppendAgentRunEventAsync(agent.Id, new AgentRunStopped(DaemonShutdownStopReason, agent.Runtime.ExitCode))
+                await _server.ReportAgentEndedForShutdownAsync(
+                    agent.Id, agent.SessionId, "Failed", DaemonShutdownStopReason, agent.Runtime.ExitCode, budget.Token)
                     .WaitAsync(budget.Token);
-                await _server.EndAgentSessionAsync(agent.Id, DaemonShutdownStopReason).WaitAsync(budget.Token);
-                await _server.AgentUnregisteredAsync(agent.Id).WaitAsync(budget.Token);
 
                 LogShutdownReported(agent.Id);
             } catch (OperationCanceledException) {

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -910,6 +910,63 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public virtual Task AgentUnregisteredAsync(string agentId)
         => _hub.InvokeAsync("AgentUnregistered", new AgentUnregistered(agentId), cancellationToken: _ct);
 
+    /// <summary>
+    /// The one report a shutting-down daemon can still make. Every other method here bakes in
+    /// <c>_ct</c>, which is <c>ApplicationStopping</c> and therefore already cancelled by the time
+    /// teardown reaches this — so a caller using them at that point sends nothing and cannot tell.
+    /// This one takes the caller's own live token and uses it throughout, including for the run event,
+    /// which normally rides a background queue whose drain is dead for the same reason.
+    ///
+    /// <para>Best-effort by contract: every step is contained, and a failure in one does not skip the
+    /// rest. Nothing here retries — the caller is holding a shutdown open.</para>
+    /// </summary>
+    public virtual async Task ReportAgentEndedForShutdownAsync(
+            string agentId, string? sessionId, string status, string reason, int? exitCode, CancellationToken ct) {
+        await SafeShutdownStepAsync(
+            () => _hub.InvokeAsync("AgentStatusChanged", new AgentStatusChanged(agentId, status, sessionId), cancellationToken: ct),
+            agentId, "status");
+
+        await SafeShutdownStepAsync(
+            () => PostAgentRunEventAsync(agentId, new AgentRunStopped(reason, exitCode), ct), agentId, "run-stopped");
+
+        await SafeShutdownStepAsync(
+            () => _hub.InvokeAsync<EndAgentSessionResult>("EndAgentSession", agentId, reason, cancellationToken: ct),
+            agentId, "session-end");
+
+        await SafeShutdownStepAsync(
+            () => _hub.InvokeAsync("AgentUnregistered", new AgentUnregistered(agentId), cancellationToken: ct),
+            agentId, "unregister");
+    }
+
+    async Task SafeShutdownStepAsync(Func<Task> step, string agentId, string label) {
+        try {
+            await step();
+        } catch (Exception ex) {
+            LogShutdownReportStepFailed(ex, agentId, label);
+        }
+    }
+
+    /// <summary>The queued run-event POST, sent directly on the caller's token. Same endpoint and
+    /// payload shape as the drain, without its retry loop.</summary>
+    async Task PostAgentRunEventAsync(string agentId, object evt, CancellationToken ct) {
+        var data = JsonSerializer.SerializeToNode(evt, evt.GetType(), CapacitorJsonContext.Default)!.AsObject();
+        var payload = new JsonObject { ["event_type"] = evt.GetType().Name, ["data"] = data }.ToJsonString();
+
+        _httpClient ??= new();
+
+        var resolution = await new TokenStore(_config.ConfigRoot)
+            .GetValidTokensForServerAsync(_config.Profiles.Name, _config.ServerUrl, ct);
+
+        if (resolution.Tokens?.AccessToken is not null)
+            _httpClient.DefaultRequestHeaders.Authorization = new("Bearer", resolution.Tokens.AccessToken);
+
+        var response = await _httpClient.PostAsync(
+            $"{_config.ServerUrl.TrimEnd('/')}/api/agent-runs/{agentId}/events",
+            new StringContent(payload, Encoding.UTF8, "application/json"), ct);
+
+        response.EnsureSuccessStatusCode();
+    }
+
     public virtual Task LaunchFailedAsync(string agentId, string reason)
         => _hub.InvokeAsync("LaunchFailed", new LaunchFailed(agentId, reason), cancellationToken: _ct);
 
@@ -1616,6 +1673,9 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
     [LoggerMessage(Level = LogLevel.Information, Message = "EndAgentSession for agent {AgentId} interrupted by a connection drop (retry {Attempt}); waiting for the daemon connection to recover before retrying")]
     partial void LogEndSessionRetry(string agentId, int attempt);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Shutdown report step '{Step}' failed for agent {AgentId}")]
+    partial void LogShutdownReportStepFailed(Exception ex, string agentId, string step);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "AcpSessionStarted for agent {AgentId} interrupted by a connection drop (retry {Attempt}); waiting for the daemon connection to recover before retrying")]
     partial void LogAcpSessionStartedRetry(string agentId, int attempt);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
@@ -319,15 +319,30 @@ sealed class CaptureServerConnection() : ServerConnection(
         }
     }
 
-    /// <summary>Every (agentId, event) pair passed to AppendAgentRunEventAsync, in call order — the
-    /// only place a run's stop REASON is observable, and the reason is what distinguishes a daemon
-    /// that went away from a user who asked it to stop.</summary>
+    /// <summary>Every (agentId, event) pair passed to AppendAgentRunEventAsync, in call order.</summary>
     public List<(string AgentId, object Event)> RunEvents { get; } = [];
 
     public override Task AppendAgentRunEventAsync(string agentId, object evt) {
         lock (RunEvents) RunEvents.Add((agentId, evt));
 
         return Task.CompletedTask;
+    }
+
+    /// <summary>Every shutdown report, with the state of the token it was handed. The token matters
+    /// more than the arguments: every other method on the real connection bakes in one that is
+    /// already cancelled during teardown, so a report made with a cancelled token sends nothing and
+    /// says nothing about it — a double that ignored the token would pass either way.</summary>
+    public List<(string AgentId, string Status, string Reason, bool TokenAlreadyCancelled)> ShutdownReports { get; } = [];
+
+    /// <summary>When set, the shutdown report blocks on this until its own token cancels — the hung
+    /// server a shutdown must not wait on.</summary>
+    public bool ShutdownReportHangs { get; init; }
+
+    public override async Task ReportAgentEndedForShutdownAsync(
+            string agentId, string? sessionId, string status, string reason, int? exitCode, CancellationToken ct) {
+        lock (ShutdownReports) ShutdownReports.Add((agentId, status, reason, ct.IsCancellationRequested));
+
+        if (ShutdownReportHangs) await Task.Delay(Timeout.Infinite, ct);
     }
 
     // ── Task 8: resolved-model report capture ──────────────────────────────────

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
@@ -319,8 +319,16 @@ sealed class CaptureServerConnection() : ServerConnection(
         }
     }
 
-    public override Task AppendAgentRunEventAsync(string agentId, object evt)
-        => Task.CompletedTask;
+    /// <summary>Every (agentId, event) pair passed to AppendAgentRunEventAsync, in call order — the
+    /// only place a run's stop REASON is observable, and the reason is what distinguishes a daemon
+    /// that went away from a user who asked it to stop.</summary>
+    public List<(string AgentId, object Event)> RunEvents { get; } = [];
+
+    public override Task AppendAgentRunEventAsync(string agentId, object evt) {
+        lock (RunEvents) RunEvents.Add((agentId, evt));
+
+        return Task.CompletedTask;
+    }
 
     // ── Task 8: resolved-model report capture ──────────────────────────────────
     /// <summary>Every legacy (agentId, model) pair passed to ReportAgentResolvedModelAsync — proves

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ShutdownAgentReportTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ShutdownAgentReportTests.cs
@@ -1,0 +1,69 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// What a daemon says about its agents on the way out. The transport dropping tells the server a
+/// daemon went away; it says nothing about the agents it was hosting, and a successor reconnecting
+/// under the same name re-binds those retained entries onto its own connection — leaving sessions
+/// the surface still composes into and a Stop with nothing to act on.
+/// </summary>
+public class ShutdownAgentReportTests {
+    [Test]
+    public async Task Disposing_reports_every_live_agent_ended_with_a_shutdown_reason() {
+        var server = new CaptureServerConnection();
+        var orch   = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.SeedAgentForTest("shutdown-1", status: "Running");
+        orch.SeedAgentForTest("shutdown-2", status: "Running");
+
+        await orch.DisposeAsync();
+
+        foreach (var id in new[] { "shutdown-1", "shutdown-2" }) {
+            await Assert.That(server.StatusChangedCalls).Contains((id, "Completed"));
+            await Assert.That(server.AgentUnregisteredCalls).Contains(id);
+            await Assert.That(server.RunEvents.Where(e => e.AgentId == id)
+                .Select(e => e.Event).OfType<AgentRunStopped>().Select(e => e.Reason))
+                .Contains(AgentOrchestrator.DaemonShutdownStopReason);
+        }
+
+        await Assert.That(server.EndSessionReasons)
+            .Contains(AgentOrchestrator.DaemonShutdownStopReason);
+    }
+
+    /// <summary>A private agent was never registered, so there is nothing to end and nobody to tell.</summary>
+    [Test]
+    public async Task A_private_agent_is_not_reported() {
+        var server = new CaptureServerConnection();
+        var orch   = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.SeedAgentForTest("private-1", status: "Running", isPrivate: true);
+
+        await orch.DisposeAsync();
+
+        await Assert.That(server.StatusChangedCalls.Any(c => c.AgentId == "private-1")).IsFalse();
+        await Assert.That(server.AgentUnregisteredCalls).DoesNotContain("private-1");
+    }
+
+    /// <summary>A server that has stopped answering must not hold a shutdown open: the budget is a
+    /// ceiling on the whole pass, and teardown continues past it either way.</summary>
+    [Test]
+    public async Task A_hung_server_does_not_hold_shutdown_past_the_budget() {
+        using var blockForever = new CancellationTokenSource();
+        var server = new CaptureServerConnection { EndSessionBlockUntil = blockForever };
+        var orch   = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.SeedAgentForTest("hung-1", status: "Running");
+
+        var started = DateTime.UtcNow;
+        await orch.DisposeAsync();
+        var elapsed = DateTime.UtcNow - started;
+
+        await Assert.That(elapsed).IsLessThan(AgentOrchestrator.ShutdownReportBudget + TimeSpan.FromSeconds(15));
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ShutdownAgentReportTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ShutdownAgentReportTests.cs
@@ -1,4 +1,3 @@
-using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Services;
 using Capacitor.Cli.Daemon.Tests.Unit.Pty;
 
@@ -22,16 +21,41 @@ public class ShutdownAgentReportTests {
 
         await orch.DisposeAsync();
 
-        foreach (var id in new[] { "shutdown-1", "shutdown-2" }) {
-            await Assert.That(server.StatusChangedCalls).Contains((id, "Completed"));
-            await Assert.That(server.AgentUnregisteredCalls).Contains(id);
-            await Assert.That(server.RunEvents.Where(e => e.AgentId == id)
-                .Select(e => e.Event).OfType<AgentRunStopped>().Select(e => e.Reason))
-                .Contains(AgentOrchestrator.DaemonShutdownStopReason);
-        }
+        foreach (var id in new[] { "shutdown-1", "shutdown-2" })
+            await Assert.That(server.ShutdownReports)
+                .Contains((id, "Failed", AgentOrchestrator.DaemonShutdownStopReason, false));
+    }
 
-        await Assert.That(server.EndSessionReasons)
-            .Contains(AgentOrchestrator.DaemonShutdownStopReason);
+    /// <summary>The token is the whole point: every other method on the real connection bakes in
+    /// ApplicationStopping, which is cancelled before this teardown runs, so a report made on it
+    /// would send nothing and report success for having done so.</summary>
+    [Test]
+    public async Task The_report_is_made_on_a_token_that_is_still_live() {
+        var server = new CaptureServerConnection();
+        var orch   = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.SeedAgentForTest("live-token-1", status: "Running");
+
+        await orch.DisposeAsync();
+
+        await Assert.That(server.ShutdownReports).IsNotEmpty();
+        await Assert.That(server.ShutdownReports.All(r => !r.TokenAlreadyCancelled)).IsTrue();
+    }
+
+    /// <summary>An agent whose own finalizer already ran has reported its real ending; a second stop
+    /// event over the top of it would be less true, and its unregister races that finalizer's.</summary>
+    [Test]
+    public async Task An_already_finalized_agent_is_not_reported_again() {
+        var server = new CaptureServerConnection();
+        var orch   = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+        orch.SeedAgentForTest("done-1", status: "Completed");
+
+        await orch.DisposeAsync();
+
+        await Assert.That(server.ShutdownReports.Any(r => r.AgentId == "done-1")).IsFalse();
     }
 
     /// <summary>A private agent was never registered, so there is nothing to end and nobody to tell.</summary>
@@ -45,16 +69,14 @@ public class ShutdownAgentReportTests {
 
         await orch.DisposeAsync();
 
-        await Assert.That(server.StatusChangedCalls.Any(c => c.AgentId == "private-1")).IsFalse();
-        await Assert.That(server.AgentUnregisteredCalls).DoesNotContain("private-1");
+        await Assert.That(server.ShutdownReports.Any(r => r.AgentId == "private-1")).IsFalse();
     }
 
     /// <summary>A server that has stopped answering must not hold a shutdown open: the budget is a
     /// ceiling on the whole pass, and teardown continues past it either way.</summary>
     [Test]
     public async Task A_hung_server_does_not_hold_shutdown_past_the_budget() {
-        using var blockForever = new CancellationTokenSource();
-        var server = new CaptureServerConnection { EndSessionBlockUntil = blockForever };
+        var server = new CaptureServerConnection { ShutdownReportHangs = true };
         var orch   = AgentOrchestratorHarness.BuildOrchestrator(
             server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 


### PR DESCRIPTION
Part of #714 — AI-2383

## What & why

`DisposeAsync` terminates every runtime and cleans up locally, but `CleanupAgentAsync`'s unregister is gated out once `_shutdownCts` is cancelled, so a shutting-down daemon told the server nothing at all: no status, no run-stopped, no session end, no unregister. The comment there says the server detects the disconnection through SignalR — it does, but that says a *daemon* went away, not what became of the agents it was hosting, and a successor daemon reconnecting under the same name re-binds every retained entry onto its own connection. The result is a session the surface still composes into and a Stop with nothing to act on, which is the zombie in #714.

The daemon now reports each live agent ended, after the children are actually gone, with the stop reason `daemon_shutdown` — distinct from a user-requested stop, which is otherwise indistinguishable downstream.

## Where to look

The report runs on its own token and its own budget. Its own token because `_shutdownCts` is already cancelled by that point and passing it would cancel every call before it left; its own budget because a shutdown that waits on the server is one that can be killed mid-teardown, so the five seconds is a ceiling on the whole pass rather than a per-call timeout — whatever is reported inside it is reported, and the rest degrades to exactly today's behaviour.

This is the daemon half only. It does not by itself stop the resurrection: fencing `RebindDaemonConnection` on daemon epoch is server-side, and until that lands this changes what the server is *told*, not what it does with a successor's connect.

## Verification

`ShutdownAgentReportTests`: two seeded agents are each reported Completed, run-stopped with `daemon_shutdown`, session-ended and unregistered; a private agent (never registered) is reported not at all; and a server whose session-end never returns does not hold shutdown past the budget. Daemon unit suite 2897 total with one failure — `Installed_codex_schema_matches_the_vendored_pin`, which fails identically on `main` at 43bb3f7e (the locally installed codex CLI has drifted from the vendored schema pin). AOT publish of the daemon clean of IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)