### PR TITLE
Drop the recency-only ordering claim from MemoryIndexEmitter docs

### DIFF
--- a/src/Capacitor.Cli/MemoryIndexEmitter.cs
+++ b/src/Capacitor.Cli/MemoryIndexEmitter.cs
@@ -8,7 +8,7 @@ namespace Capacitor.Cli;
 /// builds the SessionStart "team memory" index
 /// fragment from the <c>GET /api/memories/index</c> response body: a JSON array of
 /// <c>{memory_id, slug, audience, description, kind, scope_kind, project_slug}</c>,
-/// already capped and most-recently-updated first by the server.
+/// already capped and ranked by the server.
 /// <para>
 /// Entries are grouped by <c>audience</c> (org → team → user), preserving the
 /// server's order within each group, and rendered as <c>slug [scope]: description</c>

--- a/test/Capacitor.Cli.Tests.Unit/MemoryIndexEmitterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/MemoryIndexEmitterTests.cs
@@ -114,21 +114,21 @@ public class MemoryIndexEmitterTests {
 
     [Test]
     public async Task Preserves_server_order_within_a_group() {
-        // Server returns most-recently-updated first; the emitter must not reorder within a bucket.
+        // The server ranks entries; the emitter must not reorder within a bucket.
         var index = Index(
-            ("newest", "org", "a"),
-            ("middle", "org", "b"),
-            ("oldest", "org", "c")
+            ("first", "org", "a"),
+            ("second", "org", "b"),
+            ("third", "org", "c")
         );
 
         var fragment = MemoryIndexEmitter.BuildFragment(index, disabled: false)!;
 
-        var newest = fragment.IndexOf("- newest:", StringComparison.Ordinal);
-        var middle = fragment.IndexOf("- middle:", StringComparison.Ordinal);
-        var oldest = fragment.IndexOf("- oldest:", StringComparison.Ordinal);
+        var first = fragment.IndexOf("- first:", StringComparison.Ordinal);
+        var second = fragment.IndexOf("- second:", StringComparison.Ordinal);
+        var third = fragment.IndexOf("- third:", StringComparison.Ordinal);
 
-        await Assert.That(newest).IsLessThan(middle);
-        await Assert.That(middle).IsLessThan(oldest);
+        await Assert.That(first).IsLessThan(second);
+        await Assert.That(second).IsLessThan(third);
     }
 
     [Test]


### PR DESCRIPTION
Closes #273 — AI-1201

## What & why

The server ranks the memory index by fusing usage and recency, but the emitter's class doc and its order-preservation test still described the index as most-recently-updated first. The emitter never depended on that: its only invariant is to preserve the server's order within each audience group. The comments now state just that invariant, so a future change to the server's ranking cannot re-stale them. No behavior change.

## Verification

```
dotnet run --project test/Capacitor.Cli.Tests.Unit/Capacitor.Cli.Tests.Unit.csproj -- --treenode-filter "/*/*/MemoryIndexEmitterTests/*"
total: 15  failed: 0  succeeded: 15
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018ZiqUWy7AdXKWnbmynkNAu
