### PR TITLE
Report a broken import run instead of staying silent

### DIFF
--- a/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
@@ -426,7 +426,7 @@ public sealed class BrowserFirstRunFlow(
         if (FirstRunFlowOutcomes.Import(view) is not { } answer) {
             if (view.ImportDecidedAt is { } unreadable && state.ImportedThrough != unreadable) {
                 state.ImportedThrough = unreadable;
-                state.Outcome        = Refusal(unreadable, FirstRunImportOutcomeReasons.DecisionUnreadable);
+                state.Outcome        = ReasonOnly(unreadable, FirstRunImportOutcomeReasons.DecisionUnreadable);
 
                 await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
             }
@@ -449,7 +449,7 @@ public sealed class BrowserFirstRunFlow(
         if (answer.Choices.Count == 0) {
             state.Outcome = answer.IsDecline
                 ? Outcome(answer.DecidedAt, default, null)
-                : Refusal(answer.DecidedAt, FirstRunImportOutcomeReasons.DecisionUnreadable);
+                : ReasonOnly(answer.DecidedAt, FirstRunImportOutcomeReasons.DecisionUnreadable);
 
             await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
 
@@ -459,7 +459,7 @@ public sealed class BrowserFirstRunFlow(
         // Nothing to scan, so nothing to run. Reported as a refusal rather than as three zeroes, which
         // is what a clean import over an already-loaded history also looks like.
         if (answer.NoReadableVendors) {
-            state.Outcome = Refusal(answer.DecidedAt, FirstRunImportOutcomeReasons.NoReadableAgents);
+            state.Outcome = ReasonOnly(answer.DecidedAt, FirstRunImportOutcomeReasons.NoReadableAgents);
 
             await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
 
@@ -488,7 +488,7 @@ public sealed class BrowserFirstRunFlow(
         // reads exactly like a machine that died, and the browser waits that out before saying anything.
         state.Outcome = moved is { } totals
             ? Outcome(answer.DecidedAt, totals, null)
-            : Refusal(answer.DecidedAt, FirstRunImportOutcomeReasons.RunFailed);
+            : ReasonOnly(answer.DecidedAt, FirstRunImportOutcomeReasons.RunFailed);
 
         await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
 
@@ -506,10 +506,11 @@ public sealed class BrowserFirstRunFlow(
             Reason    = reason
         };
 
-    /// <summary>A refusal: three zeroes and a token. The server rejects the report outright if a reason
-    /// arrives on counts that moved something, so the zeroes are part of the contract rather than a
-    /// convenience.</summary>
-    static ReportFirstRunImportOutcomeRequest Refusal(DateTimeOffset decidedAt, string reason) =>
+    /// <summary>A token and no figures. The server rejects the report outright if a reason arrives on
+    /// counts that moved something, so the zeroes are the wire's requirement — on
+    /// <see cref="FirstRunImportOutcomeReasons.RunFailed"/> they are not a claim that nothing
+    /// landed.</summary>
+    static ReportFirstRunImportOutcomeRequest ReasonOnly(DateTimeOffset decidedAt, string reason) =>
         Outcome(decidedAt, default, reason);
 
     /// <summary>Hands over the owed outcome, keeping it for a later tick unless the server took it.</summary>

--- a/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
@@ -483,13 +483,14 @@ public sealed class BrowserFirstRunFlow(
             progress.ImportEnded();
         }
 
-        // Nothing is sent for a run that lost a pass. Its sessions are unaccounted, and three counts
-        // cannot say so — the surviving pass's figures alone would report a clean import.
-        if (moved is { } totals) {
-            state.Outcome = Outcome(answer.DecidedAt, totals, null);
+        // A run that lost a pass reports the token, not its counts: its sessions are unaccounted, and the
+        // surviving pass's figures alone would state a clean import. Silence is not available either — it
+        // reads exactly like a machine that died, and the browser waits that out before saying anything.
+        state.Outcome = moved is { } totals
+            ? Outcome(answer.DecidedAt, totals, null)
+            : Refusal(answer.DecidedAt, FirstRunImportOutcomeReasons.RunFailed);
 
-            await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
-        }
+        await DeliverOutcomeAsync(serverUrl, flowId, state, ct);
 
         return _clock.GetUtcNow() - began;
     }

--- a/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/BrowserFirstRunFlow.cs
@@ -507,7 +507,7 @@ public sealed class BrowserFirstRunFlow(
         };
 
     /// <summary>A token and no figures. The server rejects the report outright if a reason arrives on
-    /// counts that moved something, so the zeroes are the wire's requirement — on
+    /// non-zero counts, so the zeroes are the wire's requirement — on
     /// <see cref="FirstRunImportOutcomeReasons.RunFailed"/> they are not a claim that nothing
     /// landed.</summary>
     static ReportFirstRunImportOutcomeRequest ReasonOnly(DateTimeOffset decidedAt, string reason) =>

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowModels.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunFlowModels.cs
@@ -114,8 +114,8 @@ public sealed record ReportFirstRunImportOutcomeRequest {
     [JsonPropertyName("skipped")]  public required int Skipped  { get; init; }
     [JsonPropertyName("failed")]   public required int Failed   { get; init; }
 
-    /// <summary>A <see cref="FirstRunImportOutcomeReasons"/> token, and only on a run that moved
-    /// nothing — the server rejects the whole report otherwise.</summary>
+    /// <summary>A <see cref="FirstRunImportOutcomeReasons"/> token, and only alongside three zeroes —
+    /// the server rejects the whole report otherwise.</summary>
     [JsonPropertyName("reason")] public string? Reason { get; init; }
 }
 

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunImportOutcome.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunImportOutcome.cs
@@ -19,7 +19,11 @@ public static class FirstRunImportOutcomeReasons {
     /// polling again.</summary>
     public const string DecisionUnreadable = "decision_unreadable";
 
-    public static readonly IReadOnlyList<string> All = [NoReadableAgents, DecisionUnreadable];
+    /// <summary>A pass was lost, so the run's counts are unaccounted. Three zeroes rather than a partial
+    /// tally: the passes that did survive would otherwise read as a clean import.</summary>
+    public const string RunFailed = "run_failed";
+
+    public static readonly IReadOnlyList<string> All = [NoReadableAgents, DecisionUnreadable, RunFailed];
 
     public static bool IsKnown(string? reason) =>
         reason is not null && All.Contains(reason, StringComparer.Ordinal);

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunImportOutcome.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunImportOutcome.cs
@@ -5,9 +5,9 @@ namespace Capacitor.Cli.Core.FirstRun;
 /// already-loaded history looks like, so this is what separates a coded ending from a no-op — and
 /// <see cref="RunFailed"/> from the two that really did leave the history alone.
 ///
-/// <para><b>The server's closed set, spelled once.</b> It rejects a token it does not know and rejects
-/// any token at all on an outcome that moved something, so a second spelling here is a silent wire
-/// break rather than a rejected field.</para>
+/// <para><b>The server's closed set, spelled once.</b> It rejects a token it does not know, and any
+/// token that arrives on non-zero counts, so a second spelling here is a silent wire break rather than
+/// a rejected field.</para>
 /// </summary>
 public static class FirstRunImportOutcomeReasons {
     /// <summary>Repositories were chosen and no vendor on this machine could be read for them. The one

--- a/src/Capacitor.Cli.Core/FirstRun/FirstRunImportOutcome.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/FirstRunImportOutcome.cs
@@ -1,8 +1,9 @@
 namespace Capacitor.Cli.Core.FirstRun;
 
 /// <summary>
-/// Why an import moved nothing, as a coded token. Three zeroes are also what a clean run over an
-/// already-loaded history looks like, so this is what separates a refusal from a no-op.
+/// Why an import reported no figures, as a coded token. Three zeroes are also what a clean run over an
+/// already-loaded history looks like, so this is what separates a coded ending from a no-op — and
+/// <see cref="RunFailed"/> from the two that really did leave the history alone.
 ///
 /// <para><b>The server's closed set, spelled once.</b> It rejects a token it does not know and rejects
 /// any token at all on an outcome that moved something, so a second spelling here is a silent wire
@@ -19,8 +20,10 @@ public static class FirstRunImportOutcomeReasons {
     /// polling again.</summary>
     public const string DecisionUnreadable = "decision_unreadable";
 
-    /// <summary>A pass was lost, so the run's counts are unaccounted. Three zeroes rather than a partial
-    /// tally: the passes that did survive would otherwise read as a clean import.</summary>
+    /// <summary>A pass was lost, so the run's counts are unaccounted. <b>A failure, where the other two
+    /// are refusals</b>: sessions may well have landed, and the three zeroes are the wire's requirement
+    /// rather than a claim the history was left alone — a surviving pass's figures on their own would
+    /// read as a clean import.</summary>
     public const string RunFailed = "run_failed";
 
     public static readonly IReadOnlyList<string> All = [NoReadableAgents, DecisionUnreadable, RunFailed];

--- a/src/Capacitor.Cli.Core/FirstRun/IFirstRunImportLane.cs
+++ b/src/Capacitor.Cli.Core/FirstRun/IFirstRunImportLane.cs
@@ -42,7 +42,8 @@ public interface IFirstRunImportLane {
     /// <para>Null is not <c>(0,0,0)</c>, and the difference is the point: the sessions that pass was
     /// uploading are unaccounted, and there is no way to say "some unknown number failed" in three
     /// counts. Reporting the surviving pass's figures alone would state a clean import over a run that
-    /// lost one, so the caller sends nothing and the screen keeps saying it cannot tell.</para>
+    /// lost one, so the caller reports <see cref="FirstRunImportOutcomeReasons.RunFailed"/> on three
+    /// zeroes instead.</para>
     /// </returns>
     Task<FirstRunImportTotals?> ImportAsync(FirstRunImportAnswer answer, DateOnly today, CancellationToken ct);
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
@@ -274,8 +274,8 @@ public class BrowserFirstRunFlowTests {
 
         public List<DateOnly> Dates { get; } = [];
 
-        /// <summary>What the run reports. Null models a run that lost a pass, which must be reported as
-        /// nothing rather than as a clean zero.</summary>
+        /// <summary>What the run reports. Null models a run that lost a pass, whose counts are
+        /// unaccounted rather than zero.</summary>
         public FirstRunImportTotals? Moved { get; set; } = new(3, 1, 0);
 
         public Task<FirstRunImportTotals?> ImportAsync(
@@ -1570,10 +1570,13 @@ public class BrowserFirstRunFlowTests {
         await Assert.That(sent.Reason).IsNull().Because("nothing was refused; nothing was asked for");
     }
 
+    /// <summary>
+    /// A lost pass reports the token, not the figures: its sessions are unaccounted, three counts cannot
+    /// say so, and the surviving pass's numbers alone would state a clean import. What it must not do is
+    /// stay silent — that reads exactly like a machine that died, which the browser waits out.
+    /// </summary>
     [Test]
-    public async Task Reports_nothing_for_a_run_that_lost_a_pass() {
-        // Its sessions are unaccounted and three counts cannot say so. Reporting the surviving figures
-        // would state a clean import over a run that dropped one.
+    public async Task Reports_a_token_and_no_figures_for_a_run_that_lost_a_pass() {
         var h = Build(importing: true);
         h.Importing!.Moved = null;
         h.Channel.Polls.Enqueue(new(200, ImportAnswered()));
@@ -1582,7 +1585,12 @@ public class BrowserFirstRunFlowTests {
         await Run(h);
 
         await Assert.That(h.Importing.Imports).HasSingleItem().Because("the run still happened");
-        await Assert.That(h.Channel.OutcomeReports).IsEmpty();
+
+        var sent = h.Channel.OutcomeReports.Single();
+
+        await Assert.That(sent.Reason).IsEqualTo(FirstRunImportOutcomeReasons.RunFailed);
+        await Assert.That((sent.Imported, sent.Skipped, sent.Failed)).IsEqualTo((0, 0, 0))
+                    .Because("a partial tally would put a measured-looking zero where nobody measured");
     }
 
     [Test]
@@ -1735,6 +1743,10 @@ public class BrowserFirstRunFlowTests {
 
         await Assert.That(result).IsTypeOf<FirstRunFlowResult.Finished>();
         await Assert.That(h.Progress.ImportEnds).IsEqualTo(1).Because("the wait has to reopen either way");
+
+        // A throw is as unaccounted as a lost pass, and just as unavailable to report as silence.
+        await Assert.That(h.Channel.OutcomeReports.Single().Reason)
+                    .IsEqualTo(FirstRunImportOutcomeReasons.RunFailed);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/FirstRun/BrowserFirstRunFlowTests.cs
@@ -1570,11 +1570,8 @@ public class BrowserFirstRunFlowTests {
         await Assert.That(sent.Reason).IsNull().Because("nothing was refused; nothing was asked for");
     }
 
-    /// <summary>
-    /// A lost pass reports the token, not the figures: its sessions are unaccounted, three counts cannot
-    /// say so, and the surviving pass's numbers alone would state a clean import. What it must not do is
-    /// stay silent — that reads exactly like a machine that died, which the browser waits out.
-    /// </summary>
+    /// <summary>Pins the wire literal, not the constant: a mistyped token would keep a constant-to-constant
+    /// compare green while the server rejected every report.</summary>
     [Test]
     public async Task Reports_a_token_and_no_figures_for_a_run_that_lost_a_pass() {
         var h = Build(importing: true);
@@ -1588,7 +1585,7 @@ public class BrowserFirstRunFlowTests {
 
         var sent = h.Channel.OutcomeReports.Single();
 
-        await Assert.That(sent.Reason).IsEqualTo(FirstRunImportOutcomeReasons.RunFailed);
+        await Assert.That(sent.Reason).IsEqualTo("run_failed");
         await Assert.That((sent.Imported, sent.Skipped, sent.Failed)).IsEqualTo((0, 0, 0))
                     .Because("a partial tally would put a measured-looking zero where nobody measured");
     }


### PR DESCRIPTION
AI-2405 - https://github.com/kurrent-io/kcap-cli/pull/749#pullrequestreview-5103814406

## What & why

The browser's Done screen waits for the machine's word rather than inferring an ending from the figures, so an import whose pass threw has to say so. It reports three zeros and the `run_failed` token: three counts cannot express "some unknown number is unaccounted", and the surviving pass's figures alone would state a clean import.

## Where to look

Silence is the one option not available — it reads identically to a machine that died, which is a different ending, with different copy and half an hour of waiting between them. Partial counts are worse than zeros: the lost pass's skipped and failed are unknown and the route requires all three, so they would put a measured-looking zero where nobody measured.

`run_failed` is the one token that is not a refusal — sessions may have landed behind its zeros — so the token vocabulary and the lane's contract name it a failure, and copy saying the history was left alone is wrong for it. It also needs the server to know the token before this ships: reversed, the store refuses the report and the retry re-sends it every tick until the budget runs out.

## Verification

`Capacitor.Cli.Core.Tests.Unit` → 2583 passed.

The throwing path pins the wire literal `"run_failed"` and three zero counts; mutating the constant to `run_faled` fails that assertion.
