### PR TITLE
Report a dropped input to the server instead of only the log

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1934,7 +1934,10 @@ public record BorrowProbeResult(
 public readonly record struct SendInputCommand(
         string    AgentId,
         string    Text,
-        string[]? AttachmentIds
+        string[]? AttachmentIds,
+        // Names this dispatch when the daemon has to refuse it. Null from a server that does not send
+        // one, in which case there is nothing to name and no refusal is reported.
+        Guid?     DispatchId = null
     );
 
 public readonly record struct ResizeTerminalCommand(

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3527,9 +3527,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         public const string ReaperClaimedLate = "reaper_claimed_late";
     }
 
-    /// <summary>Reports a drop to the server, when the dispatch carried an id to name. Never throws
-    /// and never blocks the caller's own return: the drop has already happened, and a report that
-    /// fails must leave the daemon exactly where reporting nothing would.</summary>
+    /// <summary>Reports a drop to the server, when the dispatch carried an id to name. Never throws:
+    /// the drop has already happened, and a report that fails must leave the daemon exactly where
+    /// reporting nothing would. Callers inside a held section report after releasing it — the invoke
+    /// has no timeout of its own.</summary>
     async Task ReportInputDroppedAsync(SendInputCommand cmd, string reason) {
         if (cmd.DispatchId is not { } dispatchId) return;
 
@@ -3576,6 +3577,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         long? codexBaseline = null;
         long  codexGen      = 0;
 
+        // Set inside the section, reported outside it: the report is an unbounded server round trip,
+        // and awaiting one while holding this gate would hold every later input for that agent behind
+        // a stalled connection — and stretch the section the reaper's own claim races against.
+        string? dropReason = null;
+
         await agent.BorrowedSnapshotGate.WaitAsync(_shutdownCts.Token);
         try {
             // Losing side of the reap claim (round-dispatch grace §3): a reap-claimed agent gets
@@ -3583,7 +3589,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // into a dying runtime) is deliberate; the server heals it on resubmit.
             if (agent.IsReapClaimed) {
                 LogSendInputReapClaimed(agentId);
-                await ReportInputDroppedAsync(cmd, SendInputDropReason.ReaperClaimed);
+                dropReason = SendInputDropReason.ReaperClaimed;
 
                 return;
             }
@@ -3609,7 +3615,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             if (agent.IsReapClaimed) {
                 LogSendInputReapClaimedLate(agentId);
-                await ReportInputDroppedAsync(cmd, SendInputDropReason.ReaperClaimedLate);
+                dropReason = SendInputDropReason.ReaperClaimedLate;
 
                 return;
             }
@@ -3655,6 +3661,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             LogSendInputDelivered(agentId, agent.Runtime.Vendor, message.Length);
         } finally {
             agent.BorrowedSnapshotGate.Release();
+
+            // After the release, never before it — see dropReason's own note.
+            if (dropReason is { } reason) await ReportInputDroppedAsync(cmd, reason);
         }
 
         // Codex turn diagnostic: arm the post-send rollout-growth probe. Only reached on the

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3517,16 +3517,43 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             || trimmed.Equals("/exit", StringComparison.OrdinalIgnoreCase);
     }
 
+    /// <summary>The reasons this daemon drops a dispatched input, as the server records them. Stable
+    /// tokens, not prose: the surface shows which one applied, and <c>unknown_agent</c> additionally
+    /// stands as per-id absence proof from the only daemon that could have hosted the agent.</summary>
+    internal static class SendInputDropReason {
+        public const string UnknownAgent      = "unknown_agent";
+        public const string PrivateAgent      = "private_agent";
+        public const string ReaperClaimed     = "reaper_claimed";
+        public const string ReaperClaimedLate = "reaper_claimed_late";
+    }
+
+    /// <summary>Reports a drop to the server, when the dispatch carried an id to name. Never throws
+    /// and never blocks the caller's own return: the drop has already happened, and a report that
+    /// fails must leave the daemon exactly where reporting nothing would.</summary>
+    async Task ReportInputDroppedAsync(SendInputCommand cmd, string reason) {
+        if (cmd.DispatchId is not { } dispatchId) return;
+
+        try {
+            await _server.SendInputRejectedAsync(dispatchId, cmd.AgentId, reason);
+        } catch (Exception ex) {
+            LogSendInputRejectReportFailed(ex, cmd.AgentId, reason);
+        }
+    }
+
     async Task HandleSendInput(SendInputCommand cmd) {
-        var (agentId, text, attachmentIds) = cmd;
+        var (agentId, text, attachmentIds, _) = cmd;
 
         if (!_agents.TryGetValue(agentId, out var agent)) {
             LogSendInputUnknownAgent(agentId, _agents.Count);
+            await ReportInputDroppedAsync(cmd, SendInputDropReason.UnknownAgent);
+
             return;
         }
 
         if (agent.IsPrivate) {
             LogSendInputPrivateAgent(agentId);
+            await ReportInputDroppedAsync(cmd, SendInputDropReason.PrivateAgent);
+
             return; // server-origin input ignored for private agents
         }
 
@@ -3556,6 +3583,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // into a dying runtime) is deliberate; the server heals it on resubmit.
             if (agent.IsReapClaimed) {
                 LogSendInputReapClaimed(agentId);
+                await ReportInputDroppedAsync(cmd, SendInputDropReason.ReaperClaimed);
+
                 return;
             }
 
@@ -3580,6 +3609,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
             if (agent.IsReapClaimed) {
                 LogSendInputReapClaimedLate(agentId);
+                await ReportInputDroppedAsync(cmd, SendInputDropReason.ReaperClaimedLate);
+
                 return;
             }
 
@@ -4974,6 +5005,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Information, Message = "SendInput delivered to agent {AgentId}'s {Vendor} runtime ({Chars} chars)")]
     partial void LogSendInputDelivered(string agentId, string vendor, int chars);
+
+    [LoggerMessage(Level = LogLevel.Debug, Message = "Could not report the dropped input for agent {AgentId} ({Reason})")]
+    partial void LogSendInputRejectReportFailed(Exception ex, string agentId, string reason);
 
     [LoggerMessage(Level = LogLevel.Warning, Message = "SendInput dropped: agent {AgentId} not found on this daemon ({KnownAgents} agents registered)")]
     partial void LogSendInputUnknownAgent(string agentId, int knownAgents);

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -919,11 +919,17 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// talking to an older server has to behave exactly as it did before this existed.</para></summary>
     public virtual async Task SendInputRejectedAsync(Guid dispatchId, string agentId, string reason) {
         try {
-            await _hub.InvokeAsync("SendInputRejected", dispatchId, agentId, reason, cancellationToken: _ct);
+            await _hub.InvokeAsync("SendInputRejected", dispatchId, agentId, reason, cancellationToken: _ct)
+                .WaitAsync(SendInputRejectedBudget, _ct);
         } catch (Exception ex) {
             _logger.LogDebug(ex, "Could not report the dropped input for agent {AgentId} ({Reason})", agentId, reason);
         }
     }
+
+    /// <summary>Bounds the report so an unresponsive server cannot pin the receive handler that is
+    /// waiting on it. The invoke has no timer of its own, and the input this reports on is already
+    /// dropped — waiting longer buys nothing anyone is still listening for.</summary>
+    static readonly TimeSpan SendInputRejectedBudget = TimeSpan.FromSeconds(10);
 
     /// <summary>
     /// The one report a shutting-down daemon can still make. Every other method here bakes in

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -910,6 +910,21 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     public virtual Task AgentUnregisteredAsync(string agentId)
         => _hub.InvokeAsync("AgentUnregistered", new AgentUnregistered(agentId), cancellationToken: _ct);
 
+    /// <summary>Tells the server this daemon dropped a dispatched input rather than delivering it.
+    /// Without it a drop is visible only in this log, while the sender is shown a message that was
+    /// delivered — the send returning proves the transport wrote and nothing more.
+    ///
+    /// <para>Best-effort by contract, and swallowed at Debug in particular for the server that has no
+    /// such method: reporting a refusal must never be able to fail a delivery path, and a daemon
+    /// talking to an older server has to behave exactly as it did before this existed.</para></summary>
+    public virtual async Task SendInputRejectedAsync(Guid dispatchId, string agentId, string reason) {
+        try {
+            await _hub.InvokeAsync("SendInputRejected", dispatchId, agentId, reason, cancellationToken: _ct);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "Could not report the dropped input for agent {AgentId} ({Reason})", agentId, reason);
+        }
+    }
+
     /// <summary>
     /// The one report a shutting-down daemon can still make. Every other method here bakes in
     /// <c>_ct</c>, which is <c>ApplicationStopping</c> and therefore already cancelled by the time

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
@@ -289,6 +289,16 @@ sealed class CaptureServerConnection() : ServerConnection(
     /// launch-catch + read-loop cleanup.</summary>
     public List<string> AgentUnregisteredCalls { get; } = [];
 
+    /// <summary>Every dropped-input report, in call order — the only place a drop reason becomes
+    /// observable to anyone but this daemon's own log.</summary>
+    public List<(Guid DispatchId, string AgentId, string Reason)> InputRejections { get; } = [];
+
+    public override Task SendInputRejectedAsync(Guid dispatchId, string agentId, string reason) {
+        lock (InputRejections) InputRejections.Add((dispatchId, agentId, reason));
+
+        return Task.CompletedTask;
+    }
+
     public override Task AgentUnregisteredAsync(string agentId) {
         lock (AgentUnregisteredCalls) AgentUnregisteredCalls.Add(agentId);
         OnAgentUnregistered?.Invoke();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SendInputRejectionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SendInputRejectionTests.cs
@@ -1,0 +1,55 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// What the sender learns when this daemon drops a dispatched input. The server's send returning
+/// proves the transport wrote and nothing about what the agent received, so without these reports a
+/// dropped message renders to whoever typed it as delivered.
+/// </summary>
+public class SendInputRejectionTests {
+    static AgentOrchestrator Build(CaptureServerConnection server) =>
+        AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+    [Test]
+    public async Task An_agent_this_daemon_does_not_have_is_reported_as_unknown() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        var dispatchId = Guid.NewGuid();
+
+        await orch.HandleSendInputForTest(new SendInputCommand("nobody", "hello", null, dispatchId));
+
+        await Assert.That(server.InputRejections)
+            .Contains((dispatchId, "nobody", AgentOrchestrator.SendInputDropReason.UnknownAgent));
+    }
+
+    /// <summary>A private agent ignores server-origin input by design; the sender is still owed the
+    /// reason, which is the difference between "ignored" and "delivered".</summary>
+    [Test]
+    public async Task A_private_agent_is_reported_rather_than_silently_ignored() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        orch.SeedAgentForTest("private-1", status: "Running", isPrivate: true);
+        var dispatchId = Guid.NewGuid();
+
+        await orch.HandleSendInputForTest(new SendInputCommand("private-1", "hello", null, dispatchId));
+
+        await Assert.That(server.InputRejections)
+            .Contains((dispatchId, "private-1", AgentOrchestrator.SendInputDropReason.PrivateAgent));
+    }
+
+    /// <summary>A server that sends no dispatch id has nothing for a refusal to name, and predates
+    /// the method that would receive one — it must see exactly the behaviour it always did.</summary>
+    [Test]
+    public async Task A_dispatch_with_no_id_reports_nothing() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+
+        await orch.HandleSendInputForTest(new SendInputCommand("nobody", "hello", null));
+
+        await Assert.That(server.InputRejections).IsEmpty();
+    }
+}


### PR DESCRIPTION
AI-2399 (daemon half) — the server half is kurrent-io/kcap-server#1778

## What & why

This daemon drops a dispatched input at four points — an agent it does not have, a private agent, and two reviewer-reaper claim races — and every one was log-only. The server reads its own completed send as delivery, so a message this daemon threw away rendered to whoever typed it as delivered, and the reason reached nothing but this log. The four sites now report their reason through `SendInputRejected`, which the server records against the dispatch and uses to retire the pending message.

## Where to look

Reporting is best-effort in two directions, and both matter. A server that predates the hub method throws on the invoke — swallowed at Debug, so such a daemon behaves exactly as it did before this existed. And a dispatch that carried no id has nothing for a refusal to name, so nothing is sent: the drop has already happened, and a report is never allowed to change what the delivery path does next.

The drop reasons are stable tokens rather than prose because the server stores them and the surface renders which one applied — `unknown_agent` especially, which stands as per-id absence proof from the only daemon that could have hosted the agent.

## Verification

`SendInputRejectionTests` covers the unknown agent, the private agent, and a dispatch with no id reporting nothing. Daemon unit suite 2935 total with one failure — `Installed_codex_schema_matches_the_vendored_pin`, which fails identically on `main` (the locally installed codex CLI has drifted from the vendored pin). Core suite 2581 total, 0 failed. AOT publish of the daemon clean of IL3050/IL2026.

🤖 Generated with [Claude Code](https://claude.com/claude-code)