### PR TITLE
Fold consecutive tool calls into one expandable group in the Chat tab

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -471,6 +471,26 @@ what bounds the outgoing resolve frame by arithmetic. An unparseable or oversize
 back to the permission card (Allow = let the TUI ask) with "Allow always" hidden for the
 question tool.
 
+## Compact tool calls in the Chat tab
+
+**AI-2418** (spec: `docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md`) folds a
+run of consecutive tool calls into one `ToolGroupItem` row: settled calls collapse to a summary line
+("Read files, ran a command"), live calls stay listed beneath it, and any prose (user turn, assistant
+text, system note) closes the run. **The fold is uniform** — a lone settled call still reads "Ran a
+command" — and **folding never hides an error**: a failed call inside a folded group puts the danger
+`✕` on the summary line. The group binds ONE inner list whose source swaps on toggle, because a
+hidden `ItemsControl` keeps its containers; expanding a group realizes every row and folding releases
+them. Expanding holds follow-tail once, so the clicked summary stays in view. Summary wording keys on
+the transcript's tool name (Codex's rollout says `shell`, its hook says `Bash`), with Codex shell
+commands classified by `CodexCommandClassifier`, ported verbatim from the server into Core so the
+server can delete its copy on the next submodule bump. A row waiting on a permission shows an accent
+`?` in the outcome slot: `PermissionPendingDto` gains an optional `tool_use_id` the daemon reads from
+the hook body (Claude's PermissionRequest hook carries it; Codex's deliberately does not), and the
+view-model recomputes the marks from pending requests and running calls on every change, diffing
+against the last marks so a call that settles while its request is still pending is cleared rather
+than masked by its `✓`. A request without an id marks the agent's sole running call and abstains
+when two or more are running.
+
 ## Launch and stop command routing
 
 The receive pump no longer awaits launch/stop EXECUTION for either command format: arrival order is

--- a/docs/superpowers/plans/2026-09-02-ai2418-compact-tool-calls.md
+++ b/docs/superpowers/plans/2026-09-02-ai2418-compact-tool-calls.md
@@ -1,0 +1,1560 @@
+# Compact tool calls in the Chat tab (AI-2418) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fold consecutive completed tool calls in the desktop Chat tab into one expandable summary line, keep live calls visible, and mark a row that is waiting on a permission.
+
+**Architecture:** A new `ToolGroupItem` row holds a run of `ToolCallItem`s; `ChatTabViewModel.Apply` appends calls to the trailing group and any prose closes it. Summary wording comes from a per-call `ToolCategory` fixed at creation, with Codex shell commands classified by `CodexCommandClassifier`, ported from the server into Core. The permission wire gains an optional `tool_use_id` the daemon reads from the hook body; the view-model recomputes "awaiting permission" marks from pending requests and running calls on every change.
+
+**Tech Stack:** .NET 10, Avalonia 12 (headless tests), ReactiveUI, DynamicData, TUnit on Microsoft Testing Platform, System.Text.Json source-gen.
+
+**Spec:** `docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md`
+
+## Global Constraints
+
+- Comments: scarce, no ticket ids, no change narration, no design coordinates (CLAUDE.md "Comments"). A ported file keeps its code verbatim but loses comment lines that violate this.
+- Commit subjects: one imperative clause, at most 80 characters, no issue reference (none exists yet for AI-2418).
+- Tests: TUnit. Every App test that touches the dispatcher runs under `RunOnUiAsync` and carries `[NotInParallel("AvaloniaSession")]`. Throwaway files come from `[TempDir] public required TempDir Tmp { get; init; }`.
+- Never `Path.Combine(tmp.Path, …)`; use `Tmp.CreateFile(...)` / `Tmp.PathTo(...)`.
+- Use `JsonElementExtensions` (`Str`, `Arr`, `Obj`, `IsObject`) instead of checking `ValueKind` by hand where one exists.
+- Wire: `PermissionPendingDto` is JSON snake_case via `PermissionIpcJsonContext`; a missing member decodes to null. `FrameType` values are never touched.
+- `dotnet build` does not surface AOT warnings; the final task runs `dotnet publish -c Release` and greps `IL[23][01][0-9]{2}`.
+- Run one suite: `dotnet run --project test/<Suite>/<Suite>.csproj -- --treenode-filter '/*/*/<ClassName>/*'`.
+- The server checkout for the port is `/Users/alexey/dev/temp/kcap-server`; copy, never edit it.
+
+---
+
+## File structure
+
+| File | Responsibility |
+|---|---|
+| `src/Capacitor.Cli.Core/Harness/Codex/CodexCommandClassifier.cs` (create) | Verbatim port of the server's Codex `parse_command` classifier: `CodexCommandHint`, `CodexCommandClassifier.Classify`, internal `ShellTokenizer`. |
+| `test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs` (create) | The server's pure `Classify` tests, namespace changed. |
+| `src/Capacitor.Cli.Core/LocalIpc/PermissionIpc.cs` (modify) | `PermissionPendingDto.ToolUseId`, `PermissionWire.MaxToolUseIdBytes`. |
+| `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/PermissionWireContractsTests.cs` (modify) | Round-trip, absence, worst-case frame with the new field. |
+| `src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs` (modify) | `BuildPending` takes the hook body's `tool_use_id`, capped. |
+| `test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalPermissionBridgeInteractiveTests.cs` (modify) | Bounds and the end-to-end hook-body case. |
+| `src/Capacitor.App/Services/IPermissionService.cs` (modify) | `PendingPermissionRequest.ToolUseId`. |
+| `src/Capacitor.App/ViewModels/ToolSummary.cs` (create) | `ToolCategory`, the name map, `Categorize`, `Describe`. |
+| `test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs` (create) | Pure tests for the above. |
+| `src/Capacitor.App/ViewModels/ChatItems.cs` (modify) | `ToolCallItem` gains `Category`, `IsAwaitingPermission`, `IsSettled`; new `ToolGroupItem`. |
+| `test/Capacitor.App.Tests.Unit/ToolGroupItemTests.cs` (create) | Group behaviour in isolation. |
+| `src/Capacitor.App/ViewModels/ChatTabViewModel.cs` (modify) | `_openGroup` grouping; `_requests`/`_marked`/`Reconcile()`. |
+| `test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs` (modify) | Grouping, folding, marking. |
+| `test/Capacitor.App.Tests.Unit/FakePermissionService.cs` (modify) | `PermissionEntries.Entry(toolUseId:)`. |
+| `src/Capacitor.App/Views/ChatTabView.axaml` (modify) | `ToolGroupItem` template. |
+| `src/Capacitor.App/Views/ChatTabView.axaml.cs` (modify) | One-shot follow-tail hold on a summary click. |
+| `test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs` (modify) | Rendering, follow-tail, expansion, realization. |
+| `docs/CHANGES.md` (modify) | The feature's section. |
+
+---
+
+### Task 1: Port `CodexCommandClassifier` into Core
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/Harness/Codex/CodexCommandClassifier.cs`
+- Create: `test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs`
+
+**Interfaces:**
+- Produces: `namespace Capacitor.Cli.Core.Harness.Codex` — `public sealed record CodexCommandHint(string Type, string? Path = null, string? Name = null, string? Query = null)`; `public static class CodexCommandClassifier { public static CodexCommandHint? Classify(string? cmd); }`. `Type` is `"read"`, `"search"` or `"list_files"`; null means unknown/unclassifiable.
+
+- [ ] **Step 1: Copy the server's classifier and re-namespace it**
+
+```bash
+cp /Users/alexey/dev/temp/kcap-server/src/Capacitor.Server.Core/CodexCommandClassifier.cs \
+   src/Capacitor.Cli.Core/Harness/Codex/CodexCommandClassifier.cs
+```
+
+Edit line 1 of the new file: `namespace Capacitor;` → `namespace Capacitor.Cli.Core.Harness.Codex;`. Then read the file top to bottom and delete comment lines (only comment lines) that name a ticket (`AI-713` and similar), narrate history ("no longer", "0.5.x rollouts no longer ship…" style), or point at a dashboard; keep comments that describe a trap or a rule the code enforces (the "any-unknown collapses the pipeline" rule, the outer-redirection detection reason, the `bash -lc` peel condition). Do not change code. `ShellTokenizer` stays `internal static`.
+
+- [ ] **Step 2: Copy the pure tests**
+
+```bash
+mkdir -p test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex
+cp /Users/alexey/dev/temp/kcap-server/test/Capacitor.Server.Tests.Chat/CodexCommandClassifierTests.cs \
+   test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs
+```
+
+Edit the copy:
+1. Replace the header (`using Capacitor.Server.TestHelpers.Helpers;` and the namespace line) with:
+
+```csharp
+using Capacitor.Cli.Core.Harness.Codex;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Harness.Codex;
+
+/// Parity pin against the server's copy of the classifier: these cases must pass identically
+/// on both until the server deletes its own.
+public class CodexCommandClassifierTests {
+```
+
+   (delete the original `/// <summary> … </summary>` class comment and the `public class` line it precedes).
+2. Delete the `BuildInv(...)` static helper and every test whose name starts with `EffectiveCodexHint_` or `EffectiveCodexPatch_` (they call server-only `CodexAccessors`). Keep: `Classifies_ReadCommands`, `Classifies_ListFilesCommands`, `Classifies_SearchCommands`, `Classifies_UnknownCommands_AsNull`, `UnwrapsBashLcWrapper`, `Pipeline_WithUnknownStage_FallsBackToUnknown`, `NullOrWhitespace_ReturnsNull`, `HelperStages_DoNotCollapsePipeline`, `DestructiveXargs_CollapsesPipeline`, `DisplayOnlyXargs_KeepsPrimaryClassification`, `Redirections_CollapsePipeline`, `BashLc_OuterSideEffects_CollapsePipeline`, `BashLc_CleanWrapper_StillClassifies`, `QuotedAngleBrackets_StayClassified`, `HelperOnlyPipelines_ReturnNull`.
+3. Strip any `//` comment inside the kept tests that names a ticket or narrates history.
+
+- [ ] **Step 3: Build and run the ported tests**
+
+Run:
+```bash
+dotnet build test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj 2>&1 | tail -3
+dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter '/*/*/CodexCommandClassifierTests/*'
+```
+Expected: build succeeds with 0 warnings from the new file; every kept test passes (the `[Arguments]` rows expand to many cases).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/Harness/Codex/CodexCommandClassifier.cs test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs
+git commit -m "Port the Codex shell command classifier into Core" -m "Verbatim copy of the server's port of Codex's parse_command; the server switches to this copy and deletes its own on the next submodule bump, so the code must not drift."
+```
+
+---
+
+### Task 2: `tool_use_id` on the permission wire
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/PermissionIpc.cs:8-11` (the record) and the `PermissionWire` constants block
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/PermissionWireContractsTests.cs`
+
+**Interfaces:**
+- Produces: `PermissionPendingDto(..., string RequestedAt, string? ToolUseId = null)` serialized as `tool_use_id`; `PermissionWire.MaxToolUseIdBytes = 128`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Add to `PermissionWireContractsTests`:
+
+```csharp
+    [Test]
+    public async Task Pending_dto_carries_an_optional_tool_use_id_and_decodes_without_it() {
+        var dto = new PermissionPendingDto("r1", "a1", "s1", "claude", "Bash", null, null, false, false, "t", "toolu_01ABC");
+        var json = JsonSerializer.Serialize(dto, PermissionIpcJsonContext.Default.PermissionPendingDto);
+        await Assert.That(json).Contains("\"tool_use_id\":\"toolu_01ABC\"");
+        var back = JsonSerializer.Deserialize(json, PermissionIpcJsonContext.Default.PermissionPendingDto)!;
+        await Assert.That(back.ToolUseId).IsEqualTo("toolu_01ABC");
+
+        var older = JsonSerializer.Deserialize(
+            """{"request_id":"r1","agent_id":"a1","session_id":"s1","vendor":"claude","tool_name":"Bash","requested_at":"t"}""",
+            PermissionIpcJsonContext.Default.PermissionPendingDto)!;
+        await Assert.That(older.ToolUseId).IsNull();
+        await Assert.That(PermissionWire.IsPendingStructurallyValid(older)).IsTrue();
+    }
+```
+
+And in `Worst_case_pending_frame_writes_and_reads_under_the_codec_cap`, change the dto line to include a worst-case id:
+
+```csharp
+        var id   = new string('"', PermissionWire.MaxToolUseIdBytes);               // every byte escapes to \"
+        var dto  = new PermissionPendingDto("r1", key, "s1", "claude", name, El(big), El(big), false, false, "t", id);
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet build test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj 2>&1 | grep -E 'error' | head -3`
+Expected: compile errors (no 11-argument constructor, no `MaxToolUseIdBytes`).
+
+- [ ] **Step 3: Add the field and the cap**
+
+In `PermissionIpc.cs`, the record becomes:
+
+```csharp
+public sealed record PermissionPendingDto(
+    string RequestId, string AgentId, string SessionId, string Vendor, string ToolName,
+    JsonElement? ToolInput, JsonElement? Suggestions, bool ToolInputOmitted, bool SuggestionsOmitted,
+    string RequestedAt, string? ToolUseId = null);
+```
+
+In `PermissionWire`, after `MaxAgentIdBytes`:
+
+```csharp
+    public const int MaxToolUseIdBytes = 128;
+```
+
+- [ ] **Step 4: Run the wire tests**
+
+Run: `dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter '/*/*/PermissionWireContractsTests/*'`
+Expected: all pass, including `Empty_object_decodes_to_nulls_and_false_flags` unchanged.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Core/LocalIpc/PermissionIpc.cs test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/PermissionWireContractsTests.cs
+git commit -m "Carry an optional tool-use id on the pending permission frame"
+```
+
+---
+
+### Task 3: The daemon forwards the hook body's `tool_use_id`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs` — the `BuildPending` call at ~line 624 and the method at ~line 694
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalPermissionBridgeInteractiveTests.cs`
+
+**Interfaces:**
+- Consumes: `PermissionPendingDto.ToolUseId`, `PermissionWire.MaxToolUseIdBytes` (Task 2).
+- Produces: `LocalPermissionBridge.BuildPending(string requestId, string agentId, string sessionId, string vendor, string? toolName, JsonElement? toolInput, JsonElement? suggestions, string requestedAt, string? toolUseId = null)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Extend `Build_pending_bounds` with two lines at its end:
+
+```csharp
+        await Assert.That(LocalPermissionBridge.BuildPending("r", "a1", Session, "claude", "Bash", null, null, "t", "toolu_1")!.ToolUseId).IsEqualTo("toolu_1");
+        await Assert.That(LocalPermissionBridge.BuildPending("r", "a1", Session, "claude", "Bash", null, null, "t", new string('i', PermissionWire.MaxToolUseIdBytes + 1))!.ToolUseId).IsNull();
+```
+
+Add an end-to-end test beside `App_claim_first_...`:
+
+```csharp
+    [Test, NotInParallel(nameof(LocalPermissionBridgeInteractiveTests))]
+    public async Task The_hook_bodys_tool_use_id_rides_the_pending_dto() {
+        await using var h = new Harness();
+        h.Server.AwaitScript = (_, ct) => new TaskCompletionSource<PermissionDecision>().Task.WaitAsync(ct);
+        await h.StartAsync();
+
+        var response = h.Client.PostAsync($"{h.Bridge.BaseUrl}/claude/permission-request",
+            JsonContent.Create(new { session_id = Session, tool_name = "Bash", tool_input = new { command = "ls" }, tool_use_id = "toolu_01X", agent_id = "agent-1", cwd = "/repo" }));
+        var pending = await h.WaitPendingAsync();
+        await Assert.That(pending.ToolUseId).IsEqualTo("toolu_01X");
+
+        await Assert.That(h.Broker.TrySettle(pending.RequestId, Allow, "allow", "app")).IsTrue();
+        await Assert.That(await Harness.BehaviorOf(await response)).IsEqualTo("allow");
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet build test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj 2>&1 | grep -E 'error' | head -3`
+Expected: compile error on the 9-argument `BuildPending`.
+
+- [ ] **Step 3: Read and forward the id**
+
+In `LocalPermissionBridge.BuildPending`:
+
+```csharp
+    internal static PermissionPendingDto? BuildPending(
+            string requestId, string agentId, string sessionId, string vendor, string? toolName,
+            JsonElement? toolInput, JsonElement? suggestions, string requestedAt, string? toolUseId = null) {
+        var name = toolName ?? "";
+        if (Encoding.UTF8.GetByteCount(name) > PermissionWire.MaxToolNameBytes) return null;
+        if (Encoding.UTF8.GetByteCount(agentId) > PermissionWire.MaxAgentIdBytes) return null;
+        var (input, inputOmitted)   = Bound(toolInput);
+        var (sugg,  suggOmitted)    = Bound(suggestions);
+        // Over-cap is dropped, not refused: the id only decorates a chat row.
+        var id = toolUseId is { Length: > 0 } t && Encoding.UTF8.GetByteCount(t) <= PermissionWire.MaxToolUseIdBytes ? t : null;
+        return new PermissionPendingDto(requestId, agentId, sessionId, vendor, name, input, sugg, inputOmitted, suggOmitted, requestedAt, id);
+```
+
+At the call site (the `attributed is { } a ? BuildPending(...)` expression), pass the ninth argument:
+
+```csharp
+                var pending = attributed is { } a
+                    ? BuildPending(Guid.NewGuid().ToString("N"), a.AgentId, canonicalSessionId!, vendor, toolName, toolInput, suggestions,
+                        DateTimeOffset.UtcNow.ToString("O"), ToolUseIdOf(node))
+                    : null;
+```
+
+and add beside `ExtractElement`:
+
+```csharp
+    static string? ToolUseIdOf(JsonNode node) =>
+        node["tool_use_id"] is JsonValue v && v.TryGetValue<string>(out var id) ? id : null;
+```
+
+- [ ] **Step 4: Run the bridge tests**
+
+Run: `dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj -- --treenode-filter '/*/*/LocalPermissionBridgeInteractiveTests/*'`
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalPermissionBridgeInteractiveTests.cs
+git commit -m "Forward the hook's tool_use_id on the pending permission"
+```
+
+---
+
+### Task 4: `ToolSummary` — categories and wording
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/ToolSummary.cs`
+- Create: `test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs`
+
+**Interfaces:**
+- Consumes: `CodexCommandClassifier.Classify` (Task 1), `JsonElementExtensions.Str/Arr`.
+- Produces: `public enum ToolCategory { Read, Edit, Command, Search, WebSearch, Fetch, Skill, Agent, Plan, Question, Other }`; `public static class ToolSummary { internal static IReadOnlyDictionary<string, ToolCategory> Names; public static ToolCategory Categorize(string name, string? inputJson); public static string Describe(IEnumerable<ToolCategory> categories); }`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs`:
+
+```csharp
+using Capacitor.App.ViewModels;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Pure: no dispatcher, so no session constraint.
+public class ToolSummaryTests {
+    /// The spec's table, held here so the test pins the map in both directions.
+    static readonly (ToolCategory Category, string[] Names)[] Rows = [
+        (ToolCategory.Read,      ["Read", "NotebookRead", "read_file", "view_image"]),
+        (ToolCategory.Edit,      ["Edit", "MultiEdit", "Write", "NotebookEdit", "apply_patch", "write_file"]),
+        (ToolCategory.Command,   ["Bash", "BashOutput", "KillShell", "shell", "shell_command", "exec", "exec_command", "write_stdin", "local_shell", "container.exec"]),
+        (ToolCategory.Search,    ["Grep", "Glob", "LS"]),
+        (ToolCategory.WebSearch, ["WebSearch", "web_search"]),
+        (ToolCategory.Fetch,     ["WebFetch"]),
+        (ToolCategory.Skill,     ["Skill"]),
+        (ToolCategory.Agent,     ["Task", "Agent", "TaskOutput", "TaskStop", "spawn_agent", "wait_agent", "send_input", "send_message", "resume_agent", "interrupt_agent", "close_agent", "list_agents"]),
+        (ToolCategory.Plan,      ["TodoWrite", "update_plan"]),
+        (ToolCategory.Question,  ["AskUserQuestion", "request_user_input"]),
+    ];
+
+    [Test]
+    public async Task Every_declared_name_maps_to_its_row_case_insensitively_and_nothing_else_is_declared() {
+        var expected = Rows.SelectMany(r => r.Names.Select(n => (n, r.Category))).ToDictionary(p => p.n, p => p.Category, StringComparer.Ordinal);
+        foreach (var (name, category) in expected) {
+            await Assert.That(ToolSummary.Categorize(name, null)).IsEqualTo(category);
+            await Assert.That(ToolSummary.Categorize(name.ToUpperInvariant(), null)).IsEqualTo(category);
+        }
+        await Assert.That(ToolSummary.Names.Keys.ToHashSet(StringComparer.Ordinal).SetEquals(expected.Keys)).IsTrue();
+    }
+
+    [Test]
+    [Arguments("mcp__github__create_issue")]
+    [Arguments("SomethingNew")]
+    [Arguments("")]
+    public async Task Unknown_and_mcp_names_are_other(string name) {
+        await Assert.That(ToolSummary.Categorize(name, """{"x":1}""")).IsEqualTo(ToolCategory.Other);
+    }
+
+    [Test]
+    public async Task Describe_uses_article_for_one_plural_for_many_first_appearance_order_and_lower_cases_after_the_first() {
+        await Assert.That(ToolSummary.Describe([])).IsEqualTo("");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Command])).IsEqualTo("Ran a command");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Read, ToolCategory.Read])).IsEqualTo("Read files");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Read, ToolCategory.Command, ToolCategory.Read, ToolCategory.Edit]))
+            .IsEqualTo("Read files, ran a command, edited a file");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Agent, ToolCategory.Skill, ToolCategory.Other, ToolCategory.Other]))
+            .IsEqualTo("Ran an agent, loaded a skill, called tools");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Search, ToolCategory.Search, ToolCategory.WebSearch, ToolCategory.Fetch, ToolCategory.Fetch, ToolCategory.Plan, ToolCategory.Question]))
+            .IsEqualTo("Searched files, searched the web, fetched pages, updated the plan, asked a question");
+    }
+
+    [Test]
+    [Arguments("Read", """{"file_path":"/repo/.claude/skills/review/SKILL.md"}""", ToolCategory.Skill)]
+    [Arguments("Read", """{"file_path":"/repo/SKILL.md.bak"}""", ToolCategory.Read)]
+    [Arguments("exec_command", """{"cmd":"sed -n '1,40p' a.cs"}""", ToolCategory.Read)]
+    [Arguments("exec_command", """{"cmd":"rg foo src"}""", ToolCategory.Search)]
+    [Arguments("exec_command", """{"cmd":"ls src"}""", ToolCategory.Search)]
+    [Arguments("exec_command", """{"cmd":"cat a && make"}""", ToolCategory.Command)]
+    [Arguments("exec_command", """{"cmd":"cat skills/review/SKILL.md"}""", ToolCategory.Skill)]
+    [Arguments("shell", """{"command":["rg","foo","src"]}""", ToolCategory.Search)]
+    [Arguments("shell", """{"command":["bash","-lc","cat a.md"]}""", ToolCategory.Read)]
+    [Arguments("Bash", """{"description":"List files"}""", ToolCategory.Command)]
+    [Arguments("Bash", """{"command":"git status"}""", ToolCategory.Command)]
+    [Arguments("Bash", "not json", ToolCategory.Command)]
+    [Arguments("Bash", """["cat","a"]""", ToolCategory.Command)]
+    [Arguments("exec", """{"input":"const r = 1;"}""", ToolCategory.Command)]
+    [Arguments("spawn_agent", """{"task":"t"}""", ToolCategory.Agent)]
+    public async Task Categorize_refines_reads_and_shell_commands_from_the_input(string name, string? input, ToolCategory expected) {
+        await Assert.That(ToolSummary.Categorize(name, input)).IsEqualTo(expected);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet build test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj 2>&1 | grep -E 'error' | head -3`
+Expected: compile errors (`ToolSummary`, `ToolCategory` undefined).
+
+- [ ] **Step 3: Implement `ToolSummary`**
+
+`src/Capacitor.App/ViewModels/ToolSummary.cs`:
+
+```csharp
+using System.Text;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Harness.Codex;
+
+namespace Capacitor.App.ViewModels;
+
+public enum ToolCategory { Read, Edit, Command, Search, WebSearch, Fetch, Skill, Agent, Plan, Question, Other }
+
+/// What a group of settled tool calls says about itself. The name map keys on the name the
+/// transcript carries (Codex's rollout says `shell`, its hook says `Bash`); a name in no row is
+/// Other, so an unknown vendor tool still reads "Called a tool" rather than nothing.
+public static class ToolSummary {
+    internal static readonly IReadOnlyDictionary<string, ToolCategory> Names = new Dictionary<string, ToolCategory>(StringComparer.OrdinalIgnoreCase) {
+        ["Read"] = ToolCategory.Read, ["NotebookRead"] = ToolCategory.Read, ["read_file"] = ToolCategory.Read, ["view_image"] = ToolCategory.Read,
+        ["Edit"] = ToolCategory.Edit, ["MultiEdit"] = ToolCategory.Edit, ["Write"] = ToolCategory.Edit, ["NotebookEdit"] = ToolCategory.Edit,
+        ["apply_patch"] = ToolCategory.Edit, ["write_file"] = ToolCategory.Edit,
+        ["Bash"] = ToolCategory.Command, ["BashOutput"] = ToolCategory.Command, ["KillShell"] = ToolCategory.Command, ["shell"] = ToolCategory.Command,
+        ["shell_command"] = ToolCategory.Command, ["exec"] = ToolCategory.Command, ["exec_command"] = ToolCategory.Command,
+        ["write_stdin"] = ToolCategory.Command, ["local_shell"] = ToolCategory.Command, ["container.exec"] = ToolCategory.Command,
+        ["Grep"] = ToolCategory.Search, ["Glob"] = ToolCategory.Search, ["LS"] = ToolCategory.Search,
+        ["WebSearch"] = ToolCategory.WebSearch, ["web_search"] = ToolCategory.WebSearch,
+        ["WebFetch"] = ToolCategory.Fetch,
+        ["Skill"] = ToolCategory.Skill,
+        ["Task"] = ToolCategory.Agent, ["Agent"] = ToolCategory.Agent, ["TaskOutput"] = ToolCategory.Agent, ["TaskStop"] = ToolCategory.Agent,
+        ["spawn_agent"] = ToolCategory.Agent, ["wait_agent"] = ToolCategory.Agent, ["send_input"] = ToolCategory.Agent, ["send_message"] = ToolCategory.Agent,
+        ["resume_agent"] = ToolCategory.Agent, ["interrupt_agent"] = ToolCategory.Agent, ["close_agent"] = ToolCategory.Agent, ["list_agents"] = ToolCategory.Agent,
+        ["TodoWrite"] = ToolCategory.Plan, ["update_plan"] = ToolCategory.Plan,
+        ["AskUserQuestion"] = ToolCategory.Question, ["request_user_input"] = ToolCategory.Question,
+    };
+
+    // Indexed by ToolCategory.
+    static readonly (string One, string Many)[] Phrases = [
+        ("Read a file", "Read files"),
+        ("Edited a file", "Edited files"),
+        ("Ran a command", "Ran commands"),
+        ("Searched files", "Searched files"),
+        ("Searched the web", "Searched the web"),
+        ("Fetched a page", "Fetched pages"),
+        ("Loaded a skill", "Loaded skills"),
+        ("Ran an agent", "Ran agents"),
+        ("Updated the plan", "Updated the plan"),
+        ("Asked a question", "Asked questions"),
+        ("Called a tool", "Called tools"),
+    ];
+
+    public static ToolCategory Categorize(string name, string? inputJson) {
+        var category = Names.TryGetValue(name, out var known) ? known : ToolCategory.Other;
+        if (category is not (ToolCategory.Read or ToolCategory.Command) || string.IsNullOrEmpty(inputJson)) return category;
+        try {
+            using var doc = JsonDocument.Parse(inputJson);
+            var root = doc.RootElement;
+            if (!root.IsObject) return category;
+            if (category == ToolCategory.Read)
+                return IsSkillFile(root.Str("file_path")) ? ToolCategory.Skill : category;
+            var hint = CodexCommandClassifier.Classify(CommandText(root));
+            return hint?.Type switch {
+                "read"                   => IsSkillFile(hint.Name) ? ToolCategory.Skill : ToolCategory.Read,
+                "search" or "list_files" => ToolCategory.Search,
+                _                        => category,
+            };
+        } catch (JsonException) {
+            return category;
+        }
+    }
+
+    public static string Describe(IEnumerable<ToolCategory> categories) {
+        var order = new List<ToolCategory>();
+        var counts = new Dictionary<ToolCategory, int>();
+        foreach (var c in categories) {
+            if (!counts.TryAdd(c, 1)) counts[c]++;
+            else order.Add(c);
+        }
+        var sb = new StringBuilder();
+        foreach (var c in order) {
+            var (one, many) = Phrases[(int)c];
+            var phrase = counts[c] == 1 ? one : many;
+            if (sb.Length == 0) sb.Append(phrase);
+            else sb.Append(", ").Append(char.ToLowerInvariant(phrase[0])).Append(phrase, 1, phrase.Length - 1);
+        }
+        return sb.ToString();
+    }
+
+    static bool IsSkillFile(string? path) =>
+        path is not null && (path == "SKILL.md" || path.EndsWith("/SKILL.md", StringComparison.Ordinal));
+
+    /// `cmd` (unified exec), then `command` as a string, then `command` as an argv array — a
+    /// `bash -lc <script>` array hands its script through, since the classifier only peels the
+    /// wrapper when the script is one quoted token.
+    static string? CommandText(JsonElement root) {
+        if (root.Str("cmd") is { } cmd) return cmd;
+        if (root.Str("command") is { } command) return command;
+        if (root.Arr("command") is not { } argv) return null;
+        var parts = argv.EnumerateArray().Where(p => p.ValueKind == JsonValueKind.String).Select(p => p.GetString()!).ToList();
+        if (parts.Count == 3 && parts[1] is "-lc" or "-c" && parts[0].EndsWith("sh", StringComparison.Ordinal)) return parts[2];
+        return string.Join(' ', parts);
+    }
+}
+```
+
+`JsonElementExtensions.Str` returns `string?` and `Arr` returns `JsonElement?`, both null when the property is absent or of another kind.
+
+- [ ] **Step 4: Run the tests**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter '/*/*/ToolSummaryTests/*'`
+Expected: all pass. If `cat skills/review/SKILL.md` does not yield a `read` hint with `Name == "SKILL.md"`, check the classifier's read-case for `cat` (it is in the ported `Classifies_ReadCommands` rows: `cat README.md` → name `README.md`), then fix the test input, not the classifier.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/ToolSummary.cs test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs
+git commit -m "Categorize tool calls and phrase a group summary"
+```
+
+---
+
+### Task 5: `ToolCallItem` state and `ToolGroupItem`
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/ChatItems.cs`
+- Create: `test/Capacitor.App.Tests.Unit/ToolGroupItemTests.cs`
+
+**Interfaces:**
+- Consumes: `ToolCategory`, `ToolSummary.Describe` (Task 4).
+- Produces: `ToolCallItem(string name, string detail, ToolCategory category = ToolCategory.Other)` with `Category`, `Outcome`, `IsAwaitingPermission`, `IsSettled`, `IsError`, `OutcomeGlyph`; `ToolGroupItem` with `Calls`, `LiveCalls`, `VisibleCalls`, `IsExpanded`, `ToggleCommand`, `Toggle()`, `Summary`, `HasSummary`, `HasFailure`, `Add(ToolCallItem)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`test/Capacitor.App.Tests.Unit/ToolGroupItemTests.cs`:
+
+```csharp
+using Capacitor.App.ViewModels;
+using TUnit.Assertions.Enums;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The group in isolation: folding, summary, failure, and the visible-list swap. Under the
+/// session constraint because ToggleCommand is a ReactiveCommand.
+public class ToolGroupItemTests {
+    static ToolCallItem Call(string name, ToolCategory category) => new(name, "", category);
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Live_calls_show_until_they_settle_and_the_summary_appears_with_the_first_settlement() {
+        await RunOnUiAsync(async () => {
+            var group = new ToolGroupItem();
+            var a = Call("Bash", ToolCategory.Command);
+            var b = Call("Read", ToolCategory.Read);
+            group.Add(a);
+            group.Add(b);
+            await Assert.That(group.HasSummary).IsFalse();
+            await Assert.That(group.Summary).IsEqualTo("");
+            await Assert.That(group.LiveCalls).IsEquivalentTo(new[] { a, b }, CollectionOrdering.Matching);
+            await Assert.That(group.VisibleCalls).IsEquivalentTo(new[] { a, b }, CollectionOrdering.Matching);
+
+            b.Outcome = ToolOutcome.Done;
+            await Assert.That(group.HasSummary).IsTrue();
+            await Assert.That(group.Summary).IsEqualTo("Read a file");
+            await Assert.That(group.LiveCalls).IsEquivalentTo(new[] { a });
+            await Assert.That(group.Calls).IsEquivalentTo(new[] { a, b }, CollectionOrdering.Matching);
+
+            a.Outcome = ToolOutcome.Error;
+            await Assert.That(group.LiveCalls).IsEmpty();
+            await Assert.That(group.Summary).IsEqualTo("Ran a command, read a file");
+            await Assert.That(group.HasFailure).IsTrue();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Toggle_swaps_the_visible_list_between_live_and_every_call() {
+        await RunOnUiAsync(async () => {
+            var group = new ToolGroupItem();
+            var settled = Call("Bash", ToolCategory.Command);
+            var live = Call("Read", ToolCategory.Read);
+            group.Add(settled);
+            group.Add(live);
+            settled.Outcome = ToolOutcome.Done;
+            var raised = new List<string?>();
+            group.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+            await Assert.That(group.IsExpanded).IsFalse();
+            await Assert.That(group.VisibleCalls).IsEquivalentTo(new[] { live });
+
+            group.Toggle();
+            await Assert.That(group.IsExpanded).IsTrue();
+            await Assert.That(group.VisibleCalls).IsEquivalentTo(new[] { settled, live }, CollectionOrdering.Matching);
+            await Assert.That(raised).Contains(nameof(ToolGroupItem.VisibleCalls));
+
+            group.ToggleCommand.Execute().Subscribe();
+            await Assert.That(group.IsExpanded).IsFalse();
+            await Assert.That(group.VisibleCalls).IsEquivalentTo(new[] { live });
+        });
+    }
+
+    [Test]
+    public async Task A_call_glyph_shows_the_question_mark_only_while_running_and_awaiting() {
+        var call = Call("Bash", ToolCategory.Command);
+        await Assert.That(call.OutcomeGlyph).IsEqualTo("");
+        call.IsAwaitingPermission = true;
+        await Assert.That(call.OutcomeGlyph).IsEqualTo("?");
+        await Assert.That(call.IsSettled).IsFalse();
+        call.Outcome = ToolOutcome.Done;
+        await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
+        await Assert.That(call.IsSettled).IsTrue();
+        call.IsAwaitingPermission = false;
+        await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet build test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj 2>&1 | grep -E 'error' | head -3`
+Expected: compile errors (`ToolGroupItem`, the 3-argument `ToolCallItem`).
+
+- [ ] **Step 3: Implement**
+
+Replace the `ToolCallItem` class in `ChatItems.cs` and add `ToolGroupItem` after it; add the usings the file needs:
+
+```csharp
+using System.ComponentModel;
+using System.Reactive;
+using Avalonia.Collections;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+/// One row of the Chat tab. Five shapes, matched by DataTemplates on the concrete type.
+public abstract class ChatItemViewModel : ReactiveObject { }
+
+public sealed class UserTurnItem(string text) : ChatItemViewModel {
+    public string Text { get; } = text;
+}
+
+public sealed class AssistantTextItem(string text) : ChatItemViewModel {
+    public string Text { get; } = text;
+}
+
+/// System-attributed text — a finished background task, a reconnect note — never anyone's speech.
+public sealed class SystemNoteItem(string text) : ChatItemViewModel {
+    public string Text { get; } = text;
+}
+
+public enum ToolOutcome { Running, Done, Error }
+
+public sealed class ToolCallItem(string name, string detail, ToolCategory category = ToolCategory.Other) : ChatItemViewModel {
+    public string Name { get; } = name;
+    public string Detail { get; } = detail;
+    public ToolCategory Category { get; } = category;
+
+    ToolOutcome _outcome;
+    /// Flipped in place when the matching tool_result arrives; a result is terminal.
+    public ToolOutcome Outcome {
+        get => _outcome;
+        set {
+            if (_outcome == value) return;
+            _outcome = value;
+            this.RaisePropertyChanged();
+            this.RaisePropertyChanged(nameof(OutcomeGlyph));
+            this.RaisePropertyChanged(nameof(IsError));
+            this.RaisePropertyChanged(nameof(IsSettled));
+        }
+    }
+
+    bool _isAwaitingPermission;
+    /// Owned by the permission cache, not the transcript: the two arrive in either order.
+    public bool IsAwaitingPermission {
+        get => _isAwaitingPermission;
+        set {
+            if (_isAwaitingPermission == value) return;
+            _isAwaitingPermission = value;
+            this.RaisePropertyChanged();
+            this.RaisePropertyChanged(nameof(OutcomeGlyph));
+        }
+    }
+
+    public bool IsSettled => _outcome != ToolOutcome.Running;
+    public bool IsError => _outcome == ToolOutcome.Error;
+    public string OutcomeGlyph => _outcome switch {
+        ToolOutcome.Done  => "✓",
+        ToolOutcome.Error => "✕",
+        _                 => _isAwaitingPermission ? "?" : "",
+    };
+}
+
+/// A run of consecutive tool calls. Settled calls fold into Summary; live ones stay listed.
+/// VisibleCalls is the one list the view binds, swapped on toggle so a folded group holds no
+/// containers for its settled rows.
+public sealed class ToolGroupItem : ChatItemViewModel {
+    readonly AvaloniaList<ToolCallItem> _calls = new();
+    readonly AvaloniaList<ToolCallItem> _live = new();
+
+    public IAvaloniaReadOnlyList<ToolCallItem> Calls => _calls;
+    public IAvaloniaReadOnlyList<ToolCallItem> LiveCalls => _live;
+    public IAvaloniaReadOnlyList<ToolCallItem> VisibleCalls => _isExpanded ? _calls : _live;
+
+    bool _isExpanded;
+    public bool IsExpanded {
+        get => _isExpanded;
+        private set {
+            if (_isExpanded == value) return;
+            _isExpanded = value;
+            this.RaisePropertyChanged();
+            this.RaisePropertyChanged(nameof(VisibleCalls));
+        }
+    }
+
+    public ReactiveCommand<Unit, Unit> ToggleCommand { get; }
+
+    string _summary = "";
+    public string Summary { get => _summary; private set => this.RaiseAndSetIfChanged(ref _summary, value); }
+
+    bool _hasSummary;
+    public bool HasSummary { get => _hasSummary; private set => this.RaiseAndSetIfChanged(ref _hasSummary, value); }
+
+    bool _hasFailure;
+    public bool HasFailure { get => _hasFailure; private set => this.RaiseAndSetIfChanged(ref _hasFailure, value); }
+
+    public ToolGroupItem() {
+        ToggleCommand = ReactiveCommand.Create(Toggle);
+    }
+
+    public void Toggle() => IsExpanded = !IsExpanded;
+
+    public void Add(ToolCallItem call) {
+        _calls.Add(call);
+        if (call.IsSettled) { Recompute(); return; }
+        _live.Add(call);
+        call.PropertyChanged += OnCallChanged;
+    }
+
+    void OnCallChanged(object? sender, PropertyChangedEventArgs e) {
+        if (e.PropertyName != nameof(ToolCallItem.Outcome) || sender is not ToolCallItem call || !call.IsSettled) return;
+        call.PropertyChanged -= OnCallChanged;
+        _live.Remove(call);
+        Recompute();
+    }
+
+    void Recompute() {
+        var settled = _calls.Where(c => c.IsSettled).ToList();
+        Summary = ToolSummary.Describe(settled.Select(c => c.Category));
+        HasFailure = settled.Any(c => c.IsError);
+        HasSummary = settled.Count > 0;
+    }
+}
+```
+
+- [ ] **Step 4: Run the tests**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter '/*/*/ToolGroupItemTests/*'`
+Expected: all three pass. The existing `ChatTabViewModelTests` still compile (the `ToolCallItem` ctor's third argument defaults) but three of them will fail once Task 6 lands; do not touch them here.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/ChatItems.cs test/Capacitor.App.Tests.Unit/ToolGroupItemTests.cs
+git commit -m "Add the tool-call group row and the awaiting-permission state"
+```
+
+---
+
+### Task 6: Group consecutive calls in `Apply`
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/ChatTabViewModel.cs` — fields near line 37, `SwitchPath` (~line 253), `Apply` (~line 292)
+- Test: `test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `ToolGroupItem`, `ToolSummary.Categorize`.
+- Produces: `Items` holds `ToolGroupItem` rows in place of `ToolCallItem` rows; `_pendingTools` unchanged.
+
+- [ ] **Step 1: Update the existing tests and add the grouping tests**
+
+In `ChatTabViewModelTests`, add fixtures beside the existing consts:
+
+```csharp
+    const string ReadCallLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"/repo/x/src/a.cs"}}]}}""";
+    const string NoteLine = """{"type":"user","origin":{"kind":"task-notification"},"message":{"content":"<task-notification>\n<summary>Agent finished</summary>\n<result>\nAll good.\n</result>\n</task-notification>"}}""";
+
+    static ToolGroupItem Group(ChatTabViewModel chat, int index) => (ToolGroupItem)chat.Items[index];
+```
+
+Edit `Waits_until_a_path_then_renders_the_initial_load_in_file_order`: the expected type names become `nameof(ToolGroupItem)` for the third item and the two detail/outcome assertions read through the group:
+
+```csharp
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(
+                new[] { nameof(UserTurnItem), nameof(AssistantTextItem), nameof(ToolGroupItem) }, CollectionOrdering.Matching);
+            await Assert.That(((UserTurnItem)h.Chat.Items[0]).Text).IsEqualTo("hello");
+            await Assert.That(Group(h.Chat, 2).Calls[0].Detail).IsEqualTo("ls -la");
+            await Assert.That(Group(h.Chat, 2).Calls[0].Outcome).IsEqualTo(ToolOutcome.Running);
+            await Assert.That(Group(h.Chat, 2).Calls[0].Category).IsEqualTo(ToolCategory.Command);
+```
+
+Edit `Tool_results_flip_their_call_in_place_and_unmatched_results_are_ignored` body:
+
+```csharp
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ToolResultLine]);
+            await h.PushAsync(Dto(path));
+            var call = Group(h.Chat, 0).Calls.Single();
+            await Assert.That(call.Outcome).IsEqualTo(ToolOutcome.Done);
+            await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
+
+            File.AppendAllText(path, ToolCallLine + "\n" + ToolErrorLine + "\n" + ToolErrorLine.Replace("t1", "unknown") + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(Group(h.Chat, 0).Calls).Count().IsEqualTo(2);
+            await Assert.That(Group(h.Chat, 0).Calls[1].Outcome).IsEqualTo(ToolOutcome.Error);
+            await Assert.That(Group(h.Chat, 0).Calls[1].IsError).IsTrue();
+            await h.TeardownAsync();
+```
+
+Edit `Length_regression_resets_items_missing_recovers_and_failed_keeps_items`: `IsTypeOf<ToolCallItem>()` → `IsTypeOf<ToolGroupItem>()`.
+
+Add:
+
+```csharp
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Consecutive_calls_across_reads_share_a_group_and_any_prose_closes_it() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+
+            File.AppendAllText(path, ReadCallLine + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(Group(h.Chat, 0).Calls.Select(c => c.Name)).IsEquivalentTo(new[] { "Bash", "Read" }, CollectionOrdering.Matching);
+
+            File.AppendAllText(path, AssistantLine + "\n" + ToolCallLine.Replace("t1", "t3") + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(
+                new[] { nameof(ToolGroupItem), nameof(AssistantTextItem), nameof(ToolGroupItem) }, CollectionOrdering.Matching);
+            await Assert.That(Group(h.Chat, 2).Calls).Count().IsEqualTo(1);
+
+            File.AppendAllText(path, NoteLine + "\n" + ToolCallLine.Replace("t1", "t4") + "\n" + UserLine + "\n" + ToolCallLine.Replace("t1", "t5") + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(new[] {
+                nameof(ToolGroupItem), nameof(AssistantTextItem), nameof(ToolGroupItem),
+                nameof(SystemNoteItem), nameof(ToolGroupItem), nameof(UserTurnItem), nameof(ToolGroupItem),
+            }, CollectionOrdering.Matching);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_result_folds_its_call_and_the_summary_follows_the_settled_calls() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ReadCallLine]);
+            await h.PushAsync(Dto(path));
+            var group = Group(h.Chat, 0);
+            await Assert.That(group.HasSummary).IsFalse();
+            await Assert.That(group.LiveCalls).Count().IsEqualTo(2);
+
+            File.AppendAllText(path, ToolResultLine + "\n");
+            await h.TickAsync();
+            await Assert.That(group.LiveCalls.Select(c => c.Name)).IsEquivalentTo(new[] { "Read" });
+            await Assert.That(group.Summary).IsEqualTo("Ran a command");
+            await Assert.That(group.HasSummary).IsTrue();
+            await Assert.That(group.HasFailure).IsFalse();
+
+            File.AppendAllText(path, ToolErrorLine.Replace("t1", "unknown") + "\n");
+            await h.TickAsync();
+            await Assert.That(group.LiveCalls).Count().IsEqualTo(1);
+
+            File.AppendAllText(path, ToolErrorLine.Replace("t1", "t2") + "\n");
+            await h.TickAsync();
+            await Assert.That(group.LiveCalls).IsEmpty();
+            await Assert.That(group.Summary).IsEqualTo("Ran a command, read a file");
+            await Assert.That(group.HasFailure).IsTrue();
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_reset_and_a_path_switch_start_a_fresh_group_for_later_calls() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine, ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(2);
+
+            File.WriteAllLines(path, [ToolCallLine]);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            File.AppendAllText(path, ReadCallLine + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(Group(h.Chat, 0).Calls).Count().IsEqualTo(2);
+
+            var other = Tmp.CreateFile("o.jsonl", [ToolCallLine]);
+            await h.PushAsync(Dto(other));
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(Group(h.Chat, 0).Calls).Count().IsEqualTo(1);
+            File.AppendAllText(other, ReadCallLine + "\n");
+            await h.TickAsync();
+            await Assert.That(Group(h.Chat, 0).Calls).Count().IsEqualTo(2);
+            await h.TeardownAsync();
+        });
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter '/*/*/ChatTabViewModelTests/*'`
+Expected: the edited and new tests fail with `InvalidCastException` (items are still `ToolCallItem`).
+
+- [ ] **Step 3: Group in `Apply`**
+
+In `ChatTabViewModel`, add a field beside `_pendingTools`:
+
+```csharp
+    ToolGroupItem? _openGroup;
+```
+
+In `SwitchPath`, after `_pendingTools.Clear();` add `_openGroup = null;`. In `Apply`'s `TailStatus.Reset` case, after `_pendingTools.Clear();` add `_openGroup = null;`. Replace the envelope loop:
+
+```csharp
+        var fresh = new List<ChatItemViewModel>();
+        foreach (var e in envelopes) {
+            switch (e.Kind) {
+                case AcpEventKind.UserMessage:
+                    _openGroup = null;
+                    fresh.Add(new UserTurnItem(e.Text ?? ""));
+                    break;
+                case AcpEventKind.AssistantText:
+                    _openGroup = null;
+                    fresh.Add(new AssistantTextItem(e.Text ?? ""));
+                    break;
+                case AcpEventKind.SystemNote:
+                    _openGroup = null;
+                    fresh.Add(new SystemNoteItem(e.Text ?? ""));
+                    break;
+                case AcpEventKind.ToolCall: {
+                    var name = e.ToolName ?? "tool";
+                    var item = new ToolCallItem(name, ToolDetail.From(e.ToolInputJson, _root), ToolSummary.Categorize(name, e.ToolInputJson));
+                    if (e.ToolCallId is { } id) _pendingTools[id] = item;
+                    if (_openGroup is null) {
+                        _openGroup = new ToolGroupItem();
+                        fresh.Add(_openGroup);
+                    }
+                    _openGroup.Add(item);
+                    break;
+                }
+                case AcpEventKind.ToolResult:
+                    if (e.ToolCallId is { } resultId && _pendingTools.Remove(resultId, out var call))
+                        call.Outcome = e.ToolIsError ? ToolOutcome.Error : ToolOutcome.Done;
+                    break;
+            }
+        }
+        if (fresh.Count > 0) _items.AddRange(fresh);
+```
+
+- [ ] **Step 4: Run the view-model tests**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter '/*/*/ChatTabViewModelTests/*'`
+Expected: all pass. `ChatTabViewSmokeTests` will now fail on the three tool-row tests; they are rewritten in Task 8.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/ViewModels/ChatTabViewModel.cs test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+git commit -m "Fold consecutive tool calls into one group row in the chat"
+```
+
+---
+
+### Task 7: Mark the row a pending permission is waiting on
+
+**Files:**
+- Modify: `src/Capacitor.App/Services/IPermissionService.cs` (`PendingPermissionRequest`)
+- Modify: `test/Capacitor.App.Tests.Unit/FakePermissionService.cs` (`PermissionEntries.Entry`)
+- Modify: `src/Capacitor.App/ViewModels/ChatTabViewModel.cs` — ctor after `cards.Subscribe()`, `Apply`, `SwitchPath`
+- Test: `test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs`
+
+**Interfaces:**
+- Consumes: `PermissionPendingDto.ToolUseId` (Task 2), `ToolCallItem.IsAwaitingPermission` (Task 5).
+- Produces: `PendingPermissionRequest.ToolUseId`; `PermissionEntries.Entry(..., string? toolUseId = null)`.
+
+- [ ] **Step 1: Extend the fixture and write the failing tests**
+
+In `FakePermissionService.cs`, `PermissionEntries.Entry` gains a trailing parameter and passes it to the DTO:
+
+```csharp
+    public static PendingPermissionRequest Entry(
+            string requestId = "r1", string agentId = "a1", string vendor = "claude", string toolName = "Bash",
+            string? toolInputJson = """{"command":"ls"}""", bool omitted = false, string requestedAt = "2026-08-28T10:00:00.0000000+00:00",
+            string? toolUseId = null) {
+        System.Text.Json.JsonElement? input = null;
+        if (toolInputJson is not null) { using var d = System.Text.Json.JsonDocument.Parse(toolInputJson); input = d.RootElement.Clone(); }
+        return new PendingPermissionRequest(new PermissionPendingDto(requestId, agentId, "s1", vendor, toolName, input, null, omitted, false, requestedAt, toolUseId));
+    }
+```
+
+Add to `ChatTabViewModelTests` (rows are addressed by position through the `Group(...)` helper from Task 6):
+
+```csharp
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_request_with_an_id_marks_its_row_in_either_order_and_clears_on_resolve() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ReadCallLine]);
+            await h.PushAsync(Dto(path));
+            var bash = Group(h.Chat, 0).Calls[0];
+            var read = Group(h.Chat, 0).Calls[1];
+            await WaitUntilAsync(() => bash.IsAwaitingPermission, what: "the card-first mark");
+            await Assert.That(bash.OutcomeGlyph).IsEqualTo("?");
+            await Assert.That(read.IsAwaitingPermission).IsFalse();
+
+            h.Permissions.Remove("r1");
+            await WaitUntilAsync(() => !bash.IsAwaitingPermission, what: "cleared on resolve");
+
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", toolUseId: "t2"));
+            await WaitUntilAsync(() => read.IsAwaitingPermission, what: "the row-first mark");
+            await Assert.That(bash.IsAwaitingPermission).IsFalse();
+
+            h.Permissions.Add(PermissionEntries.Entry("r3", "a1", toolUseId: "nope"));
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 2, what: "the unmatched card");
+            await Assert.That(bash.IsAwaitingPermission).IsFalse();
+            await Assert.That(read.IsAwaitingPermission).IsTrue();
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Two_requests_on_one_row_keep_the_mark_until_both_go_and_a_settled_row_is_cleared() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            var bash = Group(h.Chat, 0).Calls[0];
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", toolUseId: "t1"));
+            await WaitUntilAsync(() => bash.IsAwaitingPermission, what: "marked");
+
+            h.Permissions.Remove("r1");
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "one card left");
+            await Assert.That(bash.IsAwaitingPermission).IsTrue();
+
+            File.AppendAllText(path, ToolResultLine + "\n");
+            await h.TickAsync();
+            await Assert.That(bash.Outcome).IsEqualTo(ToolOutcome.Done);
+            await Assert.That(bash.IsAwaitingPermission).IsFalse();
+            await Assert.That(h.Chat.PendingCards).Count().IsEqualTo(1);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_request_without_an_id_marks_the_sole_running_call_and_abstains_on_two() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", vendor: "codex"));
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            var first = Group(h.Chat, 0).Calls[0];
+            await WaitUntilAsync(() => first.IsAwaitingPermission, what: "the sole running call, row after card");
+
+            File.AppendAllText(path, ReadCallLine + "\n");
+            await h.TickAsync();
+            var second = Group(h.Chat, 0).Calls[1];
+            await Assert.That(first.IsAwaitingPermission).IsFalse();
+            await Assert.That(second.IsAwaitingPermission).IsFalse();
+
+            File.AppendAllText(path, ToolResultLine + "\n");
+            await h.TickAsync();
+            await Assert.That(first.IsAwaitingPermission).IsFalse();
+            await Assert.That(second.IsAwaitingPermission).IsTrue();
+
+            h.Permissions.Remove("r1");
+            await WaitUntilAsync(() => !second.IsAwaitingPermission, what: "cleared on resolve");
+
+            File.AppendAllText(path, ToolErrorLine.Replace("t1", "t2") + "\n");
+            await h.TickAsync();
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", vendor: "codex"));
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "a card with nothing running");
+            await Assert.That(second.IsAwaitingPermission).IsFalse();
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_pending_request_marks_the_rebuilt_row_after_a_reset_and_a_path_switch() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine, ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", vendor: "codex"));
+            await WaitUntilAsync(() => Group(h.Chat, 1).Calls[0].IsAwaitingPermission, what: "marked before the reset");
+
+            File.WriteAllLines(path, [ToolCallLine]);
+            await h.TickAsync();
+            await Assert.That(Group(h.Chat, 0).Calls[0].IsAwaitingPermission).IsTrue();
+
+            var other = Tmp.CreateFile("o.jsonl", [ToolCallLine.Replace("t1", "t9")]);
+            await h.PushAsync(Dto(other));
+            await Assert.That(Group(h.Chat, 0).Calls[0].IsAwaitingPermission).IsTrue();
+
+            h.Permissions.Remove("r2");
+            await WaitUntilAsync(() => !Group(h.Chat, 0).Calls[0].IsAwaitingPermission, what: "only the id-less request fitted t9");
+            await h.TeardownAsync();
+        });
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter '/*/*/ChatTabViewModelTests/*'`
+Expected: the four new tests time out in `WaitUntilAsync` (nothing ever marks a row) or fail on a false flag.
+
+- [ ] **Step 3: Implement the marking**
+
+`IPermissionService.cs`, in `PendingPermissionRequest`, after `ToolInputOmitted`:
+
+```csharp
+    public string? ToolUseId => Dto.ToolUseId;
+```
+
+`ChatTabViewModel.cs`, fields beside `_pendingTools`:
+
+```csharp
+    readonly Dictionary<string, PendingPermissionRequest> _requests = new(StringComparer.Ordinal);
+    readonly HashSet<ToolCallItem> _marked = new(ReferenceEqualityComparer.Instance);
+```
+
+In the ctor, after `cards.Subscribe().DisposeWith(_disposables);`:
+
+```csharp
+        permissions.Pending
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Filter(p => p.AgentId == agentId)
+            .Subscribe(changes => {
+                foreach (var change in changes) {
+                    switch (change.Reason) {
+                        case ChangeReason.Add or ChangeReason.Update: _requests[change.Key] = change.Current; break;
+                        case ChangeReason.Remove: _requests.Remove(change.Key); break;
+                    }
+                }
+                Reconcile();
+            })
+            .DisposeWith(_disposables);
+```
+
+In `SwitchPath`, after `_openGroup = null;`: `_marked.Clear();`. In `Apply`'s `Reset` case likewise `_marked.Clear();`. At the end of `Apply`, after `if (fresh.Count > 0) _items.AddRange(fresh);` add `Reconcile();`. Add the method after `Apply`:
+
+```csharp
+    /// A row is marked iff some pending request targets it: by tool-use id when the request has
+    /// one, else the sole running call. Recomputed whole on every change to either set and diffed
+    /// against the last marks, because a settled call has already left _pendingTools by the time
+    /// its outcome flips, so the running set alone could never reach it to clear it.
+    void Reconcile() {
+        var targets = new HashSet<ToolCallItem>(ReferenceEqualityComparer.Instance);
+        var sole = _pendingTools.Count == 1 ? _pendingTools.Values.First() : null;
+        foreach (var request in _requests.Values) {
+            if (request.ToolUseId is { } id) {
+                if (_pendingTools.TryGetValue(id, out var call)) targets.Add(call);
+            } else if (sole is not null) {
+                targets.Add(sole);
+            }
+        }
+        foreach (var call in _marked) if (!targets.Contains(call)) call.IsAwaitingPermission = false;
+        foreach (var call in targets) call.IsAwaitingPermission = true;
+        _marked.Clear();
+        _marked.UnionWith(targets);
+    }
+```
+
+`ReferenceEqualityComparer` is `System.Collections.Generic.ReferenceEqualityComparer`; `ChangeReason` is DynamicData's (already imported).
+
+- [ ] **Step 4: Run the view-model tests**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter '/*/*/ChatTabViewModelTests/*'`
+Expected: all pass. If a `WaitUntilAsync` on a mark times out while the card count is right, the change-set subscription is missing `ObserveOn` or `Reconcile()` is not called after `Apply`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/Capacitor.App/Services/IPermissionService.cs src/Capacitor.App/ViewModels/ChatTabViewModel.cs test/Capacitor.App.Tests.Unit/FakePermissionService.cs test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+git commit -m "Mark the chat row a pending permission is waiting on"
+```
+
+---
+
+### Task 8: Render the group, hold the tail on expansion
+
+**Files:**
+- Modify: `src/Capacitor.App/Views/ChatTabView.axaml` — the `DataTemplates` block
+- Modify: `src/Capacitor.App/Views/ChatTabView.axaml.cs`
+- Test: `test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs`
+
+**Interfaces:**
+- Consumes: `ToolGroupItem` (`HasSummary`, `Summary`, `HasFailure`, `IsExpanded`, `ToggleCommand`, `VisibleCalls`, `Toggle()`), `PermissionEntries.Entry(toolUseId:)`.
+
+- [ ] **Step 1: Rewrite the three tool-row smoke tests and add the new ones**
+
+Add fixtures and helpers to `ChatTabViewSmokeTests`:
+
+```csharp
+    const string ReadCallLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"/repo/x/src/a.cs"}}]}}""";
+    const string ReadResultLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t2","content":"ok"}]}}""";
+
+    static string CallLine(int n) => ToolCallLine.Replace("\"t1\"", $"\"t{n}\"");
+    static string ResultLine(int n) => ToolResultLine.Replace("\"t1\"", $"\"t{n}\"");
+
+    static List<StackPanel> ToolRows(ChatTabView view) => view.GetVisualDescendants().OfType<StackPanel>()
+        .Where(p => p.Orientation == Orientation.Horizontal && p.DataContext is ToolCallItem).ToList();
+    static Button Summary(ChatTabView view) => view.GetVisualDescendants().OfType<Button>().Single(b => b.Classes.Contains("toolSummary"));
+    static ToolGroupItem OnlyGroup(Host host) => (ToolGroupItem)host.Chat.Items.Single();
+
+    static void Click(Host host, Control target) {
+        var origin = target.TranslatePoint(new Point(2, 2), host.Window)!.Value;
+        host.Window.MouseDown(origin, MouseButton.Left);
+        host.Window.MouseUp(origin, MouseButton.Left);
+        host.Settle();
+    }
+```
+
+Add to `Host`:
+
+```csharp
+        public async Task AppendLinesAndTickAsync(string path, params string[] lines) {
+            File.AppendAllLines(path, lines);
+            Time.Advance(ChatTabViewModel.PollInterval);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+            Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+        }
+```
+
+Rewrite `A_paired_tool_row_paints_its_glyph_with_the_outcome_brush` so it expands the group first:
+
+```csharp
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("tools.jsonl",
+                [ToolCallLine, ToolResultLine, ToolCallLine.Replace("t1", "t2"), ToolErrorLine.Replace("t1", "t2")]));
+            OnlyGroup(host).Toggle();
+            host.Settle();
+
+            await Assert.That(OnlyGroup(host).Calls.Select(i => i.Outcome))
+                .IsEquivalentTo([ToolOutcome.Done, ToolOutcome.Error], CollectionOrdering.Matching);
+            var glyphs = host.View.GetVisualDescendants().OfType<TextBlock>()
+                .Where(t => t.DataContext is ToolCallItem && t.Text is "✓" or "✕").ToList();
+```
+
+(the rest of that test unchanged).
+
+Rewrite `Tool_rows_stack_densely_and_keep_their_distance_from_text` so it expands the group after loading and asserts on `ToolRows(host.View)`:
+
+```csharp
+            await host.LoadAsync(Tmp.CreateFile("rows.jsonl",
+                [ToolCallLine, ToolResultLine, ToolCallLine.Replace("t1", "t2"), ToolResultLine.Replace("t1", "t2"), AssistantLinkLine]));
+            ((ToolGroupItem)host.Chat.Items[0]).Toggle();
+            host.Settle();
+            var rows = ToolRows(host.View);
+```
+
+Add:
+
+```csharp
+    /// Pins the fold: settled calls become one summary line, live calls stay as rows, and a click
+    /// on the summary reveals every call and hides them again.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_group_folds_settled_calls_into_a_summary_and_expands_on_click() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("fold.jsonl", [ToolCallLine, ToolResultLine, ReadCallLine, ReadResultLine, CallLine(3)]));
+
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(1);
+            var summary = Summary(host.View);
+            await Assert.That(summary.IsVisible).IsTrue();
+            await Assert.That(summary.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text)).Contains("Ran a command, read a file");
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
+            await Assert.That(((ToolCallItem)ToolRows(host.View)[0].DataContext!).Outcome).IsEqualTo(ToolOutcome.Running);
+
+            Click(host, summary);
+            await Assert.That(OnlyGroup(host).IsExpanded).IsTrue();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(3);
+
+            Click(host, summary);
+            await Assert.That(OnlyGroup(host).IsExpanded).IsFalse();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
+            await host.CloseAsync();
+        });
+    }
+
+    /// A group with nothing settled has no summary line at all.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_group_of_only_live_calls_shows_rows_and_no_summary() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("live.jsonl", [ToolCallLine, ReadCallLine]));
+            await Assert.That(Summary(host.View).IsVisible).IsFalse();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(2);
+            await host.CloseAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_failed_call_inside_a_folded_group_shows_the_danger_cross_on_the_summary() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("fail.jsonl", [ToolCallLine, ToolErrorLine]));
+            var cross = Summary(host.View).GetVisualDescendants().OfType<TextBlock>().Single(t => t.Text == "✕");
+            await Assert.That(cross.IsVisible).IsTrue();
+            await Assert.That(cross.Foreground).IsSameReferenceAs(Avalonia.Application.Current!.FindResource("KcapDangerBrush"));
+            await host.CloseAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_awaiting_row_paints_the_question_glyph_with_the_accent_brush() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("ask.jsonl", [ToolCallLine]));
+            host.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            await WaitUntilAsync(() => OnlyGroup(host).Calls[0].IsAwaitingPermission, what: "the mark");
+            host.Settle();
+            var glyph = host.View.GetVisualDescendants().OfType<TextBlock>().Single(t => t.DataContext is ToolCallItem && t.Text == "?");
+            await Assert.That(glyph.Foreground).IsSameReferenceAs(Brush(isError: false));
+            await host.CloseAsync();
+        });
+    }
+
+    /// The inner lists mutate without an outer collection notification; follow-tail still reads
+    /// the extent change.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Follow_tail_tracks_inner_group_growth_and_folding_and_leaves_a_scrolled_up_reader_alone() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var path = Tmp.CreateFile("inner.jsonl", [.. Enumerable.Repeat(UserLine, 60), CallLine(1)]);
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            await host.AppendLinesAndTickAsync(path, CallLine(2), CallLine(3));
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(61);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            await host.AppendLinesAndTickAsync(path, ResultLine(1));
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            host.Scroll.Offset = new Vector(0, 0);
+            host.Window.UpdateLayout();
+            await host.AppendLinesAndTickAsync(path, CallLine(4), ResultLine(2));
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
+            await host.CloseAsync();
+        });
+    }
+
+    /// Expanding keeps the viewport: the hold is one-shot, so a reader who returns to the bottom is
+    /// followed again on the next append.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Expanding_the_trailing_group_keeps_the_offset_and_the_hold_is_one_shot() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var lines = new List<string>(Enumerable.Repeat(UserLine, 60));
+            for (var i = 1; i <= 30; i++) { lines.Add(CallLine(i)); lines.Add(ResultLine(i)); }
+            var path = Tmp.CreateFile("expand.jsonl", lines.ToArray());
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+            var before = host.Scroll.Offset.Y;
+
+            Click(host, Summary(host.View));
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(((ToolGroupItem)host.Chat.Items[^1]).IsExpanded).IsTrue();
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(before);
+            await Assert.That(host.AtBottom()).IsFalse();
+
+            host.Scroll.ScrollToEnd();
+            host.Window.UpdateLayout();
+            await host.AppendAndTickAsync(path, 5);
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.AtBottom()).IsTrue();
+            await host.CloseAsync();
+        });
+    }
+
+    /// Expansion realizes every row; folding releases them again.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_thousand_call_group_realizes_on_expansion_and_releases_on_fold() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var lines = new List<string>();
+            for (var i = 1; i <= 1000; i++) { lines.Add(CallLine(i)); lines.Add(ResultLine(i)); }
+            lines.Add(CallLine(1001));
+            await host.LoadAsync(Tmp.CreateFile("thousand.jsonl", lines.ToArray()));
+            var items = host.View.FindControl<ItemsControl>("ChatItems")!;
+
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(items.GetRealizedContainers().Count()).IsEqualTo(1);
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
+
+            OnlyGroup(host).Toggle();
+            host.Settle();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1001);
+            await Assert.That(items.GetRealizedContainers().Count()).IsEqualTo(1);
+
+            OnlyGroup(host).Toggle();
+            host.Settle();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
+            await host.CloseAsync();
+        });
+    }
+```
+
+- [ ] **Step 2: Run to verify they fail**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter '/*/*/ChatTabViewSmokeTests/*'`
+Expected: the new tests fail — no `toolSummary` button exists (`Single()` throws), rows for a group are not rendered at all (no template for `ToolGroupItem` renders the type name as text).
+
+- [ ] **Step 3: Add the template**
+
+In `ChatTabView.axaml`, inside `<ItemsControl.DataTemplates>` after the `vm:ToolCallItem` template:
+
+```xml
+                <DataTemplate x:DataType="vm:ToolGroupItem">
+                    <StackPanel>
+                        <Button Classes="toolSummary" IsVisible="{Binding HasSummary}" Command="{Binding ToggleCommand}"
+                                Background="Transparent" BorderBrush="Transparent" Padding="0" Margin="0,0,0,6" Cursor="Hand"
+                                HorizontalAlignment="Left">
+                            <StackPanel Orientation="Horizontal" Spacing="9">
+                                <!-- Stroked chevron, not a text glyph — the 9px ▸ rendered as a dot. -->
+                                <Panel Width="12" Height="12" VerticalAlignment="Center">
+                                    <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.8"
+                                          StrokeLineCap="Round" StrokeJoin="Round"
+                                          Data="M3,4.5 L6,7.5 L9,4.5" IsVisible="{Binding IsExpanded}" />
+                                    <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.8"
+                                          StrokeLineCap="Round" StrokeJoin="Round"
+                                          Data="M4.5,3 L7.5,6 L4.5,9" IsVisible="{Binding !IsExpanded}" />
+                                </Panel>
+                                <TextBlock Text="{Binding Summary}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
+                                <TextBlock Text="✕" FontSize="11" Foreground="{StaticResource KcapDangerBrush}"
+                                           IsVisible="{Binding HasFailure}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                        <ItemsControl ItemsSource="{Binding VisibleCalls}" />
+                    </StackPanel>
+                </DataTemplate>
+```
+
+- [ ] **Step 4: Hold the tail on a summary click**
+
+`ChatTabView.axaml.cs`: make `OnScrollChanged` an instance method with the one-shot hold, and arm it from a bubbling click:
+
+```csharp
+public partial class ChatTabView : UserControl {
+    const double BottomTolerance = 2;
+
+    ScrollViewer? _scroll;
+    /// Armed by a click on a group's summary line, consumed by the extent change that click causes:
+    /// expanding a group must not scroll the clicked line out of view.
+    bool _holdTail;
+
+    public ChatTabView() {
+        InitializeComponent();
+        ComposerInput.AddHandler(KeyDownEvent, OnComposerKeyDown, RoutingStrategies.Tunnel);
+        ChatItems.AddHandler(Button.ClickEvent, OnItemButtonClick);
+        ChatItems.TemplateApplied += (_, _) => {
+            if (_scroll is not null) _scroll.ScrollChanged -= OnScrollChanged;
+            _scroll = ChatItems.GetVisualDescendants().OfType<ScrollViewer>().FirstOrDefault();
+            if (_scroll is not null) _scroll.ScrollChanged += OnScrollChanged;
+        };
+    }
+
+    void OnItemButtonClick(object? sender, RoutedEventArgs e) {
+        if (e.Source is Button button && button.Classes.Contains("toolSummary")) _holdTail = true;
+    }
+
+    void OnScrollChanged(object? sender, ScrollChangedEventArgs e) {
+        if (sender is not ScrollViewer scroll || (e.ExtentDelta.Y == 0 && e.ViewportDelta.Y == 0)) return;
+        if (_holdTail && e.ExtentDelta.Y != 0) { _holdTail = false; return; }
+        var offsetBefore   = scroll.Offset.Y - e.OffsetDelta.Y;
+        var viewportBefore = scroll.Viewport.Height - e.ViewportDelta.Y;
+        var extentBefore   = scroll.Extent.Height - e.ExtentDelta.Y;
+        var stayed = e.OffsetDelta.Y >= 0;
+        if (stayed && offsetBefore + viewportBefore >= extentBefore - BottomTolerance) scroll.ScrollToEnd();
+    }
+```
+
+Keep the existing comments on the tunnel handler and the template-applied hook; keep `OnComposerKeyDown` and `FocusComposer` as they are.
+
+- [ ] **Step 5: Run the smoke tests**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter '/*/*/ChatTabViewSmokeTests/*'`
+Expected: all pass. Likely first failures and their fixes:
+- `Summary(...)` finds no button on a folded group: the `ToolCallItem` template is not being resolved inside the nested `ItemsControl` → confirm the nested list has no `ItemTemplate` of its own and the outer `DataTemplates` block still holds the row template.
+- `Expanding_the_trailing_group_keeps_the_offset...` sees the offset move: the click's `ScrollChanged` carried `ExtentDelta.Y == 0` on the first pass and the hold was consumed by a later one — log `e.ExtentDelta` in the handler once, then consume the hold only on a non-zero extent delta (as written) and make sure the handler is the instance method (the static one cannot see `_holdTail`).
+- `A_thousand_call_group...` is slow but must not time out; if it exceeds the suite's per-test budget, drop to 500 rows in both the file and the assertion and say so in the test's doc comment.
+
+- [ ] **Step 6: Run the whole App suite**
+
+Run: `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj`
+Expected: green (the pre-existing nudge test failures noted in memory are not in this suite).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/Capacitor.App/Views/ChatTabView.axaml src/Capacitor.App/Views/ChatTabView.axaml.cs test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+git commit -m "Render folded tool groups and hold the tail on expansion"
+```
+
+---
+
+### Task 9: CHANGES entry and final verification
+
+**Files:**
+- Modify: `docs/CHANGES.md` — insert after the "Elicitation question cards for PTY sessions" section (before `## Launch and stop command routing`)
+
+- [ ] **Step 1: Write the section**
+
+```markdown
+## Compact tool calls in the Chat tab
+
+**AI-2418** (spec: `docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md`) folds a
+run of consecutive tool calls into one `ToolGroupItem` row: settled calls collapse to a summary line
+("Read files, ran a command"), live calls stay listed beneath it, and any prose (user turn, assistant
+text, system note) closes the run. **The fold is uniform** — a lone settled call still reads "Ran a
+command" — and **folding never hides an error**: a failed call inside a folded group puts the danger
+`✕` on the summary line. The group binds ONE inner list whose source swaps on toggle, because a
+hidden `ItemsControl` keeps its containers; expanding a group realizes every row and folding releases
+them. Expanding holds follow-tail once, so the clicked summary stays in view. Summary wording keys on
+the transcript's tool name (Codex's rollout says `shell`, its hook says `Bash`), with Codex shell
+commands classified by `CodexCommandClassifier`, ported verbatim from the server into Core so the
+server can delete its copy on the next submodule bump. A row waiting on a permission shows an accent
+`?` in the outcome slot: `PermissionPendingDto` gains an optional `tool_use_id` the daemon reads from
+the hook body (Claude's PermissionRequest hook carries it; Codex's deliberately does not), and the
+view-model recomputes the marks from pending requests and running calls on every change, diffing
+against the last marks so a call that settles while its request is still pending is cleared rather
+than masked by its `✓`. A request without an id marks the agent's sole running call and abstains
+when two or more are running.
+```
+
+- [ ] **Step 2: Full solution build and every suite**
+
+Run:
+```bash
+dotnet build src/Capacitor.Cli/Capacitor.Cli.csproj 2>&1 | tail -3
+dotnet test --solution Capacitor.slnx 2>&1 | tail -20
+```
+Expected: build clean; the four suites green apart from the pre-existing nudge session-start failures recorded in memory (`local-preexisting-nudge-test-failures`), which are unrelated.
+
+- [ ] **Step 3: AOT publish check**
+
+Run: `dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'`
+Expected: no output.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/CHANGES.md
+git commit -m "Record the compact tool-call design in CHANGES"
+```
+
+---
+
+## Self-review
+
+**Spec coverage.** Decision 1 and §1 grouping → Tasks 5, 6. Decision 2 (uniform fold) → `HasSummary` on any settled call, Task 5. Decision 3 (live rows beneath) → `VisibleCalls`, Tasks 5, 8. Decision 4 and §4 (id then sole-running, `_marked` diff, both orders, reset/switch) → Tasks 2, 3, 7. Decision 5 (✕ on summary) → Task 8 template and test. Decision 6 and §2 wording, table, refinements → Task 4. Decision 7 (`?` glyph, accent brush) → Tasks 5, 8. Decision 8 (classifier port) → Task 1, consumed in Task 4. §3 template, one inner list, chevron, follow-tail hold, thousand-call realization → Task 8. §5 tests → each task's tests; the wire worst-case frame → Task 2; the daemon over-cap drop → Task 3. §6 docs → Task 9.
+
+**Placeholders.** None; every code step carries its code.
+
+**Type consistency.** `ToolCallItem(string, string, ToolCategory = Other)` everywhere; `ToolGroupItem.Toggle()` used by tests in Tasks 5 and 8; `PermissionEntries.Entry(..., toolUseId:)` defined in Task 7 and used in Tasks 7 and 8; `BuildPending`'s ninth parameter defined and consumed in Task 3; `PendingPermissionRequest.ToolUseId` defined in Task 7 and read by `Reconcile()` there.

--- a/docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md
+++ b/docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md
@@ -1,0 +1,402 @@
+# Compact tool calls in the Chat tab (AI-2418)
+
+Slice of the desktop shell (parent AI-2171), on the AI-2196 chat and the AI-2308
+permission lane. The Chat tab renders one row per tool call, forever: a session
+that reads twenty files before answering shows twenty muted rows between two
+paragraphs of prose, and the prose is what the reader came for.
+
+What already exists: `ChatTabViewModel.Apply` turns each `ToolCall` envelope into
+a `ToolCallItem` (name, one-line detail, `Outcome` of Running/Done/Error) and
+flips it in place when the matching `ToolResult` arrives; the row's trailing
+glyph slot shows nothing while running, an accent `✓` on success and a danger
+`✕` on error. Permission requests never touch the transcript list: they arrive
+from the daemon as `PermissionPendingDto` over `permission/1` and render as
+cards on the NEEDS YOU row. That DTO carries no tool-use id, so the app cannot
+tell which row a pending card belongs to, although the daemon builds it from the
+raw hook body and Claude's `PermissionRequest` hook payload includes
+`tool_use_id`. Codex's does not: its `PermissionRequest` payload is a closed set
+of fields with no call id (its own tests assert the absence), while `PreToolUse`
+and `PostToolUse` carry `tool_use_id` equal to the rollout's `call_id`. The
+Codex desktop app correlates through the app-server protocol's item id, which
+a PTY session never exposes. Codex's hook also renames the tool: a shell
+approval arrives as `tool_name: "Bash"` with `{command, description}` while the
+rollout names the call `shell` or `exec_command`.
+
+This slice is the app's item model and rendering plus one optional field on the
+local permission wire, read by the daemon from the hook body. The app works
+against a daemon that does not send the field, and for a vendor whose hook
+never sends it, by falling back to the one call that can be asking.
+
+Out of scope: a per-category icon on rows (the reference screenshots' book and
+terminal glyphs; ours keep the `›`); a "Running …" verb prefix on live rows;
+persisting a group's expansion across restarts or transcript resets; showing
+tool output on expansion; structured ACP vendors (no transcript projection, so
+no chat rows at all); the server's own transcript rendering.
+
+## Decisions
+
+Settled with the owner during brainstorming, 2026-09-02:
+
+1. **A group item in the flat list, not per-row hiding.** Consecutive tool calls
+   become one `ToolGroupItem` holding its calls. The alternative (one item per
+   call, hidden when folded, plus an inserted summary row) spreads group state
+   across N items and leaves zero-height rows in the virtualizing panel.
+2. **Uniform fold.** A group whose only completed call is one call still folds to
+   a summary ("Ran a command"). One rule, one vertical rhythm; the detail is one
+   click away. Keeping a lone row visible is a one-line change if it proves
+   better in use.
+3. **Live rows stay visible beneath the summary.** A call still running, or
+   waiting on a permission, is never folded. The summary line exists only once
+   the first call in the group settles; before that the group renders exactly as
+   the rows do today.
+4. **Correlate permissions by tool-use id when the hook gives one; otherwise by
+   the sole running call.** Matching on tool name plus input fails on omitted
+   large inputs, on repeated identical calls, and on Codex outright (its hook
+   renames the tool and reshapes the input). Claude's id is free at the source
+   and exact under parallel calls. A request with no id marks the agent's only
+   running call, and marks nothing when two or more are running: a wrong marker
+   is worse than none, and the NEEDS YOU card stays the affordance.
+5. **A failure inside a folded group surfaces on the summary line**, as the same
+   danger `✕` a row would carry. Folding never hides an error.
+6. **Codex-style wording, no counts.** "Read files, ran a command, edited a
+   file": singular takes an article, plural drops it, categories in order of
+   first appearance.
+7. **The waiting marker is an accent `?` in the outcome slot.** Same place the
+   check lands, same converter, one character to change.
+8. **A Codex shell command classifies through Core's port of the server's
+   `CodexCommandClassifier`.** Codex reads and searches through the shell
+   (`cat`, `sed -n`, `rg`), so without classification every Codex group reads
+   "Ran commands". The server already carries a faithful port of Codex's own
+   `parse_command` (quote-aware tokenizer, redirection detection, the
+   any-unknown-collapses rule) to label the dashboard; the desktop app needs the
+   same verdicts, and Core is where transcript normalization is heading. The
+   classifier and its tests move into Core verbatim under `Harness/Codex/`; the
+   server drops its copy when it takes the submodule bump. A category is fixed
+   when the row is created, from the call's name and input; the summary counts
+   categories.
+
+## 1. Item model
+
+`src/Capacitor.App/ViewModels/ChatItems.cs`.
+
+### `ToolCallItem`
+
+Gains a category, one state and one derived flag:
+
+- `ToolCategory Category` — fixed at construction by `ToolSummary.Categorize`
+  (§2) from the call's name and input JSON; the group sums these.
+- `bool IsAwaitingPermission` — set from the permission cache (§4), independent
+  of `Outcome`, since the two arrive from different sources in either order.
+- `bool IsSettled => Outcome != ToolOutcome.Running`.
+- `OutcomeGlyph` becomes: Done `✓`, Error `✕`, else awaiting `?`, else `""`. The
+  existing `ToolOutcomeBrushConverter` keyed on `IsError` already paints `?`
+  with the accent brush, so no view change beyond the glyph text.
+
+Setting `Outcome` raises `OutcomeGlyph`, `IsError` and `IsSettled`; setting
+`IsAwaitingPermission` raises `OutcomeGlyph`. `Outcome` only ever moves away from
+Running; a result is terminal.
+
+### `ToolGroupItem`
+
+One row of the list holding a run of calls:
+
+```csharp
+public sealed class ToolGroupItem : ChatItemViewModel {
+    public IAvaloniaReadOnlyList<ToolCallItem> Calls { get; }      // every call, transcript order
+    public IAvaloniaReadOnlyList<ToolCallItem> LiveCalls { get; }  // Outcome == Running, same order
+    public IAvaloniaReadOnlyList<ToolCallItem> VisibleCalls { get; } // IsExpanded ? Calls : LiveCalls
+    public bool IsExpanded { get; }                                 // default false
+    public ReactiveCommand<Unit, Unit> ToggleCommand { get; }
+    public string Summary { get; }                                  // §2, over settled calls
+    public bool HasSummary { get; }                                 // any call settled
+    public bool HasFailure { get; }                                 // any settled call errored
+    public void Add(ToolCallItem call);
+}
+```
+
+`Add` appends to both lists and subscribes to the call's `PropertyChanged` for
+`Outcome` (a plain event subscription, not `WhenAnyValue`: the rail's comment on
+ReactiveUI's global init under the headless dispatcher applies here too). When
+a call settles the group removes it from `LiveCalls`, recomputes `Summary` and
+`HasFailure` over `Calls`, and raises the three plus `HasSummary`. Recompute is
+O(n) per settlement; a group is tens of calls, hundreds at the worst, and
+settlements arrive one read at a time. `VisibleCalls` returns one of the two
+lists by `IsExpanded` and is raised on toggle; the view binds that one property
+(§3), so a toggle swaps the rendered source rather than hiding a second list.
+
+### Grouping in `Apply`
+
+`ChatTabViewModel` keeps `ToolGroupItem? _openGroup`, the trailing group that
+new calls join. In the envelope loop:
+
+- `ToolCall`: if `_openGroup` is null, create one and add it to `fresh`; then
+  `_openGroup.Add(item)`. The group persists across reads until something closes
+  it, so calls arriving one poll apart still share a group.
+- `UserMessage`, `AssistantText`, `SystemNote`: set `_openGroup = null` before
+  adding the item. `AssistantThinking` produces no item and does not close the
+  group.
+- `ToolResult`: unchanged; the call flips, the group reacts.
+- `SwitchPath` and a `Reset` read clear `_openGroup` with the items.
+
+`_pendingTools` keeps mapping tool-call id to `ToolCallItem` for result pairing;
+nothing else about the read pipeline changes.
+
+## 2. Summary text
+
+`src/Capacitor.App/ViewModels/ToolSummary.cs`, beside `ToolDetail`: a
+`ToolCategory` enum, `Categorize(string name, string? inputJson)` run once per
+call when `Apply` creates the row, and `Describe(IEnumerable<ToolCategory>)`
+over the settled calls' categories.
+
+### Categories
+
+Each name maps to a category, case-insensitively; a name in no row is `Other`.
+The table keys on the name the transcript carries, not the one the vendor's
+hook reports (Codex's hook says `Bash` for a call its rollout names `shell`).
+The Codex names are the handlers in `codex-rs/core/src/tools/handlers/`; the
+Claude names are Claude Code's built-in tools. The map is an internal static so
+the test can enumerate it rather than sample it:
+
+| Category   | Names                                                                          | One                 | Many               |
+|------------|--------------------------------------------------------------------------------|---------------------|--------------------|
+| Read       | `Read`, `NotebookRead`, `read_file`, `view_image`                              | Read a file         | Read files         |
+| Edit       | `Edit`, `MultiEdit`, `Write`, `NotebookEdit`, `apply_patch`, `write_file`      | Edited a file       | Edited files       |
+| Command    | `Bash`, `BashOutput`, `KillShell`, `shell`, `shell_command`, `exec`, `exec_command`, `write_stdin`, `local_shell`, `container.exec` | Ran a command | Ran commands |
+| Search     | `Grep`, `Glob`, `LS`                                                           | Searched files      | Searched files     |
+| Web search | `WebSearch`, `web_search`                                                      | Searched the web    | Searched the web   |
+| Fetch      | `WebFetch`                                                                     | Fetched a page      | Fetched pages      |
+| Skill      | `Skill`                                                                        | Loaded a skill      | Loaded skills      |
+| Agent      | `Task`, `Agent`, `TaskOutput`, `TaskStop`, `spawn_agent`, `wait_agent`, `send_input`, `send_message`, `resume_agent`, `interrupt_agent`, `close_agent`, `list_agents` | Ran an agent | Ran agents |
+| Plan       | `TodoWrite`, `update_plan`                                                     | Updated the plan    | Updated the plan   |
+| Question   | `AskUserQuestion`, `request_user_input`                                        | Asked a question    | Asked questions    |
+| Other      | everything else, MCP tools (`mcp__…`) included                                 | Called a tool       | Called tools       |
+
+Two refinements read the input, both best-effort and both falling back to the
+table's answer:
+
+- **A skill read.** A Read-category call whose `file_path` ends in `/SKILL.md`,
+  or a shell read whose classified `Name` is `SKILL.md`, is `Skill`. Claude
+  subagents and Codex both load a skill by reading that file.
+- **A shell command's verdict.** A Command-category call's command text
+  (`cmd`, or `command`; an array `command` joins with spaces) goes through
+  `CodexCommandClassifier.Classify`: a `read` hint is `Read`, a `search` or
+  `list_files` hint is `Search`, and null (any unknown segment, a redirection,
+  a helper-only pipeline) stays `Command`. The classifier moves from the
+  server into Core, `src/Capacitor.Cli.Core/Harness/Codex/`, with its tests,
+  as a verbatim port: the server switches to Core's copy and deletes its own
+  when it takes the submodule bump, so the two must not drift in the meantime.
+
+Phrases join with `", "` in order of the category's first appearance; the first
+keeps its capital, every later one lower-cases its first character:
+`Read files, ran a command, edited a file`. An empty input yields `""`.
+
+The table is the one place vendor tool names are known to the app; adding a
+vendor's names is a row edit, and an unknown name degrades to "Called a tool"
+rather than to nothing. A vendor-neutral tool kind on the canonical envelope
+would replace the table's name rows; that is a separate issue, and the summary
+would then sum kinds instead.
+
+## 3. Rendering
+
+`src/Capacitor.App/Views/ChatTabView.axaml`, a new type-keyed template beside
+the four existing ones. The `ToolCallItem` template is unchanged and stays in
+the outer list's `DataTemplates`; the nested lists below resolve it by walking
+the logical tree.
+
+```xml
+<DataTemplate x:DataType="vm:ToolGroupItem">
+    <StackPanel>
+        <Button Classes="toolSummary" IsVisible="{Binding HasSummary}" Command="{Binding ToggleCommand}"
+                Background="Transparent" BorderBrush="Transparent" Padding="0" Margin="0,0,0,6" Cursor="Hand">
+            <StackPanel Orientation="Horizontal" Spacing="9">
+                <Panel Width="12" Height="12" VerticalAlignment="Center">
+                    <!-- the rail's stroked chevrons: down when expanded, right when collapsed -->
+                </Panel>
+                <TextBlock Text="{Binding Summary}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
+                <TextBlock Text="✕" FontSize="11" Foreground="{StaticResource KcapDangerBrush}"
+                           IsVisible="{Binding HasFailure}" VerticalAlignment="Center" />
+            </StackPanel>
+        </Button>
+        <ItemsControl ItemsSource="{Binding VisibleCalls}" />
+    </StackPanel>
+</DataTemplate>
+```
+
+One inner list, its source swapped on toggle, rather than two lists toggled
+by `IsVisible`: a hidden control keeps its template, presenter and generated
+containers, so two lists would leave every row of an expanded group realized
+after it is folded again. Swapping the source drops the old containers and
+generates the new ones.
+
+The chevron sits in the row prefix's column, so a folded summary and an open
+row's `›` align. The summary line keeps the rows' `0,0,0,6` bottom margin and
+the group adds none of its own, so the dense-stacking rule and the gap before
+prose hold whether a group is folded or open.
+
+Collapsed: the summary line (when any call has settled) and the live rows.
+Expanded: the summary line and every call in transcript order, live ones
+included, each with its own glyph. A group with nothing settled yet has no
+summary line in either state, so a run of calls that is all still running looks
+exactly as today.
+
+Virtualization: a group is one realized item of the outer `VirtualizingStackPanel`;
+its inner list is a plain stack. Expanding a group realizes every one of its
+rows in one layout pass, four `TextBlock`s each, and nothing bounds a group's
+size but the transcript itself: a run of a thousand calls between two prose
+items is a thousand rows on expansion. That is accepted as the cost of a
+click the reader chose, not of loading or following a transcript: a folded
+group realizes only its live rows, whether it was never expanded or has been
+folded again, and `LiveCalls` is bounded by the vendor's parallelism, not by
+transcript length. The smoke test pins both halves at a thousand-call group:
+expansion lays out in the headless host with every row realized, and folding
+it again leaves only the live rows' containers, with no timing assertion.
+
+Follow-tail: `OnScrollChanged` follows any extent growth while the reader is
+at the bottom, so a live row joining an existing group across polls, or a row
+folding away, needs no new code, although both mutate only a group's inner
+lists (the outer `Items` does not notify) and the existing follow-tail tests
+exercise outer additions only; §5 adds both paths. Expansion is the exception:
+it also grows the extent, and following it would carry the clicked summary and
+the first revealed rows out of view on a tall group. **Expanding keeps the
+viewport where it is.** The view arms a one-shot hold when a `toolSummary`
+button is clicked (a `Button.ClickEvent` handler on the list, class-filtered),
+and the next `ScrollChanged` carrying a non-zero extent delta consumes the hold
+instead of scrolling to the end. A collapse consumes it the same way; its
+shrink never scrolled anyway. A hold armed by a click that changes no extent
+cannot happen: the summary is visible only with a settled call, and a settled
+call is hidden while folded, so expansion always adds a row.
+
+## 4. Awaiting permission
+
+### Wire
+
+`PermissionPendingDto` gains `string? ToolUseId`, serialized `tool_use_id` by the
+existing snake-case context. Source-gen leaves a missing member null, so an older
+daemon's frame decodes unchanged and an older app ignores the extra member.
+`PermissionWire` gains `MaxToolUseIdBytes = 128`; the id is opaque, not a GUID,
+so it is not canonicalized. `IsPendingStructurallyValid` does not require it.
+
+### Daemon
+
+`LocalPermissionBridge.BuildPending` takes the id read from the hook body's
+`tool_use_id`; an id over the cap is dropped to null, not a reason to refuse the
+request. Nothing else in the bridge, broker or server leg reads it.
+
+### App
+
+`PendingPermissionRequest.ToolUseId => Dto.ToolUseId`.
+
+`ChatTabViewModel` subscribes a second time to the already agent-filtered,
+main-thread `permissions.Pending` change set and keeps
+`Dictionary<string, PendingPermissionRequest> _requests`, this agent's pending
+requests by request id. The marking is a pure function of two sets, the pending
+requests and the running calls in `_pendingTools`, recomputed from scratch by
+one `Reconcile()` whenever either set changes; no entry remembers a target. A
+request's target is:
+
+- the running call under the request's `ToolUseId`, when the request has one,
+  or null while no such row exists; or
+- when it has none, the agent's sole running call; two or more running calls,
+  or none, give null.
+
+A row's `IsAwaitingPermission` is whether any request targets it, so two
+requests on one row keep it marked until both go. `Reconcile()` computes the
+new target set, then diffs it against `HashSet<ToolCallItem> _marked`, the
+rows it marked last time: a row in `_marked` but not in the new set is cleared,
+a row in the new set is marked, and `_marked` becomes the new set. The diff is
+what clears a row the running set no longer contains: a settling call leaves
+`_pendingTools` before its outcome flips, so a recompute over the running set
+alone could never reach it, and its `✓` would mask a flag still true. It runs
+after the change set is applied, after `Apply` adds a read's rows (a request
+whose row arrived after the card now finds it; an id-less request whose sole
+call gained a sibling loses its mark), after a call settles (the settled row is
+cleared; an id-less request that had two candidates now has one, the
+survivor), and after a reset or path switch has rebuilt the rows, where
+`_marked` is emptied with the rows since those objects are gone. `_requests` is
+permission state, not transcript state: a rebuild re-derives the marks from
+the requests still pending and leaves the requests alone. The recompute is
+requests times a dictionary lookup plus the diff, per change; all three sets
+are small.
+
+A request that resolves leaves the row Running until the tool result flips it;
+a request still pending when the result lands is a vendor oddity the glyph
+resolves in favour of the outcome, since Done and Error take precedence over the
+waiting marker.
+
+With an id, correlation is an exact string match between the hook's
+`tool_use_id` and the transcript's tool-call id; Claude's are the same
+`toolu_…` value by construction. Codex requests arrive without one and take the
+sole-running-call rule, which is exact whenever Codex runs its calls one at a
+time and abstains when it does not.
+
+## 5. Testing
+
+Pure, `test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs`: every name in the
+internal map resolves to its row's category (enumerated from the map, not
+sampled), the names the Codex and Claude projection tests emit (`spawn_agent`,
+`exec`, `shell`, and the Claude fixtures' `tool_use` names) land in a
+non-Other row, singular
+against plural, first-appearance order, lower-casing after the first phrase,
+`mcp__` and unknown names as Other, case-insensitive names, empty input.
+Categorize: a Read of `…/SKILL.md` is Skill; a shell `sed -n '1,40p' a.cs` is
+Read, `rg foo src` is Search, `ls src` is Search, `cat a && make` is Command,
+a `cat SKILL.md` is Skill, an array `command` joins, a Bash call whose input
+has only `description` stays Command. The classifier's pure `Classify` tests
+come across with it, `test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs`,
+unchanged except for namespace, as the parity pin against the server's copy;
+the server file's `EffectiveCodexHint` and `EffectiveCodexPatch` tests exercise
+server-only accessors and stay where they are.
+
+View-model, `ChatTabViewModelTests`:
+
+- Consecutive calls across two reads form one group; a user turn, an assistant
+  text and a system note each close it; the next call opens a new one.
+- A result folds its call: `LiveCalls` shrinks, `Summary` and `HasSummary`
+  update, `HasFailure` follows an error; an unmatched result changes nothing.
+- A reset and a path switch clear the open group with the items.
+- The waiting flag with an id: card before row, row before card, cleared on
+  resolve, and an id matching no row marks nothing. Two requests naming one
+  row: removing one leaves the mark, removing both clears it. A marked call
+  that settles while its request stays pending and no other call qualifies is
+  cleared, not merely masked by its outcome glyph.
+- The waiting flag without an id: one running call is marked; a second call
+  starting clears it; two running calls mark nothing until one settles, then
+  the survivor is marked; a row created after the card is marked when it is
+  the only running call; the mark clears on resolve.
+- A request pending across a reset and across a path switch marks the rebuilt
+  row again, by id and by the sole-running rule.
+- The existing pairing, initial-load and reset tests move their assertions onto
+  the group's `Calls`.
+
+Rendered, `ChatTabViewSmokeTests`:
+
+- A folded group renders one summary line and no rows; toggling renders every
+  row beneath it; a live row is visible in both states.
+- The summary line carries the danger `✕` when a folded call failed.
+- An awaiting row paints `?` with the accent brush; a settled row's glyph still
+  takes the outcome brush (the existing test, on an expanded group).
+- Rows inside an open group stack densely and keep their distance from prose
+  (the existing test, on an expanded group).
+- Follow-tail on inner mutations: a live call appended to an existing group on
+  a later poll, and a call folding away, each keep the reader at the bottom
+  when they were there and leave the offset alone when they were scrolled up.
+- Expanding the trailing group while at the bottom leaves the offset where it
+  was; the next transcript append follows the tail again.
+- A thousand-call group expands: every row is realized and laid out in the
+  headless host, and the view stays a single virtualized outer item. Folding
+  it again leaves only the live rows' containers realized.
+
+Wire, `PermissionWireContractsTests`: `tool_use_id` round-trips in snake case, a
+frame without it decodes to null, and the worst-case frame still fits the codec
+cap with it.
+
+Daemon, `LocalPermissionBridgeInteractiveTests`: the pending DTO carries the
+hook body's `tool_use_id`; an over-cap id is dropped and the request still
+registers.
+
+## 6. Documentation
+
+`docs/CHANGES.md` gains a "Compact tool calls in the Chat tab" section naming the
+group rule, the uniform fold, the wire field and the fold-never-hides-an-error
+rule. No CLI surface changes, so the README is untouched. The spec rides the
+implementation PR and is posted to AI-2418 as a comment.

--- a/docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md
+++ b/docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md
@@ -381,7 +381,8 @@ Rendered, `ChatTabViewSmokeTests`:
   a later poll, and a call folding away, each keep the reader at the bottom
   when they were there and leave the offset alone when they were scrolled up.
 - Expanding the trailing group while at the bottom leaves the offset where it
-  was; the next transcript append follows the tail again.
+  was; the hold is one-shot, so once the reader scrolls back to the bottom the
+  next transcript append follows the tail again.
 - A thousand-call group expands: every row is realized and laid out in the
   headless host, and the view stays a single virtualized outer item. Folding
   it again leaves only the live rows' containers realized.

--- a/src/Capacitor.App/Services/IPermissionService.cs
+++ b/src/Capacitor.App/Services/IPermissionService.cs
@@ -29,6 +29,7 @@ public sealed class PendingPermissionRequest {
     public string ToolName => Dto.ToolName;
     public string? ToolInputJson => Dto.ToolInput?.GetRawText();
     public bool ToolInputOmitted => Dto.ToolInputOmitted;
+    public string? ToolUseId => Dto.ToolUseId;
     public DateTimeOffset RequestedAt { get; }
     public ElicitationQuestions? Questions { get; }
 }

--- a/src/Capacitor.App/ViewModels/ChatItems.cs
+++ b/src/Capacitor.App/ViewModels/ChatItems.cs
@@ -1,8 +1,11 @@
+using System.ComponentModel;
+using System.Reactive;
+using Avalonia.Collections;
 using ReactiveUI;
 
 namespace Capacitor.App.ViewModels;
 
-/// One row of the Chat tab. Four shapes, matched by DataTemplates on the concrete type.
+/// One row of the Chat tab. Five shapes, matched by DataTemplates on the concrete type.
 public abstract class ChatItemViewModel : ReactiveObject { }
 
 public sealed class UserTurnItem(string text) : ChatItemViewModel {
@@ -20,12 +23,13 @@ public sealed class SystemNoteItem(string text) : ChatItemViewModel {
 
 public enum ToolOutcome { Running, Done, Error }
 
-public sealed class ToolCallItem(string name, string detail) : ChatItemViewModel {
+public sealed class ToolCallItem(string name, string detail, ToolCategory category = ToolCategory.Other) : ChatItemViewModel {
     public string Name { get; } = name;
     public string Detail { get; } = detail;
+    public ToolCategory Category { get; } = category;
 
     ToolOutcome _outcome;
-    /// Flipped in place when the matching tool_result arrives; never rebuilt.
+    /// Flipped in place when the matching tool_result arrives; a result is terminal.
     public ToolOutcome Outcome {
         get => _outcome;
         set {
@@ -34,9 +38,88 @@ public sealed class ToolCallItem(string name, string detail) : ChatItemViewModel
             this.RaisePropertyChanged();
             this.RaisePropertyChanged(nameof(OutcomeGlyph));
             this.RaisePropertyChanged(nameof(IsError));
+            this.RaisePropertyChanged(nameof(IsSettled));
         }
     }
 
-    public string OutcomeGlyph => _outcome switch { ToolOutcome.Done => "✓", ToolOutcome.Error => "✕", _ => "" };
+    bool _isAwaitingPermission;
+    /// Owned by the permission cache, not the transcript: the two arrive in either order.
+    public bool IsAwaitingPermission {
+        get => _isAwaitingPermission;
+        set {
+            if (_isAwaitingPermission == value) return;
+            _isAwaitingPermission = value;
+            this.RaisePropertyChanged();
+            this.RaisePropertyChanged(nameof(OutcomeGlyph));
+        }
+    }
+
+    public bool IsSettled => _outcome != ToolOutcome.Running;
     public bool IsError => _outcome == ToolOutcome.Error;
+    public string OutcomeGlyph => _outcome switch {
+        ToolOutcome.Done  => "✓",
+        ToolOutcome.Error => "✕",
+        _                 => _isAwaitingPermission ? "?" : "",
+    };
+}
+
+/// A run of consecutive tool calls. Settled calls fold into Summary; live ones stay listed.
+/// VisibleCalls is the one list the view binds, swapped on toggle so a folded group holds no
+/// containers for its settled rows.
+public sealed class ToolGroupItem : ChatItemViewModel {
+    readonly AvaloniaList<ToolCallItem> _calls = new();
+    readonly AvaloniaList<ToolCallItem> _live = new();
+
+    public IAvaloniaReadOnlyList<ToolCallItem> Calls => _calls;
+    public IAvaloniaReadOnlyList<ToolCallItem> LiveCalls => _live;
+    public IAvaloniaReadOnlyList<ToolCallItem> VisibleCalls => _isExpanded ? _calls : _live;
+
+    bool _isExpanded;
+    public bool IsExpanded {
+        get => _isExpanded;
+        private set {
+            if (_isExpanded == value) return;
+            _isExpanded = value;
+            this.RaisePropertyChanged();
+            this.RaisePropertyChanged(nameof(VisibleCalls));
+        }
+    }
+
+    public ReactiveCommand<Unit, Unit> ToggleCommand { get; }
+
+    string _summary = "";
+    public string Summary { get => _summary; private set => this.RaiseAndSetIfChanged(ref _summary, value); }
+
+    bool _hasSummary;
+    public bool HasSummary { get => _hasSummary; private set => this.RaiseAndSetIfChanged(ref _hasSummary, value); }
+
+    bool _hasFailure;
+    public bool HasFailure { get => _hasFailure; private set => this.RaiseAndSetIfChanged(ref _hasFailure, value); }
+
+    public ToolGroupItem() {
+        ToggleCommand = ReactiveCommand.Create(Toggle);
+    }
+
+    public void Toggle() => IsExpanded = !IsExpanded;
+
+    public void Add(ToolCallItem call) {
+        _calls.Add(call);
+        if (call.IsSettled) { Recompute(); return; }
+        _live.Add(call);
+        call.PropertyChanged += OnCallChanged;
+    }
+
+    void OnCallChanged(object? sender, PropertyChangedEventArgs e) {
+        if (e.PropertyName != nameof(ToolCallItem.Outcome) || sender is not ToolCallItem call || !call.IsSettled) return;
+        call.PropertyChanged -= OnCallChanged;
+        _live.Remove(call);
+        Recompute();
+    }
+
+    void Recompute() {
+        var settled = _calls.Where(c => c.IsSettled).ToList();
+        Summary = ToolSummary.Describe(settled.Select(c => c.Category));
+        HasFailure = settled.Any(c => c.IsError);
+        HasSummary = settled.Count > 0;
+    }
 }

--- a/src/Capacitor.App/ViewModels/ChatItems.cs
+++ b/src/Capacitor.App/ViewModels/ChatItems.cs
@@ -23,7 +23,7 @@ public sealed class SystemNoteItem(string text) : ChatItemViewModel {
 
 public enum ToolOutcome { Running, Done, Error }
 
-public sealed class ToolCallItem(string name, string detail, ToolCategory category = ToolCategory.Other) : ChatItemViewModel {
+public sealed class ToolCallItem(string name, string detail, ToolCategory category) : ChatItemViewModel {
     public string Name { get; } = name;
     public string Detail { get; } = detail;
     public ToolCategory Category { get; } = category;

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -37,6 +37,8 @@ public sealed class ChatTabViewModel : ReactiveObject {
     readonly AvaloniaList<ChatItemViewModel> _items = new();
     readonly Dictionary<string, ToolCallItem> _pendingTools = new(StringComparer.Ordinal);
     readonly ConcurrentDictionary<string, byte> _loggedFailures = new(StringComparer.Ordinal);
+    readonly Dictionary<string, PendingPermissionRequest> _requests = new(StringComparer.Ordinal);
+    readonly HashSet<ToolCallItem> _marked = new(ReferenceEqualityComparer.Instance);
     ToolGroupItem? _openGroup;
 
     /// The tail and the generation it belongs to, taken as one reference: reading the two
@@ -186,6 +188,20 @@ public sealed class ChatTabViewModel : ReactiveObject {
 
         cards.Subscribe().DisposeWith(_disposables);
 
+        permissions.Pending
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Filter(p => p.AgentId == agentId)
+            .Subscribe(changes => {
+                foreach (var change in changes) {
+                    switch (change.Reason) {
+                        case ChangeReason.Add or ChangeReason.Update: _requests[change.Key] = change.Current; break;
+                        case ChangeReason.Remove: _requests.Remove(change.Key); break;
+                    }
+                }
+                Reconcile();
+            })
+            .DisposeWith(_disposables);
+
         daemon.Agents.Connect()
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(OnAgentsChanged)
@@ -259,6 +275,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
         _items.Clear();
         _pendingTools.Clear();
         _openGroup = null;
+        _marked.Clear();
         _path = path;
         _lease = new TailLease(new JsonlTail(path), Interlocked.Increment(ref _generation));
         var wasWaiting = _phase == ChatTabPhase.Waiting;
@@ -309,6 +326,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
                 _items.Clear();
                 _pendingTools.Clear();
                 _openGroup = null;
+                _marked.Clear();
                 break;
         }
 
@@ -348,6 +366,27 @@ public sealed class ChatTabViewModel : ReactiveObject {
             }
         }
         if (fresh.Count > 0) _items.AddRange(fresh);
+        Reconcile();
+    }
+
+    /// A row is marked iff some pending request targets it: by tool-use id when the request has
+    /// one, else the sole running call. Recomputed whole on every change to either set and diffed
+    /// against the last marks, because a settled call has already left _pendingTools by the time
+    /// its outcome flips, so the running set alone could never reach it to clear it.
+    void Reconcile() {
+        var targets = new HashSet<ToolCallItem>(ReferenceEqualityComparer.Instance);
+        var sole = _pendingTools.Count == 1 ? _pendingTools.Values.First() : null;
+        foreach (var request in _requests.Values) {
+            if (request.ToolUseId is { } id) {
+                if (_pendingTools.TryGetValue(id, out var call)) targets.Add(call);
+            } else if (sole is not null) {
+                targets.Add(sole);
+            }
+        }
+        foreach (var call in _marked) if (!targets.Contains(call)) call.IsAwaitingPermission = false;
+        foreach (var call in targets) call.IsAwaitingPermission = true;
+        _marked.Clear();
+        _marked.UnionWith(targets);
     }
 
     void LogOnce(string reason) {

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -37,6 +37,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
     readonly AvaloniaList<ChatItemViewModel> _items = new();
     readonly Dictionary<string, ToolCallItem> _pendingTools = new(StringComparer.Ordinal);
     readonly ConcurrentDictionary<string, byte> _loggedFailures = new(StringComparer.Ordinal);
+    ToolGroupItem? _openGroup;
 
     /// The tail and the generation it belongs to, taken as one reference: reading the two
     /// separately lets a switch land between them and tag a read of the old file with the new
@@ -257,6 +258,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
     void SwitchPath(string path) {
         _items.Clear();
         _pendingTools.Clear();
+        _openGroup = null;
         _path = path;
         _lease = new TailLease(new JsonlTail(path), Interlocked.Increment(ref _generation));
         var wasWaiting = _phase == ChatTabPhase.Waiting;
@@ -306,6 +308,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
             case TailStatus.Reset:
                 _items.Clear();
                 _pendingTools.Clear();
+                _openGroup = null;
                 break;
         }
 
@@ -316,18 +319,26 @@ public sealed class ChatTabViewModel : ReactiveObject {
         foreach (var e in envelopes) {
             switch (e.Kind) {
                 case AcpEventKind.UserMessage:
+                    _openGroup = null;
                     fresh.Add(new UserTurnItem(e.Text ?? ""));
                     break;
                 case AcpEventKind.AssistantText:
+                    _openGroup = null;
                     fresh.Add(new AssistantTextItem(e.Text ?? ""));
                     break;
                 case AcpEventKind.SystemNote:
+                    _openGroup = null;
                     fresh.Add(new SystemNoteItem(e.Text ?? ""));
                     break;
                 case AcpEventKind.ToolCall: {
-                    var item = new ToolCallItem(e.ToolName ?? "tool", ToolDetail.From(e.ToolInputJson, _root));
+                    var name = e.ToolName ?? "tool";
+                    var item = new ToolCallItem(name, ToolDetail.From(e.ToolInputJson, _root), ToolSummary.Categorize(name, e.ToolInputJson));
                     if (e.ToolCallId is { } id) _pendingTools[id] = item;
-                    fresh.Add(item);
+                    if (_openGroup is null) {
+                        _openGroup = new ToolGroupItem();
+                        fresh.Add(_openGroup);
+                    }
+                    _openGroup.Add(item);
                     break;
                 }
                 case AcpEventKind.ToolResult:

--- a/src/Capacitor.App/ViewModels/ToolSummary.cs
+++ b/src/Capacitor.App/ViewModels/ToolSummary.cs
@@ -1,0 +1,98 @@
+using System.Text;
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Harness.Codex;
+
+namespace Capacitor.App.ViewModels;
+
+public enum ToolCategory { Read, Edit, Command, Search, WebSearch, Fetch, Skill, Agent, Plan, Question, Other }
+
+/// What a group of settled tool calls says about itself. The name map keys on the name the
+/// transcript carries (Codex's rollout says `shell`, its hook says `Bash`); a name in no row is
+/// Other, so an unknown vendor tool still reads "Called a tool" rather than nothing.
+public static class ToolSummary {
+    internal static readonly IReadOnlyDictionary<string, ToolCategory> Names = new Dictionary<string, ToolCategory>(StringComparer.OrdinalIgnoreCase) {
+        ["Read"] = ToolCategory.Read, ["NotebookRead"] = ToolCategory.Read, ["read_file"] = ToolCategory.Read, ["view_image"] = ToolCategory.Read,
+        ["Edit"] = ToolCategory.Edit, ["MultiEdit"] = ToolCategory.Edit, ["Write"] = ToolCategory.Edit, ["NotebookEdit"] = ToolCategory.Edit,
+        ["apply_patch"] = ToolCategory.Edit, ["write_file"] = ToolCategory.Edit,
+        ["Bash"] = ToolCategory.Command, ["BashOutput"] = ToolCategory.Command, ["KillShell"] = ToolCategory.Command, ["shell"] = ToolCategory.Command,
+        ["shell_command"] = ToolCategory.Command, ["exec"] = ToolCategory.Command, ["exec_command"] = ToolCategory.Command,
+        ["write_stdin"] = ToolCategory.Command, ["local_shell"] = ToolCategory.Command, ["container.exec"] = ToolCategory.Command,
+        ["Grep"] = ToolCategory.Search, ["Glob"] = ToolCategory.Search, ["LS"] = ToolCategory.Search,
+        ["WebSearch"] = ToolCategory.WebSearch, ["web_search"] = ToolCategory.WebSearch,
+        ["WebFetch"] = ToolCategory.Fetch,
+        ["Skill"] = ToolCategory.Skill,
+        ["Task"] = ToolCategory.Agent, ["Agent"] = ToolCategory.Agent, ["TaskOutput"] = ToolCategory.Agent, ["TaskStop"] = ToolCategory.Agent,
+        ["spawn_agent"] = ToolCategory.Agent, ["wait_agent"] = ToolCategory.Agent, ["send_input"] = ToolCategory.Agent, ["send_message"] = ToolCategory.Agent,
+        ["resume_agent"] = ToolCategory.Agent, ["interrupt_agent"] = ToolCategory.Agent, ["close_agent"] = ToolCategory.Agent, ["list_agents"] = ToolCategory.Agent,
+        ["TodoWrite"] = ToolCategory.Plan, ["update_plan"] = ToolCategory.Plan,
+        ["AskUserQuestion"] = ToolCategory.Question, ["request_user_input"] = ToolCategory.Question,
+    };
+
+    // Indexed by ToolCategory.
+    static readonly (string One, string Many)[] Phrases = [
+        ("Read a file", "Read files"),
+        ("Edited a file", "Edited files"),
+        ("Ran a command", "Ran commands"),
+        ("Searched files", "Searched files"),
+        ("Searched the web", "Searched the web"),
+        ("Fetched a page", "Fetched pages"),
+        ("Loaded a skill", "Loaded skills"),
+        ("Ran an agent", "Ran agents"),
+        ("Updated the plan", "Updated the plan"),
+        ("Asked a question", "Asked questions"),
+        ("Called a tool", "Called tools"),
+    ];
+
+    public static ToolCategory Categorize(string name, string? inputJson) {
+        var category = Names.TryGetValue(name, out var known) ? known : ToolCategory.Other;
+        if (category is not (ToolCategory.Read or ToolCategory.Command) || string.IsNullOrEmpty(inputJson)) return category;
+        try {
+            using var doc = JsonDocument.Parse(inputJson);
+            var root = doc.RootElement;
+            if (!root.IsObject) return category;
+            if (category == ToolCategory.Read)
+                return IsSkillFile(root.Str("file_path")) ? ToolCategory.Skill : category;
+            var hint = CodexCommandClassifier.Classify(CommandText(root));
+            return hint?.Type switch {
+                "read"                   => IsSkillFile(hint.Name) ? ToolCategory.Skill : ToolCategory.Read,
+                "search" or "list_files" => ToolCategory.Search,
+                _                        => category,
+            };
+        } catch (JsonException) {
+            return category;
+        }
+    }
+
+    public static string Describe(IEnumerable<ToolCategory> categories) {
+        var order = new List<ToolCategory>();
+        var counts = new Dictionary<ToolCategory, int>();
+        foreach (var c in categories) {
+            if (!counts.TryAdd(c, 1)) counts[c]++;
+            else order.Add(c);
+        }
+        var sb = new StringBuilder();
+        foreach (var c in order) {
+            var (one, many) = Phrases[(int)c];
+            var phrase = counts[c] == 1 ? one : many;
+            if (sb.Length == 0) sb.Append(phrase);
+            else sb.Append(", ").Append(char.ToLowerInvariant(phrase[0])).Append(phrase, 1, phrase.Length - 1);
+        }
+        return sb.ToString();
+    }
+
+    static bool IsSkillFile(string? path) =>
+        path is not null && (path == "SKILL.md" || path.EndsWith("/SKILL.md", StringComparison.Ordinal));
+
+    /// `cmd` (unified exec), then `command` as a string, then `command` as an argv array — a
+    /// `bash -lc &lt;script&gt;` array hands its script through, since the classifier only peels the
+    /// wrapper when the script is one quoted token.
+    static string? CommandText(JsonElement root) {
+        if (root.Str("cmd") is { } cmd) return cmd;
+        if (root.Str("command") is { } command) return command;
+        if (root.Arr("command") is not { } argv) return null;
+        var parts = argv.EnumerateArray().Where(p => p.ValueKind == JsonValueKind.String).Select(p => p.GetString()!).ToList();
+        if (parts.Count == 3 && parts[1] is "-lc" or "-c" && parts[0].EndsWith("sh", StringComparison.Ordinal)) return parts[2];
+        return string.Join(' ', parts);
+    }
+}

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -52,6 +52,29 @@
                                    Foreground="{Binding IsError, Converter={x:Static views:ToolOutcomeBrushConverter.Instance}}" />
                     </StackPanel>
                 </DataTemplate>
+                <DataTemplate x:DataType="vm:ToolGroupItem">
+                    <StackPanel>
+                        <Button Classes="toolSummary" IsVisible="{Binding HasSummary}" Command="{Binding ToggleCommand}"
+                                Background="Transparent" BorderBrush="Transparent" Padding="0" Margin="0,0,0,6" Cursor="Hand"
+                                HorizontalAlignment="Left">
+                            <StackPanel Orientation="Horizontal" Spacing="9">
+                                <!-- Stroked chevron, not a text glyph — the 9px ▸ rendered as a dot. -->
+                                <Panel Width="12" Height="12" VerticalAlignment="Center">
+                                    <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.8"
+                                          StrokeLineCap="Round" StrokeJoin="Round"
+                                          Data="M3,4.5 L6,7.5 L9,4.5" IsVisible="{Binding IsExpanded}" />
+                                    <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.8"
+                                          StrokeLineCap="Round" StrokeJoin="Round"
+                                          Data="M4.5,3 L7.5,6 L4.5,9" IsVisible="{Binding !IsExpanded}" />
+                                </Panel>
+                                <TextBlock Text="{Binding Summary}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
+                                <TextBlock Text="✕" FontSize="11" Foreground="{StaticResource KcapDangerBrush}"
+                                           IsVisible="{Binding HasFailure}" VerticalAlignment="Center" />
+                            </StackPanel>
+                        </Button>
+                        <ItemsControl ItemsSource="{Binding VisibleCalls}" />
+                    </StackPanel>
+                </DataTemplate>
             </ItemsControl.DataTemplates>
         </ItemsControl>
 

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -2,6 +2,7 @@ using System.Windows.Input;
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Interactivity;
+using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Capacitor.App.ViewModels;
 
@@ -17,8 +18,8 @@ public partial class ChatTabView : UserControl {
     const double BottomTolerance = 2;
 
     ScrollViewer? _scroll;
-    /// Armed by a click on a group's summary line, consumed by the extent change that click causes:
-    /// expanding a group must not scroll the clicked line out of view.
+    /// Armed by a click on a group's summary line and released once the dispatcher queue drains past layout, so neither the
+    /// expansion's own extent change nor an append already queued behind the click scrolls the clicked line out of view.
     bool _holdTail;
 
     public ChatTabView() {
@@ -37,12 +38,15 @@ public partial class ChatTabView : UserControl {
     }
 
     void OnItemButtonClick(object? sender, RoutedEventArgs e) {
-        if (e.Source is Button button && button.Classes.Contains("toolSummary")) _holdTail = true;
+        if (e.Source is not Button button || !button.Classes.Contains("toolSummary")) return;
+        var wasHeld = _holdTail;
+        _holdTail = true;
+        if (!wasHeld) Dispatcher.UIThread.Post(() => _holdTail = false, DispatcherPriority.Background);
     }
 
     void OnScrollChanged(object? sender, ScrollChangedEventArgs e) {
         if (sender is not ScrollViewer scroll || (e.ExtentDelta.Y == 0 && e.ViewportDelta.Y == 0)) return;
-        if (_holdTail && e.ExtentDelta.Y != 0) { _holdTail = false; return; }
+        if (_holdTail) return;
         var offsetBefore   = scroll.Offset.Y - e.OffsetDelta.Y;
         var viewportBefore = scroll.Viewport.Height - e.ViewportDelta.Y;
         var extentBefore   = scroll.Extent.Height - e.ExtentDelta.Y;

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -17,12 +17,16 @@ public partial class ChatTabView : UserControl {
     const double BottomTolerance = 2;
 
     ScrollViewer? _scroll;
+    /// Armed by a click on a group's summary line, consumed by the extent change that click causes:
+    /// expanding a group must not scroll the clicked line out of view.
+    bool _holdTail;
 
     public ChatTabView() {
         InitializeComponent();
         // Tunnel, not bubble: TextBox's own class handler runs first on the bubbling route, where
         // it inserts the newline and marks Enter handled before any instance handler sees it.
         ComposerInput.AddHandler(KeyDownEvent, OnComposerKeyDown, RoutingStrategies.Tunnel);
+        ChatItems.AddHandler(Button.ClickEvent, OnItemButtonClick);
         // The ScrollViewer is the list template's; it exists only once the list is first measured,
         // which for a surface built before its first layout is later than the first rows.
         ChatItems.TemplateApplied += (_, _) => {
@@ -32,8 +36,13 @@ public partial class ChatTabView : UserControl {
         };
     }
 
-    static void OnScrollChanged(object? sender, ScrollChangedEventArgs e) {
+    void OnItemButtonClick(object? sender, RoutedEventArgs e) {
+        if (e.Source is Button button && button.Classes.Contains("toolSummary")) _holdTail = true;
+    }
+
+    void OnScrollChanged(object? sender, ScrollChangedEventArgs e) {
         if (sender is not ScrollViewer scroll || (e.ExtentDelta.Y == 0 && e.ViewportDelta.Y == 0)) return;
+        if (_holdTail && e.ExtentDelta.Y != 0) { _holdTail = false; return; }
         var offsetBefore   = scroll.Offset.Y - e.OffsetDelta.Y;
         var viewportBefore = scroll.Viewport.Height - e.ViewportDelta.Y;
         var extentBefore   = scroll.Extent.Height - e.ExtentDelta.Y;

--- a/src/Capacitor.Cli.Core/Harness/Codex/CodexCommandClassifier.cs
+++ b/src/Capacitor.Cli.Core/Harness/Codex/CodexCommandClassifier.cs
@@ -584,6 +584,15 @@ internal static class ShellTokenizer {
                     continue;
             }
 
+            // An unquoted line break ends a command the way `;` does: folding it into whitespace
+            // would read `rg foo src⏎rm -rf tmp` as one search and hide the mutation.
+            if (c is '\n' or '\r') {
+                Flush();
+                result.Add(";");
+
+                continue;
+            }
+
             if (char.IsWhiteSpace(c)) {
                 Flush();
 

--- a/src/Capacitor.Cli.Core/Harness/Codex/CodexCommandClassifier.cs
+++ b/src/Capacitor.Cli.Core/Harness/Codex/CodexCommandClassifier.cs
@@ -1,0 +1,630 @@
+namespace Capacitor.Cli.Core.Harness.Codex;
+
+/// <summary>
+/// Result of classifying a Codex shell command.
+/// Mirrors the <c>ParsedCommand</c> enum shape Codex's Rust parser emits on
+/// <c>event_msg.exec_command_end.parsed_cmd</c> — see
+/// <c>codex-rs/protocol/src/parse_command.rs</c> in <c>openai/codex</c>.
+/// </summary>
+/// <param name="Type">One of <c>"read"</c>, <c>"search"</c>, <c>"list_files"</c>.</param>
+public sealed record CodexCommandHint(string Type, string? Path = null, string? Name = null, string? Query = null);
+
+/// <summary>
+/// Port of (a useful subset of) Codex's <c>parse_command</c> classifier, used
+/// to label shell exec calls with the same Read/Search/List iconography
+/// Codex's own TUI uses, even when the rollout doesn't include the
+/// <c>event_msg.exec_command_end</c> envelope that carries the structured
+/// <c>parsed_cmd</c>.
+///
+/// Codex 0.5.x rollouts emit just <c>function_call</c>/<c>function_call_output</c>
+/// (no <c>exec_command_end</c>), so the canonical <c>extensions.codex.exec.parsed_cmd</c>
+/// is empty and every shell call would render as a generic "Shell". Running
+/// this classifier on the <c>arguments.cmd</c> string at render time recovers
+/// the structured kind.
+///
+/// Not exhaustive: we cover the high-traffic commands (sed/nl/cat/head/tail/
+/// less/bat/more/awk; rg/rga; grep/egrep/fgrep; ag/ack/pt; git grep / git
+/// ls-files; ls/eza/exa/tree/du/fd/find). For everything else we return null
+/// and the caller falls back to the raw shell rendering — same outcome as
+/// Codex emitting <c>type:"unknown"</c>.
+/// </summary>
+public static class CodexCommandClassifier {
+    /// <summary>
+    /// Classify a shell command. Strips <c>bash -c</c>/<c>bash -lc</c>/
+    /// <c>zsh -c</c>/<c>zsh -lc</c> wrappers, splits on <c>|</c>/<c>&amp;&amp;</c>/
+    /// <c>||</c>/<c>;</c>, drops small formatting helpers (per upstream's
+    /// <c>drop_small_formatting_commands</c>), and runs <see cref="ClassifySingle"/>
+    /// on each remaining segment. Returns null when any non-helper segment is
+    /// unknown — matching Codex's "collapse any-unknown pipeline to a single
+    /// Unknown" rule. Helper-only pipelines (e.g. <c>head -n 5</c> alone)
+    /// also return null.
+    /// </summary>
+    public static CodexCommandHint? Classify(string? cmd) {
+        if (string.IsNullOrWhiteSpace(cmd)) return null;
+
+        // Outer-shell redirection has to be detected against the raw input —
+        // unwrapping bash -lc would hide a trailing `>out` or `2>&1` that sits
+        // OUTSIDE the wrapped script and is parsed by the spawning shell, not
+        // the wrapped one.
+        if (ContainsUnquotedRedirection(cmd)) return null;
+
+        var tokens = ShellTokenizer.Split(cmd);
+
+        if (tokens.Count == 0) return null;
+
+        // Only peel `bash/zsh -c/-lc <script>` when that's the WHOLE invocation —
+        // any extra tokens after the script are either positional params for
+        // the wrapped shell ($0/$1 inside the script can mean anything) or a
+        // suffix we can't reason about. Falling through with the outer tokens
+        // makes the classifier treat `bash` as the head (no match) and collapse
+        // the whole thing to Shell, which is the safe rendering.
+        var scriptForScan = cmd;
+
+        if (tokens.Count == 3
+         && (tokens[0] == "bash" || tokens[0] == "zsh")
+         && (tokens[1] == "-c"   || tokens[1] == "-lc")) {
+            scriptForScan = tokens[2];
+            tokens        = ShellTokenizer.Split(scriptForScan);
+
+            if (tokens.Count == 0) return null;
+
+            // Re-scan the inner script — the outer `"..."` hides any `>`/`<`
+            // inside the wrapped command from the first scan (those are
+            // re-interpreted by the shell bash -lc spawns).
+            if (ContainsUnquotedRedirection(scriptForScan)) return null;
+        }
+
+        var segments = SplitOnConnectors(tokens);
+
+        if (segments.Count == 0) return null;
+
+        // Drop small formatting helpers (head/tail/sed/awk/wc/cut/sort/uniq/tee/…
+        // without file operands, plus echo, true, and `nl` with only flags) so
+        // common Codex pipelines like `rg --files | head -n 50` or
+        // `nl -ba file | sed -n '1,80p'` keep their primary classification
+        // instead of collapsing to Shell. Mirrors `is_small_formatting_command`
+        // / `simplify_once` in openai/codex codex-rs/shell-command/src/parse_command.rs.
+        var meaningful = segments
+            .Where(seg => seg.Count > 0 && seg[0] != "cd" && !IsFormattingHelper(seg))
+            .ToList();
+
+        if (meaningful.Count == 0) return null;
+
+        CodexCommandHint? first = null;
+
+        foreach (var segment in meaningful) {
+            var hint = ClassifySingle(segment);
+
+            // A non-helper segment with no classification = unknown ⇒ collapse to Shell.
+            if (hint is null) return null;
+
+            first ??= hint;
+        }
+
+        return first;
+    }
+
+    /// <summary>
+    /// Quote-aware scan for shell I/O redirection characters. Returns true on
+    /// the first unquoted <c>&gt;</c> or <c>&lt;</c> encountered. Catches:
+    /// <list type="bullet">
+    ///   <item>spaced operators: <c>cmd &gt; out</c>, <c>cmd 2&gt; err</c>;</item>
+    ///   <item>glued operators: <c>cmd &gt;out</c>, <c>cmd 2&gt;err</c>,
+    ///     <c>foo.txt&gt;bar.txt</c>;</item>
+    ///   <item>combined fd dups: <c>cmd &gt; out 2&gt;&amp;1</c>;</item>
+    /// </list>
+    /// while still respecting single/double quoting so <c>rg '&gt;' src</c>
+    /// and <c>grep "&lt;tag&gt;" file</c> stay classified as Search.
+    /// </summary>
+    static bool ContainsUnquotedRedirection(string input) {
+        var quote = '\0';
+
+        for (var i = 0; i < input.Length; i++) {
+            var c = input[i];
+
+            if (quote != '\0') {
+                if (c == '\\' && quote == '"' && i + 1 < input.Length) {
+                    i++;
+
+                    continue;
+                }
+
+                if (c == quote) quote = '\0';
+
+                continue;
+            }
+
+            switch (c) {
+                case '\'' or '"':
+                    quote = c;
+
+                    continue;
+                case '\\' when i + 1 < input.Length:
+                    i++;
+
+                    continue;
+                case '>' or '<':
+                    return true;
+            }
+        }
+
+        return false;
+    }
+
+    /// <summary>
+    /// Mirrors upstream's <c>is_small_formatting_command</c>: returns true for
+    /// the well-known pipeline helpers (<c>wc</c>/<c>tr</c>/<c>cut</c>/<c>sort</c>/
+    /// <c>uniq</c>/<c>tee</c>/<c>column</c>/<c>yes</c>/<c>printf</c>; <c>head</c>/
+    /// <c>tail</c>/<c>sed</c>/<c>awk</c>/<c>nl</c> when they have no file operand;
+    /// <c>echo</c>, the boolean <c>true</c>, and <c>xargs</c> with a known
+    /// display-only subcommand).
+    ///
+    /// <c>xargs</c> is treated as Unknown (i.e. not a helper) by default —
+    /// upstream only flags a narrow set of mutating subcommands, which misses
+    /// obvious destructive forms (<c>xargs rm</c>, <c>xargs mv</c>,
+    /// <c>xargs sh -c '…'</c>). Defaulting to Unknown collapses any such
+    /// pipeline back to Shell so the row surfaces the full command.
+    /// </summary>
+    static bool IsFormattingHelper(List<string> tokens) {
+        if (tokens.Count == 0) return false;
+
+        var head = tokens[0];
+        var tail = tokens.Skip(1).ToList();
+
+        return head switch {
+            "wc" or "tr" or "cut" or "sort" or "uniq" or "tee" or "column" or "yes" or "printf" => true,
+            "echo"                                                                              => true,
+            "true"                                                                              => tokens.Count == 1,
+            "xargs"                                                                             => IsSafeDisplayOnlyXargs(tokens),
+            // awk: helper unless there's a clear data-file operand. We don't fully
+            // emulate Codex's awk_data_file_operand; treat as helper when no bare
+            // non-flag operand follows the script.
+            "awk" => tail.SkipWhile(t => t.StartsWith('-') || t.StartsWith('\'') || t.StartsWith('"'))
+                .Skip(1)
+                .All(t => t.StartsWith('-')),
+            "head" => HeadTailIsHelper(tail, allowPlus: false),
+            "tail" => HeadTailIsHelper(tail, allowPlus: true),
+            // sed: helper unless it would classify as a Read (`sed -n '<range>p' file`);
+            // otherwise it's a pipe formatter.
+            "sed" => SedRead(tail) is null,
+            // nl: helper when no file operand (only flags).
+            "nl" => NlRead(tail) is null,
+            _    => false
+        };
+    }
+
+    static bool HeadTailIsHelper(List<string> tail, bool allowPlus) {
+        return tail.Count switch {
+            // `head` / `tail` alone, or with a single flag/option, or with `-n COUNT` / `-c COUNT`
+            // and no trailing file operand — all formatters.
+            0                                                                          => true,
+            1                                                                          => tail[0].StartsWith('-'),
+            2 when (tail[0] == "-n" || tail[0] == "-c") && IsCount(tail[1], allowPlus) => true,
+            _                                                                          => false
+        };
+    }
+
+    static bool IsCount(string s, bool allowPlus) {
+        if (s.Length == 0) return false;
+
+        var body = allowPlus && s[0] == '+' ? s[1..] : s;
+
+        return body.Length > 0 && body.All(char.IsAsciiDigit);
+    }
+
+    /// <summary>
+    /// True only when the xargs subcommand is one of a strict allowlist of
+    /// display-only programs (<c>cat</c>/<c>head</c>/<c>tail</c>/<c>less</c>/
+    /// <c>more</c>/<c>bat</c>/<c>wc</c>/<c>file</c>/<c>ls</c>/<c>du</c>/
+    /// <c>echo</c>/<c>printf</c>/<c>stat</c>) — and only when that subcommand
+    /// itself looks display-only (no in-place flag on sed, no <c>--replace</c>
+    /// on rg, none of the obvious destructive verbs <c>rm</c>/<c>mv</c>/
+    /// <c>cp</c>/<c>rmdir</c>/<c>sh</c>/<c>bash</c>/<c>perl</c>/<c>ruby</c>/
+    /// <c>python</c>/<c>git</c>/<c>chmod</c>/<c>chown</c>/<c>kill</c>).
+    /// Everything else collapses the pipeline to Shell so the row surfaces the
+    /// full command instead of hiding a destructive xargs side effect.
+    /// </summary>
+    static bool IsSafeDisplayOnlyXargs(List<string> tokens) {
+        // Skip xargs's own flags first.
+        var i = 1;
+
+        while (i < tokens.Count) {
+            var t = tokens[i];
+
+            if (t == "--") {
+                i++;
+
+                break;
+            }
+
+            if (!t.StartsWith('-')) break;
+
+            var takesValue = t is "-E" or "-e" or "-I" or "-L" or "-n" or "-P" or "-s";
+            i += takesValue && t.Length == 2 ? 2 : 1;
+        }
+
+        // Bare xargs (no subcommand) defaults to echo — safe.
+        if (i >= tokens.Count) return true;
+
+        var sub = tokens[i];
+
+        return sub switch {
+            "cat" or "head" or "tail" or "less" or "more" or "bat" or "batcat"
+                or "wc" or "file" or "ls" or "du" or "echo" or "printf" or "stat"
+                => true,
+            _ => false
+        };
+    }
+
+    static List<List<string>> SplitOnConnectors(IReadOnlyList<string> tokens) {
+        var result  = new List<List<string>>();
+        var current = new List<string>();
+
+        foreach (var t in tokens) {
+            if (t is "|" or "&&" or "||" or ";") {
+                if (current.Count > 0) result.Add(current);
+                current = [];
+            } else {
+                current.Add(t);
+            }
+        }
+
+        if (current.Count > 0) result.Add(current);
+
+        return result;
+    }
+
+    static CodexCommandHint? ClassifySingle(List<string> tokens) {
+        if (tokens.Count == 0) return null;
+
+        var head = tokens[0];
+        var tail = tokens.Skip(1).ToList();
+
+        return head switch {
+            "sed" => SedRead(tail),
+            "nl" => NlRead(tail),
+            "cat" or "more" => SingleFileRead(tail, []),
+            "bat" or "batcat" => SingleFileRead(tail, ["--theme", "--language", "--style", "--terminal-width", "--tabs", "--line-range", "--map-syntax"]),
+            "less" => SingleFileRead(tail, ["-p", "-P", "-x", "-y", "-z", "-j", "--pattern", "--prompt", "--tabs", "--shift", "--jump-target"]),
+            "head" or "tail" => HeadTailRead(tail),
+            "rg" or "rga" or "ripgrep-all" => RgClassify(tail),
+            "grep" or "egrep" or "fgrep" => GrepLike(tail, []),
+            "ag" or "ack" or "pt" => GrepLike(tail, ["-G", "-g", "--file-search-regex", "--ignore-dir", "--ignore-file", "--path-to-ignore"]),
+            "ls" or "eza" or "exa" => ListFiles(tail, ["-I", "-w", "--block-size", "--format", "--time-style", "--color", "--quoting-style", "--ignore-glob", "--sort", "--time"]),
+            "tree" => ListFiles(tail, ["-L", "-P", "-I", "--charset", "--filelimit", "--sort"]),
+            "du" => ListFiles(tail, ["-d", "--max-depth", "-B", "--block-size", "--exclude", "--time-style"]),
+            "fd" => FdClassify(tail),
+            "find" => FindClassify(tail),
+            "git" when tail.Count > 0 && tail[0] == "grep" => GrepLike(tail.Skip(1).ToList(), []),
+            "git" when tail.Count > 0 && tail[0] == "ls-files" => ListFiles(tail.Skip(1).ToList(), ["--exclude", "--exclude-from", "--pathspec-from-file"]),
+            _ => null
+        };
+    }
+
+    static CodexCommandHint? SedRead(List<string> tail) {
+        var trimmed = TrimAtConnector(tail);
+
+        if (trimmed.All(t => t != "-n")) return null;
+
+        // sed -n '1,220p' file  or  sed -n -e '1,220p' file
+        var hasRange = false;
+
+        for (var i = 0; i < trimmed.Count; i++) {
+            var arg = trimmed[i];
+
+            if (arg is "-e" or "--expression") {
+                if (i + 1 < trimmed.Count && IsValidSedNArg(trimmed[i + 1])) hasRange = true;
+                i++;
+
+                continue;
+            }
+
+            if (arg is "-f" or "--file") {
+                i++;
+
+                continue;
+            }
+
+            if (!arg.StartsWith('-') && IsValidSedNArg(arg)) hasRange = true;
+        }
+
+        if (!hasRange) return null;
+
+        var candidates = SkipFlagValues(trimmed, ["-e", "-f", "--expression", "--file"]);
+        var nonFlags   = candidates.Where(a => !a.StartsWith('-')).ToList();
+
+        // When the range arg sits among the positionals (sed -n '1,50p' file),
+        // it appears before the file path; skip it. When it's the ONLY positional
+        // (sed -n '1,50p' alone), there's no file → not a Read.
+        string? path = nonFlags switch {
+            []                                                     => null,
+            [var only] when IsValidSedNArg(only)                   => null,
+            [var first, var second, ..] when IsValidSedNArg(first) => second,
+            [var first, ..]                                        => first,
+        };
+
+        if (path is null) return null;
+
+        return new CodexCommandHint("read", Path: path, Name: ShortDisplayName(path));
+    }
+
+    static bool IsValidSedNArg(string s) {
+        if (string.IsNullOrEmpty(s) || !s.EndsWith('p')) return false;
+
+        var core  = s[..^1];
+        var parts = core.Split(',');
+
+        return parts.Length switch {
+            1 => parts[0].Length > 0 && parts[0].All(char.IsAsciiDigit),
+            2 => parts[0].Length > 0 && parts[1].Length > 0 && parts[0].All(char.IsAsciiDigit) && parts[1].All(char.IsAsciiDigit),
+            _ => false
+        };
+    }
+
+    static CodexCommandHint? NlRead(List<string> tail) {
+        var candidates = SkipFlagValues(tail, ["-s", "-w", "-v", "-i", "-b"]);
+        var path       = candidates.FirstOrDefault(a => !a.StartsWith('-'));
+
+        return path is null
+            ? null
+            : new CodexCommandHint("read", Path: path, Name: ShortDisplayName(path));
+    }
+
+    static CodexCommandHint? SingleFileRead(List<string> tail, string[] flagsWithValues) {
+        var candidates = SkipFlagValues(tail, flagsWithValues);
+        var nonFlags   = candidates.Where(a => !a.StartsWith('-')).ToList();
+
+        if (nonFlags.Count != 1) return null;
+
+        var path = nonFlags[0];
+
+        return new CodexCommandHint("read", Path: path, Name: ShortDisplayName(path));
+    }
+
+    static CodexCommandHint? HeadTailRead(List<string> tail) {
+        // head -n 50 file  /  head -n50 file  /  head file
+        var hasValidN = false;
+
+        if (tail.Count > 0) {
+            if (tail[0] == "-n" && tail.Count > 1) {
+                var n = tail[1].TrimStart('+');
+                hasValidN = n.Length > 0 && n.All(char.IsAsciiDigit);
+            } else if (tail[0].StartsWith("-n", StringComparison.Ordinal)) {
+                var n = tail[0][2..].TrimStart('+');
+                hasValidN = n.Length > 0 && n.All(char.IsAsciiDigit);
+            }
+        }
+
+        if (hasValidN) {
+            var candidates = new List<string>();
+            var i          = 0;
+
+            while (i < tail.Count) {
+                if (i == 0 && tail[i] == "-n" && i + 1 < tail.Count) {
+                    var n = tail[i + 1].TrimStart('+');
+
+                    if (n.Length > 0 && n.All(char.IsAsciiDigit)) {
+                        i += 2;
+
+                        continue;
+                    }
+                }
+
+                candidates.Add(tail[i]);
+                i++;
+            }
+
+            var path = candidates.FirstOrDefault(p => !p.StartsWith('-'));
+
+            if (path is not null) return new CodexCommandHint("read", Path: path, Name: ShortDisplayName(path));
+        }
+
+        if (tail is [var single] && !single.StartsWith('-')) {
+            return new CodexCommandHint("read", Path: single, Name: ShortDisplayName(single));
+        }
+
+        return null;
+    }
+
+    static CodexCommandHint RgClassify(List<string> tail) {
+        var trimmed  = TrimAtConnector(tail);
+        var hasFiles = trimmed.Any(a => a == "--files");
+
+        var candidates = SkipFlagValues(
+            trimmed,
+            [
+                "-g", "--glob", "--iglob", "-t", "--type", "--type-add", "--type-not",
+                "-m", "--max-count", "-A", "-B", "-C", "--context", "--max-depth"
+            ]
+        );
+        var nonFlags = candidates.Where(p => !p.StartsWith('-')).ToList();
+
+        if (hasFiles) {
+            var path = nonFlags.Count > 0 ? nonFlags[0] : null;
+
+            return new CodexCommandHint("list_files", Path: path);
+        }
+
+        var query = nonFlags.Count > 0 ? nonFlags[0] : null;
+        var pth   = nonFlags.Count > 1 ? nonFlags[1] : null;
+
+        return new CodexCommandHint("search", Path: pth, Query: query);
+    }
+
+    static CodexCommandHint GrepLike(List<string> tail, string[] flagsWithValues) {
+        var trimmed    = TrimAtConnector(tail);
+        var candidates = SkipFlagValues(trimmed, flagsWithValues);
+        var nonFlags   = candidates.Where(p => !p.StartsWith('-')).ToList();
+        var query      = nonFlags.Count > 0 ? nonFlags[0] : null;
+        var path       = nonFlags.Count > 1 ? nonFlags[1] : null;
+
+        return new CodexCommandHint("search", Path: path, Query: query);
+    }
+
+    static CodexCommandHint ListFiles(List<string> tail, string[] flagsWithValues) {
+        var trimmed    = TrimAtConnector(tail);
+        var candidates = SkipFlagValues(trimmed, flagsWithValues);
+        var path       = candidates.FirstOrDefault(p => !p.StartsWith('-'));
+
+        return new CodexCommandHint("list_files", Path: path);
+    }
+
+    static CodexCommandHint FdClassify(List<string> tail) {
+        var trimmed    = TrimAtConnector(tail);
+        var candidates = SkipFlagValues(trimmed, ["-e", "--extension", "-t", "--type", "-d", "--max-depth", "-E", "--exclude"]);
+        var nonFlags   = candidates.Where(p => !p.StartsWith('-')).ToList();
+        var query      = nonFlags.Count > 0 ? nonFlags[0] : null;
+        var path       = nonFlags.Count > 1 ? nonFlags[1] : null;
+
+        return query is null
+            ? new CodexCommandHint("list_files", Path: path)
+            : new CodexCommandHint("search", Path: path, Query: query);
+    }
+
+    static CodexCommandHint FindClassify(List<string> tail) {
+        // Very basic: first non-flag is the search path; `-name <pattern>` becomes query.
+        string? path  = null;
+        string? query = null;
+
+        for (var i = 0; i < tail.Count; i++) {
+            var arg = tail[i];
+
+            if (arg is "-name" or "-iname") {
+                if (i + 1 < tail.Count) query = tail[i + 1];
+                i++;
+
+                continue;
+            }
+
+            if (!arg.StartsWith('-') && path is null) path = arg;
+        }
+
+        return query is null
+            ? new("list_files", Path: path)
+            : new CodexCommandHint("search", Path: path, Query: query);
+    }
+
+    static List<string> TrimAtConnector(IReadOnlyList<string> tokens) {
+        return tokens.TakeWhile(t => t is not ("|" or "&&" or "||" or ";")).ToList();
+    }
+
+    static List<string> SkipFlagValues(IReadOnlyList<string> tokens, string[] flagsWithValues) {
+        var result = new List<string>();
+
+        for (var i = 0; i < tokens.Count; i++) {
+            var t = tokens[i];
+
+            if (Array.IndexOf(flagsWithValues, t) >= 0) {
+                i++; // skip the value following this flag
+
+                continue;
+            }
+
+            result.Add(t);
+        }
+
+        return result;
+    }
+
+    static string ShortDisplayName(string path) {
+        var lastSlash = path.LastIndexOfAny(['/', '\\']);
+
+        return lastSlash >= 0 && lastSlash < path.Length - 1 ? path[(lastSlash + 1)..] : path;
+    }
+}
+
+/// <summary>
+/// Minimal POSIX-ish shell tokenizer — whitespace splits tokens, single and
+/// double quotes group content, backslash escapes the next character.
+/// Connectors (<c>|</c>, <c>&amp;&amp;</c>, <c>||</c>, <c>;</c>) come out as their own
+/// tokens. Enough to classify the well-formed <c>cmd</c> strings Codex emits
+/// without pulling in a full shell grammar (the upstream Rust impl uses
+/// <c>shlex</c>; the rules below mirror its handling of quoted strings).
+/// </summary>
+internal static class ShellTokenizer {
+    public static List<string> Split(string input) {
+        var result   = new List<string>();
+        var current  = new System.Text.StringBuilder();
+        var quote    = '\0';
+        var hasToken = false;
+
+        void Flush() {
+            if (hasToken) result.Add(current.ToString());
+            current.Clear();
+            hasToken = false;
+        }
+
+        for (var i = 0; i < input.Length; i++) {
+            var c = input[i];
+
+            if (quote != '\0') {
+                if (c == quote) {
+                    quote = '\0';
+                } else if (c == '\\' && quote == '"' && i + 1 < input.Length) {
+                    current.Append(input[++i]);
+                } else {
+                    current.Append(c);
+                }
+
+                hasToken = true;
+
+                continue;
+            }
+
+            switch (c) {
+                case '\'' or '"':
+                    quote    = c;
+                    hasToken = true;
+
+                    continue;
+                case '\\' when i + 1 < input.Length:
+                    current.Append(input[++i]);
+                    hasToken = true;
+
+                    continue;
+            }
+
+            if (char.IsWhiteSpace(c)) {
+                Flush();
+
+                continue;
+            }
+
+            // Connectors.
+            if (c == '|') {
+                Flush();
+
+                if (i + 1 < input.Length && input[i + 1] == '|') {
+                    result.Add("||");
+                    i++;
+                } else {
+                    result.Add("|");
+                }
+
+                continue;
+            }
+
+            if (c == '&' && i + 1 < input.Length && input[i + 1] == '&') {
+                Flush();
+                result.Add("&&");
+                i++;
+
+                continue;
+            }
+
+            if (c == ';') {
+                Flush();
+                result.Add(";");
+
+                continue;
+            }
+
+            current.Append(c);
+            hasToken = true;
+        }
+
+        Flush();
+
+        return result;
+    }
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/PermissionIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/PermissionIpc.cs
@@ -8,7 +8,7 @@ namespace Capacitor.Cli.Core.LocalIpc;
 public sealed record PermissionPendingDto(
     string RequestId, string AgentId, string SessionId, string Vendor, string ToolName,
     JsonElement? ToolInput, JsonElement? Suggestions, bool ToolInputOmitted, bool SuggestionsOmitted,
-    string RequestedAt);
+    string RequestedAt, string? ToolUseId = null);
 
 public sealed record PermissionResolveDto(
     string RequestId, string Decision, JsonElement? ApplyPermissions, JsonElement? UpdatedInput);
@@ -31,6 +31,7 @@ public static class PermissionWire {
     public const int MaxToolNameBytes = 512;
     public const int MaxElementBytes  = 64 * 1024;
     public const int MaxAgentIdBytes  = 128;
+    public const int MaxToolUseIdBytes = 128;
 
     /// A GUID in any case, with or without dashes, as "N"; null when the value is not a GUID.
     public static string? Canonical(string? id) =>

--- a/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalPermissionBridge.cs
@@ -622,7 +622,7 @@ internal sealed partial class LocalPermissionBridge(
                     node["agent_id"]?.GetValue<string>(), canonicalSessionId, node["cwd"]?.GetValue<string>()));
                 var pending = attributed is { } a
                     ? BuildPending(Guid.NewGuid().ToString("N"), a.AgentId, canonicalSessionId!, vendor, toolName, toolInput, suggestions,
-                        DateTimeOffset.UtcNow.ToString("O"))
+                        DateTimeOffset.UtcNow.ToString("O"), ToolUseIdOf(node))
                     : null;
 
                 if (pending is null) {
@@ -693,13 +693,15 @@ internal sealed partial class LocalPermissionBridge(
 
     internal static PermissionPendingDto? BuildPending(
             string requestId, string agentId, string sessionId, string vendor, string? toolName,
-            JsonElement? toolInput, JsonElement? suggestions, string requestedAt) {
+            JsonElement? toolInput, JsonElement? suggestions, string requestedAt, string? toolUseId = null) {
         var name = toolName ?? "";
         if (Encoding.UTF8.GetByteCount(name) > PermissionWire.MaxToolNameBytes) return null;
         if (Encoding.UTF8.GetByteCount(agentId) > PermissionWire.MaxAgentIdBytes) return null;
         var (input, inputOmitted)   = Bound(toolInput);
         var (sugg,  suggOmitted)    = Bound(suggestions);
-        return new PermissionPendingDto(requestId, agentId, sessionId, vendor, name, input, sugg, inputOmitted, suggOmitted, requestedAt);
+        // Over-cap is dropped, not refused: the id only decorates a chat row.
+        var id = toolUseId is { Length: > 0 } t && Encoding.UTF8.GetByteCount(t) <= PermissionWire.MaxToolUseIdBytes ? t : null;
+        return new PermissionPendingDto(requestId, agentId, sessionId, vendor, name, input, sugg, inputOmitted, suggOmitted, requestedAt, id);
 
         static (JsonElement?, bool) Bound(JsonElement? el) =>
             el is { } e && Encoding.UTF8.GetByteCount(e.GetRawText()) > PermissionWire.MaxElementBytes ? (null, true) : (el, false);
@@ -779,6 +781,9 @@ internal sealed partial class LocalPermissionBridge(
 
         return doc.RootElement.Clone();
     }
+
+    static string? ToolUseIdOf(JsonNode node) =>
+        node["tool_use_id"] is JsonValue v && v.TryGetValue<string>(out var id) ? id : null;
 
     /// <summary>
     /// True when the permission request names one of the reserved result channel's unattended-safe

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -22,9 +22,13 @@ public class ChatTabViewModelTests {
     const string ToolCallLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t1","name":"Bash","input":{"command":"ls -la"}}]}}""";
     const string ToolResultLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}}""";
     const string ToolErrorLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"boom","is_error":true}]}}""";
+    const string ReadCallLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"/repo/x/src/a.cs"}}]}}""";
+    const string NoteLine = """{"type":"user","origin":{"kind":"task-notification"},"message":{"content":"<task-notification>\n<summary>Agent finished</summary>\n<result>\nAll good.\n</result>\n</task-notification>"}}""";
 
     static AgentStatusDto Dto(string? transcriptPath, string vendor = "claude") =>
         Agent("a1", vendor, hasTerminal: true, repoPath: "/repo/x") with { TranscriptPath = transcriptPath };
+
+    static ToolGroupItem Group(ChatTabViewModel chat, int index) => (ToolGroupItem)chat.Items[index];
 
     sealed class Harness {
         public FakeDaemonClientService Daemon { get; } = new();
@@ -87,10 +91,11 @@ public class ChatTabViewModelTests {
 
             await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
             await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(
-                new[] { nameof(UserTurnItem), nameof(AssistantTextItem), nameof(ToolCallItem) }, CollectionOrdering.Matching);
+                new[] { nameof(UserTurnItem), nameof(AssistantTextItem), nameof(ToolGroupItem) }, CollectionOrdering.Matching);
             await Assert.That(((UserTurnItem)h.Chat.Items[0]).Text).IsEqualTo("hello");
-            await Assert.That(((ToolCallItem)h.Chat.Items[2]).Detail).IsEqualTo("ls -la");
-            await Assert.That(((ToolCallItem)h.Chat.Items[2]).Outcome).IsEqualTo(ToolOutcome.Running);
+            await Assert.That(Group(h.Chat, 2).Calls[0].Detail).IsEqualTo("ls -la");
+            await Assert.That(Group(h.Chat, 2).Calls[0].Outcome).IsEqualTo(ToolOutcome.Running);
+            await Assert.That(Group(h.Chat, 2).Calls[0].Category).IsEqualTo(ToolCategory.Search);
             await h.TeardownAsync();
         });
     }
@@ -144,15 +149,16 @@ public class ChatTabViewModelTests {
             var h = Claude();
             var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ToolResultLine]);
             await h.PushAsync(Dto(path));
-            var call = (ToolCallItem)h.Chat.Items.Single();
+            var call = Group(h.Chat, 0).Calls.Single();
             await Assert.That(call.Outcome).IsEqualTo(ToolOutcome.Done);
             await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
 
             File.AppendAllText(path, ToolCallLine + "\n" + ToolErrorLine + "\n" + ToolErrorLine.Replace("t1", "unknown") + "\n");
             await h.TickAsync();
-            await Assert.That(h.Chat.Items).Count().IsEqualTo(2);
-            await Assert.That(((ToolCallItem)h.Chat.Items[1]).Outcome).IsEqualTo(ToolOutcome.Error);
-            await Assert.That(((ToolCallItem)h.Chat.Items[1]).IsError).IsTrue();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(Group(h.Chat, 0).Calls).Count().IsEqualTo(2);
+            await Assert.That(Group(h.Chat, 0).Calls[1].Outcome).IsEqualTo(ToolOutcome.Error);
+            await Assert.That(Group(h.Chat, 0).Calls[1].IsError).IsTrue();
             await h.TeardownAsync();
         });
     }
@@ -175,7 +181,7 @@ public class ChatTabViewModelTests {
             File.WriteAllLines(path, [ToolCallLine]);
             await h.TickAsync();
             await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
-            await Assert.That(h.Chat.Items[0]).IsTypeOf<ToolCallItem>();
+            await Assert.That(h.Chat.Items[0]).IsTypeOf<ToolGroupItem>();
 
             File.Delete(path);
             Directory.CreateDirectory(path);
@@ -183,6 +189,95 @@ public class ChatTabViewModelTests {
             await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
             await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
             Directory.Delete(path);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Consecutive_calls_across_reads_share_a_group_and_any_prose_closes_it() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+
+            File.AppendAllText(path, ReadCallLine + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(Group(h.Chat, 0).Calls.Select(c => c.Name)).IsEquivalentTo(new[] { "Bash", "Read" }, CollectionOrdering.Matching);
+
+            File.AppendAllText(path, AssistantLine + "\n" + ToolCallLine.Replace("t1", "t3") + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(
+                new[] { nameof(ToolGroupItem), nameof(AssistantTextItem), nameof(ToolGroupItem) }, CollectionOrdering.Matching);
+            await Assert.That(Group(h.Chat, 2).Calls).Count().IsEqualTo(1);
+
+            File.AppendAllText(path, NoteLine + "\n" + ToolCallLine.Replace("t1", "t4") + "\n" + UserLine + "\n" + ToolCallLine.Replace("t1", "t5") + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(new[] {
+                nameof(ToolGroupItem), nameof(AssistantTextItem), nameof(ToolGroupItem),
+                nameof(SystemNoteItem), nameof(ToolGroupItem), nameof(UserTurnItem), nameof(ToolGroupItem),
+            }, CollectionOrdering.Matching);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_result_folds_its_call_and_the_summary_follows_the_settled_calls() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ReadCallLine]);
+            await h.PushAsync(Dto(path));
+            var group = Group(h.Chat, 0);
+            await Assert.That(group.HasSummary).IsFalse();
+            await Assert.That(group.LiveCalls).Count().IsEqualTo(2);
+
+            File.AppendAllText(path, ToolResultLine + "\n");
+            await h.TickAsync();
+            await Assert.That(group.LiveCalls.Select(c => c.Name)).IsEquivalentTo(new[] { "Read" });
+            await Assert.That(group.Summary).IsEqualTo("Searched files");
+            await Assert.That(group.HasSummary).IsTrue();
+            await Assert.That(group.HasFailure).IsFalse();
+
+            File.AppendAllText(path, ToolErrorLine.Replace("t1", "unknown") + "\n");
+            await h.TickAsync();
+            await Assert.That(group.LiveCalls).Count().IsEqualTo(1);
+
+            File.AppendAllText(path, ToolErrorLine.Replace("t1", "t2") + "\n");
+            await h.TickAsync();
+            await Assert.That(group.LiveCalls).IsEmpty();
+            await Assert.That(group.Summary).IsEqualTo("Searched files, read a file");
+            await Assert.That(group.HasFailure).IsTrue();
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_reset_and_a_path_switch_start_a_fresh_group_for_later_calls() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine, ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(2);
+
+            File.WriteAllLines(path, [ToolCallLine]);
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            File.AppendAllText(path, ReadCallLine + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(Group(h.Chat, 0).Calls).Count().IsEqualTo(2);
+
+            var other = Tmp.CreateFile("o.jsonl", [ToolCallLine]);
+            await h.PushAsync(Dto(other));
+            await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(Group(h.Chat, 0).Calls).Count().IsEqualTo(1);
+            File.AppendAllText(other, ReadCallLine + "\n");
+            await h.TickAsync();
+            await Assert.That(Group(h.Chat, 0).Calls).Count().IsEqualTo(2);
             await h.TeardownAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -117,7 +117,7 @@ public class ChatTabViewModelTests {
             var path = Tmp.CreateFile("t.jsonl", [readLine]);
             await h.PushAsync(Dto(path) with { WorktreePath = worktree, WorkLocation = "owned" });
 
-            await Assert.That(((ToolCallItem)h.Chat.Items.Single()).Detail).IsEqualTo("src/Foo.cs");
+            await Assert.That(Group(h.Chat, 0).Calls.Single().Detail).IsEqualTo("src/Foo.cs");
             await WaitUntilAsync(() => ((PermissionCardViewModel)h.Chat.PendingCards[0]).Detail == "src/Bar.cs", what: "relative to the worktree once the root lands");
             await h.TeardownAsync();
         });

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -433,4 +433,117 @@ public class ChatTabViewModelTests {
             await h.TeardownAsync();
         });
     }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_request_with_an_id_marks_its_row_in_either_order_and_clears_on_resolve() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ReadCallLine]);
+            await h.PushAsync(Dto(path));
+            var bash = Group(h.Chat, 0).Calls[0];
+            var read = Group(h.Chat, 0).Calls[1];
+            await WaitUntilAsync(() => bash.IsAwaitingPermission, what: "the card-first mark");
+            await Assert.That(bash.OutcomeGlyph).IsEqualTo("?");
+            await Assert.That(read.IsAwaitingPermission).IsFalse();
+
+            h.Permissions.Remove("r1");
+            await WaitUntilAsync(() => !bash.IsAwaitingPermission, what: "cleared on resolve");
+
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", toolUseId: "t2"));
+            await WaitUntilAsync(() => read.IsAwaitingPermission, what: "the row-first mark");
+            await Assert.That(bash.IsAwaitingPermission).IsFalse();
+
+            h.Permissions.Add(PermissionEntries.Entry("r3", "a1", toolUseId: "nope"));
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 2, what: "the unmatched card");
+            await Assert.That(bash.IsAwaitingPermission).IsFalse();
+            await Assert.That(read.IsAwaitingPermission).IsTrue();
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Two_requests_on_one_row_keep_the_mark_until_both_go_and_a_settled_row_is_cleared() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            var bash = Group(h.Chat, 0).Calls[0];
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", toolUseId: "t1"));
+            await WaitUntilAsync(() => bash.IsAwaitingPermission, what: "marked");
+
+            h.Permissions.Remove("r1");
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "one card left");
+            await Assert.That(bash.IsAwaitingPermission).IsTrue();
+
+            File.AppendAllText(path, ToolResultLine + "\n");
+            await h.TickAsync();
+            await Assert.That(bash.Outcome).IsEqualTo(ToolOutcome.Done);
+            await Assert.That(bash.IsAwaitingPermission).IsFalse();
+            await Assert.That(h.Chat.PendingCards).Count().IsEqualTo(1);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_request_without_an_id_marks_the_sole_running_call_and_abstains_on_two() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", vendor: "codex"));
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            var first = Group(h.Chat, 0).Calls[0];
+            await WaitUntilAsync(() => first.IsAwaitingPermission, what: "the sole running call, row after card");
+
+            File.AppendAllText(path, ReadCallLine + "\n");
+            await h.TickAsync();
+            var second = Group(h.Chat, 0).Calls[1];
+            await Assert.That(first.IsAwaitingPermission).IsFalse();
+            await Assert.That(second.IsAwaitingPermission).IsFalse();
+
+            File.AppendAllText(path, ToolResultLine + "\n");
+            await h.TickAsync();
+            await Assert.That(first.IsAwaitingPermission).IsFalse();
+            await Assert.That(second.IsAwaitingPermission).IsTrue();
+
+            h.Permissions.Remove("r1");
+            await WaitUntilAsync(() => !second.IsAwaitingPermission, what: "cleared on resolve");
+
+            File.AppendAllText(path, ToolErrorLine.Replace("t1", "t2") + "\n");
+            await h.TickAsync();
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", vendor: "codex"));
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "a card with nothing running");
+            await Assert.That(second.IsAwaitingPermission).IsFalse();
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_pending_request_marks_the_rebuilt_row_after_a_reset_and_a_path_switch() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine, ToolCallLine]);
+            await h.PushAsync(Dto(path));
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", vendor: "codex"));
+            await WaitUntilAsync(() => Group(h.Chat, 1).Calls[0].IsAwaitingPermission, what: "marked before the reset");
+
+            File.WriteAllLines(path, [ToolCallLine]);
+            await h.TickAsync();
+            await Assert.That(Group(h.Chat, 0).Calls[0].IsAwaitingPermission).IsTrue();
+
+            var other = Tmp.CreateFile("o.jsonl", [ToolCallLine.Replace("t1", "t9")]);
+            await h.PushAsync(Dto(other));
+            await Assert.That(Group(h.Chat, 0).Calls[0].IsAwaitingPermission).IsTrue();
+
+            h.Permissions.Remove("r2");
+            await WaitUntilAsync(() => !Group(h.Chat, 0).Calls[0].IsAwaitingPermission, what: "only the id-less request fitted t9");
+            await h.TeardownAsync();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -24,6 +24,7 @@ public class ChatTabViewModelTests {
     const string ToolErrorLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"boom","is_error":true}]}}""";
     const string ReadCallLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"/repo/x/src/a.cs"}}]}}""";
     const string NoteLine = """{"type":"user","origin":{"kind":"task-notification"},"message":{"content":"<task-notification>\n<summary>Agent finished</summary>\n<result>\nAll good.\n</result>\n</task-notification>"}}""";
+    const string ThinkingLine = """{"type":"assistant","message":{"content":[{"type":"thinking","thinking":"weighing it"}]}}""";
 
     static AgentStatusDto Dto(string? transcriptPath, string vendor = "claude") =>
         Agent("a1", vendor, hasTerminal: true, repoPath: "/repo/x") with { TranscriptPath = transcriptPath };
@@ -202,7 +203,7 @@ public class ChatTabViewModelTests {
             await h.PushAsync(Dto(path));
             await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
 
-            File.AppendAllText(path, ReadCallLine + "\n");
+            File.AppendAllText(path, ThinkingLine + "\n" + ReadCallLine + "\n");
             await h.TickAsync();
             await Assert.That(h.Chat.Items).Count().IsEqualTo(1);
             await Assert.That(Group(h.Chat, 0).Calls.Select(c => c.Name)).IsEquivalentTo(new[] { "Bash", "Read" }, CollectionOrdering.Matching);

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -45,8 +45,18 @@ public class ChatTabViewSmokeTests {
     static Button Summary(ChatTabView view) => view.GetVisualDescendants().OfType<Button>().Single(b => b.Classes.Contains("toolSummary"));
     static ToolGroupItem OnlyGroup(Host host) => (ToolGroupItem)host.Chat.Items.Single();
 
+    /// A synthetic pointer event hit-tests the compositor's last committed scene, which layout alone
+    /// does not refresh: a control shown since the last frame is invisible to the click until the
+    /// render timer ticks once more.
+    static Point PresentAndLocate(Host host, Control target) {
+        host.Settle();
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+        Dispatcher.UIThread.RunJobs();
+        return target.TranslatePoint(new Point(2, 2), host.Window)!.Value;
+    }
+
     static void Click(Host host, Control target) {
-        var origin = target.TranslatePoint(new Point(2, 2), host.Window)!.Value;
+        var origin = PresentAndLocate(host, target);
         host.Window.MouseDown(origin, MouseButton.Left);
         host.Window.MouseUp(origin, MouseButton.Left);
         host.Settle();
@@ -582,8 +592,7 @@ public class ChatTabViewSmokeTests {
             await Assert.That(host.AtBottom()).IsTrue();
             var before = host.Scroll.Offset.Y;
 
-            var summary = Summary(host.View);
-            var origin = summary.TranslatePoint(new Point(2, 2), host.Window)!.Value;
+            var origin = PresentAndLocate(host, Summary(host.View));
             host.Window.MouseDown(origin, MouseButton.Left);
             host.Window.MouseUp(origin, MouseButton.Left);
             File.AppendAllLines(path, Enumerable.Repeat(UserLine, 5));

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -34,6 +34,23 @@ public class ChatTabViewSmokeTests {
     const string ToolResultLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"ok"}]}}""";
     const string ToolErrorLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t1","content":"boom","is_error":true}]}}""";
     static readonly TimeSpan CrDelay = TimeSpan.FromMilliseconds(150);
+    const string ReadCallLine = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t2","name":"Read","input":{"file_path":"/repo/x/src/a.cs"}}]}}""";
+    const string ReadResultLine = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t2","content":"ok"}]}}""";
+
+    static string CallLine(int n) => ToolCallLine.Replace("\"t1\"", $"\"t{n}\"");
+    static string ResultLine(int n) => ToolResultLine.Replace("\"t1\"", $"\"t{n}\"");
+
+    static List<StackPanel> ToolRows(ChatTabView view) => view.GetVisualDescendants().OfType<StackPanel>()
+        .Where(p => p.Orientation == Orientation.Horizontal && p.DataContext is ToolCallItem).ToList();
+    static Button Summary(ChatTabView view) => view.GetVisualDescendants().OfType<Button>().Single(b => b.Classes.Contains("toolSummary"));
+    static ToolGroupItem OnlyGroup(Host host) => (ToolGroupItem)host.Chat.Items.Single();
+
+    static void Click(Host host, Control target) {
+        var origin = target.TranslatePoint(new Point(2, 2), host.Window)!.Value;
+        host.Window.MouseDown(origin, MouseButton.Left);
+        host.Window.MouseUp(origin, MouseButton.Left);
+        host.Settle();
+    }
 
     sealed class Host {
         bool _shown;
@@ -110,6 +127,15 @@ public class ChatTabViewSmokeTests {
             File.AppendAllLines(path, Enumerable.Repeat(UserLine, lines));
             Time.Advance(ChatTabViewModel.PollInterval);
             await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+        }
+
+        public async Task AppendLinesAndTickAsync(string path, params string[] lines) {
+            File.AppendAllLines(path, lines);
+            Time.Advance(ChatTabViewModel.PollInterval);
+            await (Chat.PendingReadForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+            Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
         }
 
         public bool AtBottom() => Scroll.Offset.Y + Scroll.Viewport.Height >= Scroll.Extent.Height - 1;
@@ -279,11 +305,13 @@ public class ChatTabViewSmokeTests {
             var host = new Host();
             await host.LoadAsync(Tmp.CreateFile("tools.jsonl",
                 [ToolCallLine, ToolResultLine, ToolCallLine.Replace("t1", "t2"), ToolErrorLine.Replace("t1", "t2")]));
+            OnlyGroup(host).Toggle();
+            host.Settle();
 
-            await Assert.That(host.Chat.Items.Cast<ToolCallItem>().Select(i => i.Outcome))
+            await Assert.That(OnlyGroup(host).Calls.Select(i => i.Outcome))
                 .IsEquivalentTo([ToolOutcome.Done, ToolOutcome.Error], CollectionOrdering.Matching);
             var glyphs = host.View.GetVisualDescendants().OfType<TextBlock>()
-                .Where(t => t.Text is "✓" or "✕").ToList();
+                .Where(t => t.DataContext is ToolCallItem && t.Text is "✓" or "✕").ToList();
 
             await Assert.That(glyphs.Select(g => g.Text!)).IsEquivalentTo(["✓", "✕"], CollectionOrdering.Matching);
             await Assert.That(glyphs[0].Foreground).IsSameReferenceAs(Brush(isError: false));
@@ -400,9 +428,9 @@ public class ChatTabViewSmokeTests {
             var host = new Host();
             await host.LoadAsync(Tmp.CreateFile("rows.jsonl",
                 [ToolCallLine, ToolResultLine, ToolCallLine.Replace("t1", "t2"), ToolResultLine.Replace("t1", "t2"), AssistantLinkLine]));
-
-            var rows = host.View.GetVisualDescendants().OfType<StackPanel>()
-                .Where(p => p.Orientation == Orientation.Horizontal && p.DataContext is ToolCallItem).ToList();
+            ((ToolGroupItem)host.Chat.Items[0]).Toggle();
+            host.Settle();
+            var rows = ToolRows(host.View);
             var text = host.View.GetVisualDescendants().OfType<MarkdownView>().Single();
             double Top(Control c) => c.TranslatePoint(new Point(0, 0), host.View)!.Value.Y;
             double Bottom(Control c) => Top(c) + c.Bounds.Height;
@@ -410,6 +438,160 @@ public class ChatTabViewSmokeTests {
             await Assert.That(rows).Count().IsEqualTo(2);
             await Assert.That(Top(rows[1]) - Bottom(rows[0])).IsLessThan(10);
             await Assert.That(Top(text) - Bottom(rows[1])).IsGreaterThanOrEqualTo(12);
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins the fold: settled calls become one summary line, live calls stay as rows, and a click
+    /// on the summary reveals every call and hides them again.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_group_folds_settled_calls_into_a_summary_and_expands_on_click() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("fold.jsonl", [ToolCallLine, ToolResultLine, ReadCallLine, ReadResultLine, CallLine(3)]));
+
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(1);
+            var summary = Summary(host.View);
+            await Assert.That(summary.IsVisible).IsTrue();
+            await Assert.That(summary.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text)).Contains("Searched files, read a file");
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
+            await Assert.That(((ToolCallItem)ToolRows(host.View)[0].DataContext!).Outcome).IsEqualTo(ToolOutcome.Running);
+
+            Click(host, summary);
+            await Assert.That(OnlyGroup(host).IsExpanded).IsTrue();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(3);
+
+            Click(host, summary);
+            await Assert.That(OnlyGroup(host).IsExpanded).IsFalse();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
+            await host.CloseAsync();
+        });
+    }
+
+    /// A group with nothing settled has no summary line at all.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_group_of_only_live_calls_shows_rows_and_no_summary() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("live.jsonl", [ToolCallLine, ReadCallLine]));
+            await Assert.That(Summary(host.View).IsVisible).IsFalse();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(2);
+            await host.CloseAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_failed_call_inside_a_folded_group_shows_the_danger_cross_on_the_summary() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("fail.jsonl", [ToolCallLine, ToolErrorLine]));
+            var cross = Summary(host.View).GetVisualDescendants().OfType<TextBlock>().Single(t => t.Text == "✕");
+            await Assert.That(cross.IsVisible).IsTrue();
+            await Assert.That(cross.Foreground).IsSameReferenceAs(Avalonia.Application.Current!.FindResource("KcapDangerBrush"));
+            await host.CloseAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_awaiting_row_paints_the_question_glyph_with_the_accent_brush() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("ask.jsonl", [ToolCallLine]));
+            host.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            await WaitUntilAsync(() => OnlyGroup(host).Calls[0].IsAwaitingPermission, what: "the mark");
+            host.Settle();
+            var glyph = host.View.GetVisualDescendants().OfType<TextBlock>().Single(t => t.DataContext is ToolCallItem && t.Text == "?");
+            await Assert.That(glyph.Foreground).IsSameReferenceAs(Brush(isError: false));
+            await host.CloseAsync();
+        });
+    }
+
+    /// The inner lists mutate without an outer collection notification; follow-tail still reads
+    /// the extent change.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Follow_tail_tracks_inner_group_growth_and_folding_and_leaves_a_scrolled_up_reader_alone() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var path = Tmp.CreateFile("inner.jsonl", [.. Enumerable.Repeat(UserLine, 60), CallLine(1)]);
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            await host.AppendLinesAndTickAsync(path, CallLine(2), CallLine(3));
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(61);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            await host.AppendLinesAndTickAsync(path, ResultLine(1));
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            host.Scroll.Offset = new Vector(0, 0);
+            host.Window.UpdateLayout();
+            await host.AppendLinesAndTickAsync(path, CallLine(4), ResultLine(2));
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
+            await host.CloseAsync();
+        });
+    }
+
+    /// Expanding keeps the viewport: the hold is one-shot, so a reader who returns to the bottom is
+    /// followed again on the next append.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Expanding_the_trailing_group_keeps_the_offset_and_the_hold_is_one_shot() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var lines = new List<string>(Enumerable.Repeat(UserLine, 60));
+            for (var i = 1; i <= 30; i++) { lines.Add(CallLine(i)); lines.Add(ResultLine(i)); }
+            var path = Tmp.CreateFile("expand.jsonl", lines.ToArray());
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+            var before = host.Scroll.Offset.Y;
+
+            Click(host, Summary(host.View));
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(((ToolGroupItem)host.Chat.Items[^1]).IsExpanded).IsTrue();
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(before);
+            await Assert.That(host.AtBottom()).IsFalse();
+
+            host.Scroll.ScrollToEnd();
+            host.Window.UpdateLayout();
+            await host.AppendAndTickAsync(path, 5);
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.AtBottom()).IsTrue();
+            await host.CloseAsync();
+        });
+    }
+
+    /// Expansion realizes every row; folding releases them again.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_thousand_call_group_realizes_on_expansion_and_releases_on_fold() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var lines = new List<string>();
+            for (var i = 1; i <= 1000; i++) { lines.Add(CallLine(i)); lines.Add(ResultLine(i)); }
+            lines.Add(CallLine(1001));
+            await host.LoadAsync(Tmp.CreateFile("thousand.jsonl", lines.ToArray()));
+            var items = host.View.FindControl<ItemsControl>("ChatItems")!;
+
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(1);
+            await Assert.That(items.GetRealizedContainers().Count()).IsEqualTo(1);
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
+
+            OnlyGroup(host).Toggle();
+            host.Settle();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1001);
+            await Assert.That(items.GetRealizedContainers().Count()).IsEqualTo(1);
+
+            OnlyGroup(host).Toggle();
+            host.Settle();
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
             await host.CloseAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -568,6 +568,46 @@ public class ChatTabViewSmokeTests {
         });
     }
 
+    /// An append that lands in the same dispatcher turn as the click is held with the expansion:
+    /// the reader stays put, and only a later append, after they return to the bottom, follows.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_append_queued_behind_the_expansion_click_does_not_steal_the_hold() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var lines = new List<string>(Enumerable.Repeat(UserLine, 60));
+            for (var i = 1; i <= 30; i++) { lines.Add(CallLine(i)); lines.Add(ResultLine(i)); }
+            var path = Tmp.CreateFile("race.jsonl", lines.ToArray());
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+            var before = host.Scroll.Offset.Y;
+
+            var summary = Summary(host.View);
+            var origin = summary.TranslatePoint(new Point(2, 2), host.Window)!.Value;
+            host.Window.MouseDown(origin, MouseButton.Left);
+            host.Window.MouseUp(origin, MouseButton.Left);
+            File.AppendAllLines(path, Enumerable.Repeat(UserLine, 5));
+            host.Time.Advance(ChatTabViewModel.PollInterval);
+            await (host.Chat.PendingReadForTesting ?? Task.CompletedTask);
+            host.Settle();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(((ToolGroupItem)host.Chat.Items[^6]).IsExpanded).IsTrue();
+            await Assert.That(host.Chat.Items).Count().IsEqualTo(66);
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(before);
+
+            host.Scroll.ScrollToEnd();
+            host.Window.UpdateLayout();
+            await host.AppendAndTickAsync(path, 5);
+            Dispatcher.UIThread.RunJobs();
+            host.Window.UpdateLayout();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(host.AtBottom()).IsTrue();
+            await host.CloseAsync();
+        });
+    }
+
     /// Expansion realizes every row; folding releases them again.
     [Test]
     [NotInParallel("AvaloniaSession")]

--- a/test/Capacitor.App.Tests.Unit/FakePermissionService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakePermissionService.cs
@@ -9,10 +9,11 @@ namespace Capacitor.App.Tests.Unit;
 static class PermissionEntries {
     public static PendingPermissionRequest Entry(
             string requestId = "r1", string agentId = "a1", string vendor = "claude", string toolName = "Bash",
-            string? toolInputJson = """{"command":"ls"}""", bool omitted = false, string requestedAt = "2026-08-28T10:00:00.0000000+00:00") {
+            string? toolInputJson = """{"command":"ls"}""", bool omitted = false, string requestedAt = "2026-08-28T10:00:00.0000000+00:00",
+            string? toolUseId = null) {
         System.Text.Json.JsonElement? input = null;
         if (toolInputJson is not null) { using var d = System.Text.Json.JsonDocument.Parse(toolInputJson); input = d.RootElement.Clone(); }
-        return new PendingPermissionRequest(new PermissionPendingDto(requestId, agentId, "s1", vendor, toolName, input, null, omitted, false, requestedAt));
+        return new PendingPermissionRequest(new PermissionPendingDto(requestId, agentId, "s1", vendor, toolName, input, null, omitted, false, requestedAt, toolUseId));
     }
 
     public static PendingPermissionRequest Question(

--- a/test/Capacitor.App.Tests.Unit/ToolGroupItemTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ToolGroupItemTests.cs
@@ -1,0 +1,79 @@
+using Capacitor.App.ViewModels;
+using TUnit.Assertions.Enums;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The group in isolation: folding, summary, failure, and the visible-list swap. Under the
+/// session constraint because ToggleCommand is a ReactiveCommand.
+public class ToolGroupItemTests {
+    static ToolCallItem Call(string name, ToolCategory category) => new(name, "", category);
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Live_calls_show_until_they_settle_and_the_summary_appears_with_the_first_settlement() {
+        await RunOnUiAsync(async () => {
+            var group = new ToolGroupItem();
+            var a = Call("Bash", ToolCategory.Command);
+            var b = Call("Read", ToolCategory.Read);
+            group.Add(a);
+            group.Add(b);
+            await Assert.That(group.HasSummary).IsFalse();
+            await Assert.That(group.Summary).IsEqualTo("");
+            await Assert.That(group.LiveCalls).IsEquivalentTo(new[] { a, b }, CollectionOrdering.Matching);
+            await Assert.That(group.VisibleCalls).IsEquivalentTo(new[] { a, b }, CollectionOrdering.Matching);
+
+            b.Outcome = ToolOutcome.Done;
+            await Assert.That(group.HasSummary).IsTrue();
+            await Assert.That(group.Summary).IsEqualTo("Read a file");
+            await Assert.That(group.LiveCalls).IsEquivalentTo(new[] { a });
+            await Assert.That(group.Calls).IsEquivalentTo(new[] { a, b }, CollectionOrdering.Matching);
+
+            a.Outcome = ToolOutcome.Error;
+            await Assert.That(group.LiveCalls).IsEmpty();
+            await Assert.That(group.Summary).IsEqualTo("Ran a command, read a file");
+            await Assert.That(group.HasFailure).IsTrue();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Toggle_swaps_the_visible_list_between_live_and_every_call() {
+        await RunOnUiAsync(async () => {
+            var group = new ToolGroupItem();
+            var settled = Call("Bash", ToolCategory.Command);
+            var live = Call("Read", ToolCategory.Read);
+            group.Add(settled);
+            group.Add(live);
+            settled.Outcome = ToolOutcome.Done;
+            var raised = new List<string?>();
+            group.PropertyChanged += (_, e) => raised.Add(e.PropertyName);
+
+            await Assert.That(group.IsExpanded).IsFalse();
+            await Assert.That(group.VisibleCalls).IsEquivalentTo(new[] { live });
+
+            group.Toggle();
+            await Assert.That(group.IsExpanded).IsTrue();
+            await Assert.That(group.VisibleCalls).IsEquivalentTo(new[] { settled, live }, CollectionOrdering.Matching);
+            await Assert.That(raised).Contains(nameof(ToolGroupItem.VisibleCalls));
+
+            group.ToggleCommand.Execute().Subscribe();
+            await Assert.That(group.IsExpanded).IsFalse();
+            await Assert.That(group.VisibleCalls).IsEquivalentTo(new[] { live });
+        });
+    }
+
+    [Test]
+    public async Task A_call_glyph_shows_the_question_mark_only_while_running_and_awaiting() {
+        var call = Call("Bash", ToolCategory.Command);
+        await Assert.That(call.OutcomeGlyph).IsEqualTo("");
+        call.IsAwaitingPermission = true;
+        await Assert.That(call.OutcomeGlyph).IsEqualTo("?");
+        await Assert.That(call.IsSettled).IsFalse();
+        call.Outcome = ToolOutcome.Done;
+        await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
+        await Assert.That(call.IsSettled).IsTrue();
+        call.IsAwaitingPermission = false;
+        await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs
@@ -56,6 +56,7 @@ public class ToolSummaryTests {
     [Arguments("exec_command", """{"cmd":"rg foo src"}""", ToolCategory.Search)]
     [Arguments("exec_command", """{"cmd":"ls src"}""", ToolCategory.Search)]
     [Arguments("exec_command", """{"cmd":"cat a && make"}""", ToolCategory.Command)]
+    [Arguments("exec_command", """{"cmd":"rg foo src\nrm -rf tmp"}""", ToolCategory.Command)]
     [Arguments("exec_command", """{"cmd":"cat skills/review/SKILL.md"}""", ToolCategory.Skill)]
     [Arguments("shell", """{"command":["rg","foo","src"]}""", ToolCategory.Search)]
     [Arguments("shell", """{"command":["bash","-lc","cat a.md"]}""", ToolCategory.Read)]

--- a/test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs
@@ -4,7 +4,7 @@ namespace Capacitor.App.Tests.Unit;
 
 /// Pure: no dispatcher, so no session constraint.
 public class ToolSummaryTests {
-    /// The spec's table, held here so the test pins the map in both directions.
+    /// The declared name map, held here so the test pins it in both directions.
     static readonly (ToolCategory Category, string[] Names)[] Rows = [
         (ToolCategory.Read,      ["Read", "NotebookRead", "read_file", "view_image"]),
         (ToolCategory.Edit,      ["Edit", "MultiEdit", "Write", "NotebookEdit", "apply_patch", "write_file"]),

--- a/test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs
@@ -1,0 +1,71 @@
+using Capacitor.App.ViewModels;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Pure: no dispatcher, so no session constraint.
+public class ToolSummaryTests {
+    /// The spec's table, held here so the test pins the map in both directions.
+    static readonly (ToolCategory Category, string[] Names)[] Rows = [
+        (ToolCategory.Read,      ["Read", "NotebookRead", "read_file", "view_image"]),
+        (ToolCategory.Edit,      ["Edit", "MultiEdit", "Write", "NotebookEdit", "apply_patch", "write_file"]),
+        (ToolCategory.Command,   ["Bash", "BashOutput", "KillShell", "shell", "shell_command", "exec", "exec_command", "write_stdin", "local_shell", "container.exec"]),
+        (ToolCategory.Search,    ["Grep", "Glob", "LS"]),
+        (ToolCategory.WebSearch, ["WebSearch", "web_search"]),
+        (ToolCategory.Fetch,     ["WebFetch"]),
+        (ToolCategory.Skill,     ["Skill"]),
+        (ToolCategory.Agent,     ["Task", "Agent", "TaskOutput", "TaskStop", "spawn_agent", "wait_agent", "send_input", "send_message", "resume_agent", "interrupt_agent", "close_agent", "list_agents"]),
+        (ToolCategory.Plan,      ["TodoWrite", "update_plan"]),
+        (ToolCategory.Question,  ["AskUserQuestion", "request_user_input"]),
+    ];
+
+    [Test]
+    public async Task Every_declared_name_maps_to_its_row_case_insensitively_and_nothing_else_is_declared() {
+        var expected = Rows.SelectMany(r => r.Names.Select(n => (n, r.Category))).ToDictionary(p => p.n, p => p.Category, StringComparer.Ordinal);
+        foreach (var (name, category) in expected) {
+            await Assert.That(ToolSummary.Categorize(name, null)).IsEqualTo(category);
+            await Assert.That(ToolSummary.Categorize(name.ToUpperInvariant(), null)).IsEqualTo(category);
+        }
+        await Assert.That(ToolSummary.Names.Keys.ToHashSet(StringComparer.Ordinal).SetEquals(expected.Keys)).IsTrue();
+    }
+
+    [Test]
+    [Arguments("mcp__github__create_issue")]
+    [Arguments("SomethingNew")]
+    [Arguments("")]
+    public async Task Unknown_and_mcp_names_are_other(string name) {
+        await Assert.That(ToolSummary.Categorize(name, """{"x":1}""")).IsEqualTo(ToolCategory.Other);
+    }
+
+    [Test]
+    public async Task Describe_uses_article_for_one_plural_for_many_first_appearance_order_and_lower_cases_after_the_first() {
+        await Assert.That(ToolSummary.Describe([])).IsEqualTo("");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Command])).IsEqualTo("Ran a command");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Read, ToolCategory.Read])).IsEqualTo("Read files");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Read, ToolCategory.Command, ToolCategory.Read, ToolCategory.Edit]))
+            .IsEqualTo("Read files, ran a command, edited a file");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Agent, ToolCategory.Skill, ToolCategory.Other, ToolCategory.Other]))
+            .IsEqualTo("Ran an agent, loaded a skill, called tools");
+        await Assert.That(ToolSummary.Describe([ToolCategory.Search, ToolCategory.Search, ToolCategory.WebSearch, ToolCategory.Fetch, ToolCategory.Fetch, ToolCategory.Plan, ToolCategory.Question]))
+            .IsEqualTo("Searched files, searched the web, fetched pages, updated the plan, asked a question");
+    }
+
+    [Test]
+    [Arguments("Read", """{"file_path":"/repo/.claude/skills/review/SKILL.md"}""", ToolCategory.Skill)]
+    [Arguments("Read", """{"file_path":"/repo/SKILL.md.bak"}""", ToolCategory.Read)]
+    [Arguments("exec_command", """{"cmd":"sed -n '1,40p' a.cs"}""", ToolCategory.Read)]
+    [Arguments("exec_command", """{"cmd":"rg foo src"}""", ToolCategory.Search)]
+    [Arguments("exec_command", """{"cmd":"ls src"}""", ToolCategory.Search)]
+    [Arguments("exec_command", """{"cmd":"cat a && make"}""", ToolCategory.Command)]
+    [Arguments("exec_command", """{"cmd":"cat skills/review/SKILL.md"}""", ToolCategory.Skill)]
+    [Arguments("shell", """{"command":["rg","foo","src"]}""", ToolCategory.Search)]
+    [Arguments("shell", """{"command":["bash","-lc","cat a.md"]}""", ToolCategory.Read)]
+    [Arguments("Bash", """{"description":"List files"}""", ToolCategory.Command)]
+    [Arguments("Bash", """{"command":"git status"}""", ToolCategory.Command)]
+    [Arguments("Bash", "not json", ToolCategory.Command)]
+    [Arguments("Bash", """["cat","a"]""", ToolCategory.Command)]
+    [Arguments("exec", """{"input":"const r = 1;"}""", ToolCategory.Command)]
+    [Arguments("spawn_agent", """{"task":"t"}""", ToolCategory.Agent)]
+    public async Task Categorize_refines_reads_and_shell_commands_from_the_input(string name, string? input, ToolCategory expected) {
+        await Assert.That(ToolSummary.Categorize(name, input)).IsEqualTo(expected);
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs
@@ -2,8 +2,8 @@ using Capacitor.Cli.Core.Harness.Codex;
 
 namespace Capacitor.Cli.Core.Tests.Unit.Harness.Codex;
 
-/// Parity pin against the server's copy of the classifier: these cases must pass identically
-/// on both until the server deletes its own.
+/// The classifier's verdicts, pinned so the same command labels the same way wherever it is
+/// classified: the dashboard and the desktop chat must never disagree about one shell line.
 public class CodexCommandClassifierTests {
     [Test]
     [Arguments("sed -n '1,220p' docs/SKILL.md", "read", "docs/SKILL.md", "SKILL.md")]

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs
@@ -1,0 +1,225 @@
+using Capacitor.Cli.Core.Harness.Codex;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Harness.Codex;
+
+/// Parity pin against the server's copy of the classifier: these cases must pass identically
+/// on both until the server deletes its own.
+public class CodexCommandClassifierTests {
+    [Test]
+    [Arguments("sed -n '1,220p' docs/SKILL.md", "read", "docs/SKILL.md", "SKILL.md")]
+    [Arguments("sed -n '1,220p' /Users/alexey/.codex/file.md", "read", "/Users/alexey/.codex/file.md", "file.md")]
+    [Arguments("nl -ba docs/superpowers/specs/foo.md", "read", "docs/superpowers/specs/foo.md", "foo.md")]
+    [Arguments("cat README.md", "read", "README.md", "README.md")]
+    [Arguments("head -n 50 src/Models.cs", "read", "src/Models.cs", "Models.cs")]
+    [Arguments("head -n50 src/Models.cs", "read", "src/Models.cs", "Models.cs")]
+    [Arguments("tail -n +10 log.txt", "read", "log.txt", "log.txt")]
+    [Arguments("less src/Foo.cs", "read", "src/Foo.cs", "Foo.cs")]
+    [Arguments("bat src/Foo.cs", "read", "src/Foo.cs", "Foo.cs")]
+    public async Task Classifies_ReadCommands(string cmd, string expectedType, string expectedPath, string expectedName) {
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNotNull();
+        await Assert.That(hint!.Type).IsEqualTo(expectedType);
+        await Assert.That(hint.Path).IsEqualTo(expectedPath);
+        await Assert.That(hint.Name).IsEqualTo(expectedName);
+    }
+
+    [Test]
+    [Arguments("rg --files", "list_files", null)]
+    [Arguments("rg --files src", "list_files", "src")]
+    [Arguments("ls", "list_files", null)]
+    [Arguments("ls src", "list_files", "src")]
+    [Arguments("git ls-files", "list_files", null)]
+    [Arguments("git ls-files src", "list_files", "src")]
+    [Arguments("find src -type f", "list_files", "src")]
+    [Arguments("tree -L 2 src", "list_files", "src")]
+    public async Task Classifies_ListFilesCommands(string cmd, string expectedType, string? expectedPath) {
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNotNull();
+        await Assert.That(hint!.Type).IsEqualTo(expectedType);
+        await Assert.That(hint.Path).IsEqualTo(expectedPath);
+    }
+
+    [Test]
+    [Arguments("rg foo src", "search", "foo", "src")]
+    [Arguments("rg -n 'pattern' src/Models.cs", "search", "pattern", "src/Models.cs")]
+    [Arguments("grep TODO README.md", "search", "TODO", "README.md")]
+    [Arguments("git grep TODO src", "search", "TODO", "src")]
+    public async Task Classifies_SearchCommands(string cmd, string expectedType, string expectedQuery, string? expectedPath) {
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNotNull();
+        await Assert.That(hint!.Type).IsEqualTo(expectedType);
+        await Assert.That(hint.Query).IsEqualTo(expectedQuery);
+        await Assert.That(hint.Path).IsEqualTo(expectedPath);
+    }
+
+    [Test]
+    [Arguments("git status --short")]
+    [Arguments("git status")]
+    [Arguments("pwd")]
+    [Arguments("npm install")]
+    [Arguments("docker compose up")]
+    public async Task Classifies_UnknownCommands_AsNull(string cmd) {
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNull();
+    }
+
+    [Test]
+    public async Task UnwrapsBashLcWrapper() {
+        // Codex sometimes wraps the model's `cmd` in `bash -lc "..."` — the
+        // classifier must look through the wrapper to find the real verb.
+        var hint = CodexCommandClassifier.Classify("bash -lc \"sed -n '1,220p' src/Models.cs\"");
+        await Assert.That(hint).IsNotNull();
+        await Assert.That(hint!.Type).IsEqualTo("read");
+        await Assert.That(hint.Path).IsEqualTo("src/Models.cs");
+    }
+
+    [Test]
+    public async Task Pipeline_WithUnknownStage_FallsBackToUnknown() {
+        // Codex collapses any pipeline that contains an unknown segment to a
+        // single Unknown — matches the Rust impl's behavior.
+        var hint = CodexCommandClassifier.Classify("rg --files | xargs perl -pi -e 's/foo/bar/'");
+        await Assert.That(hint).IsNull();
+    }
+
+    [Test]
+    public async Task NullOrWhitespace_ReturnsNull() {
+        await Assert.That(CodexCommandClassifier.Classify(null)).IsNull();
+        await Assert.That(CodexCommandClassifier.Classify("")).IsNull();
+        await Assert.That(CodexCommandClassifier.Classify("   ")).IsNull();
+    }
+
+    // Codex's TUI keeps pipelines like `rg --files | head -n 50` labelled as
+    // ListFiles because head/tail/sed/wc/awk without file operands are
+    // formatting helpers, not unknown stages. Mirror that behaviour so common
+    // Codex preview pipelines don't fall back to Shell.
+
+    [Test]
+    [Arguments("rg --files | head -n 50", "list_files", null, null)]
+    [Arguments("rg --files src | head -n 50", "list_files", null, "src")]
+    [Arguments("rg -n TODO src | head -n 50", "search", "TODO", "src")]
+    [Arguments("nl -ba src/Models.cs | sed -n '1,80p'", "read", null, "src/Models.cs")]
+    [Arguments("cat README.md | wc -l", "read", null, "README.md")]
+    [Arguments("ls src | sort | uniq", "list_files", null, "src")]
+    public async Task HelperStages_DoNotCollapsePipeline(string cmd, string expectedType, string? expectedQuery, string? expectedPath) {
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNotNull();
+        await Assert.That(hint!.Type).IsEqualTo(expectedType);
+        await Assert.That(hint.Query).IsEqualTo(expectedQuery);
+        await Assert.That(hint.Path).IsEqualTo(expectedPath);
+    }
+
+    [Test]
+    [Arguments("rg -l Foo src | xargs perl -pi -e 's/Foo/Bar/'")]
+    [Arguments("rg -l Foo src | xargs sed -i s/Foo/Bar/")]
+    [Arguments("rg --files | xargs rm -f")]
+    [Arguments("rg --files | xargs mv -t /tmp")]
+    [Arguments("rg --files | xargs sh -c 'rm \"$@\"'")]
+    [Arguments("rg --files | xargs bash -c 'echo x > $1'")]
+    [Arguments("find . -name '*.tmp' | xargs chmod +x")]
+    [Arguments("rg --files | xargs python apply.py")]
+    [Arguments("rg --files | xargs git add")]
+    public async Task DestructiveXargs_CollapsesPipeline(string cmd) {
+        // Mutating / destructive pipelines must NOT be silently dropped — they
+        // change state beyond what the primary command's classification implies.
+        // Default xargs to Unknown except a strict display-only allowlist so any
+        // xargs subcommand we don't explicitly recognize falls back to Shell.
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNull();
+    }
+
+    [Test]
+    [Arguments("rg --files | xargs cat", "list_files", null)]
+    [Arguments("rg --files src | xargs wc -l", "list_files", "src")]
+    [Arguments("rg --files | xargs file", "list_files", null)]
+    [Arguments("rg --files | xargs ls -la", "list_files", null)]
+    public async Task DisplayOnlyXargs_KeepsPrimaryClassification(string cmd, string expectedType, string? expectedPath) {
+        // xargs into cat/wc/file/ls is purely read-only — keep the primary
+        // command's classification so the row labels what the user actually sees.
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNotNull();
+        await Assert.That(hint!.Type).IsEqualTo(expectedType);
+        await Assert.That(hint.Path).IsEqualTo(expectedPath);
+    }
+
+    [Test]
+    [Arguments("rg TODO src > results.txt")]
+    [Arguments("rg TODO src >> results.txt")]
+    [Arguments("rg --files >> file-list.txt")]
+    [Arguments("cat foo.txt > bar.txt")]
+    [Arguments("ls src 2> err.log")]
+    [Arguments("rg TODO src &> all.log")]
+    [Arguments("rg TODO src > out 2>&1")]
+    // Glued forms (no space between operator and target). The tokenizer
+    // emits these as single tokens like `>results.txt` or `foo.txt>bar.txt`,
+    // so the redirection guard must scan the raw script — not check token
+    // equality — to catch them.
+    [Arguments("rg TODO src >results.txt")]
+    [Arguments("rg TODO src 2>err.log")]
+    [Arguments("rg TODO src 1>out.txt")]
+    [Arguments("cat foo.txt>bar.txt")]
+    [Arguments("rg --files>file-list.txt")]
+    [Arguments("ls src &>log")]
+    // bash -lc wrapper around a redirecting inner script must still collapse —
+    // the inner shell is the one that parses `>` as redirection.
+    [Arguments("bash -lc \"rg TODO src > out\"")]
+    public async Task Redirections_CollapsePipeline(string cmd) {
+        // A redirection means the shell did more than the primary command's
+        // classification implies (wrote a file, swallowed stderr, etc.). Don't
+        // mislabel `rg TODO src > results.txt` as a benign Grep.
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNull();
+    }
+
+    [Test]
+    // Outer-shell suffixes around bash -lc must NOT be silently dropped: an
+    // outer redirection (`>out`) or connector (`&& rm -f out`) is executed by
+    // the spawning shell, not the wrapped script.
+    [Arguments("bash -lc \"rg TODO src\" >out")]
+    [Arguments("bash -lc \"rg TODO src\" 2>err.log")]
+    [Arguments("zsh -c \"rg TODO src\" > out")]
+    [Arguments("bash -lc \"rg TODO src\" && rm -f out")]
+    [Arguments("bash -lc \"rg --files\" | xargs rm -f")]
+    public async Task BashLc_OuterSideEffects_CollapsePipeline(string cmd) {
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNull();
+    }
+
+    [Test]
+    // A clean `bash -lc "..."` with no outer suffix still unwraps and
+    // classifies (the unwrap only fires for exactly 3 outer tokens).
+    [Arguments("bash -lc \"sed -n '1,220p' src/Models.cs\"", "read", "src/Models.cs")]
+    [Arguments("bash -lc \"rg --files src\"", "list_files", "src")]
+    [Arguments("zsh -c \"rg TODO src\"", "search", "src")]
+    public async Task BashLc_CleanWrapper_StillClassifies(string cmd, string expectedType, string? expectedPath) {
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNotNull();
+        await Assert.That(hint!.Type).IsEqualTo(expectedType);
+        await Assert.That(hint.Path).IsEqualTo(expectedPath);
+    }
+
+    [Test]
+    [Arguments("rg '>' src", "search", ">", "src")]
+    [Arguments("rg \"<\" src", "search", "<", "src")]
+    [Arguments("grep '<tag>' file.txt", "search", "<tag>", "file.txt")]
+    [Arguments("rg \">>\" src", "search", ">>", "src")]
+    public async Task QuotedAngleBrackets_StayClassified(string cmd, string expectedType, string expectedQuery, string expectedPath) {
+        // Single- or double-quoted `>` / `<` are literal regex chars, not
+        // redirections. The quote-aware scanner must skip them so legit
+        // searches don't regress to Shell.
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNotNull();
+        await Assert.That(hint!.Type).IsEqualTo(expectedType);
+        await Assert.That(hint.Query).IsEqualTo(expectedQuery);
+        await Assert.That(hint.Path).IsEqualTo(expectedPath);
+    }
+
+    [Test]
+    [Arguments("head -n 50")]         // helper alone
+    [Arguments("sed -n '1,50p'")]     // sed without file
+    [Arguments("nl -ba")]             // nl with only flags
+    [Arguments("head -n 50 | wc -l")] // helpers all the way down
+    public async Task HelperOnlyPipelines_ReturnNull(string cmd) {
+        var hint = CodexCommandClassifier.Classify(cmd);
+        await Assert.That(hint).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexCommandClassifierTests.cs
@@ -222,4 +222,27 @@ public class CodexCommandClassifierTests {
         var hint = CodexCommandClassifier.Classify(cmd);
         await Assert.That(hint).IsNull();
     }
+
+    /// An unquoted line break separates commands the way `;` does: a script whose first line
+    /// searches and whose second line mutates must not read as a search.
+    [Test]
+    [Arguments("rg foo src\nrm -rf tmp")]
+    [Arguments("rg foo src\r\nrm -rf tmp")]
+    [Arguments("cat a.md\n\nmake")]
+    [Arguments("bash -lc \"rg foo src\nrm -rf tmp\"")]
+    public async Task Unquoted_newlines_separate_commands_so_a_later_mutation_collapses_the_script(string cmd) {
+        await Assert.That(CodexCommandClassifier.Classify(cmd)).IsNull();
+    }
+
+    [Test]
+    public async Task Newline_separated_reads_classify_like_semicolon_separated_reads_and_a_quoted_newline_is_literal() {
+        await Assert.That(CodexCommandClassifier.Classify("cat a.md\ncat b.md")!.Type).IsEqualTo("read");
+        await Assert.That(CodexCommandClassifier.Classify("cat a.md; cat b.md")!.Type).IsEqualTo("read");
+        await Assert.That(CodexCommandClassifier.Classify("rg foo src\n")!.Type).IsEqualTo("search");
+
+        var quoted = CodexCommandClassifier.Classify("rg 'foo\nbar' src");
+        await Assert.That(quoted).IsNotNull();
+        await Assert.That(quoted!.Type).IsEqualTo("search");
+        await Assert.That(quoted.Query).IsEqualTo("foo\nbar");
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/PermissionWireContractsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/PermissionWireContractsTests.cs
@@ -67,11 +67,27 @@ public class PermissionWireContractsTests {
     }
 
     [Test]
+    public async Task Pending_dto_carries_an_optional_tool_use_id_and_decodes_without_it() {
+        var dto = new PermissionPendingDto("r1", "a1", "s1", "claude", "Bash", null, null, false, false, "t", "toolu_01ABC");
+        var json = JsonSerializer.Serialize(dto, PermissionIpcJsonContext.Default.PermissionPendingDto);
+        await Assert.That(json).Contains("\"tool_use_id\":\"toolu_01ABC\"");
+        var back = JsonSerializer.Deserialize(json, PermissionIpcJsonContext.Default.PermissionPendingDto)!;
+        await Assert.That(back.ToolUseId).IsEqualTo("toolu_01ABC");
+
+        var older = JsonSerializer.Deserialize(
+            """{"request_id":"r1","agent_id":"a1","session_id":"s1","vendor":"claude","tool_name":"Bash","requested_at":"t"}""",
+            PermissionIpcJsonContext.Default.PermissionPendingDto)!;
+        await Assert.That(older.ToolUseId).IsNull();
+        await Assert.That(PermissionWire.IsPendingStructurallyValid(older)).IsTrue();
+    }
+
+    [Test]
     public async Task Worst_case_pending_frame_writes_and_reads_under_the_codec_cap() {
         var name = new string('"', PermissionWire.MaxToolNameBytes);               // every byte escapes to \"
         var key  = new string('\\', PermissionWire.MaxAgentIdBytes);               // every byte escapes to \\
         var big  = "\"" + new string('x', PermissionWire.MaxElementBytes - 2) + "\"";
-        var dto  = new PermissionPendingDto("r1", key, "s1", "claude", name, El(big), El(big), false, false, "t");
+        var id   = new string('"', PermissionWire.MaxToolUseIdBytes);               // every byte escapes to \"
+        var dto  = new PermissionPendingDto("r1", key, "s1", "claude", name, El(big), El(big), false, false, "t", id);
         var json = JsonSerializer.Serialize(dto, PermissionIpcJsonContext.Default.PermissionPendingDto);
         await Assert.That(Encoding.UTF8.GetByteCount(json) < FrameCodec.MaxPayload).IsTrue();
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalPermissionBridgeInteractiveTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalPermissionBridgeInteractiveTests.cs
@@ -86,6 +86,21 @@ public class LocalPermissionBridgeInteractiveTests {
     }
 
     [Test, NotInParallel(nameof(LocalPermissionBridgeInteractiveTests))]
+    public async Task The_hook_bodys_tool_use_id_rides_the_pending_dto() {
+        await using var h = new Harness();
+        h.Server.AwaitScript = (_, ct) => new TaskCompletionSource<PermissionDecision>().Task.WaitAsync(ct);
+        await h.StartAsync();
+
+        var response = h.Client.PostAsync($"{h.Bridge.BaseUrl}/claude/permission-request",
+            JsonContent.Create(new { session_id = Session, tool_name = "Bash", tool_input = new { command = "ls" }, tool_use_id = "toolu_01X", agent_id = "agent-1", cwd = "/repo" }));
+        var pending = await h.WaitPendingAsync();
+        await Assert.That(pending.ToolUseId).IsEqualTo("toolu_01X");
+
+        await Assert.That(h.Broker.TrySettle(pending.RequestId, Allow, "allow", "app")).IsTrue();
+        await Assert.That(await Harness.BehaviorOf(await response)).IsEqualTo("allow");
+    }
+
+    [Test, NotInParallel(nameof(LocalPermissionBridgeInteractiveTests))]
     public async Task Server_claim_first_answers_the_hook_pushes_resolved_server_and_a_later_app_claim_loses() {
         await using var h = new Harness();
         var serverDecision = new TaskCompletionSource<PermissionDecision>();
@@ -224,6 +239,8 @@ public class LocalPermissionBridgeInteractiveTests {
         await Assert.That(LocalPermissionBridge.BuildPending("r", "a1", Session, "claude", new string('n', PermissionWire.MaxToolNameBytes + 1), null, null, "t")).IsNull();
         await Assert.That(LocalPermissionBridge.BuildPending("r", new string('k', PermissionWire.MaxAgentIdBytes + 1), Session, "claude", "Bash", null, null, "t")).IsNull();
         await Assert.That(LocalPermissionBridge.BuildPending("r", "a1", Session, "codex", null, null, null, "t")!.ToolName).IsEqualTo("");
+        await Assert.That(LocalPermissionBridge.BuildPending("r", "a1", Session, "claude", "Bash", null, null, "t", "toolu_1")!.ToolUseId).IsEqualTo("toolu_1");
+        await Assert.That(LocalPermissionBridge.BuildPending("r", "a1", Session, "claude", "Bash", null, null, "t", new string('i', PermissionWire.MaxToolUseIdBytes + 1))!.ToolUseId).IsNull();
     }
 
     static async Task WaitUntil(Func<bool> condition, string what) {


### PR DESCRIPTION
AI-2418 — no GitHub issue exists for this item (opened in Linear directly), so the closing keyword is dropped. Follow-up: #746.

## What & why

The Chat tab showed one muted row per tool call for the life of a session, so twenty reads between two paragraphs buried the prose. Consecutive tool calls now fold into one group row: settled calls collapse to a summary line ("Read files, ran a command"), calls still running stay listed beneath it, any prose row closes the run, and a click expands the group. A row waiting on a permission shows an accent `?` in the slot the check lands in later.

## Where to look

Codex's `PermissionRequest` hook carries no call id (Claude's does), so `PermissionPendingDto` gains an optional `tool_use_id`, and a request without one marks the agent's sole running call, abstaining when two or more run. `CodexCommandClassifier` moves from the server into Core byte-for-byte; the server should delete its copy when it takes this submodule bump. Expanding a group holds follow-tail for the dispatcher turn the click begins, so an append queued behind the click cannot jump the reader.

## Verification

`dotnet test --solution Capacitor.slnx` on 057e8330: App, Core, CLI unit and integration suites pass. The daemon suite's four timing-assertion failures (real-subprocess flood and wedged-initialize tests, files untouched here) pass when rerun in isolation; `Installed_codex_schema_matches_the_vendored_pin` fails on the locally installed Codex version alone. `dotnet publish -c Release | grep -E 'IL[23][01][0-9]{2}'` prints nothing. Design: `docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md`.
