### PR TITLE
Rework the desktop launcher composer with a Claude permission-mode chip

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,7 +6,6 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
-
 ## The flow can enable the daemon as a service
 
 `kcap daemon service ensure` existed with no caller in the product. Making the browser able to ask for it
@@ -125,7 +124,6 @@ call site asks. Every hook, watch, daemon and MCP path shares that helper and th
 attempt; changing it for all of them in service of one caption is not the trade. An exhausted budget
 returns the status rather than throwing — the call sites catch `HttpRequestException` only, so a throw
 would turn a 503 into a crash mid-import.
-
 
 ## Secret redaction is structural
 
@@ -517,3 +515,28 @@ the workspace subtitle alike, through one `CheckoutLabel` so the two cannot drif
 tool paths against `worktree_path`, the checkout the agent actually runs in. `work_location` is derived from `borrowed_from` at the one stamping site,
 so the two cannot disagree, and a client that only needs the marker reads the token instead of
 comparing paths.
+
+## Desktop launcher: permission mode
+
+The new-session composer gains a Claude permission-mode chip (Manual, Accept edits, Auto, Bypass
+permissions) beside the effort chip, and Start becomes a round arrow button. Manual sends nothing —
+the `permission_mode` key is omitted, not null — so an unchanged launch is byte-identical to one
+predating the chip and an older server or daemon behaves exactly as before. Any other choice rides
+one name-bound field through `RequestLaunchAgentV2`, the server's `LaunchAgentCommand` and the
+daemon's `LauncherContext` to a `--permission-mode` argument on the interactive Claude arm only. The
+tokens live once, in Core's `ClaudePermissionModes`, so the chip and the daemon guard cannot drift.
+
+**The mode is a preference, never a containment override.** A reviewer's `bypassPermissions` and a
+borrowed checkout's prompting are guarantees, so the server's `ClaudePermissionModeRequestPolicy` and
+the daemon's `ClaudePermissionModePolicy` refuse a mode on a review-flow, PR-review, borrowed or
+non-Claude launch with a coded reason — before consent and before any worktree work, mirroring the
+Codex posture and ACP preset guards rather than silently dropping or honouring it. Only the four
+offered tokens pass; `plan` and `dontAsk` are Claude's but not the product's. The daemon advertises
+`PermissionModeVendors` on connect and the server refuses a mode toward a daemon that does not list
+the vendor, so an older daemon can never quietly run Manual under a Bypass selection.
+
+**An interactive bypass launch keeps the single-Enter submit.** `DisablesApprovalPrompts` stays true
+only for owned review-flow reviewers: bypass silences permission prompts, not question cards or the
+one-time bypass consent dialog, and the multi-CR spray would answer either. The chip is withheld for
+every vendor but Claude, the mode is session-scoped like the effort, and the harness picker no
+longer offers "Remember" — a chosen harness is always persisted for the repository.

--- a/src/Capacitor.App/Services/HostedHarnessCatalog.cs
+++ b/src/Capacitor.App/Services/HostedHarnessCatalog.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core.Harness;
+using Capacitor.Cli.Core.Harness.Claude;
 
 namespace Capacitor.App.Services;
 
@@ -7,6 +8,8 @@ public sealed record HarnessOption(string Vendor, string Label, string Transport
 /// One curated model suggestion for the combined harness+model picker. Slug is what the wire
 /// carries verbatim; Label is the picker's friendly name.
 public sealed record ModelChoice(string Slug, string Label);
+
+public sealed record PermissionModeChoice(string Token, string Label);
 
 /// The picker's vendor list. Availability comes from what the daemon advertises
 /// (DaemonInfoDto.SupportedVendors), never from a version check — a vendor auto-update must not
@@ -90,6 +93,21 @@ public static class HostedHarnessCatalog {
     /// picker's Default entry (null on the wire) hands the choice back to the harness. Lives here
     /// beside the model catalog so the launch vocabularies have one authority.
     public static readonly IReadOnlyList<string> EffortLadder = ["low", "medium", "high", "xhigh"];
+
+    public static readonly IReadOnlyList<PermissionModeChoice> PermissionModes = [
+        new(ClaudePermissionModes.Manual, "Manual"),
+        new(ClaudePermissionModes.AcceptEdits, "Accept edits"),
+        new(ClaudePermissionModes.Auto, "Auto"),
+        new(ClaudePermissionModes.BypassPermissions, "Bypass permissions"),
+    ];
+
+    public static string PermissionModeLabelFor(string token) =>
+        PermissionModes.FirstOrDefault(m => string.Equals(m.Token, token, StringComparison.Ordinal))?.Label ?? token;
+
+    /// The daemon rejects a mode for any other vendor, so the chip is withheld rather than sent
+    /// and refused.
+    public static bool SupportsPermissionMode(string vendor) =>
+        string.Equals(vendor, "claude", StringComparison.OrdinalIgnoreCase);
 
     // Monogram + tint per vendor: the glyph is the fallback where the view layer has no brand
     // mark (VendorIcons); the tint colors both. Monochrome brands render in the near-white text

--- a/src/Capacitor.App/Services/ILaunchClient.cs
+++ b/src/Capacitor.App/Services/ILaunchClient.cs
@@ -2,11 +2,11 @@ using System.Text.Json.Serialization;
 
 namespace Capacitor.App.Services;
 
-/// Model "" and Effort null both mean "vendor default" — the wire's own conventions (the server
-/// rejects a null model; the daemon treats whitespace as no request).
+/// Model "", Effort null and PermissionMode null all mean "vendor default" — the wire's own
+/// conventions (the server rejects a null model; the daemon treats whitespace as no request).
 public sealed record LaunchRequest(
     string DaemonName, string RepoPath, string Vendor, string? Prompt,
-    string Model = "", string? Effort = null);
+    string Model = "", string? Effort = null, string? PermissionMode = null);
 
 /// Unauthorized marks a server 401 — the caller routes it to sign-in instead of rendering the
 /// raw transport message.
@@ -42,6 +42,9 @@ public sealed record LaunchAgentRequestV2Payload {
     [JsonPropertyName("vendor")]                public required string   Vendor              { get; init; }
     [JsonPropertyName("codex_posture")]         public          object?  CodexPosture        { get; init; }
     [JsonPropertyName("acp_permission_preset")] public          string?  AcpPermissionPreset { get; init; }
+    // Omitted when null, so an unchosen mode leaves the payload an older server expects untouched.
+    [JsonPropertyName("permission_mode"), JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public string? PermissionMode { get; init; }
 }
 
 [JsonSerializable(typeof(LaunchAgentRequestV2Payload))]
@@ -56,5 +59,6 @@ public static class LaunchPayload {
         Effort     = string.IsNullOrWhiteSpace(r.Effort) ? null : r.Effort,
         RepoPath   = r.RepoPath,
         Vendor     = r.Vendor,
+        PermissionMode = string.IsNullOrWhiteSpace(r.PermissionMode) ? null : r.PermissionMode,
     };
 }

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -6,6 +6,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Harness.Claude;
 using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI;
@@ -33,6 +34,8 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// A repository with no remembered choice falls back to this — never to whatever vendor was
     /// selected for a DIFFERENT repository, which would leak a preference across repositories.
     public const string DefaultVendor = "claude";
+
+    public const string DefaultPermissionMode = ClaudePermissionModes.Manual;
 
     /// Reserved key for the not-yet-in-a-repository target. It is a normal AppState.HarnessByRepo
     /// key, so it round-trips and keeps its own remembered harness like any real repo path —
@@ -74,12 +77,6 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         private set => this.RaiseAndSetIfChanged(ref _selectedVendor, value);
     }
 
-    bool _rememberHarness = true;
-    public bool RememberHarness {
-        get => _rememberHarness;
-        set => this.RaiseAndSetIfChanged(ref _rememberHarness, value);
-    }
-
     string _selectedModel = "";
     /// "" = vendor default (the wire convention). Session-scoped, not persisted; reset whenever
     /// the vendor changes — model ids are vendor-specific, so a stale one would misfire.
@@ -94,6 +91,14 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     public string? SelectedEffort {
         get => _selectedEffort;
         set => this.RaiseAndSetIfChanged(ref _selectedEffort, value);
+    }
+
+    string _selectedPermissionMode = DefaultPermissionMode;
+    /// A ClaudePermissionModes token. Session-scoped like the effort and kept across vendor
+    /// changes; PermissionModeFor decides whether it rides a given launch.
+    public string SelectedPermissionMode {
+        get => _selectedPermissionMode;
+        set => this.RaiseAndSetIfChanged(ref _selectedPermissionMode, value);
     }
 
     string _goal = "";
@@ -255,11 +260,9 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     // the Agents subscription above run for this object's whole lifetime, not a window's.
     public void Dispose() => _disposables.Dispose();
 
-    /// Sets the selection and, when RememberHarness, persists it for SelectedRepoPath.
-    /// RememberHarness = false skips the write only — it must never erase an existing choice.
+    /// Sets the selection and persists it for SelectedRepoPath.
     public async Task ChooseHarnessAsync(string vendor) {
         SetVendor(vendor);
-        if (!RememberHarness) return;
 
         var repoPath = SelectedRepoPath;
         await _state.UpdateAsync(s => s with { HarnessByRepo = WithEntry(s.HarnessByRepo, repoPath, vendor) });
@@ -327,7 +330,8 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
 
     async Task StartAsync() {
         var request = new LaunchRequest(
-            _daemon.DaemonName, SelectedRepoPath, SelectedVendor, Goal, SelectedModel, SelectedEffort);
+            _daemon.DaemonName, SelectedRepoPath, SelectedVendor, Goal, SelectedModel, SelectedEffort,
+            PermissionModeFor(SelectedVendor, SelectedPermissionMode));
         // Captured BEFORE the call, never after (spec §3): the whole point is to notice a navigation
         // that happened WHILE the launch was in flight.
         var generation = _navigationGeneration?.Invoke() ?? 0;
@@ -351,6 +355,13 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
 
         _openSessionIfCurrent?.Invoke(agentId, generation);
     }
+
+    /// Null for Manual (the harness's own default) and for any vendor that takes no mode.
+    internal static string? PermissionModeFor(string vendor, string mode) =>
+        HostedHarnessCatalog.SupportsPermissionMode(vendor)
+     && !string.Equals(mode, ClaudePermissionModes.Manual, StringComparison.Ordinal)
+            ? mode
+            : null;
 
     /// Id shapes differ across the stack and across daemon versions: the server hub has returned
     /// DASHED Guids while a production daemon keys its status cache on SHORT (8-hex) ids — so a

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml
@@ -22,49 +22,60 @@
                          BorderThickness="0" MinHeight="72" TextWrapping="Wrap" FontSize="14"
                          VerticalContentAlignment="Top" AcceptsReturn="False" />
 
-                <WrapPanel ItemSpacing="8" LineSpacing="8" VerticalAlignment="Center">
-                    <Button x:Name="RepositoryChip" Click="OnRepositoryChipClick"
-                            Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                            Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                            Content="{Binding SelectedRepoPath, Converter={x:Static views:RepositoryLabelConverter.Instance}}"
-                            ToolTip.Tip="{Binding SelectedRepoPath}" />
+                <Grid ColumnDefinitions="*,Auto">
+                    <WrapPanel ItemSpacing="8" LineSpacing="8" VerticalAlignment="Center">
+                        <Button x:Name="RepositoryChip" Click="OnRepositoryChipClick"
+                                Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                Content="{Binding SelectedRepoPath, Converter={x:Static views:RepositoryLabelConverter.Instance}}"
+                                ToolTip.Tip="{Binding SelectedRepoPath}" />
 
-                    <!-- One picker for harness AND model (T3-style): searchable, grouped by
-                         vendor, with a per-vendor default row and a typed-custom escape hatch —
-                         built per open in code-behind, like the repository picker. -->
-                    <Button x:Name="AgentChip" Click="OnAgentChipClick"
-                            Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                            Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                            ToolTip.Tip="Harness and model">
-                        <StackPanel Orientation="Horizontal" Spacing="7">
-                            <ContentControl VerticalAlignment="Center"
-                                            Content="{Binding SelectedVendor, Converter={x:Static views:VendorGlyphConverter.Instance}, ConverterParameter=13}" />
-                            <TextBlock VerticalAlignment="Center">
-                                <TextBlock.Text>
-                                    <MultiBinding Converter="{x:Static views:AgentChipTextConverter.Instance}">
-                                        <Binding Path="Harnesses" />
-                                        <Binding Path="SelectedVendor" />
-                                        <Binding Path="SelectedModel" />
-                                    </MultiBinding>
-                                </TextBlock.Text>
-                            </TextBlock>
-                        </StackPanel>
+                        <!-- One picker for harness AND model (T3-style): searchable, grouped by
+                             vendor, with a per-vendor default row and a typed-custom escape hatch —
+                             built per open in code-behind, like the repository picker. -->
+                        <Button x:Name="AgentChip" Click="OnAgentChipClick"
+                                Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                ToolTip.Tip="Harness and model">
+                            <StackPanel Orientation="Horizontal" Spacing="7">
+                                <ContentControl VerticalAlignment="Center"
+                                                Content="{Binding SelectedVendor, Converter={x:Static views:VendorGlyphConverter.Instance}, ConverterParameter=13}" />
+                                <TextBlock VerticalAlignment="Center">
+                                    <TextBlock.Text>
+                                        <MultiBinding Converter="{x:Static views:AgentChipTextConverter.Instance}">
+                                            <Binding Path="Harnesses" />
+                                            <Binding Path="SelectedVendor" />
+                                            <Binding Path="SelectedModel" />
+                                        </MultiBinding>
+                                    </TextBlock.Text>
+                                </TextBlock>
+                            </StackPanel>
+                        </Button>
+
+                        <Button x:Name="EffortChip" Click="OnEffortChipClick"
+                                Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                Content="{Binding SelectedEffort, Converter={x:Static views:EffortChipTextConverter.Instance}}"
+                                ToolTip.Tip="Reasoning effort — Default lets the harness decide" />
+
+                        <Button x:Name="PermissionChip" Click="OnPermissionChipClick"
+                                Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                Content="{Binding SelectedPermissionMode, Converter={x:Static views:PermissionChipTextConverter.Instance}}"
+                                IsVisible="{Binding SelectedVendor, Converter={x:Static views:PermissionChipVisibleConverter.Instance}}"
+                                ToolTip.Tip="Permission mode — how much Claude asks before acting" />
+                    </WrapPanel>
+
+                    <Button Grid.Column="1" x:Name="StartButton" Command="{Binding StartCommand}"
+                            Background="{StaticResource KcapAccentBrush}" Width="36" Height="36" CornerRadius="18"
+                            Padding="0" Margin="12,0,0,0" VerticalAlignment="Bottom"
+                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                            ToolTip.Tip="Start" AutomationProperties.Name="Start"
+                            IsEnabled="{Binding SelectedRepoPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                        <Path Data="M8,13.5 L8,3 M3.5,7.5 L8,3 L12.5,7.5" Stroke="#07120E" StrokeThickness="2"
+                              StrokeLineCap="Round" StrokeJoin="Round" Width="16" Height="16" />
                     </Button>
-
-                    <Button x:Name="EffortChip" Click="OnEffortChipClick"
-                            Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                            Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                            Content="{Binding SelectedEffort, Converter={x:Static views:EffortChipTextConverter.Instance}}"
-                            ToolTip.Tip="Reasoning effort — Default lets the harness decide" />
-
-                    <CheckBox x:Name="RememberToggle" Content="Remember" IsChecked="{Binding RememberHarness}"
-                              Foreground="{StaticResource KcapMutedBrush}" />
-
-                    <Button x:Name="StartButton" Content="Start" Command="{Binding StartCommand}"
-                            Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" FontWeight="SemiBold"
-                            CornerRadius="7" Padding="16,7"
-                            IsEnabled="{Binding SelectedRepoPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                </WrapPanel>
+                </Grid>
 
                 <TextBlock x:Name="StartErrorText" Text="{Binding StartError}" Foreground="{StaticResource KcapDangerBrush}"
                            TextWrapping="Wrap"

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
@@ -110,6 +110,22 @@ public partial class LauncherPaneView : UserControl {
         flyout.ShowAt(anchor);
     }
 
+    void OnPermissionChipClick(object? sender, RoutedEventArgs e) {
+        if (DataContext is not HomeViewModel vm || sender is not Control anchor) return;
+
+        var flyout = new MenuFlyout();
+        foreach (var mode in HostedHarnessCatalog.PermissionModes) {
+            var item = new MenuItem {
+                Header = mode.Label, ToggleType = MenuItemToggleType.Radio,
+                IsChecked = string.Equals(vm.SelectedPermissionMode, mode.Token, StringComparison.Ordinal),
+            };
+            var token = mode.Token;
+            item.Click += (_, _) => vm.SelectedPermissionMode = token;
+            flyout.Items.Add(item);
+        }
+        flyout.ShowAt(anchor);
+    }
+
     /// The vendor's mark at a given size: the brand path when VendorIcons carries one, the tinted
     /// monogram otherwise (both from HostedHarnessCatalog.TileFor). UI-thread only (constructs
     /// thread-affine Geometry/brushes).
@@ -328,6 +344,26 @@ public sealed class EffortChipTextConverter : IValueConverter {
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         value is string { Length: > 0 } effort ? $"Effort: {effort}" : "Default effort";
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+public sealed class PermissionChipTextConverter : IValueConverter {
+    public static readonly PermissionChipTextConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is string token ? HostedHarnessCatalog.PermissionModeLabelFor(token) : "";
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+public sealed class PermissionChipVisibleConverter : IValueConverter {
+    public static readonly PermissionChipVisibleConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is string vendor && HostedHarnessCatalog.SupportsPermissionMode(vendor);
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.Cli.Core/Harness/Claude/ClaudePermissionModes.cs
+++ b/src/Capacitor.Cli.Core/Harness/Claude/ClaudePermissionModes.cs
@@ -1,0 +1,15 @@
+namespace Capacitor.Cli.Core.Harness.Claude;
+
+/// <summary>The Claude CLI's <c>--permission-mode</c> tokens the product offers, most to least
+/// prompting. They reach argv verbatim, so this spelling is the contract the desktop chip and the
+/// daemon's launch guard share; <c>plan</c> and <c>dontAsk</c> exist upstream but are not offered.</summary>
+public static class ClaudePermissionModes {
+    public const string Manual            = "manual";
+    public const string AcceptEdits       = "acceptEdits";
+    public const string Auto              = "auto";
+    public const string BypassPermissions = "bypassPermissions";
+
+    public static readonly IReadOnlyList<string> Offered = [Manual, AcceptEdits, Auto, BypassPermissions];
+
+    public static bool IsOffered(string token) => Offered.Contains(token, StringComparer.Ordinal);
+}

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1524,7 +1524,11 @@ public readonly record struct LaunchAgentCommand(
         // §2.7 B4: the hosted Codex thread to RESUME (via thread/resume, no second SessionStarted) instead
         // of starting fresh — set by the server only for a parked-reviewer relaunch, else null. Appended
         // last so the SignalR positional binding stays wire-compatible with old daemons.
-        string?           ResumeSessionId = null
+        string?           ResumeSessionId = null,
+        // A ClaudePermissionModes token for an interactive Claude launch; the daemon's
+        // ClaudePermissionModePolicy fails closed on any other shape. Name-bound and trailing, so
+        // old daemons ignore it and old servers never set it.
+        string?           PermissionMode = null
     );
 
 /// <summary>Caller-selected Codex launch posture. Valid ONLY for interactive, daemon-owned-worktree
@@ -2015,7 +2019,10 @@ public readonly record struct DaemonConnect(
         // Advertises the RequestStatusReport2 handler (nonce-echoed reports). False from a daemon
         // predating it — the server then never sends the correlated request. Trailing name-bound
         // field so the wire stays compatible.
-        bool                                       SupportsCorrelatedStatusReports = false
+        bool                                       SupportsCorrelatedStatusReports = false,
+        // Vendor tokens this daemon accepts a launch-time permission mode for (Claude when hosted).
+        // Null from a daemon predating this field, which the server reads as "refuse a mode".
+        string[]?                                  PermissionModeVendors = null
     );
 
 public sealed record UnattendedVendorCapability(

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -142,6 +142,11 @@ public class DaemonConfig {
     /// </summary>
     public string[]? AcpPresetVendors { get; set; }
 
+    /// <summary>Vendor tokens this daemon accepts a launch-time permission mode for — Claude when it
+    /// is hosted. Sent over <c>DaemonConnect</c> so the server refuses a mode toward a daemon that
+    /// would ignore it. <c>null</c> until the host is built.</summary>
+    public string[]? PermissionModeVendors { get; set; }
+
     /// <summary>The home directory this daemon resolved at boot. Every home-derived daemon path
     /// reads it, so a descendant can't be handed a different one than the entry point chose.</summary>
     public UserHome Home {

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -588,6 +588,8 @@ public static partial class DaemonRunner {
             .Where(Acp.AcpPermissionPresets.RoutedVendors.Contains)
             .ToArray();
 
+        config.PermissionModeVendors = Harness.Claude.ClaudePermissionModePolicy.AdvertisedVendors(config.SupportedVendors);
+
         // Reviewer vendor override support: a strict subset of SupportedVendors — only vendors that
         // can also run fully unattended without routing an interaction to a human. The server gates
         // a review-flow vendor override on this list rather than SupportedVendors alone, so a vendor

--- a/src/Capacitor.Cli.Daemon/Harness/Claude/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Claude/ClaudeLauncher.cs
@@ -19,10 +19,11 @@ internal sealed partial class ClaudeLauncher(
     public string CliPath => config.ClaudePath;
     public bool   SupportsUnattended => true;
 
-    // --permission-mode bypassPermissions is set only for an OWNED review-flow worktree (see
-    // BuildArgs); a borrowed review-flow keeps default permission mode (and is fail-closed-rejected
-    // upstream anyway), and interactive launches always prompt. So approval prompts are off only for
-    // owned review-flow launches.
+    // True only for an OWNED review-flow worktree, where BuildArgs forces bypassPermissions. A
+    // borrowed review-flow keeps the default mode (and is rejected upstream anyway). An interactive
+    // launch stays false even under a caller-selected bypassPermissions: bypass silences permission
+    // prompts, not question cards or the one-time bypass consent dialog, so a sprayed Enter could
+    // still answer something.
     public bool DisablesApprovalPrompts(LauncherContext ctx) =>
         ctx.IsReviewFlow && ctx.Work == WorkLocation.OwnedWorktree;
     /// <summary>Claude owns its own reviewer-model policy (aliases + dated concrete ids → family-level
@@ -159,6 +160,9 @@ internal sealed partial class ClaudeLauncher(
                 args.Add(ctx.Work == WorkLocation.BorrowedCwd
                     ? "Agent,Edit,MultiEdit,Write,NotebookEdit,Bash"
                     : "Agent");
+            } else if (ctx.PermissionMode is { Length: > 0 } permissionMode) {
+                args.Add("--permission-mode");
+                args.Add(permissionMode);
             }
 
             if (!string.IsNullOrEmpty(ctx.Effort)) {

--- a/src/Capacitor.Cli.Daemon/Harness/Claude/ClaudePermissionModePolicy.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Claude/ClaudePermissionModePolicy.cs
@@ -1,0 +1,50 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Harness.Claude;
+
+namespace Capacitor.Cli.Daemon.Harness.Claude;
+
+/// <summary>
+/// Eligibility and token validation for a caller-selected Claude permission mode, mirrored
+/// textually by the server's <c>ClaudePermissionModeRequestPolicy</c> (different repositories, no
+/// shared type). A mode is valid only for an interactive, non-borrowed Claude launch: a reviewer's
+/// bypass and a borrowed checkout's prompting are containment guarantees, not preferences. Every
+/// other shape is a coded rejection, never a silent drop.
+/// </summary>
+internal static class ClaudePermissionModePolicy {
+    const string Vendor = "claude";
+
+    /// <summary><c>null</c> when the launch may continue, which includes every mode-less launch.</summary>
+    public static string? RejectionReason(LaunchAgentCommand cmd) {
+        if (cmd.PermissionMode is not { } mode) return null;
+
+        if (!string.Equals(cmd.Vendor, Vendor, StringComparison.OrdinalIgnoreCase))
+            return $"permission_mode_wrong_vendor: a permission mode was supplied for vendor '{cmd.Vendor}' — "
+                 + "permission modes apply only to Claude launches.";
+
+        if (cmd.Kind != LaunchKind.Default)
+            return "permission_mode_not_overridable: " + cmd.Kind switch {
+                LaunchKind.ReviewFlow => "review-flow reviewers run under their own containment posture, so a "
+                                       + "permission mode does not apply.",
+                LaunchKind.Review     => "PR-review launches use a fixed containment; permission mode selection "
+                                       + "applies only to interactive launches.",
+                _                     => $"launch kind '{cmd.Kind}' is not an interactive launch; permission mode "
+                                       + "selection applies only to interactive launches."
+            };
+
+        if (cmd.Borrowed)
+            return "permission_mode_not_overridable: a borrowed launch runs in the requester's real checkout, so a "
+                 + "permission mode does not apply.";
+
+        if (!ClaudePermissionModes.IsOffered(mode))
+            return $"permission_mode_invalid: unknown permission mode '{mode}'. "
+                 + $"Valid values: {string.Join(", ", ClaudePermissionModes.Offered)}.";
+
+        return null;
+    }
+
+    /// <summary>Advertised on connect so the server refuses a mode toward a daemon that would ignore it.</summary>
+    public static string[] AdvertisedVendors(IEnumerable<string> supportedVendors) =>
+        supportedVendors.Any(v => string.Equals(v, Vendor, StringComparison.OrdinalIgnoreCase))
+            ? [Vendor]
+            : [];
+}

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1789,6 +1789,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
         }
 
+        // Before consent for the same reason as the preset guard above.
+        if (ClaudePermissionModePolicy.RejectionReason(cmd) is { } modeRejection) {
+            await _server.LaunchFailedAsync(cmd.AgentId, modeRejection);
+
+            return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.Semantic);
+        }
+
         // Owner consent gate. Server-driven launches only — the local 0600 socket path
         // (HandleLocalSpawnAsync) is the owner's by construction and never consults this.
         // NOTE: in prompt mode this can hold the sequenced slot up to PromptTimeoutSeconds (≤300s,
@@ -2167,7 +2174,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 AcpPermissionPreset: cmd.AcpPermissionPreset,
                 // Carried verbatim; the Codex app-server factory branches thread/start -> thread/resume
                 // on it for a parked reviewer relaunch. Ignored by every other runtime.
-                ResumeSessionId: cmd.ResumeSessionId
+                ResumeSessionId: cmd.ResumeSessionId,
+                PermissionMode: cmd.PermissionMode
             );
 
             HostedRuntimeStart start;

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentLauncher.cs
@@ -122,6 +122,11 @@ internal sealed record LauncherContext(
     /// <c>CodexPosturePolicy</c> guard; null for every other launch, which keeps the derived
     /// containment values.</summary>
     public CodexLaunchPosture? CodexPosture { get; init; }
+
+    /// <summary>Caller-selected Claude permission mode, forwarded verbatim as
+    /// <c>--permission-mode</c>. Non-null only for an interactive daemon-owned-worktree Claude launch
+    /// that passed the orchestrator's <c>ClaudePermissionModePolicy</c> guard.</summary>
+    public string? PermissionMode { get; init; }
 }
 
 internal readonly record struct LaunchArgs(string[] Args, string? McpConfigPath);

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -143,13 +143,10 @@ internal readonly record struct HostedRuntimeStart(IHostedAgentRuntime Runtime, 
 /// guards (vendor known, unattended support, repo allowed, worktree created) have already passed.
 /// </summary>
 /// <param name="CapacitorPath">
-/// Absolute path to the <c>kcap</c> binary (<c>DaemonConfig.CapacitorPath</c>) — passed to
-/// <see cref="ReviewLaunchBuilder.BuildAsync"/> as the review-launch MCP server command. This is
-/// deliberately NOT the vendor CLI path (<c>launcher.CliPath</c>): the review agent must run
-/// <c>kcap mcp review</c>, since inside the daemon the running process is <c>kcap-daemon</c> with
-/// no <c>mcp review</c> subcommand of its own, and <c>claude</c>/<c>codex</c> have no such
-/// subcommand at all (PR #244 review, Fix A — a post-refactor regression had passed
-/// <c>launcher.CliPath</c> here instead).
+/// Absolute path to the <c>kcap</c> binary (<c>DaemonConfig.CapacitorPath</c>), passed to
+/// <see cref="ReviewLaunchBuilder.BuildAsync"/> as the review-launch MCP server command. Never the
+/// vendor CLI path (<c>launcher.CliPath</c>): the review agent must run <c>kcap mcp review</c>, and
+/// neither the daemon process nor <c>claude</c>/<c>codex</c> has that subcommand.
 /// </param>
 internal sealed record RuntimeStartContext(
         string            AgentId,
@@ -248,5 +245,6 @@ internal sealed record RuntimeStartContext(
         // Non-null only for a parked reviewer relaunch: the Codex app-server runtime reopens this thread
         // via thread/resume instead of thread/start, and suppresses the second SessionStarted. Null for
         // a fresh launch, every non-Codex/non-app-server launch, and constructions predating this field.
-        string?             ResumeSessionId = null
+        string?             ResumeSessionId = null,
+        string?             PermissionMode = null
     );

--- a/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
@@ -60,15 +60,15 @@ internal sealed partial class PtyHostedAgentRuntimeFactory(
             Review: ctx.Review,
             // The review-launch MCP server command must be the kcap binary (ctx.CapacitorPath),
             // NOT the vendor CLI (launcher.CliPath) — the review agent runs `kcap mcp review` to
-            // talk to the review MCP tools. See RuntimeStartContext.CapacitorPath's doc (PR #244
-            // review, Fix A).
+            // talk to the review MCP tools.
             ReviewLaunch: ctx.IsReview && ctx.Review is { } reviewArgs
                 ? await ReviewLaunchBuilder.BuildAsync(ctx.Vendor, ctx.CapacitorPath, ctx.ServerUrl ?? "", reviewArgs.Owner, reviewArgs.Repo, reviewArgs.PrNumber)
                 : null
         ) {
             McpAllowlist = ctx.McpAllowlist,
-            Work         = ctx.Work,
-            CodexPosture = ctx.CodexPosture
+            Work           = ctx.Work,
+            CodexPosture   = ctx.CodexPosture,
+            PermissionMode = ctx.PermissionMode
         };
 
         try {

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -688,6 +688,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
                     // permissions through the ACP bridge. Null on an unwired/early-startup config;
                     // wire-compatible with old servers (ignored).
                     AcpPresetVendors: _config.AcpPresetVendors,
+                    PermissionModeVendors: _config.PermissionModeVendors,
                     // Read off the handler, never asserted: an unwired connection (early startup,
                     // a test, a second ServerConnection) would otherwise invite RequestStatusReport2
                     // frames that its null-conditional invoke answers with silence.

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -117,24 +117,6 @@ public class HomeViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Not_remembering_leaves_the_stored_choice_untouched() {
-        await AvaloniaSession.WithImmediateRxScheduler(async () => {
-            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
-            var vm = Build(out _, out var store, path);
-
-            await vm.SelectRepositoryAsync("/repo/a");
-            await vm.ChooseHarnessAsync("codex");
-            vm.RememberHarness = false;
-            await vm.ChooseHarnessAsync("pi");
-
-            await Assert.That(vm.SelectedVendor).IsEqualTo("pi");
-            var saved = await store.LoadAsync();
-            await Assert.That(saved.HarnessByRepo!["/repo/a"]).IsEqualTo("codex");
-        });
-    }
-
-    [Test]
-    [NotInParallel("AvaloniaSession")]
     public async Task Start_sends_the_selected_repository_and_harness() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
@@ -173,6 +155,45 @@ public class HomeViewModelTests {
 
             await vm.StartCommand.Execute();
             await Assert.That(launch.Last!.Model).IsEqualTo("");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Permission_mode_defaults_to_manual_which_sends_nothing() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var vm = Build(out var launch, out _, path);
+
+            await vm.SelectRepositoryAsync("/repo/a");
+            await Assert.That(vm.SelectedPermissionMode).IsEqualTo(HomeViewModel.DefaultPermissionMode);
+
+            await vm.StartCommand.Execute();
+            await Assert.That(launch.Last!.PermissionMode).IsNull();
+        });
+    }
+
+    /// The mode vocabulary is Claude's, so a choice made under Claude never rides a launch of
+    /// another vendor — but it is kept, not reset, so switching back restores it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_chosen_permission_mode_is_sent_for_claude_only() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var vm = Build(out var launch, out _, path);
+
+            await vm.SelectRepositoryAsync("/repo/a");
+            vm.SelectedPermissionMode = "bypassPermissions";
+            await vm.StartCommand.Execute();
+            await Assert.That(launch.Last!.PermissionMode).IsEqualTo("bypassPermissions");
+
+            await vm.ChooseHarnessAsync("codex");
+            await vm.StartCommand.Execute();
+            await Assert.That(launch.Last!.PermissionMode).IsNull();
+
+            await vm.ChooseHarnessAsync("claude");
+            await vm.StartCommand.Execute();
+            await Assert.That(launch.Last!.PermissionMode).IsEqualTo("bypassPermissions");
         });
     }
 
@@ -315,7 +336,6 @@ public class HomeViewModelTests {
             var daemon = new FakeDaemonClientService();
             using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
-            vm.RememberHarness = false;
             await vm.SelectRepositoryAsync("/repo/fresh");
 
             var repos = await vm.ListRepositoriesAsync();

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -1,6 +1,7 @@
 using System.Collections;
 using System.Collections.Specialized;
 using System.Reactive.Linq;
+using Avalonia.Automation;
 using Avalonia.Controls;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
@@ -60,8 +61,8 @@ public class HomeViewSmokeTests {
             Dispatcher.UIThread.RunJobs();
 
             var names = new[] {
-                "GoalInput", "RepositoryChip", "AgentChip", "StartButton", "StartErrorText",
-                "ConnectionNoticeText", "HomeSignInButton",
+                "GoalInput", "RepositoryChip", "AgentChip", "EffortChip", "PermissionChip", "StartButton",
+                "StartErrorText", "ConnectionNoticeText", "HomeSignInButton",
             };
             var resolved = names.ToDictionary(name => name, name => Find<Control>(window, name) is not null);
 
@@ -74,6 +75,8 @@ public class HomeViewSmokeTests {
         await Assert.That(found["GoalInput"]).IsTrue();
         await Assert.That(found["RepositoryChip"]).IsTrue();
         await Assert.That(found["AgentChip"]).IsTrue();
+        await Assert.That(found["EffortChip"]).IsTrue();
+        await Assert.That(found["PermissionChip"]).IsTrue();
         await Assert.That(found["StartButton"]).IsTrue();
         await Assert.That(found["StartErrorText"]).IsTrue();
         await Assert.That(found["ConnectionNoticeText"]).IsTrue();
@@ -109,6 +112,56 @@ public class HomeViewSmokeTests {
         await Assert.That(noticeAfter).IsTrue();
         await Assert.That(noticeText).IsEqualTo(HomeViewModel.ServerLostNotice);
         await Assert.That(signInAfter).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task PermissionChip_shows_for_claude_and_hides_for_other_vendors() {
+        var (forClaude, forCodex) = await AvaloniaSession.DispatchAsync(async () => {
+            var (_, vm, _, _, tmp) = Build();
+            using var _tmp = tmp;
+            var window = new Window { Content = new LauncherPaneView { DataContext = vm } };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var chip = Find<Button>(window, "PermissionChip");
+            var claude = chip?.IsVisible ?? false;
+
+            await vm.ChooseHarnessAsync("codex");
+            Dispatcher.UIThread.RunJobs();
+            var codex = chip?.IsVisible ?? true;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            vm.Dispose();
+            return (claude, codex);
+        });
+
+        await Assert.That(forClaude).IsTrue();
+        await Assert.That(forCodex).IsFalse();
+    }
+
+    /// The button carries a glyph, not text, so assistive technology reads the automation name.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task StartButton_carries_an_accessible_name() {
+        var name = await AvaloniaSession.DispatchAsync(() => {
+            var (_, vm, _, _, tmp) = Build();
+            using var _tmp = tmp;
+            var window = new Window { Content = new LauncherPaneView { DataContext = vm } };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var startButton = Find<Button>(window, "StartButton")!;
+            var automationName = AutomationProperties.GetName(startButton);
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            vm.Dispose();
+            return automationName;
+        });
+
+        await Assert.That(name).IsEqualTo("Start");
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/HostedHarnessCatalogTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HostedHarnessCatalogTests.cs
@@ -1,5 +1,6 @@
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.Harness;
+using TUnit.Assertions.Enums;
 
 namespace Capacitor.App.Tests.Unit;
 
@@ -121,5 +122,32 @@ public class HostedHarnessCatalogTests {
         await Assert.That(HostedHarnessCatalog.ModelLabelFor("claude", "some-future-id")).IsEqualTo("some-future-id");
         await Assert.That(HostedHarnessCatalog.ModelLabelFor("claude", "")).IsEqualTo("default");
         await Assert.That(HostedHarnessCatalog.ModelLabelFor("gemini", "  ")).IsEqualTo("default");
+    }
+
+    /// The tokens are the Claude CLI's own `--permission-mode` choices, listed from most to least
+    /// prompting; the daemon forwards them verbatim, so a spelling here is a spelling on argv.
+    [Test]
+    public async Task Permission_modes_are_the_claude_cli_tokens_in_escalation_order() {
+        string[] expected = ["manual", "acceptEdits", "auto", "bypassPermissions"];
+
+        await Assert.That(HostedHarnessCatalog.PermissionModes.Select(m => m.Token))
+            .IsEquivalentTo(expected, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task Permission_mode_labels_are_friendly_and_unknown_tokens_pass_through() {
+        await Assert.That(HostedHarnessCatalog.PermissionModeLabelFor("manual")).IsEqualTo("Manual");
+        await Assert.That(HostedHarnessCatalog.PermissionModeLabelFor("acceptEdits")).IsEqualTo("Accept edits");
+        await Assert.That(HostedHarnessCatalog.PermissionModeLabelFor("auto")).IsEqualTo("Auto");
+        await Assert.That(HostedHarnessCatalog.PermissionModeLabelFor("bypassPermissions")).IsEqualTo("Bypass permissions");
+        await Assert.That(HostedHarnessCatalog.PermissionModeLabelFor("weird")).IsEqualTo("weird");
+    }
+
+    [Test]
+    public async Task Only_claude_takes_a_launch_time_permission_mode() {
+        await Assert.That(HostedHarnessCatalog.SupportsPermissionMode("claude")).IsTrue();
+        await Assert.That(HostedHarnessCatalog.SupportsPermissionMode("Claude")).IsTrue();
+        await Assert.That(HostedHarnessCatalog.SupportsPermissionMode("codex")).IsFalse();
+        await Assert.That(HostedHarnessCatalog.SupportsPermissionMode("cursor")).IsFalse();
     }
 }

--- a/test/Capacitor.App.Tests.Unit/LaunchRequestTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LaunchRequestTests.cs
@@ -67,7 +67,21 @@ public class LaunchRequestTests {
     }
 
     [Test]
-    public async Task Wire_keys_are_exactly_the_twelve_hub_fields() {
+    public async Task Permission_mode_is_carried_when_chosen() {
+        var json = Payload(new LaunchRequest("kcap-dev", "/repo", "claude", "go", PermissionMode: "acceptEdits"));
+        await Assert.That(json.GetProperty("permission_mode").GetString()).IsEqualTo("acceptEdits");
+    }
+
+    /// An absent mode adds no key: the payload an older server receives is exactly the one it
+    /// received before the field existed.
+    [Test]
+    public async Task Blank_permission_mode_is_omitted() {
+        var json = Payload(new LaunchRequest("kcap-dev", "/repo", "claude", "go", PermissionMode: "  "));
+        await Assert.That(json.TryGetProperty("permission_mode", out _)).IsFalse();
+    }
+
+    [Test]
+    public async Task Wire_keys_are_exactly_the_twelve_hub_fields_when_no_mode_is_chosen() {
         var json = Payload(new LaunchRequest("kcap-dev", "/repo", "claude", "go"));
         var keys = json.EnumerateObject().Select(p => p.Name).ToArray();
 
@@ -77,6 +91,18 @@ public class LaunchRequestTests {
         await Assert.That(keys).IsEquivalentTo([
             "daemon_name", "prompt", "model", "effort", "repo_path", "tools",
             "attachment_ids", "visibility", "grants", "vendor", "codex_posture", "acp_permission_preset"
+        ]);
+    }
+
+    [Test]
+    public async Task A_chosen_mode_adds_the_permission_mode_key() {
+        var json = Payload(new LaunchRequest("kcap-dev", "/repo", "claude", "go", PermissionMode: "auto"));
+        var keys = json.EnumerateObject().Select(p => p.Name).ToArray();
+
+        await Assert.That(keys).IsEquivalentTo([
+            "daemon_name", "prompt", "model", "effort", "repo_path", "tools",
+            "attachment_ids", "visibility", "grants", "vendor", "codex_posture", "acp_permission_preset",
+            "permission_mode"
         ]);
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudePermissionModesTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudePermissionModesTests.cs
@@ -1,0 +1,29 @@
+using Capacitor.Cli.Core.Harness.Claude;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Harness.Claude;
+
+public class ClaudePermissionModesTests {
+    /// The tokens are the Claude CLI's own `--permission-mode` choices and reach argv verbatim, so
+    /// their spelling and order are the contract the app chip and the daemon policy both read.
+    [Test]
+    public async Task Offered_tokens_are_the_claude_cli_choices_from_most_to_least_prompting() {
+        string[] expected = ["manual", "acceptEdits", "auto", "bypassPermissions"];
+
+        await Assert.That(ClaudePermissionModes.Offered).IsEquivalentTo(expected, CollectionOrdering.Matching);
+        await Assert.That(ClaudePermissionModes.Manual).IsEqualTo("manual");
+    }
+
+    [Test]
+    [Arguments("manual", true)]
+    [Arguments("acceptEdits", true)]
+    [Arguments("auto", true)]
+    [Arguments("bypassPermissions", true)]
+    [Arguments("plan", false)]
+    [Arguments("dontAsk", false)]
+    [Arguments("AcceptEdits", false)]
+    [Arguments("", false)]
+    public async Task IsOffered_matches_exact_tokens_only(string token, bool offered) {
+        await Assert.That(ClaudePermissionModes.IsOffered(token)).IsEqualTo(offered);
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/ClaudeLauncherPermissionModeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/ClaudeLauncherPermissionModeTests.cs
@@ -1,0 +1,64 @@
+using Capacitor.Cli.Daemon.Harness.Claude;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Claude;
+
+public class ClaudeLauncherPermissionModeTests {
+    [TempHome] public required TempHome Home { get; init; }
+
+    ClaudeLauncher NewLauncher() =>
+        new(new DaemonConfig { ClaudePath = "claude", ServerUrl = "", CapacitorPath = "kcap" }, Home, NullLogger<ClaudeLauncher>.Instance);
+
+    static LauncherContext NewCtx(bool isReviewFlow, string? permissionMode) =>
+        new(
+            AgentId:       "a-1",
+            SourceRepoPath:"/tmp/repo",
+            Worktree:      new WorktreeInfo(Path: "/tmp/wt", Branch: "wt-branch", SourceRepo: "/tmp/repo"),
+            Prompt:        "build it",
+            Model:         "sonnet",
+            Effort:        null,
+            Tools:         null,
+            IsReview:      false,
+            IsReviewFlow:  isReviewFlow,
+            Review:        null,
+            ReviewLaunch:  null
+        ) { PermissionMode = permissionMode };
+
+    static string? ModeArg(string[] args) {
+        var i = Array.IndexOf(args, "--permission-mode");
+        return i < 0 ? null : args[i + 1];
+    }
+
+    [Test]
+    public async Task Interactive_launch_forwards_the_selected_mode_verbatim() {
+        var args = NewLauncher().BuildArgs(NewCtx(isReviewFlow: false, "acceptEdits")).Args;
+
+        await Assert.That(ModeArg(args)).IsEqualTo("acceptEdits");
+        await Assert.That(args.Count(a => a == "--permission-mode")).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Interactive_launch_without_a_mode_passes_no_flag() {
+        var args = NewLauncher().BuildArgs(NewCtx(isReviewFlow: false, null)).Args;
+
+        await Assert.That(args).DoesNotContain("--permission-mode");
+    }
+
+    /// The reviewer's bypass is a containment guarantee: a mode that somehow reaches the launcher
+    /// on a review flow (the orchestrator refuses it earlier) must not add a second flag.
+    [Test]
+    public async Task Review_flow_keeps_its_own_bypass_regardless_of_a_mode() {
+        var args = NewLauncher().BuildArgs(NewCtx(isReviewFlow: true, "manual")).Args;
+
+        await Assert.That(ModeArg(args)).IsEqualTo("bypassPermissions");
+        await Assert.That(args.Count(a => a == "--permission-mode")).IsEqualTo(1);
+    }
+
+    /// Bypass turns off permission prompts, not every prompt: a question card or the one-time
+    /// bypass consent dialog can still be open, so the composer keeps the single-Enter submit.
+    [Test]
+    public async Task Bypass_selected_interactively_keeps_the_interactive_submit_strategy() {
+        await Assert.That(NewLauncher().DisablesApprovalPrompts(NewCtx(isReviewFlow: false, "bypassPermissions"))).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/ClaudePermissionModePolicyTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Claude/ClaudePermissionModePolicyTests.cs
@@ -1,0 +1,71 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Harness.Claude;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Claude;
+
+public class ClaudePermissionModePolicyTests {
+    static LaunchAgentCommand Cmd(
+        string     vendor   = "claude",
+        LaunchKind kind     = LaunchKind.Default,
+        bool       borrowed = false,
+        string?    mode     = "acceptEdits"
+    ) => new(
+        "agent1", "prompt", "default", null, "/repo", null, null, vendor,
+        Kind: kind, Borrowed: borrowed, PermissionMode: mode
+    );
+
+    [Test]
+    public async Task Absent_mode_is_accepted_for_every_launch_shape() {
+        await Assert.That(ClaudePermissionModePolicy.RejectionReason(Cmd(mode: null))).IsNull();
+        await Assert.That(ClaudePermissionModePolicy.RejectionReason(Cmd(kind: LaunchKind.ReviewFlow, mode: null))).IsNull();
+        await Assert.That(ClaudePermissionModePolicy.RejectionReason(Cmd(vendor: "codex", borrowed: true, mode: null))).IsNull();
+    }
+
+    [Test]
+    [Arguments("manual")]
+    [Arguments("acceptEdits")]
+    [Arguments("auto")]
+    [Arguments("bypassPermissions")]
+    public async Task Every_offered_mode_is_accepted_on_an_interactive_claude_launch(string mode) {
+        await Assert.That(ClaudePermissionModePolicy.RejectionReason(Cmd(mode: mode))).IsNull();
+    }
+
+    [Test]
+    [Arguments("codex")]
+    [Arguments("cursor")]
+    [Arguments("pi")]
+    [Arguments(null)]
+    [Arguments("")]
+    public async Task Mode_for_a_non_claude_vendor_is_rejected_not_thrown(string? vendor) {
+        await Assert.That(ClaudePermissionModePolicy.RejectionReason(Cmd(vendor: vendor!))).StartsWith("permission_mode_wrong_vendor:");
+    }
+
+    [Test]
+    [Arguments(LaunchKind.ReviewFlow)]
+    [Arguments(LaunchKind.Review)]
+    public async Task Mode_on_a_non_interactive_launch_is_rejected(LaunchKind kind) {
+        await Assert.That(ClaudePermissionModePolicy.RejectionReason(Cmd(kind: kind))).StartsWith("permission_mode_not_overridable:");
+    }
+
+    [Test]
+    public async Task Mode_on_a_borrowed_launch_is_rejected() {
+        await Assert.That(ClaudePermissionModePolicy.RejectionReason(Cmd(borrowed: true))).StartsWith("permission_mode_not_overridable:");
+    }
+
+    /// Only the modes the product offers are forwarded; "plan" is a Claude token but not an offered
+    /// one, so it is refused like any other unknown value rather than reshaping the session.
+    [Test]
+    [Arguments("yolo")]
+    [Arguments("plan")]
+    [Arguments("AcceptEdits")]
+    public async Task Unknown_mode_token_is_rejected(string mode) {
+        await Assert.That(ClaudePermissionModePolicy.RejectionReason(Cmd(mode: mode))).StartsWith("permission_mode_invalid:");
+    }
+
+    [Test]
+    public async Task Advertised_vendors_is_claude_when_hosted_and_empty_otherwise() {
+        await Assert.That(ClaudePermissionModePolicy.AdvertisedVendors(["claude", "codex"])).IsEquivalentTo(new[] { "claude" });
+        await Assert.That(ClaudePermissionModePolicy.AdvertisedVendors(["codex", "cursor"])).IsEmpty();
+        await Assert.That(ClaudePermissionModePolicy.AdvertisedVendors([])).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorVendorTests.cs
@@ -235,6 +235,117 @@ public class AgentOrchestratorVendorTests {
         await Assert.That(server.LaunchFailedCalls.Any(c => c.Reason.StartsWith("codex_posture_", StringComparison.Ordinal))).IsFalse();
     }
 
+    // ── Caller-selected Claude permission mode: the same fail-closed pre-flight guard ──────────
+    // Same bogus repo path as the posture cases, so these too prove the guard runs before any
+    // repo check or worktree work.
+
+    static LaunchAgentCommand ModeCmd(
+            string     agentId,
+            string?    mode,
+            string     vendor   = "claude",
+            LaunchKind kind     = LaunchKind.Default,
+            bool       borrowed = false
+        ) => new(
+            AgentId: agentId,
+            Prompt: "hi",
+            Model: "default",
+            Effort: null,
+            RepoPath: "/tmp/kcap-posture-guard-nonexistent",
+            Tools: null,
+            AttachmentIds: null,
+            Vendor: vendor,
+            Kind: kind,
+            Borrowed: borrowed,
+            PermissionMode: mode
+        );
+
+    [Test]
+    public async Task Permission_mode_on_a_review_flow_launch_is_rejected_before_any_worktree_work() {
+        var server     = new CaptureServerConnection();
+        var ptyFactory = new SpyPtyProcessFactory();
+
+        await using var orch = BuildPostureOrchestrator(server, ptyFactory);
+
+        await orch.HandleLaunchAgentForTest(ModeCmd("agent-mode-flow", "acceptEdits", kind: LaunchKind.ReviewFlow));
+
+        await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
+        await Assert.That(server.LaunchFailedCalls[0].AgentId).IsEqualTo("agent-mode-flow");
+        await Assert.That(server.LaunchFailedCalls[0].Reason).StartsWith("permission_mode_not_overridable:");
+        await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Permission_mode_on_a_non_claude_launch_is_rejected() {
+        var server     = new CaptureServerConnection();
+        var ptyFactory = new SpyPtyProcessFactory();
+
+        await using var orch = BuildPostureOrchestrator(server, ptyFactory);
+
+        await orch.HandleLaunchAgentForTest(ModeCmd("agent-mode-codex", "auto", vendor: "codex"));
+
+        await Assert.That(server.LaunchFailedCalls.Count).IsEqualTo(1);
+        await Assert.That(server.LaunchFailedCalls[0].Reason).StartsWith("permission_mode_wrong_vendor:");
+        await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task A_valid_interactive_permission_mode_passes_the_guard() {
+        var server     = new CaptureServerConnection();
+        var ptyFactory = new SpyPtyProcessFactory();
+
+        await using var orch = BuildPostureOrchestrator(server, ptyFactory);
+
+        await orch.HandleLaunchAgentForTest(ModeCmd("agent-mode-ok", "bypassPermissions"));
+
+        await Assert.That(server.LaunchFailedCalls.Any(c => c.Reason.StartsWith("permission_mode_", StringComparison.Ordinal))).IsFalse();
+    }
+
+    static async Task<SpyHostedAgentRuntimeFactory> LaunchClaudeForHandoffAsync(string repoPath, string agentId, string? mode) {
+        var server     = new CaptureServerConnection();
+        var ptyFactory = new SpyPtyProcessFactory();
+        var claudeSpy  = new SpyHostedAgentRuntimeFactory("claude") { EmitsTerminalOutput = false, SupportsUnattended = true };
+
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            server, ptyFactory, new Dictionary<string, IHostedAgentLauncher>(),
+            extraRuntimeFactories: [claudeSpy]);
+
+        await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
+            AgentId: agentId,
+            Prompt: "do a thing",
+            Model: "default",
+            Effort: null,
+            RepoPath: repoPath,
+            Tools: null,
+            AttachmentIds: null,
+            Vendor: "claude",
+            PermissionMode: mode));
+
+        return claudeSpy;
+    }
+
+    /// The command→runtime handoff: the guard tests never reach a runtime and the launcher tests
+    /// build a LauncherContext by hand, so dropping `PermissionMode: cmd.PermissionMode` from the
+    /// RuntimeStartContext construction would leave every other mode test green.
+    [Test]
+    public async Task Interactive_claude_launch_threads_the_permission_mode_into_the_runtime_start_context() {
+        using var repoPath = GitRepo.CreateWithCommit();
+
+        var claudeSpy = await LaunchClaudeForHandoffAsync(repoPath, "agent-mode-thread", "acceptEdits");
+
+        await Assert.That(claudeSpy.LastContext).IsNotNull();
+        await Assert.That(claudeSpy.LastContext!.PermissionMode).IsEqualTo("acceptEdits");
+    }
+
+    [Test]
+    public async Task Interactive_claude_launch_without_a_mode_threads_null() {
+        using var repoPath = GitRepo.CreateWithCommit();
+
+        var claudeSpy = await LaunchClaudeForHandoffAsync(repoPath, "agent-mode-thread-null", mode: null);
+
+        await Assert.That(claudeSpy.LastContext).IsNotNull();
+        await Assert.That(claudeSpy.LastContext!.PermissionMode).IsNull();
+    }
+
     // ── Applied-posture echo on registration ────────────────────────────────────────────────
     // The echo is stamped on the AgentInstance so the initial registration AND every reconnect
     // re-registration report the same pair. It exists only for an interactive Codex launch on a

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/PtyHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/PtyHostedAgentRuntimeFactoryTests.cs
@@ -1,22 +1,22 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Commands;
+using Capacitor.Cli.Daemon.Harness.Claude;
 using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
 /// <summary>
-/// PR #244 review (Fix A, BLOCKER): the pre-refactor orchestrator passed
-/// <c>_config.CapacitorPath</c> (the <c>kcap</c> binary) as the review-launch MCP command — the
-/// review agent runs <c>kcap mcp review</c> so the daemon-embedded MCP tools work. After the Task
-/// 10 extraction, <see cref="PtyHostedAgentRuntimeFactory.StartAsync"/> passed
-/// <c>launcher.CliPath</c> (the claude/codex binary) instead, which would make a hosted PR review
-/// try to run <c>claude mcp review</c> / <c>codex mcp review</c> — broken. These tests pin the fix:
-/// <see cref="RuntimeStartContext.CapacitorPath"/> must be threaded into
-/// <see cref="ReviewLaunchBuilder.BuildAsync"/> as the MCP command, not the vendor CLI path.
+/// <see cref="RuntimeStartContext.CapacitorPath"/> must reach <see cref="ReviewLaunchBuilder.BuildAsync"/>
+/// as the review-launch MCP command: the review agent runs <c>kcap mcp review</c>, and the vendor
+/// CLI (<c>launcher.CliPath</c>) has no such subcommand.
 /// </summary>
 public class PtyHostedAgentRuntimeFactoryTests {
+    [TempHome] public required TempHome Home { get; init; }
+    [TempDir]  public required TempDir  Tmp  { get; init; }
+
     sealed class RecordingLauncher(string vendor, string cliPath) : IHostedAgentLauncher {
         public string Vendor  { get; } = vendor;
         public string CliPath { get; } = cliPath;
@@ -55,6 +55,67 @@ public class PtyHostedAgentRuntimeFactoryTests {
             DaemonBridgeUrl: null,
             CapacitorPath: capacitorPath
         );
+
+    /// Real directories, unlike BuildInteractiveContext's: ClaudeLauncher.Prepare writes into the
+    /// worktree and the home.
+    RuntimeStartContext BuildClaudeLaunchContext(string? permissionMode) {
+        var repo     = Tmp.CreateDir("repo");
+        var worktree = Tmp.CreateDir("wt");
+        return new(
+            AgentId: "agent-mode-1",
+            Vendor: "claude",
+            SourceRepoPath: repo,
+            Worktree: new WorktreeInfo(worktree, "wt-branch", repo),
+            Prompt: "build it",
+            Model: "default",
+            Effort: null,
+            Tools: null,
+            IsReview: false,
+            IsReviewFlow: false,
+            Review: null,
+            Cols: 120,
+            Rows: 40,
+            ServerUrl: "",
+            DaemonBridgeUrl: null,
+            CapacitorPath: "kcap",
+            PermissionMode: permissionMode
+        );
+    }
+
+    /// The runtime-context→launcher handoff: the launcher's own tests build a LauncherContext by
+    /// hand, so dropping `PermissionMode = ctx.PermissionMode` here would leave them green.
+    [Test]
+    public async Task Interactive_launch_hands_the_permission_mode_to_the_launcher() {
+        var launcher = new RecordingLauncher("claude", cliPath: "/opt/vendor/claude");
+        var factory  = new PtyHostedAgentRuntimeFactory(launcher, new NullPtyProcessFactory(), NullLogger<PtyHostedAgentRuntimeFactory>.Instance);
+
+        var ctx   = BuildInteractiveContext("claude") with { PermissionMode = "acceptEdits" };
+        var start = await factory.StartAsync(ctx, CancellationToken.None);
+
+        try {
+            await Assert.That(launcher.LastPrepareCtx!.PermissionMode).IsEqualTo("acceptEdits");
+        } finally {
+            await start.Runtime.DisposeAsync();
+        }
+    }
+
+    [Test]
+    public async Task Interactive_claude_launch_spawns_exactly_one_selected_mode_pair() {
+        var config   = new DaemonConfig { ClaudePath = "claude", ServerUrl = "", CapacitorPath = "kcap" };
+        var launcher = new ClaudeLauncher(config, Home, NullLogger<ClaudeLauncher>.Instance);
+        var pty      = new SpyPtyProcessFactory();
+        var factory  = new PtyHostedAgentRuntimeFactory(launcher, pty, NullLogger<PtyHostedAgentRuntimeFactory>.Instance);
+
+        var start = await factory.StartAsync(BuildClaudeLaunchContext("auto"), CancellationToken.None);
+
+        try {
+            var args = pty.LastArgs!;
+            await Assert.That(args.Count(a => a == "--permission-mode")).IsEqualTo(1);
+            await Assert.That(args[Array.IndexOf(args, "--permission-mode") + 1]).IsEqualTo("auto");
+        } finally {
+            await start.Runtime.DisposeAsync();
+        }
+    }
 
     [Test]
     public async Task Review_launch_builds_the_MCP_command_from_CapacitorPath_not_the_agent_CliPath() {


### PR DESCRIPTION
Closes #742 — AI-2424

## What & why

The new-session composer drops the "Remember" checkbox (a chosen harness is always persisted for the repository), turns Start into a round arrow button, and gains a Claude permission-mode chip: Manual, Accept edits, Auto, Bypass permissions. Manual sends nothing — the `permission_mode` key is omitted — so an unchanged launch is byte-identical to today's; any other mode rides the new field through the server to the daemon, which passes `--permission-mode` on the interactive Claude arm. The tokens live once, in Core's `ClaudePermissionModes`, shared by the chip and the daemon guard. The server half is a paired kcap-server change; either side can merge first.

## Where to look

`ClaudePermissionModePolicy` refuses a mode on a review-flow, borrowed or non-Claude launch before consent, mirroring the Codex posture and ACP preset guards, and the daemon advertises `PermissionModeVendors` so the server never sends a mode an old daemon would ignore. An interactive bypass keeps the single-Enter submit: bypass silences permission prompts, not question cards or the one-time consent dialog.

## Verification

`dotnet test --solution Capacitor.slnx`: 10944 tests, 3 failures, all environmental — `Installed_codex_schema_matches_the_vendored_pin` (installed Codex 0.152.1 vs the 0.147.0 pin) and two load flakes (`KillTree_cancelled_ct_kills_the_child_then_throws`, `ImportChainsAsync_dispatches_independent_chains_in_parallel`) that pass 1/1 in isolation. Severing either handoff hop (`PermissionMode: cmd.PermissionMode` in the orchestrator, `PermissionMode = ctx.PermissionMode` in the PTY factory) fails the new handoff tests. `dotnet publish -c Release`: no IL2026/IL3050 warnings. `claude --help` lists exactly the four forwarded tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
