### PR TITLE
[AI-2403] Say "harnesses", not "agents", in the setup flow output

### DIFF
--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunMachineReport.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunMachineReport.cs
@@ -78,7 +78,7 @@ public sealed record FirstRunMachineReport(
     /// <para><b>And reports nothing at all when it fails</b> — not an empty harness map, which the
     /// server cannot tell from a machine that was probed and found bare. The login-shell answer goes
     /// with it, because it is what keeps the server's <c>ReadFacts</c> from recording the block: a
-    /// crash rendered on the consent screen as "no coding harnesses were found" is a failure reported as
+    /// crash rendered on the consent screen as "no harnesses were found" is a failure reported as
     /// a result.</para>
     /// </summary>
     public static FirstRunMachineReport EvaluateCurrent(

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunMachineReport.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunMachineReport.cs
@@ -78,7 +78,7 @@ public sealed record FirstRunMachineReport(
     /// <para><b>And reports nothing at all when it fails</b> — not an empty harness map, which the
     /// server cannot tell from a machine that was probed and found bare. The login-shell answer goes
     /// with it, because it is what keeps the server's <c>ReadFacts</c> from recording the block: a
-    /// crash rendered on the consent screen as "no coding agents were found" is a failure reported as
+    /// crash rendered on the consent screen as "no coding harnesses were found" is a failure reported as
     /// a result.</para>
     /// </summary>
     public static FirstRunMachineReport EvaluateCurrent(

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -116,7 +116,7 @@ sessions are captured.
 
 Once you are signed in, on a server that offers browser setup kcap creates a
 setup link, opens your browser on it, and waits while you work through the
-screens there. It reports the coding agents it found on this machine — which
+screens there. It reports the coding harnesses it found on this machine — which
 ones are on your PATH, which have config on disk, which kcap is already wired
 into, and whether your login shell can find kcap — since only the machine can
 know that, and on a device-code sign-in the browser is a different box. The

--- a/src/Capacitor.Cli.Core/Resources/help-setup.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-setup.txt
@@ -116,7 +116,7 @@ sessions are captured.
 
 Once you are signed in, on a server that offers browser setup kcap creates a
 setup link, opens your browser on it, and waits while you work through the
-screens there. It reports the coding harnesses it found on this machine — which
+screens there. It reports the harnesses it found on this machine — which
 ones are on your PATH, which have config on disk, which kcap is already wired
 into, and whether your login shell can find kcap — since only the machine can
 know that, and on a device-code sign-in the browser is a different box. The

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -7,7 +7,7 @@ using Spectre.Console;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Pure logic for the "coding harnesses" step of <c>kcap setup</c>. All I/O
+/// Pure logic for the "harnesses" step of <c>kcap setup</c>. All I/O
 /// (filesystem, console, prompts) flows through injected delegates so tests
 /// can drive every branch without touching ~/.claude, ~/.codex, or AnsiConsole.
 /// </summary>

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -7,7 +7,7 @@ using Spectre.Console;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Pure logic for the "coding agents" step of <c>kcap setup</c>. All I/O
+/// Pure logic for the "coding harnesses" step of <c>kcap setup</c>. All I/O
 /// (filesystem, console, prompts) flows through injected delegates so tests
 /// can drive every branch without touching ~/.claude, ~/.codex, or AnsiConsole.
 /// </summary>

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -180,7 +180,7 @@ sealed class SpectreFirstRunFlowProgress(IKeyWatcher? keys = null) : IFirstRunFl
             ? Unreachable
             : step switch {
                 FirstRunFlowStep.SignIn => "Waiting for you to sign in",
-                FirstRunFlowStep.Agents => "Choose your coding harnesses in the browser",
+                FirstRunFlowStep.Agents => "Choose your harnesses in the browser",
                 FirstRunFlowStep.Import => "Choose what to import in the browser",
                 FirstRunFlowStep.Done   => "Finishing up in the browser",
                 _                       => "Waiting on the browser"
@@ -596,9 +596,9 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
 
         await Console.Out.WriteLineAsync();
 
-        // Step 4: Coding harnesses
-        AnsiConsole.Write(new Rule("[yellow]Step 4/6 — Coding harnesses[/]").LeftJustified());
-        await Console.Out.WriteLineAsync("  Capacitor records sessions by installing hooks into your coding harnesses.");
+        // Step 4: Harnesses
+        AnsiConsole.Write(new Rule("[yellow]Step 4/6 — Harnesses[/]").LeftJustified());
+        await Console.Out.WriteLineAsync("  Capacitor records sessions by installing hooks into your harnesses.");
         await Console.Out.WriteLineAsync();
 
         var pluginPath = ResolvePluginPath();
@@ -623,7 +623,7 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
         var detectedSummary = SetupDecisions.DetectedAgentsSummary(detected);
 
         if (detectedSummary is not null)
-            await Console.Out.WriteLineAsync($"  Detected coding harnesses: {detectedSummary}");
+            await Console.Out.WriteLineAsync($"  Detected harnesses: {detectedSummary}");
 
         bool installAgents;
 
@@ -1471,7 +1471,7 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
                 // Said out loud because it is the one part of this leg that takes noticeable time: the
                 // login-shell probe spawns a shell, and a slow profile would otherwise be dead air
                 // ahead of the only line that explains what is happening.
-                AnsiConsole.MarkupLine("  [dim]Checking this machine for coding harnesses…[/]");
+                AnsiConsole.MarkupLine("  [dim]Checking this machine for harnesses…[/]");
 
                 var report = FirstRunMachineReport.EvaluateCurrent(
                     config, HarnessRegistry.FromEnvironment(home),

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -180,7 +180,7 @@ sealed class SpectreFirstRunFlowProgress(IKeyWatcher? keys = null) : IFirstRunFl
             ? Unreachable
             : step switch {
                 FirstRunFlowStep.SignIn => "Waiting for you to sign in",
-                FirstRunFlowStep.Agents => "Choose your coding agents in the browser",
+                FirstRunFlowStep.Agents => "Choose your coding harnesses in the browser",
                 FirstRunFlowStep.Import => "Choose what to import in the browser",
                 FirstRunFlowStep.Done   => "Finishing up in the browser",
                 _                       => "Waiting on the browser"
@@ -596,9 +596,9 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
 
         await Console.Out.WriteLineAsync();
 
-        // Step 4: Coding agents
-        AnsiConsole.Write(new Rule("[yellow]Step 4/6 — Coding agents[/]").LeftJustified());
-        await Console.Out.WriteLineAsync("  Capacitor records sessions by installing hooks into your coding agent CLIs.");
+        // Step 4: Coding harnesses
+        AnsiConsole.Write(new Rule("[yellow]Step 4/6 — Coding harnesses[/]").LeftJustified());
+        await Console.Out.WriteLineAsync("  Capacitor records sessions by installing hooks into your coding harnesses.");
         await Console.Out.WriteLineAsync();
 
         var pluginPath = ResolvePluginPath();
@@ -623,7 +623,7 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
         var detectedSummary = SetupDecisions.DetectedAgentsSummary(detected);
 
         if (detectedSummary is not null)
-            await Console.Out.WriteLineAsync($"  Detected coding agents: {detectedSummary}");
+            await Console.Out.WriteLineAsync($"  Detected coding harnesses: {detectedSummary}");
 
         bool installAgents;
 
@@ -1471,7 +1471,7 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
                 // Said out loud because it is the one part of this leg that takes noticeable time: the
                 // login-shell probe spawns a shell, and a slow profile would otherwise be dead air
                 // ahead of the only line that explains what is happening.
-                AnsiConsole.MarkupLine("  [dim]Checking this machine for coding agents…[/]");
+                AnsiConsole.MarkupLine("  [dim]Checking this machine for coding harnesses…[/]");
 
                 var report = FirstRunMachineReport.EvaluateCurrent(
                     config, HarnessRegistry.FromEnvironment(home),

--- a/src/Capacitor.Cli/Commands/SetupDecisions.cs
+++ b/src/Capacitor.Cli/Commands/SetupDecisions.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core.Harness;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Pure decision helpers for <c>kcap setup</c>'s Step 4 (coding agents). Kept separate from
+/// Pure decision helpers for <c>kcap setup</c>'s Step 4 (coding harnesses). Kept separate from
 /// <see cref="CodingAgentsStep"/> so <c>SetupCommand</c>'s consent logic — building the
 /// detected-agent summary and deciding whether to install at all — is unit-testable without
 /// touching any installer delegate, filesystem, or console.

--- a/src/Capacitor.Cli/Commands/SetupDecisions.cs
+++ b/src/Capacitor.Cli/Commands/SetupDecisions.cs
@@ -4,7 +4,7 @@ using Capacitor.Cli.Core.Harness;
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Pure decision helpers for <c>kcap setup</c>'s Step 4 (coding harnesses). Kept separate from
+/// Pure decision helpers for <c>kcap setup</c>'s Step 4 (harnesses). Kept separate from
 /// <see cref="CodingAgentsStep"/> so <c>SetupCommand</c>'s consent logic — building the
 /// detected-agent summary and deciding whether to install at all — is unit-testable without
 /// touching any installer delegate, filesystem, or console.


### PR DESCRIPTION
## What & why

The setup flow's terminal output calls the tools it finds on the machine "coding agents", while the flow's own registry, create payload and filesystem layout all call them harnesses. The browser half of the same flow says harnesses too, so the two sides of one flow disagreed on the noun. This settles it on harness in the setup output and its help text.

## Where to look

Only the strings that name the tools installed on the machine change. "Agent" is doing two other jobs in this CLI and both keep the word: the daemon's hosted agents (`daemon.max_agents`, `--max-agents`, `kcap agent`), and the agent as the thing you prompt — the guided-tour line still reads "Prompt … in your coding agent", because you prompt the agent, not the harness.

## Verification

`dotnet build src/Capacitor.Cli` → 0 warnings, 0 errors. No test asserts on any of these strings (grepped `test/` for each), so nothing needed updating alongside.
