### PR TITLE
Polish the setup run's terminal output

### DIFF
--- a/src/Capacitor.Cli.Core/Auth/AuthProgress.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthProgress.cs
@@ -34,25 +34,34 @@ public interface IAuthProgress {
     void PollTick();
 }
 
-/// <summary>Reproduces exactly what the CLI printed to stdout/stderr before <see cref="IAuthProgress"/> existed.</summary>
-public sealed class ConsoleAuthProgress : IAuthProgress {
+/// <summary>Renders auth progress as console lines.</summary>
+/// <param name="indent">
+/// Shifts every line this writes, so a caller whose output belongs to an enclosing section indents the
+/// whole block. It has to live here rather than in a decorator: most of this copy is composed in these
+/// methods, so nothing wrapping <see cref="IAuthProgress"/> can reach it.
+/// </param>
+public sealed class ConsoleAuthProgress(string indent = "") : IAuthProgress {
     public static readonly ConsoleAuthProgress Instance = new();
 
-    public void Notice(string message) => Console.Out.WriteLine(message);
+    public void Notice(string message) => Console.Out.WriteLine(Shifted(message));
 
-    public void Error(string message) => Console.Error.WriteLine(message);
+    public void Error(string message) => Console.Error.WriteLine(Shifted(message));
 
     public void BrowserOpening(string url) {
-        Console.Out.WriteLine("Opening browser for authentication...");
-        Console.Out.WriteLine($"  If the browser doesn't open, visit: {url}");
+        Console.Out.WriteLine(Shifted("Opening browser for authentication..."));
+        Console.Out.WriteLine(Shifted($"  If the browser doesn't open, visit: {url}"));
     }
 
     public void DeviceCode(string code, string verificationUri, string? provider, bool prefilled) {
-        Console.Out.WriteLine(prefilled ? $"  2. Check the code shown is {code}" : $"  2. Enter the code: {code}");
-        Console.Out.WriteLine(provider is null ? "  3. Approve access when asked." : $"  3. Approve access when {provider} asks.");
+        Console.Out.WriteLine(Shifted(prefilled ? $"  2. Check the code shown is {code}" : $"  2. Enter the code: {code}"));
+        Console.Out.WriteLine(Shifted(provider is null ? "  3. Approve access when asked." : $"  3. Approve access when {provider} asks."));
         Console.Out.WriteLine();
-        Console.Write("Waiting for you to authorize...");
+        Console.Write(Shifted("Waiting for you to authorize..."));
     }
 
+    /// <summary>Unshifted: the dots continue the "Waiting…" line rather than starting one.</summary>
     public void PollTick() => Console.Write(".");
+
+    /// <summary>A blank separator stays blank — an indented one is trailing whitespace.</summary>
+    string Shifted(string line) => indent.Length == 0 || line.Length == 0 ? line : indent + line;
 }

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -50,6 +50,10 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
         string Indented => new(' ', Detail);
 
+        /// <summary>What a plain-text row adds to the indent already in its literal, so the two forms
+        /// nest by the same step.</summary>
+        string Margin => Nested ? "  " : "";
+
         public void Line(string plain, string? markup = null) {
             if (Quiet) return;
 
@@ -138,24 +142,24 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
                     foreach (var kv in bySource.OrderBy(x => x.Key, StringComparer.Ordinal)) {
                         var sc = kv.Value;
-                        Console.WriteLine($"  [{kv.Key}]");
-                        Console.WriteLine($"    New               {sc.New}");
-                        Console.WriteLine($"    Resumable         {sc.Partial}");
-                        Console.WriteLine($"    Already loaded    {sc.AlreadyLoaded}");
-                        Console.WriteLine($"    Too short         {sc.TooShort}");
-                        Console.WriteLine($"    Excluded          {sc.Excluded}");
-                        if (sc.ProbeError > 0) Console.WriteLine($"    Probe errors      {sc.ProbeError}");
+                        Console.WriteLine($"{Margin}  [{kv.Key}]");
+                        Console.WriteLine($"{Margin}    New               {sc.New}");
+                        Console.WriteLine($"{Margin}    Resumable         {sc.Partial}");
+                        Console.WriteLine($"{Margin}    Already loaded    {sc.AlreadyLoaded}");
+                        Console.WriteLine($"{Margin}    Too short         {sc.TooShort}");
+                        Console.WriteLine($"{Margin}    Excluded          {sc.Excluded}");
+                        if (sc.ProbeError > 0) Console.WriteLine($"{Margin}    Probe errors      {sc.ProbeError}");
                     }
 
                     Console.WriteLine();
                 }
 
-                Console.WriteLine($"  New               {c.New}");
-                Console.WriteLine($"  Resumable         {c.Partial}");
-                Console.WriteLine($"  Already loaded    {c.AlreadyLoaded}");
-                Console.WriteLine($"  Too short         {c.TooShort}");
-                Console.WriteLine($"  Excluded          {c.Excluded}");
-                if (c.ProbeError > 0) Console.WriteLine($"  Probe errors      {c.ProbeError}");
+                Console.WriteLine($"{Margin}  New               {c.New}");
+                Console.WriteLine($"{Margin}  Resumable         {c.Partial}");
+                Console.WriteLine($"{Margin}  Already loaded    {c.AlreadyLoaded}");
+                Console.WriteLine($"{Margin}  Too short         {c.TooShort}");
+                Console.WriteLine($"{Margin}  Excluded          {c.Excluded}");
+                if (c.ProbeError > 0) Console.WriteLine($"{Margin}  Probe errors      {c.ProbeError}");
             }
         }
 
@@ -243,27 +247,27 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                 if (f.Failed > 0) AnsiConsole.MarkupLine($"{Indented}[dim]{failureNote}[/]");
             } else {
                 Heading("Done", "green");
-                Console.WriteLine($"  {f.Imported} imported · {f.Skipped} skipped · {f.Failed} failed");
+                Console.WriteLine($"{Margin}  {f.Imported} imported · {f.Skipped} skipped · {f.Failed} failed");
 
                 if (bySource is { Count: > 1 }) {
                     Heading("By source", "green");
 
                     foreach (var kv in bySource.OrderBy(x => x.Key, StringComparer.Ordinal)) {
                         var sf = kv.Value;
-                        Console.WriteLine($"  [{kv.Key}]");
-                        Console.WriteLine($"    Loaded              {sf.Loaded}");
-                        Console.WriteLine($"    Resumed             {sf.Resumed}");
-                        Console.WriteLine($"    Already loaded      {sf.AlreadyLoaded}");
-                        if (sf.TooShort   > 0) Console.WriteLine($"    Too short           {sf.TooShort}");
-                        if (sf.Excluded   > 0) Console.WriteLine($"    Excluded            {sf.Excluded}");
-                        if (sf.ProbeError > 0) Console.WriteLine($"    Probe errors        {sf.ProbeError}");
-                        if (sf.Errored    > 0) Console.WriteLine($"    Errored             {sf.Errored}");
+                        Console.WriteLine($"{Margin}  [{kv.Key}]");
+                        Console.WriteLine($"{Margin}    Loaded              {sf.Loaded}");
+                        Console.WriteLine($"{Margin}    Resumed             {sf.Resumed}");
+                        Console.WriteLine($"{Margin}    Already loaded      {sf.AlreadyLoaded}");
+                        if (sf.TooShort   > 0) Console.WriteLine($"{Margin}    Too short           {sf.TooShort}");
+                        if (sf.Excluded   > 0) Console.WriteLine($"{Margin}    Excluded            {sf.Excluded}");
+                        if (sf.ProbeError > 0) Console.WriteLine($"{Margin}    Probe errors        {sf.ProbeError}");
+                        if (sf.Errored    > 0) Console.WriteLine($"{Margin}    Errored             {sf.Errored}");
                     }
 
                     Console.WriteLine();
                 }
 
-                Console.WriteLine($"  Loaded              {f.Loaded}");
+                Console.WriteLine($"{Margin}  Loaded              {f.Loaded}");
                 Console.WriteLine($"  Resumed             {f.Resumed}");
                 Console.WriteLine($"  Already loaded      {f.AlreadyLoaded}");
                 if (f.TooShort   > 0) Console.WriteLine($"  Too short           {f.TooShort}");

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -66,12 +66,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
         /// </summary>
         void Heading(string title, string colour) {
             if (Tty) {
-                if (Nested) {
-                    AnsiConsole.WriteLine();
-                    AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(title)}[/]");
-                } else {
-                    AnsiConsole.Write(new Rule($"[{colour}]{Markup.Escape(title)}[/]").LeftJustified());
-                }
+                if (Nested) AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(title)}[/]");
+                else AnsiConsole.Write(new Rule($"[{colour}]{Markup.Escape(title)}[/]").LeftJustified());
             } else {
                 Console.WriteLine();
                 Console.WriteLine(Nested ? $"  -- {title} --" : $"== {title} ==");

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -38,11 +38,23 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
         /// per section is right only where the run is itself the command.</summary>
         public bool Nested { get; init; }
 
+        /// <summary>
+        /// Where a line of this run's own output starts. <b>Column 0 belongs to headings</b>, and only a
+        /// heading that is a rule sits there — everything a section contains is indented under it.
+        ///
+        /// <para>Renderables need it as a <see cref="Padder"/> rather than as text: a grid or a table
+        /// ignores leading spaces and would otherwise draw against the margin while the prose beside it
+        /// is indented.</para>
+        /// </summary>
+        int Detail => Nested ? 4 : 2;
+
+        string Indented => new(' ', Detail);
+
         public void Line(string plain, string? markup = null) {
             if (Quiet) return;
 
-            if (Tty) AnsiConsole.MarkupLine(markup ?? Markup.Escape(plain));
-            else Console.WriteLine(plain);
+            if (Tty) AnsiConsole.MarkupLine(Indented + (markup ?? Markup.Escape(plain)));
+            else Console.WriteLine(Indented + plain);
         }
 
         /// <summary>
@@ -113,7 +125,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                         );
                     }
 
-                    AnsiConsole.Write(sub);
+                    AnsiConsole.Write(new Padder(sub).Padding(Detail, 0, 0, 0));
                 }
 
                 var grid = new Grid().AddColumn().AddColumn();
@@ -123,7 +135,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                 grid.AddRow("[bold]Too short[/]", c.TooShort.ToString());
                 grid.AddRow("[bold]Excluded[/]", c.Excluded.ToString());
                 if (c.ProbeError > 0) grid.AddRow("[bold]Probe errors[/]", $"[red]{c.ProbeError}[/]");
-                AnsiConsole.Write(grid);
+                AnsiConsole.Write(new Padder(grid).Padding(Detail, 0, 0, 0));
             } else {
                 if (bySource is { Count: > 1 }) {
                     Heading("By source", "yellow");
@@ -164,7 +176,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
                 // Three buckets, not one: import knows the difference and a single number would hide it.
                 AnsiConsole.MarkupLine(
-                    $"[green]{f.Imported}[/] imported · {f.Skipped} skipped · "
+                    Indented
+                  + $"[green]{f.Imported}[/] imported · {f.Skipped} skipped · "
                   + (f.Failed > 0 ? $"[red]{f.Failed}[/] failed" : "0 failed"));
 
                 if (bySource is { Count: > 1 }) {
@@ -206,7 +219,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                         );
                     }
 
-                    AnsiConsole.Write(sub);
+                    AnsiConsole.Write(new Padder(sub).Padding(Detail, 0, 0, 0));
                 }
 
                 var grid = new Grid().AddColumn().AddColumn();
@@ -229,9 +242,9 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                         grid.AddRow("[bold]Summaries[/]", $"{f.SummariesGenerated} generated, {f.SummariesFailed} failed");
                 }
 
-                AnsiConsole.Write(grid);
+                AnsiConsole.Write(new Padder(grid).Padding(Detail, 0, 0, 0));
 
-                if (f.Failed > 0) AnsiConsole.MarkupLine($"[dim]{failureNote}[/]");
+                if (f.Failed > 0) AnsiConsole.MarkupLine($"{Indented}[dim]{failureNote}[/]");
             } else {
                 Heading("Done", "green");
                 Console.WriteLine($"  {f.Imported} imported · {f.Skipped} skipped · {f.Failed} failed");

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -48,11 +48,9 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
         /// </summary>
         int Detail => Nested ? 4 : 2;
 
-        string Indented => new(' ', Detail);
-
-        /// <summary>What a plain-text row adds to the indent already in its literal, so the two forms
-        /// nest by the same step.</summary>
-        string Margin => Nested ? "  " : "";
+        /// <summary>The same step as <see cref="Detail"/>, for the callers that prefix text rather than
+        /// pad a renderable.</summary>
+        public string Indented => new(' ', Detail);
 
         public void Line(string plain, string? markup = null) {
             if (Quiet) return;
@@ -65,8 +63,10 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
         /// Every section label, so a nested run cannot end up subordinating its phases and then closing
         /// with a full-width rule of its own.
         ///
-        /// <para>The nested TTY line supplies the vertical space a <see cref="Rule"/> brings with it,
-        /// which a bare line does not.</para>
+        /// <para>Plain text keeps a blank line above the label. A <see cref="Rule"/> carries its own
+        /// break and weight distinguishes a nested label, but neither is available with output
+        /// redirected, where the blank line is the only thing separating a section from the last one's
+        /// rows.</para>
         /// </summary>
         void Heading(string title, string colour) {
             if (Tty) {
@@ -142,24 +142,24 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
                     foreach (var kv in bySource.OrderBy(x => x.Key, StringComparer.Ordinal)) {
                         var sc = kv.Value;
-                        Console.WriteLine($"{Margin}  [{kv.Key}]");
-                        Console.WriteLine($"{Margin}    New               {sc.New}");
-                        Console.WriteLine($"{Margin}    Resumable         {sc.Partial}");
-                        Console.WriteLine($"{Margin}    Already loaded    {sc.AlreadyLoaded}");
-                        Console.WriteLine($"{Margin}    Too short         {sc.TooShort}");
-                        Console.WriteLine($"{Margin}    Excluded          {sc.Excluded}");
-                        if (sc.ProbeError > 0) Console.WriteLine($"{Margin}    Probe errors      {sc.ProbeError}");
+                        Console.WriteLine($"{Indented}[{kv.Key}]");
+                        Console.WriteLine($"{Indented}  New               {sc.New}");
+                        Console.WriteLine($"{Indented}  Resumable         {sc.Partial}");
+                        Console.WriteLine($"{Indented}  Already loaded    {sc.AlreadyLoaded}");
+                        Console.WriteLine($"{Indented}  Too short         {sc.TooShort}");
+                        Console.WriteLine($"{Indented}  Excluded          {sc.Excluded}");
+                        if (sc.ProbeError > 0) Console.WriteLine($"{Indented}  Probe errors      {sc.ProbeError}");
                     }
 
                     Console.WriteLine();
                 }
 
-                Console.WriteLine($"{Margin}  New               {c.New}");
-                Console.WriteLine($"{Margin}  Resumable         {c.Partial}");
-                Console.WriteLine($"{Margin}  Already loaded    {c.AlreadyLoaded}");
-                Console.WriteLine($"{Margin}  Too short         {c.TooShort}");
-                Console.WriteLine($"{Margin}  Excluded          {c.Excluded}");
-                if (c.ProbeError > 0) Console.WriteLine($"{Margin}  Probe errors      {c.ProbeError}");
+                Console.WriteLine($"{Indented}New               {c.New}");
+                Console.WriteLine($"{Indented}Resumable         {c.Partial}");
+                Console.WriteLine($"{Indented}Already loaded    {c.AlreadyLoaded}");
+                Console.WriteLine($"{Indented}Too short         {c.TooShort}");
+                Console.WriteLine($"{Indented}Excluded          {c.Excluded}");
+                if (c.ProbeError > 0) Console.WriteLine($"{Indented}Probe errors      {c.ProbeError}");
             }
         }
 
@@ -247,43 +247,43 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                 if (f.Failed > 0) AnsiConsole.MarkupLine($"{Indented}[dim]{failureNote}[/]");
             } else {
                 Heading("Done", "green");
-                Console.WriteLine($"{Margin}  {f.Imported} imported · {f.Skipped} skipped · {f.Failed} failed");
+                Console.WriteLine($"{Indented}{f.Imported} imported · {f.Skipped} skipped · {f.Failed} failed");
 
                 if (bySource is { Count: > 1 }) {
                     Heading("By source", "green");
 
                     foreach (var kv in bySource.OrderBy(x => x.Key, StringComparer.Ordinal)) {
                         var sf = kv.Value;
-                        Console.WriteLine($"{Margin}  [{kv.Key}]");
-                        Console.WriteLine($"{Margin}    Loaded              {sf.Loaded}");
-                        Console.WriteLine($"{Margin}    Resumed             {sf.Resumed}");
-                        Console.WriteLine($"{Margin}    Already loaded      {sf.AlreadyLoaded}");
-                        if (sf.TooShort   > 0) Console.WriteLine($"{Margin}    Too short           {sf.TooShort}");
-                        if (sf.Excluded   > 0) Console.WriteLine($"{Margin}    Excluded            {sf.Excluded}");
-                        if (sf.ProbeError > 0) Console.WriteLine($"{Margin}    Probe errors        {sf.ProbeError}");
-                        if (sf.Errored    > 0) Console.WriteLine($"{Margin}    Errored             {sf.Errored}");
+                        Console.WriteLine($"{Indented}[{kv.Key}]");
+                        Console.WriteLine($"{Indented}  Loaded              {sf.Loaded}");
+                        Console.WriteLine($"{Indented}  Resumed             {sf.Resumed}");
+                        Console.WriteLine($"{Indented}  Already loaded      {sf.AlreadyLoaded}");
+                        if (sf.TooShort   > 0) Console.WriteLine($"{Indented}  Too short           {sf.TooShort}");
+                        if (sf.Excluded   > 0) Console.WriteLine($"{Indented}  Excluded            {sf.Excluded}");
+                        if (sf.ProbeError > 0) Console.WriteLine($"{Indented}  Probe errors        {sf.ProbeError}");
+                        if (sf.Errored    > 0) Console.WriteLine($"{Indented}  Errored             {sf.Errored}");
                     }
 
                     Console.WriteLine();
                 }
 
-                Console.WriteLine($"{Margin}  Loaded              {f.Loaded}");
-                Console.WriteLine($"{Margin}  Resumed             {f.Resumed}");
-                Console.WriteLine($"{Margin}  Already loaded      {f.AlreadyLoaded}");
-                if (f.TooShort   > 0) Console.WriteLine($"{Margin}  Too short           {f.TooShort}");
-                if (f.Excluded   > 0) Console.WriteLine($"{Margin}  Excluded            {f.Excluded}");
-                if (f.ProbeError > 0) Console.WriteLine($"{Margin}  Probe errors        {f.ProbeError}");
-                if (f.Errored    > 0) Console.WriteLine($"{Margin}  Errored             {f.Errored}");
+                Console.WriteLine($"{Indented}Loaded              {f.Loaded}");
+                Console.WriteLine($"{Indented}Resumed             {f.Resumed}");
+                Console.WriteLine($"{Indented}Already loaded      {f.AlreadyLoaded}");
+                if (f.TooShort   > 0) Console.WriteLine($"{Indented}Too short           {f.TooShort}");
+                if (f.Excluded   > 0) Console.WriteLine($"{Indented}Excluded            {f.Excluded}");
+                if (f.ProbeError > 0) Console.WriteLine($"{Indented}Probe errors        {f.ProbeError}");
+                if (f.Errored    > 0) Console.WriteLine($"{Indented}Errored             {f.Errored}");
 
                 if (f.RanBackground) {
                     if (f.RequestedTitles)
-                        Console.WriteLine($"{Margin}  Titles              {f.TitlesGenerated} generated, {f.TitlesSkipped} skipped, {f.TitlesFailed} failed");
+                        Console.WriteLine($"{Indented}Titles              {f.TitlesGenerated} generated, {f.TitlesSkipped} skipped, {f.TitlesFailed} failed");
 
                     if (f.RequestedSummaries)
-                        Console.WriteLine($"{Margin}  Summaries           {f.SummariesGenerated} generated, {f.SummariesFailed} failed");
+                        Console.WriteLine($"{Indented}Summaries           {f.SummariesGenerated} generated, {f.SummariesFailed} failed");
                 }
 
-                if (f.Failed > 0) Console.WriteLine($"{Margin}  {failureNote}");
+                if (f.Failed > 0) Console.WriteLine($"{Indented}{failureNote}");
             }
         }
 
@@ -1081,7 +1081,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                 totalAfterScope,
                 sampleRepos,
                 visibilityDesc,
-                skipConfirmation
+                skipConfirmation,
+                display.Indented
             )) {
             await Console.Error.WriteLineAsync("Import cancelled.");
 
@@ -1111,7 +1112,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                 .AutoClear(true)
                 .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                 .StartAsync(async ctx => {
-                        var bar = ctx.AddTask("[yellow]Probing[/]", maxValue: totalAfterScope);
+                        var bar = ctx.AddTask($"{display.Indented}[yellow]Probing[/]", maxValue: totalAfterScope);
 
                         var probeTasks = sources.Select(async (s, idx) => {
                                     var slice = filteredPerSource[idx];
@@ -1538,7 +1539,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                     .HideCompleted(false)
                     .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                     .StartAsync(async ctx => {
-                            var bar = ctx.AddTask("[green]Importing[/]", maxValue: chains.Sum(c => c.Count));
+                            var bar = ctx.AddTask($"{display.Indented}[green]Importing[/]", maxValue: chains.Sum(c => c.Count));
 
                             // Four progress tasks rendered as live "slot rows" beneath the
                             // main bar — one per worker. Each fills as its session's transcript
@@ -1549,7 +1550,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                             var slots = new ProgressTask[ImportWorkerCount];
 
                             for (var i = 0; i < ImportWorkerCount; i++) {
-                                slots[i]                 = ctx.AddTask($"  Slot {i + 1} — idle", maxValue: 1);
+                                slots[i]                 = ctx.AddTask($"{display.Indented}  Slot {i + 1} — idle", maxValue: 1);
                                 slots[i].IsIndeterminate = false;
                             }
 
@@ -1593,7 +1594,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                                     // Subagent lines don't advance the parent bar; show a stripe
                                     // and swap the description while the subagent streams.
                                     slots[slot].IsIndeterminate = true;
-                                    slots[slot].Description     = $"  [bold]Slot {slot + 1}[/] — [dim]↳[/] subagent [cyan]{Markup.Escape(aid)}[/] (parent {Markup.Escape(sid)})";
+                                    slots[slot].Description     = $"{display.Indented}  [bold]Slot {slot + 1}[/] — [dim]↳[/] subagent [cyan]{Markup.Escape(aid)}[/] (parent {Markup.Escape(sid)})";
                                 },
                                 OnSubagentFinished = (slot, _, _, _) => {
                                     // Revert to the parent's "Loading" description and resume the
@@ -1635,7 +1636,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                             return;
 
                             void IdleSlot(int slot) {
-                                slots[slot].Description     = $"  Slot {slot + 1} — idle";
+                                slots[slot].Description     = $"{display.Indented}  Slot {slot + 1} — idle";
                                 slots[slot].IsIndeterminate = false;
                                 slots[slot].Value           = 0;
                                 slots[slot].MaxValue        = 1;
@@ -1644,8 +1645,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                                 currentVerb[slot]           = "";
                             }
 
-                            static string LoadingDesc(int slot, string sid, string verb) =>
-                                $"  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(sid)}[/] ({verb})";
+                            string LoadingDesc(int slot, string sid, string verb) =>
+                                $"{display.Indented}  [bold]Slot {slot + 1}[/] — Loading [cyan]{Markup.Escape(sid)}[/] ({verb})";
                         }
                     );
                 importResult = r!;
@@ -1749,7 +1750,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                     .HideCompleted(false)
                     .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                     .StartAsync(async ctx => {
-                            var bar = ctx.AddTask("[green]Importing[/]", maxValue: routed.Count);
+                            var bar = ctx.AddTask($"{display.Indented}[green]Importing[/]", maxValue: routed.Count);
 
                             await Parallel.ForEachAsync(
                                 routed,
@@ -1861,6 +1862,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                 display.BeginPhase(forcePrivate
                     ? "Marking imported sessions private"
                     : "Sharing imported sessions with your workspace");
+
                 visibilityFailures += (await SetVisibilityForAll(
                     httpClient, baseUrl, [.. touched], explicitVisibility)).Count;
             }
@@ -1878,8 +1880,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                     .HideCompleted(false)
                     .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                     .StartAsync(async ctx => {
-                            var titleTask   = titleTaskCount   > 0 ? ctx.AddTask("[cyan]Titles[/]", maxValue: titleTaskCount) : null;
-                            var summaryTask = summaryTaskCount > 0 ? ctx.AddTask("[cyan]Summaries[/]", maxValue: summaryTaskCount) : null;
+                            var titleTask   = titleTaskCount   > 0 ? ctx.AddTask($"{display.Indented}[cyan]Titles[/]", maxValue: titleTaskCount) : null;
+                            var summaryTask = summaryTaskCount > 0 ? ctx.AddTask($"{display.Indented}[cyan]Summaries[/]", maxValue: summaryTaskCount) : null;
                             var seenT       = 0;
                             var seenS       = 0;
 

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -33,6 +33,11 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
         /// </summary>
         public bool Quiet { get; init; }
 
+        /// <summary>This run is a step inside setup, which has already drawn the rule its sections sit
+        /// under — so each one is subordinate to that rule rather than a sibling of it. A full-width rule
+        /// per section is right only where the run is itself the command.</summary>
+        public bool Nested { get; init; }
+
         public void Line(string plain, string? markup = null) {
             if (Quiet) return;
 
@@ -40,15 +45,31 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
             else Console.WriteLine(plain);
         }
 
+        /// <summary>
+        /// Every section label, so a nested run cannot end up subordinating its phases and then closing
+        /// with a full-width rule of its own.
+        ///
+        /// <para>The nested TTY line supplies the vertical space a <see cref="Rule"/> brings with it,
+        /// which a bare line does not.</para>
+        /// </summary>
+        void Heading(string title, string colour) {
+            if (Tty) {
+                if (Nested) {
+                    AnsiConsole.WriteLine();
+                    AnsiConsole.MarkupLine($"  [dim]{Markup.Escape(title)}[/]");
+                } else {
+                    AnsiConsole.Write(new Rule($"[{colour}]{Markup.Escape(title)}[/]").LeftJustified());
+                }
+            } else {
+                Console.WriteLine();
+                Console.WriteLine(Nested ? $"  -- {title} --" : $"== {title} ==");
+            }
+        }
+
         public void BeginPhase(string title) {
             if (Quiet) return;
 
-            if (Tty) {
-                AnsiConsole.Write(new Rule($"[yellow]{Markup.Escape(title)}[/]").LeftJustified());
-            } else {
-                Console.WriteLine();
-                Console.WriteLine($"== {title} ==");
-            }
+            Heading(title, "yellow");
         }
 
         public void WritePlanGrid(
@@ -57,7 +78,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
             ) {
             if (Tty) {
                 if (bySource is { Count: > 1 }) {
-                    AnsiConsole.Write(new Rule("[yellow]By source[/]").LeftJustified());
+                    Heading("By source", "yellow");
 
                     var sub = new Grid()
                         .AddColumn()
@@ -105,8 +126,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                 AnsiConsole.Write(grid);
             } else {
                 if (bySource is { Count: > 1 }) {
-                    Console.WriteLine();
-                    Console.WriteLine("== By source ==");
+                    Heading("By source", "yellow");
 
                     foreach (var kv in bySource.OrderBy(x => x.Key, StringComparer.Ordinal)) {
                         var sc = kv.Value;
@@ -140,7 +160,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
             var failureNote = $"{f.Failed} didn't land. Re-run to retry them — anything already imported isn't sent again.";
 
             if (Tty) {
-                AnsiConsole.Write(new Rule("[green]Done[/]").LeftJustified());
+                Heading("Done", "green");
 
                 // Three buckets, not one: import knows the difference and a single number would hide it.
                 AnsiConsole.MarkupLine(
@@ -148,7 +168,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                   + (f.Failed > 0 ? $"[red]{f.Failed}[/] failed" : "0 failed"));
 
                 if (bySource is { Count: > 1 }) {
-                    AnsiConsole.Write(new Rule("[green]By source[/]").LeftJustified());
+                    Heading("By source", "green");
 
                     var sub = new Grid()
                         .AddColumn()
@@ -213,13 +233,11 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
                 if (f.Failed > 0) AnsiConsole.MarkupLine($"[dim]{failureNote}[/]");
             } else {
-                Console.WriteLine();
-                Console.WriteLine("== Done ==");
+                Heading("Done", "green");
                 Console.WriteLine($"  {f.Imported} imported · {f.Skipped} skipped · {f.Failed} failed");
 
                 if (bySource is { Count: > 1 }) {
-                    Console.WriteLine();
-                    Console.WriteLine("== By source ==");
+                    Heading("By source", "green");
 
                     foreach (var kv in bySource.OrderBy(x => x.Key, StringComparer.Ordinal)) {
                         var sf = kv.Value;
@@ -256,8 +274,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
             }
         }
 
-        public static ImportDisplay Create(bool quiet = false) =>
-            new() { Tty = !quiet && !Console.IsOutputRedirected, Quiet = quiet };
+        public static ImportDisplay Create(bool quiet = false, bool nested = false) =>
+            new() { Tty = !quiet && !Console.IsOutputRedirected, Quiet = quiet, Nested = nested };
     }
 
     internal enum ClassificationStatus {
@@ -712,7 +730,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
             bool                          discoverJson            = false,
             DateTimeOffset?               windowsAsOf             = null,
             Action<ImportRunOutcome>?     onFinished              = null,
-            Action<ImportDiscoveryResult>? onDiscovered           = null
+            Action<ImportDiscoveryResult>? onDiscovered           = null,
+            bool                          nested                  = false
         ) {
         // A caller that wants the figures rather than the rendering says so by handing one over; the
         // console is the default consumer, not the only one.
@@ -725,7 +744,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
         using var httpClient = discoverOnly
             ? new HttpClient()
             : await HttpClientExtensions.CreateAuthenticatedClientAsync(config, profiles, baseUrl);
-        var       display    = ImportDisplay.Create(quiet: discoverJson);
+        var       display    = ImportDisplay.Create(quiet: discoverJson, nested: nested);
 
         // --- Sources ---
         // Back-compat: a null caller (legacy or test) means "Claude only". Once

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -1521,7 +1521,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                 var r = default(ImportChainsResult);
 
                 await AnsiConsole.Progress()
-                    .AutoClear(false)
+                    .AutoClear(true)
                     .HideCompleted(false)
                     .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                     .StartAsync(async ctx => {
@@ -1615,7 +1615,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
                             r = await ImportChainsAsync(httpClient, baseUrl, chains, wrappedEvents, CancellationToken.None, sessionCwds, chainDefaultVisibility);
 
-                            // After the await, all workers have drained; mark every slot idle.
+                            // Insurance, not presentation: the frame is erased on the way out, and an
+                            // erase that ever fails should strand idle rows rather than a session name.
                             for (var i = 0; i < ImportWorkerCount; i++) IdleSlot(i);
 
                             return;
@@ -1731,7 +1732,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
             if (display.Tty) {
                 await AnsiConsole.Progress()
-                    .AutoClear(false)
+                    .AutoClear(true)
                     .HideCompleted(false)
                     .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                     .StartAsync(async ctx => {
@@ -1860,7 +1861,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
             if (display.Tty) {
                 await AnsiConsole.Progress()
-                    .AutoClear(false)
+                    .AutoClear(true)
                     .HideCompleted(false)
                     .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                     .StartAsync(async ctx => {

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -1215,7 +1215,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                     .Distinct()
                     .Count();
                 var totalGroups = excludedByRepo.Count + excludedByPath.Count;
-                await Console.Error.WriteLineAsync($"Auto-skipping {distinctSessions} session(s) from {totalGroups} excluded source(s) (non-interactive).");
+                await Console.Error.WriteLineAsync(
+                    $"{display.Indented}Auto-skipping {distinctSessions} session(s) from {totalGroups} excluded source(s) (non-interactive).");
             }
 
             for (var i = 0; i < classifications.Count; i++) {
@@ -1484,7 +1485,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
             if (existing.Count > 0) {
                 display.BeginPhase("Making existing sessions private");
 
-                var unprivatized = await SetVisibilityNoneForAll(httpClient, baseUrl, existing);
+                var unprivatized = await SetVisibilityNoneForAll(httpClient, baseUrl, existing, display.Indented);
 
                 if (unprivatized.Count > 0) {
                     var blocked = unprivatized.ToHashSet(StringComparer.Ordinal);
@@ -1501,7 +1502,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
                     foreach (var sessionId in blocked) {
                         await Console.Error.WriteLineAsync(
-                            $"  ! skipping {sessionId}: could not make it private first, and importing "
+                            $"{display.Indented}! skipping {sessionId}: could not make it private first, and importing "
                           + "into it would publish new content to the audience it already has");
                     }
                 }
@@ -1623,7 +1624,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                                     IdleSlot(slot);
                                     // Errors print to scrollback above the live region —
                                     // Spectre.Console.Progress flushes prior writes.
-                                    AnsiConsole.MarkupLine(FormatSkippedReasonMarkup(sid, reason));
+                                    AnsiConsole.MarkupLine(display.Indented + FormatSkippedReasonMarkup(sid, reason));
                                 },
                             };
 
@@ -1762,19 +1763,19 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                                         case ImportOutcome.Loaded:
                                         case ImportOutcome.Resumed:
                                             AnsiConsole.MarkupLine(
-                                                $"[green]✓[/] Loading [cyan]{Markup.Escape(c.SessionId)}[/] ({c.Vendor.VendorId})"
+                                                $"{display.Indented}[green]✓[/] Loading [cyan]{Markup.Escape(c.SessionId)}[/] ({c.Vendor.VendorId})"
                                             );
 
                                             break;
                                         case ImportOutcome.Skipped:
                                             AnsiConsole.MarkupLine(
-                                                $"[yellow]~[/] Skipping [cyan]{Markup.Escape(c.SessionId)}[/] (already current)"
+                                                $"{display.Indented}[yellow]~[/] Skipping [cyan]{Markup.Escape(c.SessionId)}[/] (already current)"
                                             );
 
                                             break;
                                         case ImportOutcome.Failed:
                                             AnsiConsole.MarkupLine(
-                                                $"[red]✗[/] Failed [cyan]{Markup.Escape(c.SessionId)}[/]"
+                                                $"{display.Indented}[red]✗[/] Failed [cyan]{Markup.Escape(c.SessionId)}[/]"
                                             );
 
                                             break;
@@ -1784,13 +1785,13 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                                             // lifecycle-only repair, etc.), not always "nested
                                             // under parent".
                                             AnsiConsole.MarkupLine(
-                                                $"[grey]·[/] Already loaded [cyan]{Markup.Escape(c.SessionId)}[/] (no new content)"
+                                                $"{display.Indented}[grey]·[/] Already loaded [cyan]{Markup.Escape(c.SessionId)}[/] (no new content)"
                                             );
 
                                             break;
                                         case null:
                                             AnsiConsole.MarkupLine(
-                                                $"[grey]·[/] Refreshed [cyan]{Markup.Escape(c.SessionId)}[/] (repository backfill, already loaded)"
+                                                $"{display.Indented}[grey]·[/] Refreshed [cyan]{Markup.Escape(c.SessionId)}[/] (repository backfill, already loaded)"
                                             );
 
                                             break;
@@ -1864,7 +1865,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                     : "Sharing imported sessions with your workspace");
 
                 var lost = await SetVisibilityForAll(
-                    httpClient, baseUrl, [.. touched], explicitVisibility);
+                    httpClient, baseUrl, [.. touched], explicitVisibility, display.Indented);
 
                 visibilityFailures += lost.Count;
 
@@ -1901,14 +1902,14 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
                                 for (var i = seenT; i < tList.Count; i++) {
                                     var (sid, reason) = tList[i];
-                                    AnsiConsole.MarkupLine($"  [red]✗[/] title failed for [cyan]{Markup.Escape(sid)}[/]: {Markup.Escape(reason)}");
+                                    AnsiConsole.MarkupLine($"{display.Indented}[red]✗[/] title failed for [cyan]{Markup.Escape(sid)}[/]: {Markup.Escape(reason)}");
                                 }
 
                                 seenT = tList.Count;
 
                                 for (var i = seenS; i < sList.Count; i++) {
                                     var (sid, reason) = sList[i];
-                                    AnsiConsole.MarkupLine($"  [red]✗[/] summary failed for [cyan]{Markup.Escape(sid)}[/]: {Markup.Escape(reason)}");
+                                    AnsiConsole.MarkupLine($"{display.Indented}[red]✗[/] summary failed for [cyan]{Markup.Escape(sid)}[/]: {Markup.Escape(reason)}");
                                 }
 
                                 seenS = sList.Count;
@@ -3270,8 +3271,9 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
     internal static Task<IReadOnlyList<string>> SetVisibilityNoneForAll(
             HttpClient            httpClient,
             string                baseUrl,
-            IReadOnlyList<string> sessionIds
-        ) => SetVisibilityForAll(httpClient, baseUrl, sessionIds, "none");
+            IReadOnlyList<string> sessionIds,
+            string                indent = ""
+        ) => SetVisibilityForAll(httpClient, baseUrl, sessionIds, "none", indent);
 
     /// <summary>
     /// Failures are logged inline (one line per session) but never throw — the import already
@@ -3284,7 +3286,8 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
             HttpClient            httpClient,
             string                baseUrl,
             IReadOnlyList<string> sessionIds,
-            string                visibility
+            string                visibility,
+            string                indent = ""
         ) {
         var lost = new List<string>();
 
@@ -3303,14 +3306,14 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                     lost.Add(sessionId);
 
                     await Console.Error.WriteLineAsync(
-                        $"  ! visibility={visibility} failed for {sessionId}: HTTP {(int)resp.StatusCode}"
+                        $"{indent}! visibility={visibility} failed for {sessionId}: HTTP {(int)resp.StatusCode}"
                     );
                 }
             } catch (Exception ex) {
                 lost.Add(sessionId);
 
                 await Console.Error.WriteLineAsync(
-                    $"  ! visibility={visibility} failed for {sessionId}: {ex.Message}"
+                    $"{indent}! visibility={visibility} failed for {sessionId}: {ex.Message}"
                 );
             }
         }

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -268,22 +268,22 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                 }
 
                 Console.WriteLine($"{Margin}  Loaded              {f.Loaded}");
-                Console.WriteLine($"  Resumed             {f.Resumed}");
-                Console.WriteLine($"  Already loaded      {f.AlreadyLoaded}");
-                if (f.TooShort   > 0) Console.WriteLine($"  Too short           {f.TooShort}");
-                if (f.Excluded   > 0) Console.WriteLine($"  Excluded            {f.Excluded}");
-                if (f.ProbeError > 0) Console.WriteLine($"  Probe errors        {f.ProbeError}");
-                if (f.Errored    > 0) Console.WriteLine($"  Errored             {f.Errored}");
+                Console.WriteLine($"{Margin}  Resumed             {f.Resumed}");
+                Console.WriteLine($"{Margin}  Already loaded      {f.AlreadyLoaded}");
+                if (f.TooShort   > 0) Console.WriteLine($"{Margin}  Too short           {f.TooShort}");
+                if (f.Excluded   > 0) Console.WriteLine($"{Margin}  Excluded            {f.Excluded}");
+                if (f.ProbeError > 0) Console.WriteLine($"{Margin}  Probe errors        {f.ProbeError}");
+                if (f.Errored    > 0) Console.WriteLine($"{Margin}  Errored             {f.Errored}");
 
                 if (f.RanBackground) {
                     if (f.RequestedTitles)
-                        Console.WriteLine($"  Titles              {f.TitlesGenerated} generated, {f.TitlesSkipped} skipped, {f.TitlesFailed} failed");
+                        Console.WriteLine($"{Margin}  Titles              {f.TitlesGenerated} generated, {f.TitlesSkipped} skipped, {f.TitlesFailed} failed");
 
                     if (f.RequestedSummaries)
-                        Console.WriteLine($"  Summaries           {f.SummariesGenerated} generated, {f.SummariesFailed} failed");
+                        Console.WriteLine($"{Margin}  Summaries           {f.SummariesGenerated} generated, {f.SummariesFailed} failed");
                 }
 
-                if (f.Failed > 0) Console.WriteLine($"  {failureNote}");
+                if (f.Failed > 0) Console.WriteLine($"{Margin}  {failureNote}");
             }
         }
 

--- a/src/Capacitor.Cli/Commands/ImportCommand.cs
+++ b/src/Capacitor.Cli/Commands/ImportCommand.cs
@@ -1746,7 +1746,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
             if (display.Tty) {
                 await AnsiConsole.Progress()
-                    .AutoClear(true)
+                    .AutoClear(false)
                     .HideCompleted(false)
                     .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                     .StartAsync(async ctx => {
@@ -1863,8 +1863,16 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
                     ? "Marking imported sessions private"
                     : "Sharing imported sessions with your workspace");
 
-                visibilityFailures += (await SetVisibilityForAll(
-                    httpClient, baseUrl, [.. touched], explicitVisibility)).Count;
+                var lost = await SetVisibilityForAll(
+                    httpClient, baseUrl, [.. touched], explicitVisibility);
+
+                visibilityFailures += lost.Count;
+
+                // The per-session writes only speak up for a failure, so without this the heading
+                // above renders as a section with nothing in it.
+                display.Line(lost.Count == 0
+                    ? $"{touched.Count} session{(touched.Count == 1 ? "" : "s")} updated"
+                    : $"{touched.Count - lost.Count} of {touched.Count} updated, {lost.Count} failed");
             }
         }
 
@@ -1876,7 +1884,7 @@ class ImportCommand(ConfigRoot config, ProfileContext profiles, UserHome home) {
 
             if (display.Tty) {
                 await AnsiConsole.Progress()
-                    .AutoClear(true)
+                    .AutoClear(false)
                     .HideCompleted(false)
                     .Columns(new TaskDescriptionColumn(), new ProgressBarColumn(), new PercentageColumn())
                     .StartAsync(async ctx => {

--- a/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
+++ b/src/Capacitor.Cli/Commands/ImportScopePrompt.cs
@@ -58,18 +58,21 @@ public static partial class ImportScopePrompt {
     /// The same text is printed in non-TTY runs (with --yes) so the imported
     /// scope is recorded in CI logs.
     /// </summary>
+    /// <param name="indent">Shifts the whole block, label included: it belongs to whatever section the
+    /// caller has open rather than heading one of its own.</param>
     public static string FormatSummary(
             ImportScope           scope,
             int                   matchedCount,
             IReadOnlyList<string> repoSamples,
-            string                visibilityDescription
+            string                visibilityDescription,
+            string                indent = ""
         ) {
         var sb = new StringBuilder();
-        sb.AppendLine("About to import:");
-        sb.AppendLine($"  scope:   {ScopeLabel(scope)}");
-        sb.AppendLine($"{MatchedPrefix}{matchedCount}{MatchedSuffix(matchedCount, repoSamples.Count)}");
-        sb.AppendLine($"  repos:   {RepoLine(repoSamples)}");
-        sb.Append($"  visibility: {visibilityDescription}");
+        sb.AppendLine($"{indent}About to import:");
+        sb.AppendLine($"{indent}  scope:   {ScopeLabel(scope)}");
+        sb.AppendLine($"{indent}{MatchedPrefix}{matchedCount}{MatchedSuffix(matchedCount, repoSamples.Count)}");
+        sb.AppendLine($"{indent}  repos:   {RepoLine(repoSamples)}");
+        sb.Append($"{indent}  visibility: {visibilityDescription}");
 
         return sb.ToString();
     }
@@ -191,9 +194,10 @@ public static partial class ImportScopePrompt {
             int                   matchedCount,
             IReadOnlyList<string> repoSamples,
             string                visibilityDescription,
-            bool                  skip
+            bool                  skip,
+            string                indent = ""
         ) {
-        WriteSummaryToStderr(scope, matchedCount, repoSamples, visibilityDescription);
+        WriteSummaryToStderr(scope, matchedCount, repoSamples, visibilityDescription, indent);
 
         if (skip) return true;
 
@@ -213,18 +217,19 @@ public static partial class ImportScopePrompt {
             ImportScope           scope,
             int                   matchedCount,
             IReadOnlyList<string> repoSamples,
-            string                visibilityDescription
+            string                visibilityDescription,
+            string                indent
         ) {
         var console = AnsiConsole.Create(
             new AnsiConsoleSettings { Out = new AnsiConsoleOutput(Console.Error) }
         );
 
-        console.WriteLine("About to import:");
-        console.WriteLine($"  scope:   {ScopeLabel(scope)}");
+        console.WriteLine($"{indent}About to import:");
+        console.WriteLine($"{indent}  scope:   {ScopeLabel(scope)}");
         console.MarkupLine(
-            $"{MatchedPrefix}[bold cyan]{matchedCount}[/]{Markup.Escape(MatchedSuffix(matchedCount, repoSamples.Count))}"
+            $"{indent}{MatchedPrefix}[bold cyan]{matchedCount}[/]{Markup.Escape(MatchedSuffix(matchedCount, repoSamples.Count))}"
         );
-        console.WriteLine($"  repos:   {RepoLine(repoSamples)}");
-        console.WriteLine($"  visibility: {visibilityDescription}");
+        console.WriteLine($"{indent}  repos:   {RepoLine(repoSamples)}");
+        console.WriteLine($"{indent}  visibility: {visibilityDescription}");
     }
 }

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -976,7 +976,7 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
         }
 
         if (finalTokens is not null) {
-            grid.AddRow("[bold]Auth[/]", Markup.Escape($"{finalTokens.GitHubUsername} ({finalTokens.Provider})"));
+            grid.AddRow("[bold]Auth[/]", Markup.Escape(finalTokens.GitHubUsername ?? "?"));
         }
 
         grid.AddRow("[bold]Config[/]", Markup.Escape(AppConfig.GetConfigPath(config)));
@@ -1294,7 +1294,7 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
 
         try {
             var provider = await HttpClientExtensions.DiscoverProviderAsync(serverUrl, config, profiles);
-            AnsiConsole.MarkupLine($"  [green]✓[/] Reachable · auth provider: [cyan]{Markup.Escape(provider)}[/]");
+            AnsiConsole.MarkupLine("  [green]✓[/] Reachable");
 
             return (serverUrl, provider);
         } catch (Exception ex) {

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -985,29 +985,29 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
 
         grid.AddRow("[bold]Config[/]", Markup.Escape(AppConfig.GetConfigPath(config)));
 
-        AnsiConsole.Write(grid);
+        AnsiConsole.Write(new Padder(grid).Padding(2, 0, 0, 0));
 
         // hooks only load at coding-agent session start. The common case is a user
         // running `kcap setup` from inside an already-running session, which won't stream
         // live until it restarts — so tell them, but only when something was actually
         // installed (no point promising recording we never wired up).
         var restartTip = LiveRecordingRestartTip(installResult);
-        if (restartTip is not null) AnsiConsole.MarkupLine($"\n{restartTip}");
+        if (restartTip is not null) AnsiConsole.MarkupLine($"\n  {restartTip}");
 
         // Setup itself is user-scope and works fine outside a repo, but sessions recorded
         // from non-repo directories have no owner/repo/branch/PR enrichment (see
         // RepositoryDetection.DetectRepositoryAsync), which weakens grouping in the UI.
         if (gitRoot is null) {
             AnsiConsole.MarkupLine(
-                $"\n[yellow]Tip:[/] you ran setup outside a git working tree ([dim]{Markup.Escape(Environment.CurrentDirectory)}[/]).");
+                $"\n  [yellow]Tip:[/] you ran setup outside a git working tree ([dim]{Markup.Escape(Environment.CurrentDirectory)}[/]).");
             AnsiConsole.MarkupLine(
-                "  Hooks fire from any directory, but sessions recorded outside a repo won't include owner/repo/branch context.");
+                "    Hooks fire from any directory, but sessions recorded outside a repo won't include owner/repo/branch context.");
             AnsiConsole.MarkupLine(
-                "  [dim]cd[/] into your project before recording to capture full session context.");
+                "    [dim]cd[/] into your project before recording to capture full session context.");
         }
 
-        AnsiConsole.MarkupLine("\n[dim]Optional:[/] start the daemon with [cyan]kcap daemon start -d[/]");
-        AnsiConsole.MarkupLine("[dim]Optional:[/] import past sessions with [cyan]kcap import --org[/]");
+        AnsiConsole.MarkupLine("\n  [dim]Optional:[/] start the daemon with [cyan]kcap daemon start -d[/]");
+        AnsiConsole.MarkupLine("  [dim]Optional:[/] import past sessions with [cyan]kcap import --org[/]");
 
         WriteNextSteps(ShouldOfferGuidedTour(detectedSummary is not null, claudeSettingsPath, stepPaths));
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -74,7 +74,6 @@ sealed class SpectreFirstRunFlowProgress(IKeyWatcher? keys = null) : IFirstRunFl
     public void Opening(string setupUrl) {
         AnsiConsole.MarkupLine(SetupAuthProgress.Indent("Opening your browser to finish setup."));
         AnsiConsole.MarkupLine(SetupAuthProgress.Indent($"[dim]If it didn't open:[/]  {Markup.Escape(setupUrl)}"));
-        AnsiConsole.WriteLine();
 
         Refresh();
     }

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -28,13 +28,19 @@ using Profile = Capacitor.Cli.Core.Config.Profile;
 
 namespace Capacitor.Cli.Commands;
 
-/// <summary>Setup's step-scoped rendering of façade output: every non-flush line is two-space indented, and setup still owns the guidance tail.</summary>
+/// <summary>Setup's step-scoped rendering of façade output: setup owns the guidance tail, while the
+/// indent belongs to the renderer underneath — most of the auth copy is composed in there, so shifting
+/// it from out here would move the lines this class is handed and leave the rest at column 0.</summary>
 sealed class SetupAuthProgress(IAuthProgress inner) : IAuthProgress {
-    internal const string UnreachableGuidance = "  Retry later, or pass --server-url <url>.";
+    /// <summary>What a line of setup's own output is shifted by, and what its façade renderer is built
+    /// with, so the two halves of a step land on one margin.</summary>
+    internal const string StepIndent = "  ";
 
-    public void Notice(string message) => inner.Notice(Indent(message));
+    internal const string UnreachableGuidance = "Retry later, or pass --server-url <url>.";
 
-    public void Error(string message) => inner.Error(Indent(message));
+    public void Notice(string message) => inner.Notice(message);
+
+    public void Error(string message) => inner.Error(message);
 
     public void BrowserOpening(string url) => inner.BrowserOpening(url);
 
@@ -49,7 +55,7 @@ sealed class SetupAuthProgress(IAuthProgress inner) : IAuthProgress {
 
     // Blank separators and already-indented copy (the device-flow numbered list) pass through as-is.
     internal static string Indent(string message) =>
-        string.IsNullOrWhiteSpace(message) || message.StartsWith(' ') ? message : $"  {message}";
+        string.IsNullOrWhiteSpace(message) || message.StartsWith(' ') ? message : StepIndent + message;
 }
 
 /// <summary>The browser leg's rendering, at setup's two-space indent. The URL is printed whether or not
@@ -1310,7 +1316,7 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
     /// <summary>Test seam: overrides façade construction for Step 1/2. Reset to null in a finally block.</summary>
     internal static Func<ITenantProvisioner?, OnboardingFacade>? FacadeOverride;
 
-    internal static readonly SetupAuthProgress StepProgress = new(ConsoleAuthProgress.Instance);
+    internal static readonly SetupAuthProgress StepProgress = new(new ConsoleAuthProgress(SetupAuthProgress.StepIndent));
 
     OnboardingFacade NewFacade(
             ITenantProvisioner? provisioner, ITenantPicker? picker = null, RequestedWorkspace? requested = null) =>

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -245,7 +245,10 @@ sealed class SetupImportLane(
             discoverOnly: true,
             discoverJson: true,
             windowsAsOf:  asOf,
-            onDiscovered: result => found = result);
+            onDiscovered: result => found = result,
+            // Inert while the discovery call stays quiet, and the reason this is set anyway: un-quieting
+            // it would otherwise draw step-weight rules in the middle of the browser leg's own copy.
+            nested:       true);
 
         if (exit != 0 || found is null) return null;
 
@@ -301,7 +304,8 @@ sealed class SetupImportLane(
             // What makes the shared stop honest, since the profile default cannot reach the class the
             // visibility predicate admits unconditionally.
             shareWithOrg:       pass.Level is FirstRunImportLevel.Shared,
-            onFinished:         o => outcome = o);
+            onFinished:         o => outcome = o,
+            nested:             true);
 
         return outcome;
     }
@@ -1236,7 +1240,8 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
             needOrgPick:             false,
             storedOrg:               null,
             autoSkipExclusions:      inv.AutoSkipExclusions,
-            defaultVisibility:       inv.DefaultVisibility);
+            defaultVisibility:       inv.DefaultVisibility,
+            nested:                  true);
 
     /// <summary>
     /// Every import source, one per catalogue vendor.

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -1359,9 +1359,13 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
     internal async Task<int> RunLoginStepAsync(
             bool loginComplete, string provider, string serverUrl, bool forceDevice, string activeProfile) {
         if (loginComplete) {
-            var cfgAfter = await AppConfig.LoadProfileConfig(config);
-            var tokens   = await new TokenStore(config).LoadAsync(cfgAfter.ActiveProfile);
-            AnsiConsole.MarkupLine($"  [green]✓[/] Logged in as [cyan]{Markup.Escape(tokens?.GitHubUsername ?? "?")}[/]");
+            // Discovery's WorkOS leg reports the sign-in itself, naming the workspace it picked. Every
+            // other provider's discovery reports a tenant count and no identity, so this is its only one.
+            if (provider != AuthProvider.WorkOS) {
+                var cfgAfter = await AppConfig.LoadProfileConfig(config);
+                var tokens   = await new TokenStore(config).LoadAsync(cfgAfter.ActiveProfile);
+                AnsiConsole.MarkupLine($"  [green]✓[/] Logged in as [cyan]{Markup.Escape(tokens?.GitHubUsername ?? "?")}[/]");
+            }
 
             return 0;
         }
@@ -1376,13 +1380,12 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
         }
 
         if (provider == AuthProvider.None) {
-            // The façade's ConsoleAuthProgress already printed the "no authentication configured" notice.
+            // The façade already printed the "no authentication configured" notice through this sink.
             return 0;
         }
 
-        var loggedInTokens = await new TokenStore(config).LoadAsync(activeProfile);
-        await Console.Out.WriteLineAsync($"  ✓ Logged in as {loggedInTokens?.GitHubUsername}");
-
+        // The façade's notice is the shared report: `kcap login` and the desktop wizard render from it
+        // too, so setup restating it is the half to drop rather than suppress.
         return 0;
     }
 

--- a/src/Capacitor.Cli/Commands/StatusCommand.cs
+++ b/src/Capacitor.Cli/Commands/StatusCommand.cs
@@ -55,13 +55,13 @@ public sealed class StatusCommand(
                 var expiryText = remaining.TotalHours > 1
                     ? $"expires in {remaining.TotalHours:F0}h"
                     : $"expires in {remaining.TotalMinutes:F0}m";
-                await Console.Out.WriteLineAsync($"{tokens.GitHubUsername} ({tokens.Provider}) ✓ token valid ({expiryText})");
+                await Console.Out.WriteLineAsync($"{tokens.GitHubUsername} ✓ token valid ({expiryText})");
             } else {
                 var rawTokens = await new TokenStore(config).LoadForProfileAsync(profiles.Name);
 
                 await Console.Out.WriteLineAsync(
                     rawTokens is not null
-                        ? $"{rawTokens.GitHubUsername} ({rawTokens.Provider}) ✗ token expired (run: kcap login)"
+                        ? $"{rawTokens.GitHubUsername} ✗ token expired (run: kcap login)"
                         : "not authenticated (run: kcap login)"
                 );
             }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/AuthProgressTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/AuthProgressTests.cs
@@ -127,4 +127,56 @@ public class AuthProgressTests {
 
         await Assert.That(capture.GetCapturedOutput()).IsEqualTo(".");
     }
+
+    /// <summary>Pins the shift on copy this class composes rather than receives, which is the whole
+    /// reason the indent lives here: a decorator around <see cref="IAuthProgress"/> sees only the
+    /// strings it is handed, so indenting out there moves the notices and leaves these at column 0.
+    /// </summary>
+    [Test]
+    public async Task ConsoleAuthProgress_indent_shifts_the_copy_it_composes_itself() {
+        using var capture = ConsoleOutput.StartCapture();
+
+        new ConsoleAuthProgress("  ").BrowserOpening("https://example.test/authorize");
+
+        await Assert.That(capture.GetCapturedOutput()).IsEqualTo(
+            "  Opening browser for authentication..." + Environment.NewLine
+          + "    If the browser doesn't open, visit: https://example.test/authorize" + Environment.NewLine);
+    }
+
+    /// <summary>The numbered lines carry their own two spaces, so an indent has to shift them on top
+    /// of that rather than replace it — the list stays a step inside the line introducing it.</summary>
+    [Test]
+    public async Task ConsoleAuthProgress_indent_shifts_the_device_code_block() {
+        using var capture = ConsoleOutput.StartCapture();
+
+        new ConsoleAuthProgress("  ").DeviceCode("UC123", "https://example.test", null, prefilled: false);
+
+        await Assert.That(capture.GetCapturedOutput()).IsEqualTo(
+            "    2. Enter the code: UC123" + Environment.NewLine
+          + "    3. Approve access when asked." + Environment.NewLine
+          + Environment.NewLine
+          + "  Waiting for you to authorize...");
+    }
+
+    /// <summary>The login flow spaces its output with empty notices, and an indented one is a line of
+    /// trailing whitespace rather than a separator.</summary>
+    [Test]
+    public async Task ConsoleAuthProgress_indent_leaves_an_empty_notice_empty() {
+        using var capture = ConsoleOutput.StartCapture();
+
+        new ConsoleAuthProgress("  ").Notice("");
+
+        await Assert.That(capture.GetCapturedOutput()).IsEqualTo(Environment.NewLine);
+    }
+
+    /// <summary>The dots continue the "Waiting…" line rather than starting one, so shifting them would
+    /// break the line they are appended to.</summary>
+    [Test]
+    public async Task ConsoleAuthProgress_indent_does_not_shift_a_poll_dot() {
+        using var capture = ConsoleOutput.StartCapture();
+
+        new ConsoleAuthProgress("  ").PollTick();
+
+        await Assert.That(capture.GetCapturedOutput()).IsEqualTo(".");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Integration/ImportPrivateTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/ImportPrivateTests.cs
@@ -64,5 +64,27 @@ public class ImportPrivateTests : IDisposable {
 
         await Assert.That(attempted).IsEqualTo(3);
     }
+
+    /// <summary>
+    /// The failure line belongs to the phase heading above it, and this writer is a static with no
+    /// display to ask, so the margin has to arrive as an argument. Console is process-global, hence
+    /// the bare exclusion.
+    /// </summary>
+    [Test]
+    [NotInParallel]
+    public async Task SetVisibilityForAll_reports_a_failure_on_the_margin_it_was_given() {
+        _server.Given(Request.Create().WithPath("/api/sessions/*/visibility").UsingPut())
+            .RespondWith(Response.Create().WithStatusCode(500));
+
+        using var client  = new HttpClient();
+        using var capture = ConsoleOutput.StartErrorCapture("\n");
+
+        var lost = await ImportCommand.SetVisibilityForAll(
+            client, _server.Url!, ["sess1"], "org", indent: "    ");
+
+        await Assert.That(lost).IsEquivalentTo(new[] { "sess1" });
+        await Assert.That(capture.GetCapturedError())
+                    .StartsWith("    ! visibility=org failed for sess1: HTTP 500");
+    }
 }
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
@@ -180,6 +180,24 @@ public class ImportDisplayGridTests {
         RequestedTitles: requestedTitles
     );
 
+    /// <summary>The completion summary nests with its heading as the plan grid does — the same margin,
+    /// so a redirected nested run does not indent one and leave the other level.</summary>
+    [Test, NotInParallel]
+    [Arguments(false, "  Loaded")]
+    [Arguments(true, "    Loaded")]
+    public async Task the_done_summary_nests_with_its_heading(bool nested, string expected) {
+        using var capture = ConsoleOutput.StartCapture("\n");
+
+        new ImportCommand.ImportDisplay { Tty = false, Nested = nested }.WriteDoneGrid(
+            MakeFinal(loaded: 7));
+
+        var row = capture.GetCapturedOutput()
+                         .Split('\n')
+                         .First(l => l.TrimStart().StartsWith("Loaded", StringComparison.Ordinal));
+
+        await Assert.That(row).StartsWith(expected);
+    }
+
     /// <summary>
     /// The plain-text rows nest by the same step as the headings above them, so a redirected run of a
     /// nested import puts its counts under its section rather than level with it.

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
@@ -288,8 +288,9 @@ public class ImportDisplayGridTests {
     /// The TTY half, which is the only place a rule exists at all — so a nesting regression that drew one
     /// would be invisible to the plain-text pins above.
     ///
-    /// <para>Asserted structurally rather than by styling: the rule's glyph row is what reads as a step
-    /// boundary, and no capture in this suite can see dim.</para>
+    /// <para>The rule's glyph row is the whole assertion: it is what reads as a section boundary, no
+    /// capture here can see dim, and the indent is the plain-text pins' business — asserting rendered
+    /// leading whitespace measured the host's console rather than this code.</para>
     /// </summary>
     [Test, NotInParallel]
     [Arguments(false, true)]
@@ -318,7 +319,6 @@ public class ImportDisplayGridTests {
         await Assert.That(output).Contains("Discovering");
         // Spectre draws a rule as a run of box-drawing glyphs either side of the title.
         await Assert.That(output.Contains('─')).IsEqualTo(ruled);
-        await Assert.That(output.Contains("  Discovering")).IsEqualTo(!ruled);
     }
 
     /// <summary>Quiet outranks both: <c>--discover --json</c>'s whole stdout has to parse.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
@@ -181,6 +181,52 @@ public class ImportDisplayGridTests {
     );
 
     /// <summary>
+    /// Column 0 belongs to headings, so a line the run writes for itself is indented under the one it
+    /// belongs to — and one step deeper again where the whole run is nested inside a setup step.
+    /// </summary>
+    [Test, NotInParallel]
+    [Arguments(false, "  Found 3 sessions.")]
+    [Arguments(true, "    Found 3 sessions.")]
+    public async Task a_line_sits_under_its_heading_rather_than_against_the_margin(
+            bool nested, string expected) {
+        using var capture = ConsoleOutput.StartCapture("\n");
+
+        new ImportCommand.ImportDisplay { Tty = false, Nested = nested }.Line("Found 3 sessions.");
+
+        await Assert.That(capture.GetCapturedOutput()).IsEqualTo(expected + "\n");
+    }
+
+    /// <summary>
+    /// A grid ignores leading spaces, so the counts used to draw against the margin while the prose
+    /// beside them was indented. Padding is what puts them on the same line as everything else in the
+    /// section.
+    /// </summary>
+    [Test, NotInParallel]
+    public async Task the_counts_line_up_with_the_prose_around_them() {
+        var originalConsole = AnsiConsole.Console;
+        var buffer          = new StringWriter();
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
+            Ansi        = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out         = new AnsiConsoleOutput(buffer),
+        });
+
+        try {
+            new ImportCommand.ImportDisplay { Tty = true }.WritePlanGrid(
+                new(New: 5, Partial: 0, AlreadyLoaded: 0, TooShort: 0, Excluded: 0, ProbeError: 0),
+                bySource: null);
+        } finally {
+            AnsiConsole.Console = originalConsole;
+        }
+
+        var counts = buffer.ToString()
+                           .Split('\n')
+                           .First(l => l.Contains("New", StringComparison.Ordinal));
+
+        await Assert.That(counts).StartsWith("  ");
+    }
+
+    /// <summary>
     /// A section heading is the structure of the output only where the run is itself the command. Nested
     /// inside a setup step it is subordinate to a rule already drawn, and is marked as such.
     /// </summary>

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Commands;
+using Spectre.Console;
 
 namespace Capacitor.Cli.Tests.Unit.Commands;
 
@@ -178,6 +179,66 @@ public class ImportDisplayGridTests {
         RequestedSummaries: requestedSummaries,
         RequestedTitles: requestedTitles
     );
+
+    /// <summary>
+    /// A section heading is the structure of the output only where the run is itself the command. Nested
+    /// inside a setup step it is subordinate to a rule already drawn, and is marked as such.
+    /// </summary>
+    [Test, NotInParallel]
+    [Arguments(false, "== Discovering ==")]
+    [Arguments(true, "  -- Discovering --")]
+    public async Task a_phase_heading_is_subordinate_only_when_the_run_is_nested(
+            bool nested, string expected) {
+        using var capture = ConsoleOutput.StartCapture();
+
+        new ImportCommand.ImportDisplay { Tty = false, Nested = nested }.BeginPhase("Discovering");
+
+        await Assert.That(capture.GetCapturedOutput().Replace("\r\n", "\n")).Contains(expected);
+    }
+
+    /// <summary>
+    /// The TTY half, which is the only place a rule exists at all — so a nesting regression that drew one
+    /// would be invisible to the plain-text pins above.
+    ///
+    /// <para>Asserted structurally rather than by styling: the rule's glyph row is what reads as a step
+    /// boundary, and no capture in this suite can see dim.</para>
+    /// </summary>
+    [Test, NotInParallel]
+    [Arguments(false, true)]
+    [Arguments(true, false)]
+    public async Task on_a_terminal_only_an_unnested_section_draws_a_rule(bool nested, bool ruled) {
+        var originalConsole = AnsiConsole.Console;
+        var buffer          = new StringWriter();
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
+            Ansi        = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out         = new AnsiConsoleOutput(buffer),
+        });
+
+        try {
+            new ImportCommand.ImportDisplay { Tty = true, Nested = nested }.BeginPhase("Discovering");
+        } finally {
+            AnsiConsole.Console = originalConsole;
+        }
+
+        var output = buffer.ToString();
+
+        await Assert.That(output).Contains("Discovering");
+        // Spectre draws a rule as a run of box-drawing glyphs either side of the title.
+        await Assert.That(output.Contains('─')).IsEqualTo(ruled);
+        await Assert.That(output.Contains("  Discovering")).IsEqualTo(!ruled);
+    }
+
+    /// <summary>Quiet outranks both: <c>--discover --json</c>'s whole stdout has to parse.</summary>
+    [Test, NotInParallel]
+    public async Task a_quiet_run_draws_no_phase_heading_nested_or_not() {
+        using var capture = ConsoleOutput.StartCapture();
+
+        new ImportCommand.ImportDisplay { Tty = false, Quiet = true, Nested = true }.BeginPhase("Discovering");
+        new ImportCommand.ImportDisplay { Tty = false, Quiet = true }.BeginPhase("Discovering");
+
+        await Assert.That(capture.GetCapturedOutput()).DoesNotContain("Discovering");
+    }
 
     static string CaptureNonTtyOutput(Action<ImportCommand.ImportDisplay> render) {
         using var capture = ConsoleOutput.StartCapture();

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
@@ -211,6 +211,10 @@ public class ImportDisplayGridTests {
             Out         = new AnsiConsoleOutput(buffer),
         });
 
+        // Pinned, because a rule fills the width and a heading wraps against it: a runner's console
+        // reports its own, so an unpinned layout asserts whatever the host happens to be.
+        AnsiConsole.Profile.Width = 120;
+
         try {
             new ImportCommand.ImportDisplay { Tty = true }.WritePlanGrid(
                 new(New: 5, Partial: 0, AlreadyLoaded: 0, TooShort: 0, Excluded: 0, ProbeError: 0),
@@ -260,6 +264,10 @@ public class ImportDisplayGridTests {
             ColorSystem = ColorSystemSupport.NoColors,
             Out         = new AnsiConsoleOutput(buffer),
         });
+
+        // Pinned, because a rule fills the width and a heading wraps against it: a runner's console
+        // reports its own, so an unpinned layout asserts whatever the host happens to be.
+        AnsiConsole.Profile.Width = 120;
 
         try {
             new ImportCommand.ImportDisplay { Tty = true, Nested = nested }.BeginPhase("Discovering");

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportDisplayGridTests.cs
@@ -181,6 +181,27 @@ public class ImportDisplayGridTests {
     );
 
     /// <summary>
+    /// The plain-text rows nest by the same step as the headings above them, so a redirected run of a
+    /// nested import puts its counts under its section rather than level with it.
+    /// </summary>
+    [Test, NotInParallel]
+    [Arguments(false, "  New")]
+    [Arguments(true, "    New")]
+    public async Task plain_rows_nest_with_their_heading(bool nested, string expected) {
+        using var capture = ConsoleOutput.StartCapture("\n");
+
+        new ImportCommand.ImportDisplay { Tty = false, Nested = nested }.WritePlanGrid(
+            new(New: 5, Partial: 0, AlreadyLoaded: 0, TooShort: 0, Excluded: 0, ProbeError: 0),
+            bySource: null);
+
+        var row = capture.GetCapturedOutput()
+                         .Split('\n')
+                         .First(l => l.TrimStart().StartsWith("New", StringComparison.Ordinal));
+
+        await Assert.That(row).StartsWith(expected);
+    }
+
+    /// <summary>
     /// Column 0 belongs to headings, so a line the run writes for itself is indented under the one it
     /// belongs to — and one step deeper again where the whole run is nested inside a setup step.
     /// </summary>
@@ -197,9 +218,8 @@ public class ImportDisplayGridTests {
     }
 
     /// <summary>
-    /// A grid ignores leading spaces, so the counts used to draw against the margin while the prose
-    /// beside them was indented. Padding is what puts them on the same line as everything else in the
-    /// section.
+    /// A grid ignores leading spaces, so padding is the only thing that can put the counts under the
+    /// heading they belong to rather than against the margin the prose beside them is indented from.
     /// </summary>
     [Test, NotInParallel]
     public async Task the_counts_line_up_with_the_prose_around_them() {

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopePromptTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopePromptTests.cs
@@ -92,6 +92,25 @@ public class ImportScopePromptTests {
         await Assert.That(s).Contains("visibility: org_public (from profile)");
     }
 
+    /// <summary>Pins the label with the block rather than on its own: the label is what sat at column 0
+    /// while its own rows were indented, so an indent that reaches the rows and not the label leaves
+    /// exactly the raggedness the shift exists to remove.</summary>
+    [Test]
+    public async Task FormatSummary_indent_shifts_the_label_with_the_rows_under_it() {
+        var s = ImportScopePrompt.FormatSummary(
+            scope: new ImportScope.All(),
+            matchedCount: 47,
+            repoSamples: ["EventStore/kcap"],
+            visibilityDescription: "org_public (from profile)",
+            indent: "  "
+        );
+
+        await Assert.That(s.Split('\n')[0]).IsEqualTo("  About to import:");
+        await Assert.That(s).Contains("    scope:   everything");
+        await Assert.That(s).Contains("    matched: 47 sessions");
+        await Assert.That(s).Contains("    visibility: org_public (from profile)");
+    }
+
     [Test]
     public async Task FormatSummary_Org_includes_org_name() {
         var s = ImportScopePrompt.FormatSummary(

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopePromptTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportScopePromptTests.cs
@@ -105,7 +105,7 @@ public class ImportScopePromptTests {
             indent: "  "
         );
 
-        await Assert.That(s.Split('\n')[0]).IsEqualTo("  About to import:");
+        await Assert.That(s.Split(Environment.NewLine)[0]).IsEqualTo("  About to import:");
         await Assert.That(s).Contains("    scope:   everything");
         await Assert.That(s).Contains("    matched: 47 sessions");
         await Assert.That(s).Contains("    visibility: org_public (from profile)");

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportVisibilityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportVisibilityTests.cs
@@ -1399,14 +1399,17 @@ public class ImportVisibilityTests : IDisposable {
     // written to that test's writer instead of ours, and our buffer holds only whatever some other
     // test wrote to stderr in the meantime (an unrelated login-flow error was the observed symptom).
     [Test, NotInParallel]
-    public async Task HandleImport_autoSkipExclusions_completes_without_prompting_and_logs_auto_skip() {
+    [Arguments(false, "  Auto-skipping")]
+    [Arguments(true, "    Auto-skipping")]
+    public async Task HandleImport_autoSkipExclusions_completes_without_prompting_and_logs_auto_skip(
+            bool nested, string expected) {
         // Excluded PATH (not repo) so no real git repo needs to be spun up — PathExclusion.IsExcluded
         // is a plain prefix check. The profile carrying the exclusion arrives as the import's own
         // resolution, so nothing process-global has to be steered.
-        var excludedDir = Path.Combine(_tempDir, "excluded-proj");
+        var excludedDir = Path.Combine(_tempDir, $"excluded-proj-{nested}");
         Directory.CreateDirectory(excludedDir);
 
-        var projectsDir = Path.Combine(_tempDir, "claude-projects-autoskip");
+        var projectsDir = Path.Combine(_tempDir, $"claude-projects-autoskip-{nested}");
         var cwdDir      = Path.Combine(projectsDir, "-excluded-proj");
         Directory.CreateDirectory(cwdDir);
         // Serialize the cwd so a Windows path's backslashes are JSON-escaped — a raw interpolation
@@ -1437,7 +1440,8 @@ public class ImportVisibilityTests : IDisposable {
             sources: [new ClaudeImportSource(Config.Root, projectsDir)],
             scope: new ImportScope.All(),
             skipConfirmation: true,
-            autoSkipExclusions: true
+            autoSkipExclusions: true,
+            nested: nested
         );
 
         var winner    = await Task.WhenAny(task, Task.Delay(TimeSpan.FromSeconds(15)));
@@ -1447,7 +1451,11 @@ public class ImportVisibilityTests : IDisposable {
         exitCode = await task;
 
         await Assert.That(exitCode).IsEqualTo(0);
-        await Assert.That(capture.GetCapturedError()).Contains("Auto-skipping");
+        var notice = capture.GetCapturedError()
+                            .Split('\n')
+                            .First(l => l.Contains("Auto-skipping", StringComparison.Ordinal));
+
+        await Assert.That(notice).StartsWith(expected);
 
         // Never actually asked the user to include the excluded path.
         await Assert.That(capture.GetCapturedError()).DoesNotContain("Include");

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
@@ -403,7 +403,10 @@ public class SetupFacadeParityTests {
     /// add. Every other provider's discovery reports a tenant count and no identity, which is why the
     /// carve-out cannot simply drop the line for everyone.
     /// </summary>
+    // AnsiConsole.Console is process-global, so this serializes against the whole assembly as its
+    // console-swapping siblings above do — the class's keys do not cover it.
     [Test]
+    [NotInParallel]
     [Arguments(AuthProvider.WorkOS, false)]
     [Arguments(AuthProvider.GitHubApp, true)]
     public async Task A_completed_discovery_names_the_identity_only_where_discovery_did_not(

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
@@ -265,8 +265,11 @@ public class SetupFacadeParityTests {
 
     // ── the setup-scoped progress sink ───────────────────────────────────────
 
+    /// <summary>Pins the pass-through. The renderer underneath carries the step indent, so shifting
+    /// here as well would double it on the lines this sink is handed while the copy the renderer
+    /// composes for itself stayed one step out.</summary>
     [Test]
-    public async Task SetupAuthProgress_indents_facade_text_and_passes_the_rest_through() {
+    public async Task SetupAuthProgress_passes_facade_text_through_untouched() {
         var inner    = new RecordingAuthProgress();
         var progress = new SetupAuthProgress(inner);
 
@@ -279,14 +282,28 @@ public class SetupFacadeParityTests {
         progress.PollTick();
 
         await Assert.That(inner.Notices).IsEquivalentTo(new[] {
-            "  Server has no authentication configured — login not required.",
+            "Server has no authentication configured — login not required.",
             "",
             "  1. Open https://github.com/login/device in a browser",
         });
-        await Assert.That(inner.Errors).IsEquivalentTo(new[] { "  Cannot reach the Kurrent auth service." });
+        await Assert.That(inner.Errors).IsEquivalentTo(new[] { "Cannot reach the Kurrent auth service." });
         await Assert.That(inner.BrowserOpenings).IsEquivalentTo(new[] { "https://auth.example/authorize" });
         await Assert.That(inner.DeviceCodes).Count().IsEqualTo(1);
         await Assert.That(inner.PollTicks).IsEqualTo(1);
+    }
+
+    /// <summary>Pins the wiring rather than either half of it: a step's own lines and the auth copy
+    /// beside them land on one margin only if the sink handed to the façade is built with the step
+    /// indent, and neither class's own test can show that.</summary>
+    [Test]
+    public async Task StepProgress_renders_facade_copy_on_the_step_margin() {
+        using var capture = ConsoleOutput.StartCapture();
+
+        SetupCommand.StepProgress.BrowserOpening("https://auth.example/authorize");
+
+        await Assert.That(capture.GetCapturedOutput()).IsEqualTo(
+            "  Opening browser for authentication..." + Environment.NewLine
+          + "    If the browser doesn't open, visit: https://auth.example/authorize" + Environment.NewLine);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
@@ -369,6 +369,63 @@ public class SetupFacadeParityTests {
         await Assert.That(ReadConfig().Profiles["acme"].ServerUrl).IsEqualTo("https://acme.kcap.ai");
     }
 
+    /// <summary>
+    /// One report per sign-in. The façade's notice is the shared one — <c>kcap login</c> and the desktop
+    /// wizard render from it — so setup adding its own puts the same sentence on screen twice. Pinned on
+    /// both halves: exactly one notice, and nothing of setup's own on stdout.
+    /// </summary>
+    [Test]
+    [NotInParallel]
+    public async Task RunLoginStepAsync_reports_the_sign_in_once() {
+        using var handler  = AuthHttp.Script(authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""");
+        var       progress = new RecordingAuthProgress();
+
+        SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, progress, handler);
+
+        using var console = ConsoleOutput.StartCapture();
+
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), new RecordingBrowser(), Home).RunLoginStepAsync(
+            loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
+            forceDevice: true, activeProfile: "acme");
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        await Assert.That(progress.Notices.Count(n => n.StartsWith("Logged in as", StringComparison.Ordinal)))
+                    .IsEqualTo(1);
+        await Assert.That(console.GetCapturedOutput()).DoesNotContain("Logged in as");
+    }
+
+    /// <summary>
+    /// Discovery's WorkOS leg reports the sign-in with the workspace it picked, so step 2 has nothing to
+    /// add. Every other provider's discovery reports a tenant count and no identity, which is why the
+    /// carve-out cannot simply drop the line for everyone.
+    /// </summary>
+    [Test]
+    [Arguments(AuthProvider.WorkOS, false)]
+    [Arguments(AuthProvider.GitHubApp, true)]
+    public async Task A_completed_discovery_names_the_identity_only_where_discovery_did_not(
+            string provider, bool named) {
+        var originalConsole = AnsiConsole.Console;
+        var buffer          = new StringWriter();
+        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
+            Ansi        = AnsiSupport.No,
+            ColorSystem = ColorSystemSupport.NoColors,
+            Out         = new AnsiConsoleOutput(buffer),
+        });
+
+        int exitCode;
+
+        try {
+            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), new RecordingBrowser(), Home).RunLoginStepAsync(
+                loginComplete: true, provider: provider, serverUrl: "https://acme.kcap.ai",
+                forceDevice: false, activeProfile: "acme");
+        } finally {
+            AnsiConsole.Console = originalConsole;
+        }
+
+        await Assert.That(exitCode).IsEqualTo(0);
+        await Assert.That(buffer.ToString().Contains("Logged in as")).IsEqualTo(named);
+    }
+
     [Test]
     public async Task RunLoginStepAsync_explicit_login_failure_prints_login_failed_and_returns_one() {
         using var handler = AuthHttp.Script(authConfig: """{"provider":"martian"}""");

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
@@ -303,6 +303,10 @@ public class SetupFacadeParityTests {
             Out         = new AnsiConsoleOutput(buffer),
         });
 
+        // Pinned: a runner's console reports its own width, and an unpinned layout wraps the line these
+        // assertions read.
+        AnsiConsole.Profile.Width = 120;
+
         int exitCode;
 
         try {
@@ -411,6 +415,10 @@ public class SetupFacadeParityTests {
             ColorSystem = ColorSystemSupport.NoColors,
             Out         = new AnsiConsoleOutput(buffer),
         });
+
+        // Pinned: a runner's console reports its own width, and an unpinned layout wraps the line these
+        // assertions read.
+        AnsiConsole.Profile.Width = 120;
 
         int exitCode;
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
@@ -1,3 +1,4 @@
+using System.Text;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core.Auth;
 using static Capacitor.Tests.Helpers.AuthFixtures;
@@ -20,11 +21,44 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 /// differs between the ubuntu-latest and windows-latest CI legs — not something a unit test can
 /// pin (mirrors why LoginFacadeParityTests always passes --github too).
 /// </summary>
-[NotInParallel([
-    nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink),
-    "AuthProviderDiscoveryCache"
-])]
+// Bare, and one level only: these drive Console and SetupCommand.FacadeOverride, both process-global,
+// so a group key that names neither is not exclusion. A method constraint would shadow this one.
+[NotInParallel]
 public class SetupFacadeParityTests {
+    /// <summary>
+    /// Captures what setup writes through Spectre. It writes its step banners via <c>AnsiConsole</c>
+    /// rather than <c>IAuthProgress</c> or plain <c>Console.Out</c>, and the static console caches its
+    /// writer at first use, so redirecting <c>Console.Out</c> does not reach it — the singleton itself
+    /// has to be swapped.
+    ///
+    /// <para>Restoring is a call rather than a <c>using</c> so a test can put the console back before
+    /// it asserts: a failure raised while the singleton is swapped renders into the buffer.</para>
+    /// </summary>
+    sealed class SpectreCapture {
+        readonly IAnsiConsole  _original = AnsiConsole.Console;
+        readonly StringBuilder _text     = new();
+
+        public static SpectreCapture Start() {
+            var capture = new SpectreCapture();
+
+            AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
+                Ansi        = AnsiSupport.No,
+                ColorSystem = ColorSystemSupport.NoColors,
+                Out         = new AnsiConsoleOutput(new StringWriter(capture._text)),
+            });
+
+            // A runner's console reports its own width, and an unpinned layout wraps the lines these
+            // tests read back.
+            AnsiConsole.Profile.Width = 120;
+
+            return capture;
+        }
+
+        public string Text => _text.ToString();
+
+        public void Restore() => AnsiConsole.Console = _original;
+    }
+
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
     [TempHome] public required TempHome Home { get; init; }
 
@@ -171,7 +205,6 @@ public class SetupFacadeParityTests {
 
     // The façade owns the reason line; setup still owns the guidance tail its old single line carried.
     [Test]
-    [NotInParallel]
     public async Task RunDiscoveryAsync_unreachable_proxy_still_prints_the_legacy_guidance_tail() {
         using var handler = AuthHttp.Script(); // no /config route — proxy unreachable
 
@@ -189,7 +222,6 @@ public class SetupFacadeParityTests {
     // checked against them once it commits.
 
     [Test]
-    [NotInParallel]
     public async Task RunDiscoveryAsync_hands_the_requested_workspace_to_the_provisioner() {
         using var handler = AuthHttp.Script(); // no /config route — discovery fails after construction
 
@@ -209,7 +241,6 @@ public class SetupFacadeParityTests {
     // The guard is only worth anything if the boundary is the thing that refuses, so this drives the
     // real facade with it attached and asserts nothing durable was written.
     [Test]
-    [NotInParallel]
     public async Task A_commit_that_would_publish_another_workspace_writes_nothing() {
         using var handler = AuthHttp.Script(
             proxyConfig: """{"github_client_id":"cid"}""",
@@ -273,10 +304,7 @@ public class SetupFacadeParityTests {
 
     // ── Step 2: RunLoginStepAsync ────────────────────────────────────────────
 
-    // AnsiConsole.Console is process-global state (see below) — fully serialize this test against
-    // everything else, mirroring AuthProgressTests' console-redirection convention.
     [Test]
-    [NotInParallel]
     public async Task RunLoginStepAsync_loginComplete_reports_the_already_published_identity_without_a_facade_call() {
         await ConfigMutator.MutateAsync(Config.Root, c => c with {
             Profiles      = new Dictionary<string, Profile> { ["acme"] = new() { ServerUrl = "https://acme.kcap.ai" } },
@@ -292,20 +320,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => throw new InvalidOperationException("loginComplete must not call the façade");
 
-        // SetupCommand writes Step 2's banner via AnsiConsole (not IAuthProgress, and not plain
-        // Console.Out — Spectre's static AnsiConsole.Console caches its writer at first use, so
-        // Console.SetOut alone doesn't redirect it), so swap the singleton console to capture it.
-        var originalConsole = AnsiConsole.Console;
-        var buffer          = new StringWriter();
-        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
-            Ansi        = AnsiSupport.No,
-            ColorSystem = ColorSystemSupport.NoColors,
-            Out         = new AnsiConsoleOutput(buffer),
-        });
-
-        // Pinned: a runner's console reports its own width, and an unpinned layout wraps the line these
-        // assertions read.
-        AnsiConsole.Profile.Width = 120;
+        var console = SpectreCapture.Start();
 
         int exitCode;
 
@@ -314,11 +329,11 @@ public class SetupFacadeParityTests {
                 loginComplete: true, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
                 forceDevice: false, activeProfile: "acme");
         } finally {
-            AnsiConsole.Console = originalConsole;
+            console.Restore();
         }
 
         await Assert.That(exitCode).IsEqualTo(0);
-        await Assert.That(buffer.ToString()).Contains("Logged in as alice");
+        await Assert.That(console.Text).Contains("Logged in as alice");
     }
 
     // A None-provider setup must still mint the auth_provider stamp, and only inside the commit boundary.
@@ -379,7 +394,6 @@ public class SetupFacadeParityTests {
     /// both halves: exactly one notice, and nothing of setup's own on stdout.
     /// </summary>
     [Test]
-    [NotInParallel]
     public async Task RunLoginStepAsync_reports_the_sign_in_once() {
         using var handler  = AuthHttp.Script(authConfig: """{"provider":"GitHubApp","github_client_id":"cid"}""");
         var       progress = new RecordingAuthProgress();
@@ -403,25 +417,12 @@ public class SetupFacadeParityTests {
     /// add. Every other provider's discovery reports a tenant count and no identity, which is why the
     /// carve-out cannot simply drop the line for everyone.
     /// </summary>
-    // AnsiConsole.Console is process-global, so this serializes against the whole assembly as its
-    // console-swapping siblings above do — the class's keys do not cover it.
     [Test]
-    [NotInParallel]
     [Arguments(AuthProvider.WorkOS, false)]
     [Arguments(AuthProvider.GitHubApp, true)]
     public async Task A_completed_discovery_names_the_identity_only_where_discovery_did_not(
             string provider, bool named) {
-        var originalConsole = AnsiConsole.Console;
-        var buffer          = new StringWriter();
-        AnsiConsole.Console = AnsiConsole.Create(new AnsiConsoleSettings {
-            Ansi        = AnsiSupport.No,
-            ColorSystem = ColorSystemSupport.NoColors,
-            Out         = new AnsiConsoleOutput(buffer),
-        });
-
-        // Pinned: a runner's console reports its own width, and an unpinned layout wraps the line these
-        // assertions read.
-        AnsiConsole.Profile.Width = 120;
+        var console = SpectreCapture.Start();
 
         int exitCode;
 
@@ -430,11 +431,11 @@ public class SetupFacadeParityTests {
                 loginComplete: true, provider: provider, serverUrl: "https://acme.kcap.ai",
                 forceDevice: false, activeProfile: "acme");
         } finally {
-            AnsiConsole.Console = originalConsole;
+            console.Restore();
         }
 
         await Assert.That(exitCode).IsEqualTo(0);
-        await Assert.That(buffer.ToString().Contains("Logged in as")).IsEqualTo(named);
+        await Assert.That(console.Text.Contains("Logged in as")).IsEqualTo(named);
     }
 
     [Test]


### PR DESCRIPTION
AI-2411

## What & why

A full setup run read as ragged. The sign-in was announced twice, the tenant's identity provider was printed on four surfaces nobody running setup chose or can act on, the import's own phases were drawn as full-width rules indistinguishable from setup's numbered steps, four per-worker rows survived the run claiming "idle" at 0% under a bar at 100%, and nothing predicted whether a line sat at the margin or under its heading.

One commit per item, so each is reviewable on its own.

## Where to look

**The duplicate had two shapes.** On a known server the façade's notice was followed by setup's own line; on a WorkOS *discovery* run the leg already names the workspace it picked and step 2 restated the identity. The façade's notice is the shared one — the login command and the desktop wizard both render from it — so setup drops its line and keeps it only where discovery reports no identity at all, gated on the same provider test two sibling sites already use.

**Nesting is a property of the display, not a change to the headings.** Run on its own the import *is* the command and a rule per phase is right; as a step of setup it is subordinate to the rule already on screen. Every section label goes through one path so a nested run cannot subordinate its phases and then close with a full-width rule of its own.

**The indentation bug hid in the renderables.** A grid ignores leading spaces, so the counts and the completion summary drew against column 0 while the prose beside them was indented — which is why no measurement of the string literals could find it, and why the fix is a `Padder` as well as a margin.

**Sections separate by weight, not by blank lines.** A rule, a dim heading and an indent already say where one starts.

## Verification

`Capacitor.Cli.Core.Tests.Unit` → 2592 passed. `Capacitor.Cli.Tests.Unit` → 3884 passed.

Seven tests added across the five items, each mutation-checked rather than assumed: restoring the duplicate line, dropping the discovery carve-out, drawing a rule when nested, dropping the line margin and dropping the grid padding each fail a case that passes now. The nested-TTY pin exists because the rules only render on a terminal, so a regression there was invisible to the plain-text pins.

Layout was read by rendering the whole run — the real progress mirror and the real import display, at a fixed width with colour off — since a live run needs a tenant, a terminal and a transcript. That is what turned up the two column-0 renderables in setup and the stray blank under the browser hand-off.
