### PR TITLE
Report the session's worktree and borrow on the status wire

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -490,3 +490,29 @@ identity-guarded (a launch commit clears all of its id's pending-stop keys; a sa
 after a faulted stop always commits fresh), and the queued-stop count backs an edge-triggered,
 hysteresis-gated alarm exposed via `QueuedStopDepth`/`QueuedStopHighWater` accessors — additive, with
 no production consumer yet (AI-1649's supervision IPC is the natural one).
+
+## Desktop shell: the checkout on the status wire
+
+**AI-2320** adds three trailing members to `AgentStatusDto` — `worktree_path`, `work_location`,
+`borrowed_from` — and makes `repo_path` the repository for every agent. Before, one field carried two
+conventions: a primary reported the repository it was launched for while running in its owned
+worktree, and a borrowed reviewer reported the worktree it borrowed. The rail filed the two one group
+apart, and nothing on the wire said they shared a checkout.
+
+**The daemon resolves the repository; the app never reads a path's shape.** `RepoLabel` recognised
+`.claude/worktrees` and `.capacitor/worktrees` tails — a guess that a reviewer borrowing a subdirectory,
+or any other layout, defeated. The daemon holds the `WorktreeInfo` and can read the `.git` entries, so
+`AgentCheckout` resolves once per agent: the source checkout's root (a borrowed cwd may sit below it),
+the main repository behind that root (a linked worktree's `.git` file names it), and the snapshot root
+for a runtime that runs in its own copy. The rail keeps `ResolveMainRepoRoot` only so an older
+daemon's checkout-shaped `repo_path` still groups; against such a daemon a reviewer's tray and card
+labels show the worktree leaf, the price of dropping the guess. The consent prompt and the activity
+log pay it too: they label a launch request's path, a wire that carries no repository behind it, so
+they name the checkout the request is for.
+
+**Both a marker and a path go on the wire, and the path is the grouping key.** A Cursor or Copilot
+reviewer runs in a private snapshot, so `worktree_path` alone would file it under a node nobody else
+shares; `borrowed_from` names the checkout it reviews, which is where it belongs — in the rail and in
+the workspace subtitle alike. `work_location` is derived from `borrowed_from` at the one stamping site,
+so the two cannot disagree, and a client that only needs the marker reads the token instead of
+comparing paths.

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -513,6 +513,7 @@ they name the checkout the request is for.
 **Both a marker and a path go on the wire, and the path is the grouping key.** A Cursor or Copilot
 reviewer runs in a private snapshot, so `worktree_path` alone would file it under a node nobody else
 shares; `borrowed_from` names the checkout it reviews, which is where it belongs — in the rail and in
-the workspace subtitle alike. `work_location` is derived from `borrowed_from` at the one stamping site,
+the workspace subtitle alike, through one `CheckoutLabel` so the two cannot drift. The chat relativizes
+tool paths against `worktree_path`, the checkout the agent actually runs in. `work_location` is derived from `borrowed_from` at the one stamping site,
 so the two cannot disagree, and a client that only needs the marker reads the token instead of
 comparing paths.

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -241,8 +241,12 @@ public sealed class ChatTabViewModel : ReactiveObject {
         ReadOnlyNotice = notice;
         IsReadOnlyParticipant = notice.Length > 0;
         _vendor = dto.Vendor;
-        _root = dto.RepoPath;
-        _rootSubject.OnNext(dto.RepoPath);
+        // Tool paths are relative to the checkout the agent runs in. An older daemon sends only
+        // RepoPath: the repository for a primary, whose worktree beneath it ToolDetail strips, or
+        // the borrowed checkout for a reviewer.
+        var root = dto.WorktreePath ?? dto.RepoPath;
+        _root = root;
+        _rootSubject.OnNext(root);
         VendorLabel = HostedHarnessCatalog.LabelFor(_options, dto.Vendor);
         ModelLabel = HostedHarnessCatalog.ModelLabelFor(dto.Vendor, dto.Model ?? "");
         StatusText = dto.Status;

--- a/src/Capacitor.App/ViewModels/RailRepoViewModel.cs
+++ b/src/Capacitor.App/ViewModels/RailRepoViewModel.cs
@@ -51,7 +51,7 @@ public sealed class RailRepoViewModel : ReactiveObject, IDisposable {
 
         Worktrees = new ReadOnlyObservableCollection<RailWorktreeViewModel>(_worktreesSource);
         group.Cache.Connect()
-            .Group(dto => dto.RepoPath ?? "")
+            .Group(SessionRailViewModel.WorktreeKeyFor)
             .Transform(wt => new RailWorktreeViewModel(
                 wt.Key, RootPath, showHeader: !IsNoRepository, wt.Cache, collapse, selectedAgentId,
                 agentsWithPending, open))

--- a/src/Capacitor.App/ViewModels/RailSessionViewModel.cs
+++ b/src/Capacitor.App/ViewModels/RailSessionViewModel.cs
@@ -35,7 +35,8 @@ public sealed class RailSessionViewModel : ReactiveObject, IDisposable {
             IObservable<IReadOnlySet<string>> agentsWithPending, Action<string> open) {
         Id = dto.Id;
         CreatedAt = dto.CreatedAt;
-        var vendorLine = dto.Kind == "agent" ? dto.Vendor : $"{dto.Vendor} · {dto.Kind}";
+        var kindLine = dto.Kind == "agent" ? dto.Vendor : $"{dto.Vendor} · {dto.Kind}";
+        var vendorLine = dto.WorkLocation == WorkLocationText.Borrowed ? $"{kindLine} · borrowed" : kindLine;
         var age = UptimeFormat.Format(DateTime.UtcNow - DateTime.SpecifyKind(dto.CreatedAt, DateTimeKind.Utc));
 
         Primary = dto.Title ?? vendorLine;
@@ -43,7 +44,7 @@ public sealed class RailSessionViewModel : ReactiveObject, IDisposable {
             ? Join(dto.Model, age)
             : Join(vendorLine, dto.Model, age);
         StatusDot = SessionStatusDots.For(dto.Status);
-        Tooltip = Join(dto.Id, dto.Status, dto.RequesterDisplay);
+        Tooltip = Join(dto.Id, dto.Status, dto.RequesterDisplay, dto.BorrowedFrom is null ? null : $"borrowed {dto.BorrowedFrom}");
 
         _isSelected = selectedAgentId.Select(sel => sel == dto.Id)
             .ToProperty(this, x => x.IsSelected, initialValue: false)

--- a/src/Capacitor.App/ViewModels/RailWorktreeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/RailWorktreeViewModel.cs
@@ -54,8 +54,8 @@ public sealed class RailWorktreeViewModel : ReactiveObject, IDisposable {
             IObservable<string?> selectedAgentId, IObservable<IReadOnlySet<string>> agentsWithPending,
             Action<string> open) {
         Path = path;
-        IsMainCheckout = PathEquals(path, repoRoot);
-        Label = LabelFor(path, IsMainCheckout);
+        IsMainCheckout = CheckoutLabel.IsMain(path, repoRoot);
+        Label = CheckoutLabel.Format(path, repoRoot);
         ShowHeader = showHeader;
 
         // Both IsExpanded and SessionsVisible are projected off this SAME stream, rather than
@@ -102,13 +102,6 @@ public sealed class RailWorktreeViewModel : ReactiveObject, IDisposable {
             .Subscribe()
             .DisposeWith(_disposables);
     }
-
-    internal static string LabelFor(string path, bool isMainCheckout) =>
-        isMainCheckout ? "main checkout" : PlatformPaths.Leaf(path);
-
-    internal static bool PathEquals(string a, string b) =>
-        PlatformPaths.Comparer.Equals(
-            System.IO.Path.TrimEndingDirectorySeparator(a), System.IO.Path.TrimEndingDirectorySeparator(b));
 
     public void Dispose() => _disposables.Dispose();
 }

--- a/src/Capacitor.App/ViewModels/SessionRailViewModel.cs
+++ b/src/Capacitor.App/ViewModels/SessionRailViewModel.cs
@@ -98,15 +98,22 @@ public sealed class SessionRailViewModel : ReactiveObject, IDisposable {
     }
 
     /// The launch auto-open's counterpart: a session opened into an explicitly collapsed
-    /// worktree must never highlight an invisible row (spec §3).
+    /// worktree must never highlight an invisible row.
     public void NotifySessionOpened(string agentId) {
         var dto = _daemon.Agents.Lookup(agentId);
-        if (!dto.HasValue || dto.Value.RepoPath is not { Length: > 0 } path) return;
+        if (!dto.HasValue || WorktreeKeyFor(dto.Value) is not { Length: > 0 } path) return;
         _collapse.Set(path, collapsed: false);
     }
 
+    /// The worktree node a session belongs under: the checkout a reviewer borrowed comes first, so
+    /// a snapshot reviewer sits beside the session it reviews rather than under its private copy.
+    /// An older daemon sends neither, and its RepoPath is the checkout.
+    internal static string WorktreeKeyFor(AgentStatusDto dto) =>
+        dto.BorrowedFrom ?? dto.WorktreePath ?? dto.RepoPath ?? "";
+
     // Memoized: ResolveMainRepoRoot reads .git files — cheap once, not per-changeset cheap; a
-    // path's resolution never changes within a daemon's lifetime.
+    // path's resolution never changes within a daemon's lifetime. A current daemon already sends
+    // the repository, so this only ever rewrites an older daemon's checkout path.
     string RepoRootFor(AgentStatusDto dto) {
         if (dto.RepoPath is not { Length: > 0 } path) return "";
         if (_rootByPath.TryGetValue(path, out var root)) return root;

--- a/src/Capacitor.App/ViewModels/SessionRailViewModel.cs
+++ b/src/Capacitor.App/ViewModels/SessionRailViewModel.cs
@@ -105,11 +105,8 @@ public sealed class SessionRailViewModel : ReactiveObject, IDisposable {
         _collapse.Set(path, collapsed: false);
     }
 
-    /// The worktree node a session belongs under: the checkout a reviewer borrowed comes first, so
-    /// a snapshot reviewer sits beside the session it reviews rather than under its private copy.
-    /// An older daemon sends neither, and its RepoPath is the checkout.
     internal static string WorktreeKeyFor(AgentStatusDto dto) =>
-        dto.BorrowedFrom ?? dto.WorktreePath ?? dto.RepoPath ?? "";
+        CheckoutLabel.CheckoutPathFor(dto) ?? dto.RepoPath ?? "";
 
     // Memoized: ResolveMainRepoRoot reads .git files — cheap once, not per-changeset cheap; a
     // path's resolution never changes within a daemon's lifetime. A current daemon already sends

--- a/src/Capacitor.App/ViewModels/ToolDetail.cs
+++ b/src/Capacitor.App/ViewModels/ToolDetail.cs
@@ -4,8 +4,10 @@ using Capacitor.Cli.Core;
 namespace Capacitor.App.ViewModels;
 
 /// The one-line detail a tool row shows beside its name, read from the call's input object. A
-/// path under the session's root reads relative to it, the way the web UI shows it: the root is
-/// the repository, or the daemon's per-agent worktree beneath it when the path is in one.
+/// path under the session's root reads relative to it, the way the web UI shows it. The root is
+/// the checkout the agent runs in. An older daemon sends no worktree, only its RepoPath — the
+/// repository for a primary, the borrowed checkout for a reviewer — so a daemon worktree beneath
+/// a repository root is stripped as well.
 public static class ToolDetail {
     const int MaxLength = 80;
     const string WorktreesSegment = "/.capacitor/worktrees/";

--- a/src/Capacitor.App/ViewModels/TrayModels.cs
+++ b/src/Capacitor.App/ViewModels/TrayModels.cs
@@ -1,3 +1,5 @@
+using Capacitor.Cli.Core.LocalIpc;
+
 namespace Capacitor.App.ViewModels;
 
 public enum TrayState { Stopped, Connecting, Attention, Idle, Running }
@@ -8,8 +10,23 @@ public static class RepoLabel {
     public static string Leaf(string? repoPath) => repoPath is null ? "—" : PlatformPaths.Leaf(repoPath);
 }
 
-/// The path primitives every surface shares, so the platform rule and the leaf expression exist
-/// once (they were drifting into per-VM copies).
+/// The checkout a session is presented under, shared by the rail's grouping and the workspace
+/// subtitle so the two cannot disagree: the checkout a reviewer borrowed comes first, so a
+/// snapshot reviewer sits beside the session it reviews rather than under its private copy.
+public static class CheckoutLabel {
+    /// Null from an older daemon, whose RepoPath is the checkout.
+    public static string? CheckoutPathFor(AgentStatusDto dto) => dto.BorrowedFrom ?? dto.WorktreePath;
+
+    public static bool IsMain(string checkout, string repoRoot) =>
+        PlatformPaths.Comparer.Equals(
+            Path.TrimEndingDirectorySeparator(checkout), Path.TrimEndingDirectorySeparator(repoRoot));
+
+    public static string Format(string checkout, string repoRoot) =>
+        IsMain(checkout, repoRoot) ? "main checkout" : PlatformPaths.Leaf(checkout);
+}
+
+/// The path primitives every surface shares: one platform comparison rule and one leaf
+/// expression, never a per-view copy.
 public static class PlatformPaths {
     /// Repo paths compare the way the filesystem underneath them does: case-insensitively on
     /// Windows and macOS, case-sensitively on Linux where two checkouts differing only in case

--- a/src/Capacitor.App/ViewModels/TrayModels.cs
+++ b/src/Capacitor.App/ViewModels/TrayModels.cs
@@ -2,24 +2,10 @@ namespace Capacitor.App.ViewModels;
 
 public enum TrayState { Stopped, Connecting, Attention, Idle, Running }
 
-/// Last path segment of a repo path, shared by the tray entry label (spec §5) and the main-window
-/// grid's Repo cell (spec §8) — one helper, not duplicated presentation logic. When the path ends
-/// in exactly "&lt;repoDir&gt;/.claude/worktrees/&lt;leaf&gt;" (either separator flavor, case-sensitive),
-/// the generated worktree leaf is meaningless noise, so this returns just "{repoDir}" — the leaf
-/// never appears in presentation; the full path (worktree leaf included) is still the tooltip, for
-/// anyone who needs to tell worktrees of the same repo apart.
+/// Last path segment of a repo path, shared by every surface that names a repository. The status
+/// wire says which path is a worktree, so a path's shape is never read as evidence of one.
 public static class RepoLabel {
-    public static string Leaf(string? repoPath) {
-        if (repoPath is null) return "—";
-
-        var segments = repoPath.Replace('\\', '/').TrimEnd('/').Split('/');
-        // A worktree an agent runs in — Claude's own or the daemon's — sits two levels under its
-        // repository, which is the name worth showing.
-        if (segments.Length >= 4 && segments[^3] is ".claude" or ".capacitor" && segments[^2] == "worktrees" && segments[^4].Length > 0)
-            return segments[^4];
-
-        return PlatformPaths.Leaf(repoPath);
-    }
+    public static string Leaf(string? repoPath) => repoPath is null ? "—" : PlatformPaths.Leaf(repoPath);
 }
 
 /// The path primitives every surface shares, so the platform rule and the leaf expression exist
@@ -31,8 +17,7 @@ public static class PlatformPaths {
     public static readonly StringComparer Comparer =
         OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
 
-    /// The path's own last segment, verbatim — no worktree collapsing (that is RepoLabel.Leaf's
-    /// job); the rail's worktree rows need exactly the raw leaf.
+    /// The path's own last segment, verbatim.
     public static string Leaf(string path) =>
         Path.GetFileName(Path.TrimEndingDirectorySeparator(path));
 }

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -117,8 +117,8 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         _title = presence.Select(p => TitleFor(p.Dto))
             .ToProperty(this, x => x.Title, TitleFor(null))
             .DisposeWith(_disposables);
-        _repoLabelText = presence.Select(p => RepoLabel.Leaf(p.Dto?.RepoPath))
-            .ToProperty(this, x => x.RepoLabelText, RepoLabel.Leaf(null))
+        _repoLabelText = presence.Select(p => CheckoutLabelFor(p.Dto))
+            .ToProperty(this, x => x.RepoLabelText, CheckoutLabelFor(null))
             .DisposeWith(_disposables);
         _vendorChip = presence.Select(p => VendorChipFor(p.Dto))
             .ToProperty(this, x => x.VendorChip, VendorChipFor(null))
@@ -175,6 +175,20 @@ public sealed class WorkspaceViewModel : ReactiveObject {
             dto = change.Current;
         }
         return new AgentPresence(dto, ended);
+    }
+
+    /// `repo / checkout` — the checkout labeled as the rail labels its node, so the two surfaces
+    /// agree; a borrowed reviewer names the checkout it borrowed with the marker. An older daemon
+    /// sends no worktree, and the repository stands alone.
+    internal static string CheckoutLabelFor(AgentStatusDto? dto) {
+        var repo = RepoLabel.Leaf(dto?.RepoPath);
+        if (dto?.WorktreePath is null) return repo;
+
+        var checkout = dto.BorrowedFrom ?? dto.WorktreePath;
+        var isMain   = dto.RepoPath is { Length: > 0 } root && RailWorktreeViewModel.PathEquals(checkout, root);
+        var label    = $"{repo} / {RailWorktreeViewModel.LabelFor(checkout, isMain)}";
+
+        return dto.WorkLocation == WorkLocationText.Borrowed ? $"{label} · borrowed" : label;
     }
 
     static string TitleFor(AgentStatusDto? dto) => dto?.Title ?? $"{RepoLabel.Leaf(dto?.RepoPath)} · {dto?.Vendor ?? "—"}";

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -177,16 +177,13 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         return new AgentPresence(dto, ended);
     }
 
-    /// `repo / checkout` — the checkout labeled as the rail labels its node, so the two surfaces
-    /// agree; a borrowed reviewer names the checkout it borrowed with the marker. An older daemon
-    /// sends no worktree, and the repository stands alone.
+    /// `repo / checkout`, with the marker for a borrowed reviewer; the repository alone from an
+    /// older daemon.
     internal static string CheckoutLabelFor(AgentStatusDto? dto) {
         var repo = RepoLabel.Leaf(dto?.RepoPath);
-        if (dto?.WorktreePath is null) return repo;
+        if (dto is null || CheckoutLabel.CheckoutPathFor(dto) is not { } checkout) return repo;
 
-        var checkout = dto.BorrowedFrom ?? dto.WorktreePath;
-        var isMain   = dto.RepoPath is { Length: > 0 } root && RailWorktreeViewModel.PathEquals(checkout, root);
-        var label    = $"{repo} / {RailWorktreeViewModel.LabelFor(checkout, isMain)}";
+        var label = $"{repo} / {CheckoutLabel.Format(checkout, dto.RepoPath ?? "")}";
 
         return dto.WorkLocation == WorkLocationText.Borrowed ? $"{label} · borrowed" : label;
     }

--- a/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
@@ -64,7 +64,8 @@ public sealed record AgentStatusDto(
     // borrowed.
     string? BorrowedFrom = null);
 
-/// The <see cref="AgentStatusDto.WorkLocation"/> vocabulary.
+/// Wire tokens for <see cref="AgentStatusDto.WorkLocation"/>, compared literally by every
+/// client, so they never change.
 public static class WorkLocationText {
     public const string Owned    = "owned";
     public const string Borrowed = "borrowed";

--- a/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
@@ -52,7 +52,23 @@ public sealed record AgentStatusDto(
     // rollout), link-resolved. Trailing + nullable: null is "older daemon", "not found yet",
     // "no transcript for this runtime", or "found nothing before the agent exited" alike —
     // a client waits, it never distinguishes them.
-    string? TranscriptPath = null);
+    string? TranscriptPath = null,
+    // The checkout root the agent runs in. RepoPath is the repository it belongs to, for every
+    // agent: a primary runs in an owned worktree under it, a borrowed reviewer in the worktree it
+    // borrowed. Trailing + nullable: null = older daemon, which a client renders as it did before.
+    string? WorktreePath = null,
+    // "owned" or "borrowed"; derived from BorrowedFrom so the two never disagree. Null = older daemon.
+    string? WorkLocation = null,
+    // The checkout root a borrowed reviewer reviews — for a runtime that needs its own snapshot
+    // this differs from WorktreePath, and it is the node the reviewer belongs under. Null unless
+    // borrowed.
+    string? BorrowedFrom = null);
+
+/// The <see cref="AgentStatusDto.WorkLocation"/> vocabulary.
+public static class WorkLocationText {
+    public const string Owned    = "owned";
+    public const string Borrowed = "borrowed";
+}
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
 [JsonSerializable(typeof(DaemonStatusDto))]

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -46,7 +46,7 @@ internal partial class AgentOrchestrator {
             .OrderBy(a => a.CreatedAt)
             .ThenBy(a => a.Id, StringComparer.Ordinal)
             .Select(a => new AgentStatusDto(
-                a.Id, KindText(a.Kind), a.Vendor, a.RepoPath, a.Status,
+                a.Id, KindText(a.Kind), a.Vendor, a.Checkout.Repository, a.Status,
                 a.FlowRunId, a.FlowRole, a.RequesterUserId, a.CreatedAt,
                 // Local spawns store "" for "no model" (HandleLocalSpawnAsync's LauncherContext),
                 // and a server-driven launch with a blank requested model can retain "" too
@@ -54,7 +54,10 @@ internal partial class AgentOrchestrator {
                 // unchanged) — but the wire contract pins absent = null. Normalize here, at the
                 // wire boundary, rather than changing what AgentInstance stores.
                 string.IsNullOrWhiteSpace(a.Model) ? null : a.Model, a.RequesterDisplay,
-                HasTerminal: a.Runtime.EmitsTerminalOutput, Title: a.Title, TranscriptPath: a.TranscriptPath))];
+                HasTerminal: a.Runtime.EmitsTerminalOutput, Title: a.Title, TranscriptPath: a.TranscriptPath,
+                WorktreePath: a.Checkout.Worktree,
+                WorkLocation: a.Checkout.BorrowedFrom is null ? WorkLocationText.Owned : WorkLocationText.Borrowed,
+                BorrowedFrom: a.Checkout.BorrowedFrom))];
 
     /// <summary>
     /// Serves the legacy <c>Stop</c> frame from older clients that predate --force. That frame

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -21,6 +21,26 @@ using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Services;
 
+/// <summary>
+/// <paramref name="Repository"/> is the main repository behind the checkout the worktree was
+/// made from — a linked worktree's own .git file names it, so a borrowed reviewer and the
+/// primary whose worktree it borrowed resolve to the same repository. <paramref name="Worktree"/>
+/// is the checkout root the agent runs in; <paramref name="BorrowedFrom"/> the checkout root a
+/// reviewer borrowed, null unless borrowed. A snapshot reviewer runs in its own copy, so its
+/// Worktree and BorrowedFrom differ.
+/// </summary>
+internal sealed record AgentCheckout(string Repository, string Worktree, string? BorrowedFrom) {
+    public static AgentCheckout Resolve(WorktreeInfo worktree, WorkLocation work, string? borrowedSnapshotSource) {
+        var borrowed   = work == WorkLocation.BorrowedCwd || borrowedSnapshotSource is not null;
+        // The source is a cwd for a borrow, which may sit below its checkout root.
+        var sourceRoot = GitRepository.FindRoot(worktree.SourceRepo) ?? worktree.SourceRepo;
+        var repository = GitRepository.ResolveMainRepoRoot(sourceRoot);
+        var runsIn     = work == WorkLocation.BorrowedCwd ? sourceRoot : worktree.SnapshotRoot ?? worktree.Path;
+
+        return new AgentCheckout(repository, runsIn, borrowed ? sourceRoot : null);
+    }
+}
+
 internal record AgentInstance(
         string                  Id,
         string?                 Prompt,
@@ -224,6 +244,11 @@ internal record AgentInstance(
     /// <summary>Authorized live checkout mirrored into this owned worktree for a runtime that
     /// cannot safely execute in-place. Refreshed before each later review round.</summary>
     public string? BorrowedSnapshotSource { get; init; }
+
+    AgentCheckout? _checkout;
+    /// <summary>Where the work lives, as the status wire reports it. Resolved once: it reads
+    /// .git entries, and neither the worktree nor the work location changes after launch.</summary>
+    public AgentCheckout Checkout => _checkout ??= AgentCheckout.Resolve(Worktree, Work, BorrowedSnapshotSource);
 
     /// <summary>The per-agent critical section. Named for its original duty (serializing the borrowed-
     /// checkout refresh against a concurrent send) but it has always wrapped the ENTIRE
@@ -1609,23 +1634,25 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             IPtyProcess? pty = null, string? startIdentity = null, string? requester = null,
             string? requesterDisplay = null, string? model = "default", int? inactivityBoundSeconds = null,
             string? prompt = null,
-            // Task 12 (unified reviewer reaping): a test that needs to control the agent's monotonic
-            // age/idle (rather than the wall-clock CreatedAt/LastOutputAt above, which the new
-            // FindReviewersToReap no longer reads) constructs its own AgentActivityClock over a
-            // FakeTimeProvider and passes it here — the SAME wiring CreateActivityClock() gives a
-            // real launch, just with a controllable time source.
-            AgentActivityClock? activityClock = null) {
+            // A test that needs to control the agent's monotonic age/idle constructs its own
+            // AgentActivityClock over a FakeTimeProvider and passes it here — the same wiring
+            // CreateActivityClock() gives a real launch, with a controllable time source.
+            AgentActivityClock? activityClock = null,
+            WorktreeInfo? worktree = null, WorkLocation work = WorkLocation.OwnedWorktree,
+            string? borrowedSnapshotSource = null) {
         var agent = new AgentInstance(
             id, prompt, model, null, "/repo", "codex",
             new PtyHostedAgentRuntime("codex", pty ?? NoopPtyProcess.Instance),
-            new WorktreeInfo("/repo", "b", "/repo"),
+            worktree ?? new WorktreeInfo("/repo", "b", "/repo"),
             new CancellationTokenSource()) {
             Kind = kind, FlowRunId = flowRunId, FlowRole = flowRole, IsPrivate = isPrivate,
             CreatedAt = createdAt ?? DateTime.UtcNow, StartIdentity = startIdentity,
             RequesterUserId = requester,
             RequesterDisplay = requesterDisplay,
             InactivityBoundSeconds = inactivityBoundSeconds,
-            ActivityClock = activityClock ?? CreateActivityClock()
+            ActivityClock = activityClock ?? CreateActivityClock(),
+            Work = work,
+            BorrowedSnapshotSource = borrowedSnapshotSource
         };
         agent.Status = status;
         if (lastOutputAt is { } lo) agent.LastOutputAt = lo;

--- a/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
@@ -103,7 +103,9 @@ public class ActivityViewModelTests {
         await Assert.That(first.Time).IsEqualTo(expectedTime);
         await Assert.That(first.Requester).IsEqualTo("Ada Lovelace");
         await Assert.That(first.KindLabel).IsEqualTo("Review flow");
-        await Assert.That(first.RepoLeaf).IsEqualTo("kcap-cli"); // worktree leaf stripped, RepoLabel
+        // A consent record carries the launch request's path verbatim, with no repository behind
+        // it on the wire, so the leaf is that path's own; RepoFull carries the rest.
+        await Assert.That(first.RepoLeaf).IsEqualTo("tender-honking-pebble");
         await Assert.That(first.RepoFull).IsEqualTo("/repos/kcap-cli/.claude/worktrees/tender-honking-pebble");
         await Assert.That(first.Vendor).IsEqualTo("codex");
         await Assert.That(first.Outcome).IsEqualTo("allowed");

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -95,6 +95,28 @@ public class ChatTabViewModelTests {
         });
     }
 
+    /// Tool paths read relative to the checkout the agent runs in, which the wire names as
+    /// worktree_path; the repository alone would leave a checkout outside its own directory, or
+    /// one under `.claude/worktrees`, rendering absolute paths.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Tool_paths_relativize_against_the_worktree_the_agent_runs_in() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            const string worktree = "/repo/x/.claude/worktrees/slug";
+            const string readLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"/repo/x/.claude/worktrees/slug/src/Foo.cs"}}]}}""";
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolName: "Read", toolInputJson: """{"file_path":"/repo/x/.claude/worktrees/slug/src/Bar.cs"}"""));
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "the card");
+
+            var path = Tmp.CreateFile("t.jsonl", [readLine]);
+            await h.PushAsync(Dto(path) with { WorktreePath = worktree, WorkLocation = "owned" });
+
+            await Assert.That(((ToolCallItem)h.Chat.Items.Single()).Detail).IsEqualTo("src/Foo.cs");
+            await WaitUntilAsync(() => ((PermissionCardViewModel)h.Chat.PendingCards[0]).Detail == "src/Bar.cs", what: "relative to the worktree once the root lands");
+            await h.TeardownAsync();
+        });
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Appended_lines_render_after_a_tick_and_a_partial_line_waits_for_its_newline() {

--- a/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
@@ -106,7 +106,9 @@ public class ConsentPromptViewModelTests {
         await Assert.That(id).IsEqualTo("github:1");
         await Assert.That(unknown).IsEqualTo("unknown");
         await Assert.That(kindLabel).IsEqualTo("Review flow");
-        await Assert.That(repoLeaf).IsEqualTo("kcap-cli"); // the worktree leaf is noise (RepoLabel)
+        // The prompt names the checkout the launch asks for, as its own leaf: the consent wire
+        // carries no repository behind it, and RepoFull holds the whole path.
+        await Assert.That(repoLeaf).IsEqualTo("tender-honking-pebble");
         await Assert.That(repoFull).IsEqualTo("/repos/kcap-cli/.claude/worktrees/tender-honking-pebble");
         await Assert.That(vendor).IsEqualTo("codex");
     }

--- a/test/Capacitor.App.Tests.Unit/RailSessionViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/RailSessionViewModelTests.cs
@@ -47,6 +47,19 @@ public class RailSessionViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
+    public async Task Borrowed_work_location_marks_the_vendor_line_and_the_tooltip_names_the_checkout() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var dto = Dto(kind: "review-flow", vendor: "codex") with {
+                WorktreePath = "/repo/.capacitor/worktrees/agent-1", WorkLocation = "borrowed",
+                BorrowedFrom = "/repo/.capacitor/worktrees/agent-1" };
+            using var row = new RailSessionViewModel(dto, new BehaviorSubject<string?>(null), NoPending, _ => { });
+            await Assert.That(row.Sub).StartsWith("codex · review-flow · borrowed · Opus 5 · ");
+            await Assert.That(row.Tooltip).Contains("/repo/.capacitor/worktrees/agent-1");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Null_model_is_omitted_from_sub() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var row = new RailSessionViewModel(Dto(model: null), new BehaviorSubject<string?>(null), NoPending, _ => { });

--- a/test/Capacitor.App.Tests.Unit/RailWorktreeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/RailWorktreeViewModelTests.cs
@@ -27,9 +27,10 @@ public class RailWorktreeViewModelTests {
     [NotInParallel("AvaloniaSession")]
     public async Task Label_is_the_checkout_leaf_and_main_checkout_for_the_root() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
-            await Assert.That(RailWorktreeViewModel.LabelFor("/repo/.claude/worktrees/wt-a", false)).IsEqualTo("wt-a");
-            await Assert.That(RailWorktreeViewModel.LabelFor("/repo/", false)).IsEqualTo("repo");
-            await Assert.That(RailWorktreeViewModel.LabelFor("/repo", true)).IsEqualTo("main checkout");
+            await Assert.That(CheckoutLabel.Format("/repo/.claude/worktrees/wt-a", "/repo")).IsEqualTo("wt-a");
+            await Assert.That(CheckoutLabel.Format("/elsewhere/", "/repo")).IsEqualTo("elsewhere");
+            await Assert.That(CheckoutLabel.Format("/repo", "/repo")).IsEqualTo("main checkout");
+            await Assert.That(CheckoutLabel.Format("/repo/", "/repo")).IsEqualTo("main checkout");
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/RepoLabelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/RepoLabelTests.cs
@@ -3,15 +3,14 @@ using Capacitor.App.ViewModels;
 namespace Capacitor.App.Tests.Unit;
 
 public class RepoLabelTests {
-    /// Pins the repository leaf behind both worktree layouts an agent can run in — Claude's
-    /// `.claude/worktrees/…` and the daemon's `.capacitor/worktrees/agent-…` — and the
-    /// plain cases around them.
+    /// The wire says which path is a worktree; the leaf never guesses from a path's shape, so a
+    /// worktree path yields the worktree's own name and only null yields the dash.
     [Test]
-    public async Task The_leaf_is_the_repository_behind_either_worktree_layout() {
-        await Assert.That(RepoLabel.Leaf("/repo/myproj/.claude/worktrees/feature")).IsEqualTo("myproj");
-        await Assert.That(RepoLabel.Leaf("/repo/myproj/.capacitor/worktrees/agent-6da2")).IsEqualTo("myproj");
+    public async Task The_leaf_is_the_last_segment_and_never_a_guess_from_the_path_shape() {
         await Assert.That(RepoLabel.Leaf("/repo/myproj")).IsEqualTo("myproj");
         await Assert.That(RepoLabel.Leaf("/repo/myproj/")).IsEqualTo("myproj");
+        await Assert.That(RepoLabel.Leaf("/repo/myproj/.claude/worktrees/feature")).IsEqualTo("feature");
+        await Assert.That(RepoLabel.Leaf("/repo/myproj/.capacitor/worktrees/agent-6da2")).IsEqualTo("agent-6da2");
         await Assert.That(RepoLabel.Leaf(null)).IsEqualTo("—");
     }
 }

--- a/test/Capacitor.App.Tests.Unit/SessionRailViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SessionRailViewModelTests.cs
@@ -47,6 +47,34 @@ public class SessionRailViewModelTests {
         });
     }
 
+    /// A reviewer that borrowed a checkout belongs on that checkout's node, beside the session it
+    /// reviews — a snapshot reviewer too, which runs elsewhere but names what it borrowed. The
+    /// collapse key follows the same rule, so opening the reviewer expands that node.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_borrowed_reviewer_files_under_the_worktree_it_reviews() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (service, rail) = Build();
+            using (rail) {
+                const string worktree = "/dev/alpha/wt/agent-1";
+                service.Agents.AddOrUpdate(Dto("p1", "/dev/alpha") with { WorktreePath = worktree, WorkLocation = "owned" });
+                service.Agents.AddOrUpdate(Dto("r1", "/dev/alpha") with {
+                    WorktreePath = worktree, WorkLocation = "borrowed", BorrowedFrom = worktree });
+                service.Agents.AddOrUpdate(Dto("s1", "/dev/alpha") with {
+                    WorktreePath = "/snapshots/borrowed-1", WorkLocation = "borrowed", BorrowedFrom = worktree });
+
+                var node = rail.Repos.Single().Worktrees.Single();
+                await Assert.That(node.Label).IsEqualTo("agent-1");
+                await Assert.That(node.Sessions.Select(s => s.Id)).IsEquivalentTo(["p1", "r1", "s1"]);
+
+                node.ToggleCommand.Execute().Subscribe();
+                await Assert.That(node.IsExpanded).IsFalse();
+                rail.NotifySessionOpened("s1");
+                await Assert.That(node.IsExpanded).IsTrue();
+            }
+        });
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Counts_and_hosted_text_track_the_cache() {

--- a/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
@@ -384,27 +384,6 @@ public class TrayViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Entries_label_is_worktree_aware_for_claude_worktree_repo_path() {
-        await AvaloniaSession.WithImmediateRxScheduler(async () => {
-            var service = new FakeDaemonClientService();
-            var pause = new FakePauseController();
-            var actions = NewActions(service);
-            var consent = new FakeConsentService();
-            using var vm = new TrayViewModel(service, pause, actions, consent);
-
-            var agents = new List<AgentStatusDto> {
-                new("a", "agent", "claude", "/Users/alexey/dev/kcap-server/.claude/worktrees/hazy-sleeping-plum", "Running", null, null, null, DateTime.UtcNow, null, null),
-            };
-
-            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
-            service.SnapshotsSubject.OnNext(Snap("connected", 1, agents));
-
-            await Assert.That(vm.MenuModel.Agents[0].Label).IsEqualTo("agent · claude · kcap-server");
-        });
-    }
-
-    [Test]
-    [NotInParallel("AvaloniaSession")]
     public async Task Entries_empty_when_not_connected_despite_retained_snapshot() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();

--- a/test/Capacitor.App.Tests.Unit/WorkspaceFixtures.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceFixtures.cs
@@ -12,10 +12,12 @@ static class WorkspaceFixtures {
     /// own defaults (fixed repo path, hasTerminal) keep a thin local wrapper delegating here.
     public static AgentStatusDto Agent(
             string id, string vendor, bool? hasTerminal, string? repoPath = null,
-            string kind = "agent", string? model = null) => new(
+            string kind = "agent", string? model = null,
+            string? worktreePath = null, string? workLocation = null, string? borrowedFrom = null) => new(
         id, kind, vendor, repoPath, "Running",
         FlowRunId: null, FlowRole: null, Requester: null, CreatedAt: DateTime.UtcNow, Model: model,
-        RequesterDisplay: null, HasTerminal: hasTerminal);
+        RequesterDisplay: null, HasTerminal: hasTerminal,
+        WorktreePath: worktreePath, WorkLocation: workLocation, BorrowedFrom: borrowedFrom);
 
     /// An AgentActionService over the scripted/recording deps, for suites that never assert on
     /// those deps individually.

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -185,23 +185,46 @@ public class WorkspaceViewModelTests {
         });
     }
 
+    /// The subtitle names the checkout under the repository. The main checkout reads as the rail
+    /// labels it; an older daemon's null worktree keeps the repository alone; a snapshot reviewer
+    /// names the checkout it borrowed, not the copy it runs in.
+    [Test]
+    public async Task The_checkout_label_names_the_worktree_under_the_repository() {
+        var owned = Agent("a1", "claude", hasTerminal: true, repoPath: "/repo/myproj",
+            worktreePath: "/repo/myproj/.capacitor/worktrees/agent-6da2", workLocation: "owned");
+
+        await Assert.That(WorkspaceViewModel.CheckoutLabelFor(owned)).IsEqualTo("myproj / agent-6da2");
+        await Assert.That(WorkspaceViewModel.CheckoutLabelFor(owned with { WorktreePath = "/repo/myproj" }))
+            .IsEqualTo("myproj / main checkout");
+        await Assert.That(WorkspaceViewModel.CheckoutLabelFor(owned with { WorktreePath = null, WorkLocation = null }))
+            .IsEqualTo("myproj");
+        await Assert.That(WorkspaceViewModel.CheckoutLabelFor(owned with {
+                WorktreePath = "/snapshots/borrowed-1", WorkLocation = "borrowed",
+                BorrowedFrom = "/repo/myproj/.capacitor/worktrees/agent-6da2" }))
+            .IsEqualTo("myproj / agent-6da2 · borrowed");
+        await Assert.That(WorkspaceViewModel.CheckoutLabelFor(null)).IsEqualTo("—");
+    }
+
     /// Pins the header for a titled session on a borrowed checkout: the title line is the
-    /// session's own title, and the repository line reads through the worktree to the repository.
+    /// session's own title, and the subtitle names the repository, the borrowed worktree and the
+    /// marker.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task The_header_shows_the_session_title_over_the_repository_behind_a_borrowed_worktree() {
+    public async Task The_header_shows_the_session_title_over_the_borrowed_worktree() {
         await RunOnUiAsync(async () => {
             var daemon = new FakeDaemonClientService();
             var actions = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
             var vm = Build(daemon, actions, new FakeTerminalAttachClientFactory(), new FakeTimeProvider(), agentId: "r1");
 
             daemon.Agents.AddOrUpdate(
-                Agent("r1", "codex", hasTerminal: true, repoPath: "/repo/myproj/.capacitor/worktrees/agent-6da2", kind: "review-flow")
+                Agent("r1", "codex", hasTerminal: true, repoPath: "/repo/myproj", kind: "review-flow",
+                        worktreePath: "/repo/myproj/.capacitor/worktrees/agent-6da2", workLocation: "borrowed",
+                        borrowedFrom: "/repo/myproj/.capacitor/worktrees/agent-6da2")
                     with { Title = "Review this PR" });
             await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
 
             await Assert.That(vm.Title).IsEqualTo("Review this PR");
-            await Assert.That(vm.RepoLabelText).IsEqualTo("myproj");
+            await Assert.That(vm.RepoLabelText).IsEqualTo("myproj / agent-6da2 · borrowed");
             await vm.TeardownAsync();
         });
     }

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
@@ -29,7 +29,7 @@ public class StatusIpcJsonTests {
         var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
 
         await Assert.That(json).IsEqualTo(
-            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1,"pid":4242,"instance_id":"inst-abc","supported_vendors":null},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex","requester_display":"Ada Lovelace","has_terminal":null,"title":"Fix the flaky test","transcript_path":null},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null,"requester_display":null,"has_terminal":null,"title":null,"transcript_path":null}]}""");
+            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1,"pid":4242,"instance_id":"inst-abc","supported_vendors":null},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex","requester_display":"Ada Lovelace","has_terminal":null,"title":"Fix the flaky test","transcript_path":null,"worktree_path":null,"work_location":null,"borrowed_from":null},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null,"requester_display":null,"has_terminal":null,"title":null,"transcript_path":null,"worktree_path":null,"work_location":null,"borrowed_from":null}]}""");
     }
 
     [Test]
@@ -97,7 +97,7 @@ public class StatusIpcJsonTests {
     }
 
     [Test]
-    public async Task Transcript_path_serializes_last_and_null_is_emitted() {
+    public async Task Transcript_path_serializes_after_title_and_null_is_emitted() {
         var withPath = new AgentStatusDto(
             "a1", "agent", "claude", "/repo", "Running",
             null, null, null, new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc), null, null,
@@ -107,8 +107,8 @@ public class StatusIpcJsonTests {
         var json = JsonSerializer.Serialize(withPath, StatusIpcJsonContext.Default.AgentStatusDto);
         var jsonNull = JsonSerializer.Serialize(without, StatusIpcJsonContext.Default.AgentStatusDto);
 
-        await Assert.That(json).EndsWith(""","has_terminal":true,"title":"t","transcript_path":"/home/u/.claude/projects/-repo/abc.jsonl"}""");
-        await Assert.That(jsonNull).EndsWith(""","has_terminal":true,"title":"t","transcript_path":null}""");
+        await Assert.That(json).EndsWith(""","has_terminal":true,"title":"t","transcript_path":"/home/u/.claude/projects/-repo/abc.jsonl","worktree_path":null,"work_location":null,"borrowed_from":null}""");
+        await Assert.That(jsonNull).EndsWith(""","has_terminal":true,"title":"t","transcript_path":null,"worktree_path":null,"work_location":null,"borrowed_from":null}""");
     }
 
     [Test]
@@ -122,5 +122,41 @@ public class StatusIpcJsonTests {
         var back = JsonSerializer.Deserialize(stripped, StatusIpcJsonContext.Default.AgentStatusDto);
 
         await Assert.That(back!.TranscriptPath).IsNull();
+    }
+
+    /// The checkout trio is one wire unit: a borrowed reviewer names the checkout it borrowed, and
+    /// every value is emitted even when null so an older client reads absence, never a missing key.
+    [Test]
+    public async Task Checkout_members_serialize_last_and_nulls_are_emitted() {
+        var borrowed = new AgentStatusDto(
+            "r1", "review-flow", "codex", "/repo", "Running",
+            null, null, null, new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc), null, null,
+            HasTerminal: true, Title: "t", TranscriptPath: "/x.jsonl",
+            WorktreePath: "/repo/.capacitor/worktrees/agent-1", WorkLocation: "borrowed",
+            BorrowedFrom: "/repo/.capacitor/worktrees/agent-1");
+        var older = borrowed with { WorktreePath = null, WorkLocation = null, BorrowedFrom = null };
+
+        var json = JsonSerializer.Serialize(borrowed, StatusIpcJsonContext.Default.AgentStatusDto);
+        var jsonNull = JsonSerializer.Serialize(older, StatusIpcJsonContext.Default.AgentStatusDto);
+
+        await Assert.That(json).EndsWith(""","transcript_path":"/x.jsonl","worktree_path":"/repo/.capacitor/worktrees/agent-1","work_location":"borrowed","borrowed_from":"/repo/.capacitor/worktrees/agent-1"}""");
+        await Assert.That(jsonNull).EndsWith(""","transcript_path":"/x.jsonl","worktree_path":null,"work_location":null,"borrowed_from":null}""");
+    }
+
+    [Test]
+    public async Task Old_agent_json_without_checkout_members_deserializes_to_null() {
+        var dto = new AgentStatusDto(
+            "a1", "agent", "claude", "/repo", "Running",
+            null, null, null, DateTime.UtcNow, null, null,
+            WorktreePath: "/repo/.capacitor/worktrees/agent-1", WorkLocation: "owned", BorrowedFrom: "/elsewhere");
+        var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
+        var stripped = System.Text.RegularExpressions.Regex.Replace(
+            json, ",\"(worktree_path|work_location|borrowed_from)\":[^,}]+", "");
+
+        var back = JsonSerializer.Deserialize(stripped, StatusIpcJsonContext.Default.AgentStatusDto);
+
+        await Assert.That(back!.WorktreePath).IsNull();
+        await Assert.That(back.WorkLocation).IsNull();
+        await Assert.That(back.BorrowedFrom).IsNull();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
@@ -291,4 +291,74 @@ public class AgentStatusSnapshotTests {
             await fixture.CleanupAsync();
         }
     }
+
+    /// Pins the wire's checkout trio: repo_path is the repository behind whatever the agent runs
+    /// in, worktree_path the checkout root it runs in, borrowed_from the checkout a reviewer
+    /// borrowed. The fake layout is a linked worktree whose .git file points into the main
+    /// repository, so resolution must read it rather than trust any path shape.
+    [Test]
+    public async Task Snapshot_names_the_repository_and_checkout_for_owned_and_borrowed_agents() {
+        using var tmp = new TempDir();
+        string repo = tmp.CreateDir("eventuous");
+        tmp.CreateDir("eventuous", ".git", "worktrees", "agent-1");
+        string worktree = tmp.CreateDir("eventuous", ".capacitor", "worktrees", "agent-1");
+        tmp.CreateFile(["eventuous", ".capacitor", "worktrees", "agent-1", ".git"],
+            $"gitdir: {Path.Combine(repo, ".git", "worktrees", "agent-1")}\n");
+        string snapshot = tmp.CreateDir("snapshots", "borrowed-1");
+
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            orch.SeedAgentForTest("primary", worktree: new WorktreeInfo(worktree, "capacitor/agent-1", repo));
+            orch.SeedAgentForTest("direct", kind: LaunchKind.ReviewFlow,
+                worktree: WorktreeInfo.Borrowed(worktree), work: WorkLocation.BorrowedCwd);
+            orch.SeedAgentForTest("snapshot", kind: LaunchKind.ReviewFlow,
+                worktree: new WorktreeInfo(snapshot, "", worktree, IsStandalone: true, SnapshotRoot: snapshot),
+                borrowedSnapshotSource: worktree);
+
+            var byId = orch.SnapshotAgentsForStatus().ToDictionary(a => a.Id);
+
+            foreach (var id in (string[])["primary", "direct", "snapshot"])
+                await Assert.That(byId[id].RepoPath).IsEqualTo(repo);
+
+            await Assert.That(byId["primary"].WorktreePath).IsEqualTo(worktree);
+            await Assert.That(byId["primary"].WorkLocation).IsEqualTo("owned");
+            await Assert.That(byId["primary"].BorrowedFrom).IsNull();
+
+            await Assert.That(byId["direct"].WorktreePath).IsEqualTo(worktree);
+            await Assert.That(byId["direct"].WorkLocation).IsEqualTo("borrowed");
+            await Assert.That(byId["direct"].BorrowedFrom).IsEqualTo(worktree);
+
+            await Assert.That(byId["snapshot"].WorktreePath).IsEqualTo(snapshot);
+            await Assert.That(byId["snapshot"].WorkLocation).IsEqualTo("borrowed");
+            await Assert.That(byId["snapshot"].BorrowedFrom).IsEqualTo(worktree);
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
+
+    /// A borrowed cwd can sit below the checkout root; the wire names the root, so the reviewer
+    /// lands on the same node as the session that runs at that root.
+    [Test]
+    public async Task A_borrowed_subdirectory_reports_its_checkout_root() {
+        using var tmp = new TempDir();
+        string repo = tmp.CreateDir("eventuous");
+        tmp.CreateDir("eventuous", ".git");
+        string nested = tmp.CreateDir("eventuous", "src", "Core");
+
+        var fixture = Build();
+        var orch    = fixture.Orchestrator;
+        try {
+            orch.SeedAgentForTest("r1", kind: LaunchKind.ReviewFlow,
+                worktree: WorktreeInfo.Borrowed(nested), work: WorkLocation.BorrowedCwd);
+
+            var dto = orch.SnapshotAgentsForStatus().Single();
+
+            await Assert.That(dto.RepoPath).IsEqualTo(repo);
+            await Assert.That(dto.WorktreePath).IsEqualTo(repo);
+            await Assert.That(dto.BorrowedFrom).IsEqualTo(repo);
+        } finally {
+            await fixture.CleanupAsync();
+        }
+    }
 }


### PR DESCRIPTION
AI-2320 — no GitHub issue exists for this one; the Linear issue is the only tracker entry.

## What & why

`repo_path` carried two conventions — a primary's repository, a borrowed reviewer's worktree — so the rail filed a reviewer one group away from the session it reviews, with nothing on the wire saying they share a checkout. Three trailing nullable members now say which is which: `worktree_path`, `work_location`, `borrowed_from`, and `repo_path` is the repository for every agent, resolved on the daemon. The rail keys worktree nodes on `borrowed_from` first, so a snapshot reviewer files under the checkout it reviews, and the header subtitle reads `eventuous / agent-6da28a8cb8e94a · borrowed`.

## Where to look

`AgentCheckout.Resolve` is the one source of the three values. `RepoLabel.Leaf` drops the `.claude`/`.capacitor` tail guess; the consent prompt and activity log label a launch request's path, which carries no repository, so they show that checkout's own leaf.

## Verification

- Core 2583, App 1279, Daemon 2937 tests run. Remaining failures: one attach-client and one metrics test that pass when run alone, and the codex schema pin against the installed codex 0.152.1 (pinned 0.147.0).
- `dotnet publish -c Release`: no IL2026/IL3050.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
