### PR TITLE
Offer sign-in when the app is disconnected instead of a raw 401

### DIFF
--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -115,8 +115,12 @@ public partial class App : Application {
     WizardAuthService? _wizardAuth;
     ImportStepViewModel? _wizardImport;
     Window? _wizardWindow;
-    // Steady-state re-auth dialog, one at a time — a second Sign in click focuses it.
+    // Steady-state re-auth dialog, one at a time — a second Sign in click focuses it. The settle
+    // task is FinishSignInAsync for the most recent close; shutdown awaits it so a live attempt is
+    // cancelled (or a commit past the boundary finishes) before the process exits — the dialog's
+    // counterpart of the wizard sign-in quiesce.
     SignInWindow? _signInWindow;
+    Task? _reauthSettle;
     bool _shutdownStarted;
     bool _shutdownConfirmed;
     // 0 = normal shutdown. Set to 1 on a startup failure so the DEFERRED shutdown path (Cmd+Q /
@@ -399,7 +403,7 @@ public partial class App : Application {
         window.Closed += (_, _) => {
             graph.SignIn.PropertyChanged -= OnSignInChanged;
             _signInWindow = null;
-            _ = FinishSignInAsync(graph);
+            _reauthSettle = FinishSignInAsync(graph);
         };
 
         _signInWindow = window;
@@ -1179,6 +1183,13 @@ public partial class App : Application {
         // the UI thread this was invoked from. That is all it buys — the quiesce below still resumes
         // wherever ConfigureAwait(false) leaves it whenever IT suspends.
         await _workspaceTeardown.DrainAsync();
+
+        // Still on the UI thread (required by Close), and before the quiesce below: the dialog's
+        // own close path cancels a live re-auth attempt — or lets a commit already past the
+        // boundary finish — and the await stops the process exiting under it. Closed assigns
+        // _reauthSettle synchronously, so reading it after Close observes this close's task.
+        if (_signInWindow is { } reauthDialog) reauthDialog.Close();
+        if (_reauthSettle is { } reauthSettle) await reauthSettle.ConfigureAwait(false);
 
         // spec §3.6 + decision 2: an in-flight sign-in always settles, mutations get a bounded chance
         // to — both while the UI is still up, before teardown.

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -1,3 +1,4 @@
+using System.ComponentModel;
 using System.Reactive.Subjects;
 using Avalonia;
 using Avalonia.Controls;
@@ -114,6 +115,8 @@ public partial class App : Application {
     WizardAuthService? _wizardAuth;
     ImportStepViewModel? _wizardImport;
     Window? _wizardWindow;
+    // Steady-state re-auth dialog, one at a time — a second Sign in click focuses it.
+    SignInWindow? _signInWindow;
     bool _shutdownStarted;
     bool _shutdownConfirmed;
     // 0 = normal shutdown. Set to 1 on a startup failure so the DEFERRED shutdown path (Cmd+Q /
@@ -333,7 +336,8 @@ public partial class App : Application {
                 service, _config, actions, notifier, ticker, _shutdown.Token, activity, lifecycle.StartActionAsync,
                 lifecycleStatus, launch, _navigation, _workspaceTeardown.Track, BuildWorkspace,
                 // The tenant slug the rail footer shows — profiles are named after it at sign-in.
-                tenantName: profiles?.Resolution?.ProfileName, agentsWithPending: permissions.AgentsWithPending),
+                tenantName: profiles?.Resolution?.ProfileName, agentsWithPending: permissions.AgentsWithPending,
+                requestSignIn: () => OpenSignInDialog(profiles, notifier)),
             // Both close paths release the workspace: hide-to-tray keeps the window (and its
             // attach) alive, a real close discards the window the next Show() would rebuild.
             releaseWorkspace: window => (window.DataContext as MainWindowViewModel)?.CloseWorkspace());
@@ -358,6 +362,59 @@ public partial class App : Application {
             lifecycleAttention: lifecycleAttention, shimOfferable: shimOffer.Offerable,
             installShim: shimOffer.RunManualInstallAsync, permissions: permissions);
         _tray = new TrayIconManager(this, _trayVm);
+    }
+
+    /// Home's Sign in action: the re-auth dialog over a fresh ReauthComposition graph, pinned to
+    /// the resolved server. A graph is built per open — a settled attempt's rendered state must
+    /// never leak into the next sign-in.
+    void OpenSignInDialog(ProfileContext? profiles, IAppNotifier notifier) {
+        if (_signInWindow is { } open) {
+            open.Activate();
+            return;
+        }
+
+        // Reachable in the carve-out arm (gate Incomplete after an abandoned wizard), where the
+        // rail can show disconnected with no server to re-auth against.
+        if (profiles?.Resolution.ServerUrl is not { } serverUrl || !OnboardingGate.ValidServerUrl(serverUrl)) {
+            notifier.Notify("No server is configured — run kcap setup first.");
+            return;
+        }
+
+        var graph = ReauthComposition.Build(
+            _config, profiles.Name, serverUrl,
+            WizardComposition.BuildBridges(action => Dispatcher.UIThread.Post(action)),
+            new ConsentFlipClaims(_config),
+            new AppStateStore(_config.Path("app-state.json")),
+            new ShellUrlOpener(),
+            WizardComposition.NewOperation);
+        var window = new SignInWindow { DataContext = graph.SignIn };
+
+        // A committed sign-in closes the dialog itself; Closed below is the ONE finish path, so
+        // both the auto-close and the user's own close cancel/quiesce identically.
+        void OnSignInChanged(object? _, PropertyChangedEventArgs e) {
+            if (e.PropertyName == nameof(SignInStepViewModel.Satisfied) && graph.SignIn.Satisfied) window.Close();
+        }
+
+        graph.SignIn.PropertyChanged += OnSignInChanged;
+        window.Closed += (_, _) => {
+            graph.SignIn.PropertyChanged -= OnSignInChanged;
+            _signInWindow = null;
+            _ = FinishSignInAsync(graph);
+        };
+
+        _signInWindow = window;
+        window.Show();
+    }
+
+    /// Fire-and-forget from the dialog's Closed handler — nothing may block the UI close. The
+    /// quiesce is what stops a still-running attempt from committing after the window is gone.
+    async Task FinishSignInAsync(ReauthGraph graph) {
+        try {
+            await graph.CloseAsync(CancellationToken.None);
+            if (graph.SignIn.Satisfied) _home?.NotifySignInCompleted();
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: sign-in dialog teardown failed: {ex.Message}");
+        }
     }
 
     // Wizard-first mode (spec decision 2): no service, no tray, no lifecycle controller, no
@@ -649,7 +706,7 @@ public partial class App : Application {
             IObservable<string?>? lifecycleStatus = null, ILaunchClient? launch = null,
             NavigationGate? navigation = null, Action<Func<Task>>? trackWorkspaceTeardown = null,
             Func<string, WorkspaceViewModel>? workspaceFactory = null, string? tenantName = null,
-            IObservable<IReadOnlySet<string>>? agentsWithPending = null) {
+            IObservable<IReadOnlySet<string>>? agentsWithPending = null, Action? requestSignIn = null) {
         // Notifier is set on the WINDOW (spec §11 toast overlay), not the ViewModel — the toast
         // is a View-level concern (WindowNotificationManager lives on MainWindow) independent of
         // the VM's WhenActivated-scoped projections.
@@ -672,7 +729,8 @@ public partial class App : Application {
             launch ?? new ServerLaunchClient(config, null), new RepoPathStore(config).GetSortedPathsAsync, shutdownToken,
             openSession: agentId => vm?.OpenSession(agentId),
             navigationGeneration: () => vm?.NavigationGeneration ?? 0,
-            openSessionIfCurrent: (agentId, generation) => vm?.OpenSessionIfCurrent(agentId, generation));
+            openSessionIfCurrent: (agentId, generation) => vm?.OpenSessionIfCurrent(agentId, generation),
+            requestSignIn: requestSignIn);
         // Same knot as home above, over the SAME `service` instance — its own openSession
         // callback closes over `vm`, not a local, so no two-step forward-declaration is needed.
         var rail = new SessionRailViewModel(

--- a/src/Capacitor.App/Services/ILaunchClient.cs
+++ b/src/Capacitor.App/Services/ILaunchClient.cs
@@ -8,7 +8,9 @@ public sealed record LaunchRequest(
     string DaemonName, string RepoPath, string Vendor, string? Prompt,
     string Model = "", string? Effort = null);
 
-public sealed record LaunchOutcome(bool Started, string? AgentId, string? Error);
+/// Unauthorized marks a server 401 — the caller routes it to sign-in instead of rendering the
+/// raw transport message.
+public sealed record LaunchOutcome(bool Started, string? AgentId, string? Error, bool Unauthorized = false);
 
 /// Starting a session goes through the SERVER, not the local socket: the local Spawn frame
 /// resolves against the daemon's PTY launchers (claude and codex only), while the server's

--- a/src/Capacitor.App/Services/Onboarding/ReauthComposition.cs
+++ b/src/Capacitor.App/Services/Onboarding/ReauthComposition.cs
@@ -1,0 +1,38 @@
+using Capacitor.App.ViewModels.Onboarding;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.App.Services.Onboarding;
+
+/// What the steady-state sign-in dialog runs on: the wizard's sign-in step, and the driver whose
+/// quiesce the close path awaits.
+internal sealed record ReauthGraph(SignInStepViewModel SignIn, WizardAuthService Auth) {
+    /// The dialog's one close path, mirroring the wizard's handoff: a live attempt is cancelled
+    /// and its run awaited (CanLeaveAsync never vetoes), then the driver is quiesced so nothing
+    /// commits after the window is gone.
+    public async Task CloseAsync(CancellationToken ct) {
+        await SignIn.CanLeaveAsync(WizardNavigation.Next, ct).ConfigureAwait(true);
+        await Auth.QuiescedAsync().ConfigureAwait(true);
+    }
+}
+
+/// <summary>
+/// The re-auth half of the composition root: the wizard's sign-in step composed alone, with the
+/// intent pre-staged as a Paste of the profile's own server. Pasting the SAME origin is what keeps
+/// the "sign-in never repoints server_url" rule intact while reusing the wizard's commit boundary
+/// unchanged — and a Paste intent can never produce the Retarget answer, so the dialog needs no
+/// Connect step to come back to.
+/// </summary>
+internal static class ReauthComposition {
+    internal static ReauthGraph Build(
+            ConfigRoot root, string profile, string serverUrl, WizardBridges bridges,
+            ConsentFlipClaims claims, IAppStateStore appState, IUrlOpener urlOpener,
+            Func<WizardFacadeSpec, Func<ConnectIntent, CancellationToken, Task<AuthResult>>> operation) {
+        var auth = new WizardAuthService(
+            WizardComposition.BuildOperation(root, profile, bridges, claims, operation));
+        var connect = new ConnectStepViewModel();
+        connect.Prefill(serverUrl);
+
+        return new ReauthGraph(new SignInStepViewModel(auth, connect, bridges, claims, appState, urlOpener), auth);
+    }
+}

--- a/src/Capacitor.App/Services/ServerLaunchClient.cs
+++ b/src/Capacitor.App/Services/ServerLaunchClient.cs
@@ -1,3 +1,4 @@
+using System.Net;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
@@ -26,10 +27,19 @@ public sealed class ServerLaunchClient(ConfigRoot config, ProfileContext? profil
         } catch (Exception ex) {
             // HubException carries the server's own rejection text (capacity, unknown vendor,
             // consent denial) — that IS the message Home should show, not a generic wrapper.
-            return new LaunchOutcome(false, null, ex.Message);
+            return new LaunchOutcome(false, null, ex.Message, IsUnauthorized(ex));
         } finally {
             _gate.Release();
         }
+    }
+
+    /// Walks the chain because SignalR surfaces the negotiate failure wrapped as often as bare.
+    internal static bool IsUnauthorized(Exception ex) {
+        for (Exception? e = ex; e is not null; e = e.InnerException) {
+            if (e is HttpRequestException { StatusCode: HttpStatusCode.Unauthorized }) return true;
+        }
+
+        return false;
     }
 
     /// Caller MUST already hold _gate — see StartAsync. Disposes and rebuilds a connection that

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -3,6 +3,7 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core;
 using DynamicData;
@@ -15,6 +16,10 @@ namespace Capacitor.App.ViewModels;
 /// HomeViewModel.DefaultVendor when none was ever chosen there; Selected marks the entry that
 /// matches SelectedRepoPath under HomeViewModel's own path comparison.
 public sealed record RepositoryOption(string RepoPath, string Vendor, bool Selected);
+
+/// Whether a launch can reach a daemon right now, merged from the local attach state and the
+/// daemon's own upstream connection word — the same two inputs the footer's status line reads.
+internal enum LaunchAvailability { Ready, Pending, DaemonUnavailable, ServerDisconnected }
 
 /// The Home tab's view-model: repository + harness picker, a free-text goal, and
 /// the Start action that launches a session through ILaunchClient. Constructed once, like
@@ -40,6 +45,11 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// — it just has to be reached from the session list, so this is a launch-succeeded wording, not
     /// a failure one (spec §3, entry-point guards).
     public const string UnusableIdMessage = "Launched, but the session id was unusable — open it from the session list.";
+
+    internal const string ConnectingNotice     = "Connecting to the server…";
+    internal const string DaemonDownNotice     = "The daemon isn't running — start it to launch sessions.";
+    internal const string ServerLostNotice     = "Not connected to the server — sign in again to reconnect.";
+    internal const string SignInExpiredNotice  = "Your sign-in has expired — sign in again.";
 
     readonly IDaemonClientService _daemon;
     readonly IAppStateStore _state;
@@ -98,6 +108,22 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         private set => this.RaiseAndSetIfChanged(ref _startError, value);
     }
 
+    /// A 401 outcome is the only writer besides its own reset paths. A subject (not a reactive
+    /// property read via WhenAnyValue) so the ctor can compose it — see SessionRailViewModel's
+    /// _selectedAgentIdChanges for why WhenAnyValue is avoided in constructors here.
+    readonly BehaviorSubject<bool> _signInRequired = new(false);
+    readonly Action? _requestSignIn;
+
+    readonly ObservableAsPropertyHelper<string?> _connectionNotice;
+    /// Why launching is unavailable right now, or null when it isn't. The sign-in-expired text
+    /// wins over the connection-derived one — it is the more specific diagnosis.
+    public string? ConnectionNotice => _connectionNotice.Value;
+
+    readonly ObservableAsPropertyHelper<bool> _signInVisible;
+    public bool SignInVisible => _signInVisible.Value;
+
+    public ReactiveCommand<Unit, Unit> SignInCommand { get; }
+
     readonly ObservableAsPropertyHelper<IReadOnlyList<HarnessOption>> _harnesses;
     public IReadOnlyList<HarnessOption> Harnesses => _harnesses.Value;
 
@@ -130,11 +156,13 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// The launch auto-open (MainWindowViewModel.OpenSessionIfCurrent), carrying that captured
     /// generation.
     /// </param>
+    /// <param name="requestSignIn">Opens the re-auth sign-in surface (App owns the window). Null
+    /// leaves the Sign in button inert — a HomeViewModel with no windows to open.</param>
     public HomeViewModel(
             IDaemonClientService daemon, IAppStateStore state, ILaunchClient launch,
             Func<Task<string[]>> knownRepos, CancellationToken shutdown = default,
             Action<string>? openSession = null, Func<int>? navigationGeneration = null,
-            Action<string, int>? openSessionIfCurrent = null) {
+            Action<string, int>? openSessionIfCurrent = null, Action? requestSignIn = null) {
         _daemon = daemon;
         _state = state;
         _launch = launch;
@@ -143,6 +171,7 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         _openSession = openSession;
         _navigationGeneration = navigationGeneration;
         _openSessionIfCurrent = openSessionIfCurrent;
+        _requestSignIn = requestSignIn;
 
         // Never starts empty: a null SupportedVendors means "daemon
         // capability unknown", not "hosts nothing" — Build(null) offers everything until the first
@@ -168,8 +197,59 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
             .Subscribe()
             .DisposeWith(_disposables);
 
-        StartCommand = ReactiveCommand.CreateFromTask(StartAsync);
+        // The word is seeded with "" (no snapshot yet): AvailabilityFor only reads it once the
+        // attach state is Connected, by which point DaemonClientService's snapshot-before-Connected
+        // ordering guarantees a real value is there (MainWindowViewModel's identical seam comment).
+        var availability = daemon.Status.CombineLatest(
+            daemon.Snapshots.Select(s => s.Daemon.Connection).StartWith(""), AvailabilityFor);
+
+        // Explicit ObserveOn: ReactiveCommand does NOT reschedule the supplied canExecute, and a
+        // Status event arrives on the daemon client's pump thread (MainWindowViewModel's canStart
+        // comment) — without it CanExecuteChanged would touch the bound Button off the UI thread.
+        StartCommand = ReactiveCommand.CreateFromTask(
+            StartAsync,
+            availability.Select(a => a == LaunchAvailability.Ready)
+                .ObserveOn(RxSchedulers.MainThreadScheduler));
+
+        var signInState = availability
+            .CombineLatest(_signInRequired, (a, expired) => (Availability: a, Expired: expired))
+            .ObserveOn(RxSchedulers.MainThreadScheduler);
+        _connectionNotice = signInState.Select(t => NoticeFor(t.Availability, t.Expired))
+            .ToProperty(this, x => x.ConnectionNotice, ConnectingNotice)
+            .DisposeWith(_disposables);
+        _signInVisible = signInState
+            .Select(t => t.Expired || t.Availability == LaunchAvailability.ServerDisconnected)
+            .ToProperty(this, x => x.SignInVisible, initialValue: false)
+            .DisposeWith(_disposables);
+
+        SignInCommand = ReactiveCommand.Create(() => { _requestSignIn?.Invoke(); });
     }
+
+    /// The re-auth dialog's success lands here (App wires it): the expired flag lifts without
+    /// waiting for the next launch attempt to re-prove it.
+    public void NotifySignInCompleted() => _signInRequired.OnNext(false);
+
+    /// Local attach state is checked FIRST — the upstream word is only meaningful once the attach
+    /// is Connected (a stale retained snapshot might carry any word). Unknown upstream words read
+    /// as disconnected, matching the daemon's own catch-all spelling.
+    internal static LaunchAvailability AvailabilityFor(AttachStatus status, string daemonConnection) => status.State switch {
+        AttachState.Connecting  => LaunchAvailability.Pending,
+        AttachState.Unreachable => LaunchAvailability.DaemonUnavailable,
+        _ => daemonConnection switch {
+            "connected"                    => LaunchAvailability.Ready,
+            "connecting" or "reconnecting" => LaunchAvailability.Pending,
+            _                              => LaunchAvailability.ServerDisconnected,
+        },
+    };
+
+    internal static string? NoticeFor(LaunchAvailability availability, bool signInExpired) =>
+        signInExpired ? SignInExpiredNotice
+        : availability switch {
+            LaunchAvailability.Ready             => null,
+            LaunchAvailability.Pending           => ConnectingNotice,
+            LaunchAvailability.DaemonUnavailable => DaemonDownNotice,
+            _                                    => ServerLostNotice,
+        };
 
     // Constructor-scoped (like TrayViewModel/ActivityViewModel), not WhenActivated — the OAPH and
     // the Agents subscription above run for this object's whole lifetime, not a window's.
@@ -254,10 +334,14 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
 
         var outcome = await _launch.StartAsync(request, _shutdown);
         if (!outcome.Started) {
-            StartError = outcome.Error;
+            // Every finished attempt is fresh evidence, so the flag follows it both ways. An
+            // unauthorized outcome renders as the sign-in notice, never as raw transport text.
+            _signInRequired.OnNext(outcome.Unauthorized);
+            StartError = outcome.Unauthorized ? null : outcome.Error;
             return;
         }
 
+        _signInRequired.OnNext(false);
         StartError = null;
         Goal = ""; // the launch really did start — the goal is spent either way
         if (NormalizeAgentId(outcome.AgentId) is not { } agentId) {

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml
@@ -69,6 +69,18 @@
                 <TextBlock x:Name="StartErrorText" Text="{Binding StartError}" Foreground="{StaticResource KcapDangerBrush}"
                            TextWrapping="Wrap"
                            IsVisible="{Binding StartError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+                <StackPanel Orientation="Horizontal" Spacing="10"
+                            IsVisible="{Binding ConnectionNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                    <TextBlock x:Name="ConnectionNoticeText" Text="{Binding ConnectionNotice}"
+                               Foreground="{StaticResource KcapMutedBrush}" TextWrapping="Wrap"
+                               VerticalAlignment="Center"
+                               IsVisible="{Binding ConnectionNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                    <Button x:Name="HomeSignInButton" Content="Sign in" Command="{Binding SignInCommand}"
+                            Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" FontWeight="SemiBold"
+                            CornerRadius="7" Padding="12,5"
+                            IsVisible="{Binding SignInVisible}" />
+                </StackPanel>
             </StackPanel>
         </Border>
     </StackPanel>

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml
@@ -2,7 +2,7 @@
                      xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
                      xmlns:rxui="clr-namespace:ReactiveUI.Avalonia;assembly=ReactiveUI.Avalonia"
                      xmlns:vm="clr-namespace:Capacitor.App.ViewModels.Onboarding"
-                     xmlns:auth="clr-namespace:Capacitor.Cli.Core.Auth;assembly=Capacitor.Cli.Core"
+                     xmlns:views="clr-namespace:Capacitor.App.Views.Onboarding"
                      x:Class="Capacitor.App.Views.Onboarding.OnboardingWindow"
                      x:TypeArguments="vm:OnboardingViewModel"
                      x:DataType="vm:OnboardingViewModel"
@@ -43,127 +43,7 @@
         </DataTemplate>
 
         <DataTemplate DataType="vm:SignInStepViewModel">
-            <Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
-                <StackPanel Grid.Row="0" Spacing="4">
-                    <TextBlock x:Name="SignInStatusText" Text="{Binding Status}" TextWrapping="Wrap"
-                               Classes.failed="{Binding StatusIsError}">
-                        <TextBlock.Styles>
-                            <!-- Only a failure is coloured: a cancelled sign-in is not an error. -->
-                            <Style Selector="TextBlock.failed">
-                                <Setter Property="Foreground" Value="#E53935" />
-                            </Style>
-                        </TextBlock.Styles>
-                    </TextBlock>
-                    <TextBlock x:Name="SignInDetailText" Text="{Binding StatusDetail}" TextWrapping="Wrap" Opacity="0.7"
-                               IsVisible="{Binding StatusDetail, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                </StackPanel>
-
-                <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
-                    <Button x:Name="SignInButton" Content="Sign in" Command="{Binding SignInCommand}"
-                            IsEnabled="{Binding Idle}" />
-                    <Button x:Name="CancelSignInButton" Content="Cancel" Command="{Binding CancelCommand}"
-                            IsVisible="{Binding Busy}" />
-                </StackPanel>
-
-                <StackPanel Grid.Row="2" Spacing="6" Margin="0,10,0,0">
-                    <Button x:Name="OpenSignInUrlButton" Content="Open the sign-in page"
-                            Command="{Binding OpenSignInUrlCommand}"
-                            IsVisible="{Binding BrowserUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-
-                    <StackPanel Spacing="4"
-                                IsVisible="{Binding DeviceCode, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                        <TextBlock Text="Enter this code to finish signing in:" />
-                        <TextBlock x:Name="DeviceCodeText" Text="{Binding DeviceCode}" FontSize="22" FontWeight="Bold" />
-                        <Button x:Name="OpenVerificationUriButton" Content="{Binding VerificationUri}"
-                                Command="{Binding OpenVerificationUriCommand}" />
-                    </StackPanel>
-
-                    <TextBlock x:Name="WaitingText" Text="{Binding WaitingText}" Opacity="0.7"
-                               IsVisible="{Binding WaitingText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                    <TextBlock x:Name="ProvisioningText" Text="{Binding ProvisioningProgress}" TextWrapping="Wrap"
-                               IsVisible="{Binding ProvisioningProgress, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                </StackPanel>
-
-                <StackPanel Grid.Row="3" Spacing="8" Margin="0,10,0,0">
-                    <StackPanel Spacing="6" IsVisible="{Binding TenantPickerVisible}">
-                        <TextBlock Text="Which workspace would you like to use?" />
-                        <ListBox x:Name="TenantList" MaxHeight="120" ItemsSource="{Binding Tenants}"
-                                 SelectedItem="{Binding SelectedTenant, Mode=TwoWay}">
-                            <ListBox.ItemTemplate>
-                                <DataTemplate x:DataType="auth:DiscoveredTenant">
-                                    <TextBlock Text="{Binding Origin}" TextTrimming="CharacterEllipsis" />
-                                </DataTemplate>
-                            </ListBox.ItemTemplate>
-                        </ListBox>
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <Button x:Name="ConfirmTenantButton" Content="Use this workspace"
-                                    Command="{Binding ConfirmTenantCommand}" />
-                            <Button x:Name="CancelTenantButton" Content="Back" Command="{Binding CancelTenantCommand}" />
-                        </StackPanel>
-                    </StackPanel>
-
-                    <StackPanel Spacing="6" IsVisible="{Binding ModeChoiceVisible}">
-                        <TextBlock Text="No workspace was found for your account. How would you like to continue?"
-                                   TextWrapping="Wrap" />
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <Button x:Name="CreateWorkspaceButton" Content="Create a workspace"
-                                    Command="{Binding CreateWorkspaceCommand}" />
-                            <TextBox x:Name="ExistingWorkspaceBox" Width="180" Watermark="acme"
-                                     Text="{Binding ExistingWorkspaceInput, Mode=TwoWay}" />
-                            <Button x:Name="UseExistingWorkspaceButton" Content="I already have one"
-                                    Command="{Binding UseExistingWorkspaceCommand}" />
-                            <Button x:Name="CancelWorkspaceButton" Content="Cancel"
-                                    Command="{Binding CancelWorkspaceCommand}" />
-                        </StackPanel>
-                    </StackPanel>
-
-                    <StackPanel Spacing="6" IsVisible="{Binding OrgNamePromptVisible}">
-                        <TextBlock Text="Organization name" />
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBox x:Name="OrgNameBox" Width="220" Text="{Binding OrgName, Mode=TwoWay}" />
-                            <Button x:Name="SubmitOrgNameButton" Content="Continue" Command="{Binding SubmitOrgNameCommand}" />
-                            <Button x:Name="CancelOrgNameButton" Content="Cancel" Command="{Binding CancelOrgNameCommand}" />
-                        </StackPanel>
-                    </StackPanel>
-
-                    <StackPanel Spacing="6" IsVisible="{Binding SlugPromptVisible}">
-                        <TextBlock Text="Workspace address" />
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBox x:Name="SlugBox" Width="220" Text="{Binding Slug, Mode=TwoWay}" />
-                            <TextBlock Text=".kcap.ai" VerticalAlignment="Center" Opacity="0.7" />
-                            <Button x:Name="SubmitSlugButton" Content="Continue" Command="{Binding SubmitSlugCommand}" />
-                            <Button x:Name="CancelSlugButton" Content="Cancel" Command="{Binding CancelSlugCommand}" />
-                        </StackPanel>
-                        <TextBlock x:Name="SlugErrorText" Text="{Binding SlugError}" TextWrapping="Wrap" Foreground="#E53935"
-                                   IsVisible="{Binding SlugError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                    </StackPanel>
-
-                    <StackPanel Spacing="6" IsVisible="{Binding ConfirmVisible}">
-                        <TextBlock x:Name="ConfirmCreateText" Text="{Binding ConfirmText}" TextWrapping="Wrap" />
-                        <StackPanel Orientation="Horizontal" Spacing="8">
-                            <Button x:Name="ConfirmCreateButton" Content="Create" Command="{Binding ConfirmCreateCommand}" />
-                            <Button x:Name="DeclineCreateButton" Content="Not now" Command="{Binding DeclineCreateCommand}" />
-                        </StackPanel>
-                    </StackPanel>
-
-                    <StackPanel Spacing="6"
-                                IsVisible="{Binding QuarantineNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                        <TextBlock x:Name="QuarantineNoticeText" Text="{Binding QuarantineNotice}" TextWrapping="Wrap" />
-                        <Button x:Name="AcknowledgeQuarantineButton" Content="Acknowledge"
-                                Command="{Binding AcknowledgeQuarantineCommand}" HorizontalAlignment="Left" />
-                    </StackPanel>
-                </StackPanel>
-
-                <ScrollViewer Grid.Row="4" Margin="0,10,0,0" VerticalScrollBarVisibility="Auto">
-                    <ItemsControl x:Name="SignInLog" ItemsSource="{Binding Log}">
-                        <ItemsControl.ItemTemplate>
-                            <DataTemplate x:DataType="x:String">
-                                <TextBlock Text="{Binding}" FontSize="12" Opacity="0.7" TextWrapping="Wrap" />
-                            </DataTemplate>
-                        </ItemsControl.ItemTemplate>
-                    </ItemsControl>
-                </ScrollViewer>
-            </Grid>
+            <views:SignInStepView />
         </DataTemplate>
 
         <DataTemplate DataType="vm:ShimStepViewModel">

--- a/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml
+++ b/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml
@@ -1,0 +1,130 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:auth="clr-namespace:Capacitor.Cli.Core.Auth;assembly=Capacitor.Cli.Core"
+             xmlns:vm="clr-namespace:Capacitor.App.ViewModels.Onboarding"
+             x:Class="Capacitor.App.Views.Onboarding.SignInStepView"
+             x:DataType="vm:SignInStepViewModel">
+    <!-- Shared between the onboarding wizard's Sign-in step and the steady-state re-auth dialog
+         (SignInWindow) — one rendering of SignInStepViewModel, so the two can never drift. -->
+    <Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
+        <StackPanel Grid.Row="0" Spacing="4">
+            <TextBlock x:Name="SignInStatusText" Text="{Binding Status}" TextWrapping="Wrap"
+                       Classes.failed="{Binding StatusIsError}">
+                <TextBlock.Styles>
+                    <!-- Only a failure is coloured: a cancelled sign-in is not an error. -->
+                    <Style Selector="TextBlock.failed">
+                        <Setter Property="Foreground" Value="#E53935" />
+                    </Style>
+                </TextBlock.Styles>
+            </TextBlock>
+            <TextBlock x:Name="SignInDetailText" Text="{Binding StatusDetail}" TextWrapping="Wrap" Opacity="0.7"
+                       IsVisible="{Binding StatusDetail, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
+            <Button x:Name="SignInButton" Content="Sign in" Command="{Binding SignInCommand}"
+                    IsEnabled="{Binding Idle}" />
+            <Button x:Name="CancelSignInButton" Content="Cancel" Command="{Binding CancelCommand}"
+                    IsVisible="{Binding Busy}" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="2" Spacing="6" Margin="0,10,0,0">
+            <Button x:Name="OpenSignInUrlButton" Content="Open the sign-in page"
+                    Command="{Binding OpenSignInUrlCommand}"
+                    IsVisible="{Binding BrowserUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+
+            <StackPanel Spacing="4"
+                        IsVisible="{Binding DeviceCode, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                <TextBlock Text="Enter this code to finish signing in:" />
+                <TextBlock x:Name="DeviceCodeText" Text="{Binding DeviceCode}" FontSize="22" FontWeight="Bold" />
+                <Button x:Name="OpenVerificationUriButton" Content="{Binding VerificationUri}"
+                        Command="{Binding OpenVerificationUriCommand}" />
+            </StackPanel>
+
+            <TextBlock x:Name="WaitingText" Text="{Binding WaitingText}" Opacity="0.7"
+                       IsVisible="{Binding WaitingText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+            <TextBlock x:Name="ProvisioningText" Text="{Binding ProvisioningProgress}" TextWrapping="Wrap"
+                       IsVisible="{Binding ProvisioningProgress, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+        </StackPanel>
+
+        <StackPanel Grid.Row="3" Spacing="8" Margin="0,10,0,0">
+            <StackPanel Spacing="6" IsVisible="{Binding TenantPickerVisible}">
+                <TextBlock Text="Which workspace would you like to use?" />
+                <ListBox x:Name="TenantList" MaxHeight="120" ItemsSource="{Binding Tenants}"
+                         SelectedItem="{Binding SelectedTenant, Mode=TwoWay}">
+                    <ListBox.ItemTemplate>
+                        <DataTemplate x:DataType="auth:DiscoveredTenant">
+                            <TextBlock Text="{Binding Origin}" TextTrimming="CharacterEllipsis" />
+                        </DataTemplate>
+                    </ListBox.ItemTemplate>
+                </ListBox>
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button x:Name="ConfirmTenantButton" Content="Use this workspace"
+                            Command="{Binding ConfirmTenantCommand}" />
+                    <Button x:Name="CancelTenantButton" Content="Back" Command="{Binding CancelTenantCommand}" />
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Spacing="6" IsVisible="{Binding ModeChoiceVisible}">
+                <TextBlock Text="No workspace was found for your account. How would you like to continue?"
+                           TextWrapping="Wrap" />
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button x:Name="CreateWorkspaceButton" Content="Create a workspace"
+                            Command="{Binding CreateWorkspaceCommand}" />
+                    <TextBox x:Name="ExistingWorkspaceBox" Width="180" PlaceholderText="acme"
+                             Text="{Binding ExistingWorkspaceInput, Mode=TwoWay}" />
+                    <Button x:Name="UseExistingWorkspaceButton" Content="I already have one"
+                            Command="{Binding UseExistingWorkspaceCommand}" />
+                    <Button x:Name="CancelWorkspaceButton" Content="Cancel"
+                            Command="{Binding CancelWorkspaceCommand}" />
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Spacing="6" IsVisible="{Binding OrgNamePromptVisible}">
+                <TextBlock Text="Organization name" />
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <TextBox x:Name="OrgNameBox" Width="220" Text="{Binding OrgName, Mode=TwoWay}" />
+                    <Button x:Name="SubmitOrgNameButton" Content="Continue" Command="{Binding SubmitOrgNameCommand}" />
+                    <Button x:Name="CancelOrgNameButton" Content="Cancel" Command="{Binding CancelOrgNameCommand}" />
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Spacing="6" IsVisible="{Binding SlugPromptVisible}">
+                <TextBlock Text="Workspace address" />
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <TextBox x:Name="SlugBox" Width="220" Text="{Binding Slug, Mode=TwoWay}" />
+                    <TextBlock Text=".kcap.ai" VerticalAlignment="Center" Opacity="0.7" />
+                    <Button x:Name="SubmitSlugButton" Content="Continue" Command="{Binding SubmitSlugCommand}" />
+                    <Button x:Name="CancelSlugButton" Content="Cancel" Command="{Binding CancelSlugCommand}" />
+                </StackPanel>
+                <TextBlock x:Name="SlugErrorText" Text="{Binding SlugError}" TextWrapping="Wrap" Foreground="#E53935"
+                           IsVisible="{Binding SlugError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+            </StackPanel>
+
+            <StackPanel Spacing="6" IsVisible="{Binding ConfirmVisible}">
+                <TextBlock x:Name="ConfirmCreateText" Text="{Binding ConfirmText}" TextWrapping="Wrap" />
+                <StackPanel Orientation="Horizontal" Spacing="8">
+                    <Button x:Name="ConfirmCreateButton" Content="Create" Command="{Binding ConfirmCreateCommand}" />
+                    <Button x:Name="DeclineCreateButton" Content="Not now" Command="{Binding DeclineCreateCommand}" />
+                </StackPanel>
+            </StackPanel>
+
+            <StackPanel Spacing="6"
+                        IsVisible="{Binding QuarantineNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                <TextBlock x:Name="QuarantineNoticeText" Text="{Binding QuarantineNotice}" TextWrapping="Wrap" />
+                <Button x:Name="AcknowledgeQuarantineButton" Content="Acknowledge"
+                        Command="{Binding AcknowledgeQuarantineCommand}" HorizontalAlignment="Left" />
+            </StackPanel>
+        </StackPanel>
+
+        <ScrollViewer Grid.Row="4" Margin="0,10,0,0" VerticalScrollBarVisibility="Auto">
+            <ItemsControl x:Name="SignInLog" ItemsSource="{Binding Log}">
+                <ItemsControl.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <TextBlock Text="{Binding}" FontSize="12" Opacity="0.7" TextWrapping="Wrap" />
+                    </DataTemplate>
+                </ItemsControl.ItemTemplate>
+            </ItemsControl>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml.cs
+++ b/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml.cs
@@ -1,0 +1,7 @@
+using Avalonia.Controls;
+
+namespace Capacitor.App.Views.Onboarding;
+
+public partial class SignInStepView : UserControl {
+    public SignInStepView() => InitializeComponent();
+}

--- a/src/Capacitor.App/Views/SignInWindow.axaml
+++ b/src/Capacitor.App/Views/SignInWindow.axaml
@@ -1,0 +1,13 @@
+<Window xmlns="https://github.com/avaloniaui"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:Capacitor.App.ViewModels.Onboarding"
+        xmlns:onboarding="clr-namespace:Capacitor.App.Views.Onboarding"
+        x:Class="Capacitor.App.Views.SignInWindow"
+        x:DataType="vm:SignInStepViewModel"
+        Title="Sign in"
+        Icon="avares://Kurrent Capacitor/Assets/kcap-icon.png"
+        Width="560" Height="420">
+    <!-- The steady-state re-auth dialog: the wizard's sign-in step view over a ReauthComposition
+         graph pinned to the configured server. App owns opening/closing it. -->
+    <onboarding:SignInStepView Margin="16" />
+</Window>

--- a/src/Capacitor.App/Views/SignInWindow.axaml.cs
+++ b/src/Capacitor.App/Views/SignInWindow.axaml.cs
@@ -1,0 +1,13 @@
+using Avalonia.Controls;
+using Capacitor.App.ViewModels.Onboarding;
+
+namespace Capacitor.App.Views;
+
+public partial class SignInWindow : Window {
+    public SignInWindow() {
+        InitializeComponent();
+        // The wizard shell calls OnEnterAsync when navigating onto the step; standalone, opening
+        // the window IS that navigation, and without it the status line stays blank.
+        Opened += (_, _) => _ = (DataContext as SignInStepViewModel)?.OnEnterAsync(CancellationToken.None);
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -31,10 +31,14 @@ public class HomeViewModelTests {
     /// developer's own ~/.config/kcap/repos.json, which no test may touch.
     static Func<Task<string[]>> Known(params string[] paths) => () => Task.FromResult(paths);
 
+    /// Primed connected: StartCommand's canExecute gates on daemon + server both being up, so a
+    /// fixture that launches must model the connected steady state.
     static HomeViewModel Build(out RecordingLaunchClient launch, out AppStateStore store, string statePath) {
         launch = new RecordingLaunchClient();
         store = new AppStateStore(statePath);
-        return new HomeViewModel(new FakeDaemonClientService(), store, launch, Known());
+        var daemon = new FakeDaemonClientService();
+        Connect(daemon);
+        return new HomeViewModel(daemon, store, launch, Known());
     }
 
     /// Repo keys compare the way the filesystem does — so the SAME repository reached under
@@ -421,6 +425,100 @@ public class HomeViewModelTests {
             await Assert.That(piBefore).IsTrue();
             await Assert.That(vm.Harnesses.Single(h => h.Vendor == "pi").Available).IsFalse();
             await Assert.That(vm.Harnesses.Single(h => h.Vendor == "claude").Available).IsTrue();
+        });
+    }
+
+    static void Connect(FakeDaemonClientService daemon, string connection = "connected") {
+        daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: connection));
+        daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Start_is_disabled_until_daemon_and_server_are_both_connected() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
+            await vm.SelectRepositoryAsync("/repo/a");
+
+            await Assert.That(await vm.StartCommand.CanExecute.FirstAsync()).IsFalse();
+
+            Connect(daemon);
+            await Assert.That(await vm.StartCommand.CanExecute.FirstAsync()).IsTrue();
+
+            daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "disconnected"));
+            await Assert.That(await vm.StartCommand.CanExecute.FirstAsync()).IsFalse();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_lost_server_connection_tells_the_user_to_sign_in() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
+
+            Connect(daemon);
+            await Assert.That(vm.ConnectionNotice).IsNull();
+            await Assert.That(vm.SignInVisible).IsFalse();
+
+            daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "disconnected"));
+            await Assert.That(vm.ConnectionNotice).IsEqualTo(HomeViewModel.ServerLostNotice);
+            await Assert.That(vm.SignInVisible).IsTrue();
+
+            // Transient by definition — the retry resolves it or lands on "disconnected".
+            daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "reconnecting"));
+            await Assert.That(vm.ConnectionNotice).IsEqualTo(HomeViewModel.ConnectingNotice);
+            await Assert.That(vm.SignInVisible).IsFalse();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_unreachable_daemon_is_not_a_sign_in_problem() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
+
+            daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "not running", null));
+
+            await Assert.That(vm.ConnectionNotice).IsEqualTo(HomeViewModel.DaemonDownNotice);
+            await Assert.That(vm.SignInVisible).IsFalse();
+            await Assert.That(await vm.StartCommand.CanExecute.FirstAsync()).IsFalse();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_unauthorized_start_asks_for_sign_in_instead_of_the_raw_error() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            var launch = new RecordingLaunchClient();
+            var signInRequests = 0;
+            using var vm = new HomeViewModel(
+                daemon, new AppStateStore(path), launch, Known(), requestSignIn: () => signInRequests++);
+            Connect(daemon);
+            await vm.SelectRepositoryAsync("/repo/a");
+            launch.Next = new LaunchOutcome(
+                false, null, "Response status code does not indicate success: 401 (Unauthorized).",
+                Unauthorized: true);
+
+            await vm.StartCommand.Execute();
+
+            await Assert.That(vm.StartError).IsNull();
+            await Assert.That(vm.SignInVisible).IsTrue();
+            await Assert.That(vm.ConnectionNotice).IsEqualTo(HomeViewModel.SignInExpiredNotice);
+
+            await vm.SignInCommand.Execute();
+            await Assert.That(signInRequests).IsEqualTo(1);
+
+            vm.NotifySignInCompleted();
+            await Assert.That(vm.SignInVisible).IsFalse();
+            await Assert.That(vm.ConnectionNotice).IsNull();
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -33,6 +33,9 @@ public class HomeViewSmokeTests {
     static (HomeView View, HomeViewModel Vm, FakeDaemonClientService Service, RecordingLaunchClient Launch, TempDir Tmp) Build() {
         var tmp = TempDir.WithPathTo("app-state.json", out var path);
         var service = new FakeDaemonClientService();
+        // Connected steady state: StartCommand's canExecute gates on daemon + server both up.
+        service.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap());
+        service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
         var launch = new RecordingLaunchClient();
         var vm = new HomeViewModel(service, new AppStateStore(path), launch, () => Task.FromResult(Array.Empty<string>()));
         return (new HomeView { DataContext = vm }, vm, service, launch, tmp);
@@ -56,7 +59,10 @@ public class HomeViewSmokeTests {
             window.Show();
             Dispatcher.UIThread.RunJobs();
 
-            var names = new[] { "GoalInput", "RepositoryChip", "AgentChip", "StartButton", "StartErrorText" };
+            var names = new[] {
+                "GoalInput", "RepositoryChip", "AgentChip", "StartButton", "StartErrorText",
+                "ConnectionNoticeText", "HomeSignInButton",
+            };
             var resolved = names.ToDictionary(name => name, name => Find<Control>(window, name) is not null);
 
             window.Close();
@@ -70,6 +76,39 @@ public class HomeViewSmokeTests {
         await Assert.That(found["AgentChip"]).IsTrue();
         await Assert.That(found["StartButton"]).IsTrue();
         await Assert.That(found["StartErrorText"]).IsTrue();
+        await Assert.That(found["ConnectionNoticeText"]).IsTrue();
+        await Assert.That(found["HomeSignInButton"]).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_notice_and_sign_in_button_follow_the_server_connection() {
+        var (noticeBefore, signInBefore, noticeAfter, noticeText, signInAfter) = await AvaloniaSession.DispatchAsync(() => {
+            var (_, vm, service, _, tmp) = Build();
+            using var _tmp = tmp;
+            var window = new Window { Content = new LauncherPaneView { DataContext = vm } };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var notice = Find<TextBlock>(window, "ConnectionNoticeText")!;
+            var signIn = Find<Button>(window, "HomeSignInButton")!;
+            var before = (notice.IsVisible, signIn.IsVisible);
+
+            service.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "disconnected"));
+            Dispatcher.UIThread.RunJobs();
+            var after = (notice.IsVisible, notice.Text, signIn.IsVisible);
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            vm.Dispose();
+            return (before.Item1, before.Item2, after.Item1, after.Item2, after.Item3);
+        });
+
+        await Assert.That(noticeBefore).IsFalse();
+        await Assert.That(signInBefore).IsFalse();
+        await Assert.That(noticeAfter).IsTrue();
+        await Assert.That(noticeText).IsEqualTo(HomeViewModel.ServerLostNotice);
+        await Assert.That(signInAfter).IsTrue();
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/ReauthCompositionTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ReauthCompositionTests.cs
@@ -1,0 +1,106 @@
+using System.Reactive.Threading.Tasks;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.Services;
+using Capacitor.App.Services.Onboarding;
+using Capacitor.App.Views;
+using Capacitor.Cli.Core.Auth;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The steady-state re-auth graph is the wizard's sign-in step alone, pinned to the server the
+/// profile already targets — a re-auth must never repoint server_url at a different origin.
+public class ReauthCompositionTests {
+    const string ServerUrl = "https://acme.example";
+
+    static AuthResult.Committed Committed() =>
+        new("default", ServerUrl, AuthProvider.GitHubApp, "alice", []);
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Sign_in_runs_a_paste_intent_pinned_to_the_configured_server() {
+        await AvaloniaSession.RunOnUiAsync(async () => {
+            using var config = new TempConfigRoot();
+            ConnectIntent? seen = null;
+
+            var graph = ReauthComposition.Build(
+                config.Root, "default", ServerUrl,
+                WizardComposition.BuildBridges(action => action()),
+                new ConsentFlipClaims(config.Root),
+                new AppStateStore(config.PathTo("app-state.json")),
+                new RecordingOpener(),
+                _ => (intent, _) => {
+                    seen = intent;
+                    return Task.FromResult<AuthResult>(Committed());
+                });
+
+            await graph.SignIn.SignInCommand.Execute().ToTask();
+
+            await Assert.That(seen).IsEqualTo(new ConnectIntent.Paste(ServerUrl));
+            await Assert.That(graph.SignIn.Satisfied).IsTrue();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Closing_mid_attempt_cancels_it_and_quiesces() {
+        await AvaloniaSession.RunOnUiAsync(async () => {
+            using var config = new TempConfigRoot();
+            var started = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+            var graph = ReauthComposition.Build(
+                config.Root, "default", ServerUrl,
+                WizardComposition.BuildBridges(action => action()),
+                new ConsentFlipClaims(config.Root),
+                new AppStateStore(config.PathTo("app-state.json")),
+                new RecordingOpener(),
+                _ => async (_, ct) => {
+                    started.TrySetResult();
+                    await Task.Delay(Timeout.Infinite, ct);
+                    return Committed();
+                });
+
+            var run = graph.SignIn.SignInCommand.Execute().ToTask();
+            await started.Task;
+
+            await graph.CloseAsync(CancellationToken.None);
+            await run;
+
+            await Assert.That(graph.SignIn.Satisfied).IsFalse();
+            await graph.Auth.QuiescedAsync(); // completes only once no attempt is live
+        });
+    }
+
+    /// The dialog renders the SAME sign-in view the wizard shows, and entering it announces the
+    /// pinned server — the user must see where they are signing in to.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_dialog_hosts_the_wizard_sign_in_view_announcing_the_server() {
+        var (buttonFound, status) = await AvaloniaSession.DispatchAsync(() => {
+            using var config = new TempConfigRoot();
+            var graph = ReauthComposition.Build(
+                config.Root, "default", ServerUrl,
+                WizardComposition.BuildBridges(action => action()),
+                new ConsentFlipClaims(config.Root),
+                new AppStateStore(config.PathTo("app-state.json")),
+                new RecordingOpener(),
+                _ => (_, _) => Task.FromResult<AuthResult>(Committed()));
+
+            var window = new SignInWindow { DataContext = graph.SignIn };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var button = window.GetVisualDescendants().OfType<Button>().FirstOrDefault(b => b.Name == "SignInButton");
+            var text = window.GetVisualDescendants().OfType<TextBlock>()
+                .FirstOrDefault(t => t.Name == "SignInStatusText")?.Text;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            return (button is not null, text);
+        });
+
+        await Assert.That(buttonFound).IsTrue();
+        await Assert.That(status).IsEqualTo($"Ready to sign in to {ServerUrl}.");
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ServerLaunchClientTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerLaunchClientTests.cs
@@ -1,0 +1,78 @@
+using System.Net;
+using System.Net.Sockets;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// A 401 from the server means the stored sign-in is unusable — Home routes that to the sign-in
+/// dialog, so the outcome must say so in a typed way, not only in the error text.
+public class ServerLaunchClientTests {
+    static readonly LaunchRequest Request = new("daemon-a", "/repo/a", "claude", "hi");
+
+    static int FreePort() {
+        var probe = new TcpListener(IPAddress.Loopback, 0);
+        probe.Start();
+        var port = ((IPEndPoint)probe.LocalEndpoint).Port;
+        probe.Stop();
+        return port;
+    }
+
+    [Test]
+    public async Task A_401_from_the_server_marks_the_outcome_unauthorized() {
+        using var tmp = new TempDir();
+        var port = FreePort();
+        using var listener = new HttpListener();
+        listener.Prefixes.Add($"http://127.0.0.1:{port}/");
+        listener.Start();
+        _ = Task.Run(async () => {
+            while (listener.IsListening) {
+                try {
+                    var ctx = await listener.GetContextAsync();
+                    ctx.Response.StatusCode = 401;
+                    ctx.Response.Close();
+                } catch (Exception) {
+                    return; // listener stopped — test is done with it
+                }
+            }
+        });
+
+        try {
+            var config = new ConfigRoot(tmp.Path);
+            await using var client = new ServerLaunchClient(
+                config, Resolutions.At($"http://127.0.0.1:{port}", config));
+
+            var outcome = await client.StartAsync(Request, CancellationToken.None);
+
+            await Assert.That(outcome.Started).IsFalse();
+            await Assert.That(outcome.Unauthorized).IsTrue();
+        } finally {
+            listener.Stop();
+        }
+    }
+
+    [Test]
+    public async Task A_refused_connection_is_a_plain_error_not_unauthorized() {
+        using var tmp = new TempDir();
+        var config = new ConfigRoot(tmp.Path);
+        await using var client = new ServerLaunchClient(
+            config, Resolutions.At($"http://127.0.0.1:{FreePort()}", config));
+
+        var outcome = await client.StartAsync(Request, CancellationToken.None);
+
+        await Assert.That(outcome.Started).IsFalse();
+        await Assert.That(outcome.Unauthorized).IsFalse();
+        await Assert.That(outcome.Error).IsNotNull();
+    }
+
+    [Test]
+    public async Task Unauthorized_is_detected_anywhere_in_the_exception_chain() {
+        var wrapped = new InvalidOperationException(
+            "outer", new HttpRequestException("401", null, HttpStatusCode.Unauthorized));
+
+        await Assert.That(ServerLaunchClient.IsUnauthorized(wrapped)).IsTrue();
+        await Assert.That(ServerLaunchClient.IsUnauthorized(
+            new HttpRequestException("403", null, HttpStatusCode.Forbidden))).IsFalse();
+        await Assert.That(ServerLaunchClient.IsUnauthorized(new InvalidOperationException("no http"))).IsFalse();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -103,11 +103,16 @@ public class WorkspaceNavigationTests {
         return nav.Attach.Created[^1];
     }
 
-    static HomeViewModel NewHome(Nav nav, ILaunchClient launch, string statePath) =>
-        new(nav.Daemon, new AppStateStore(statePath), launch, () => Task.FromResult(Array.Empty<string>()),
+    static HomeViewModel NewHome(Nav nav, ILaunchClient launch, string statePath) {
+        // StartCommand's canExecute gates on daemon + server both up; these tests launch, so the
+        // fixture models the connected steady state.
+        nav.Daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap());
+        nav.Daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
+        return new(nav.Daemon, new AppStateStore(statePath), launch, () => Task.FromResult(Array.Empty<string>()),
             openSession: nav.Vm.OpenSession,
             navigationGeneration: () => nav.Vm.NavigationGeneration,
             openSessionIfCurrent: nav.Vm.OpenSessionIfCurrent);
+    }
 
     [Test]
     [NotInParallel("AvaloniaSession")]


### PR DESCRIPTION
Closes #739 — AI-2407

## What & why

Starting a session while the app could not authenticate rendered the raw transport text ("Response status code does not indicate success: 401 (Unauthorized).") under the composer, with no way back to a login. Start is now disabled unless both the daemon attach and its upstream server connection are up, the launcher says why (connecting / daemon not running / signed out), and both a lost server connection and a typed 401 launch outcome offer a Sign in button. That button opens the wizard's sign-in step in a standalone dialog pinned to the configured server; a committed sign-in closes the dialog and clears the prompt.

## Where to look

ReauthComposition stages the wizard's own Paste intent for the profile's server — sign-in reuses the wizard's commit boundary unchanged, cannot repoint `server_url`, and a Paste intent never produces the WorkOS Retarget answer, which is why the dialog needs no Connect step. The daemon reports no *reason* for "disconnected", so the sign-in prompt also shows when the server itself is down; the dialog then fails visibly with a network error rather than fixing anything.

## Verification

- App suite: 1277/1277 pass (`dotnet run --project test/Capacitor.App.Tests.Unit/...`).
- Full `dotnet test --solution`: 10898 tests, 2 failures — both on the documented environmental list (codex schema pin drift; `Wedged_initialize_*` load flake, passes 1/1 in isolation) in a suite that does not reference Capacitor.App.
- New behavior is mutation-checked: unhinging `AvailabilityFor` or the 401 flag fails exactly the new tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
