### PR TITLE
Resolve the cwd repository lazily and without PR detection in MCP servers

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -560,3 +560,20 @@ only for owned review-flow reviewers: bypass silences permission prompts, not qu
 one-time bypass consent dialog, and the multi-CR spray would answer either. The chip is withheld for
 every vendor but Claude, the mode is session-scoped like the effort, and the harness picker no
 longer offers "Remember" — a chosen harness is always persisted for the repository.
+
+## Repo-aware MCP servers: the working directory's repository
+
+Every kcap MCP server is spawned at session start by each harness that registers it, so its startup
+path runs once per server per session whether or not a tool is ever called. The sessions, memory,
+analytics and flows servers resolved the working directory's repository there with pull-request
+detection on — a live `gh pr view` / `glab` round-trip that is roughly the whole startup on a GitHub
+checkout (about 0.8 s per server) for a value none of them reads: they scope requests by owner and
+name only. `CwdRepository` resolves on the first tool call that asks, once per process, with PR
+detection off. **A null answer is cached too**: outside a checkout the answer does not change for
+the life of the process, and re-probing on every call would spawn git for nothing.
+
+**The integration pin is indirect by design.** Detection is the only startup-time writer under the
+config root's cache directory, so an absent directory after the initialize/tools-list handshake
+proves it never ran; the tool call that follows then proves on-demand resolution by carrying the
+repo hash. Asserting on the cache file itself would key on the child's own view of its cwd, which
+macOS reports through the resolved `/private` path rather than the one the test handed it.

--- a/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
@@ -35,8 +35,8 @@ sealed class McpAnalyticsServer(ConfigRoot config, ProfileContext profiles) {
     public async Task<int> RunAsync() {
         var baseUrl = profiles.Resolution.ServerUrl!;
 
-        var cwdRepoHash = await ResolveCwdRepoHashAsync();
-        var tools       = BuildToolsList();
+        var repository = new CwdRepository(config, Directory.GetCurrentDirectory());
+        var tools      = BuildToolsList();
 
         // MCP servers are long-lived and denylisted under the top-level "mcp" command
         // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
@@ -48,8 +48,8 @@ sealed class McpAnalyticsServer(ConfigRoot config, ProfileContext profiles) {
 
         var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
 
-        // Deferred authenticated client: auto-registered and spawned every session, so startup
-        // stays local-only until a tool is invoked. See McpMemoryServer for the
+        // Deferred authenticated client and cwd repository: auto-registered and spawned every
+        // session, so startup stays local-only until a tool is invoked. See McpMemoryServer for the
         // nullable-field-not-Lazy rationale.
         HttpClient? client = null;
 
@@ -59,7 +59,7 @@ sealed class McpAnalyticsServer(ConfigRoot config, ProfileContext profiles) {
 
             try {
                 client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(config, profiles, baseUrl, autoRetryUnauthorized: false);
-                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, cwdRepoHash);
+                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, await repository.GetHashAsync());
             } catch (Exception ex) {
                 await Console.Error.WriteLineAsync($"kcap mcp analytics: unexpected error handling tools/call: {ex}");
                 return BuildToolResult(callId, "Error: internal error handling the request.", isError: true);
@@ -126,19 +126,6 @@ sealed class McpAnalyticsServer(ConfigRoot config, ProfileContext profiles) {
         }
 
         return 0;
-    }
-
-    async Task<string?> ResolveCwdRepoHashAsync() {
-        try {
-            var cwd      = Directory.GetCurrentDirectory();
-            var repoInfo = await RepositoryDetection.DetectRepositoryAsync(config, cwd);
-
-            if (repoInfo?.Owner is null || repoInfo.RepoName is null) return null;
-
-            return RepoHashHelper.ComputeRepoHash(repoInfo.Owner, repoInfo.RepoName);
-        } catch {
-            return null;
-        }
     }
 
     const string ServerInstructions =

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -31,12 +31,7 @@ class McpFlowsServer(ConfigRoot config, ProfileContext profiles) {
         var driverVendor = DriverVendor.Infer(driverArg);
         var tools        = BuildToolsList();
 
-        RepositoryPayload? repoInfo = null;
-        try {
-            repoInfo = await RepositoryDetection.DetectRepositoryAsync(config, cwd);
-        } catch {
-            // best-effort; proceed with null
-        }
+        var repository = new CwdRepository(config, cwd);
 
         // MCP servers are long-lived and denylisted under the top-level "mcp" command
         // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
@@ -80,7 +75,7 @@ class McpFlowsServer(ConfigRoot config, ProfileContext profiles) {
                 }
 
                 return await HandleToolCallAsync(
-                    callId, callRequest, client, baseUrl, cwd, repoRoot, repoInfo,
+                    callId, callRequest, client, baseUrl, cwd, repoRoot, await repository.GetAsync(),
                     requestingSessionId: requester.SessionId, driverVendor: driverVendor,
                     reviewerVendorPreference: () => LoadReviewerVendorPreferenceAsync());
             } catch (Exception ex) {

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -18,9 +18,9 @@ sealed class McpMemoryServer(ConfigRoot config, ProfileContext profiles) {
     public async Task<int> RunAsync() {
         var baseUrl = profiles.Resolution.ServerUrl!;
 
-        var cwdRepoHash = await ResolveCwdRepoHashAsync();
-        var machineId   = await ResolveMachineIdAsync();
-        var tools       = BuildToolsList();
+        var repository = new CwdRepository(config, Directory.GetCurrentDirectory());
+        var machineId  = await ResolveMachineIdAsync();
+        var tools      = BuildToolsList();
 
         // MCP servers are long-lived and denylisted under the top-level "mcp" command
         // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
@@ -34,13 +34,14 @@ sealed class McpMemoryServer(ConfigRoot config, ProfileContext profiles) {
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
         var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
 
-        // The authenticated client is created on the first tools/call, not at startup:
-        // kcap-memory auto-registers, so Claude Code spawns `kcap mcp memory` for every
-        // session — deferring keeps startup local-only (no GET /auth/config, token load, or
-        // stderr) for sessions that never invoke a tool. Created on demand into a nullable field
-        // (rather than a Lazy<Task>) so a transient creation failure leaves it null and the next
-        // call retries, instead of a faulted task sticking for the rest of the session. Safe
-        // without locking: the stdio loop handles one request at a time.
+        // The authenticated client and the cwd repository are resolved on the first tools/call,
+        // not at startup: kcap-memory auto-registers, so Claude Code spawns `kcap mcp memory`
+        // for every session — deferring keeps startup local-only (no GET /auth/config, token load,
+        // repo detection, or stderr) for sessions that never invoke a tool. The client is created
+        // on demand into a nullable field (rather than a Lazy<Task>) so a transient creation
+        // failure leaves it null and the next call retries, instead of a faulted task sticking for
+        // the rest of the session. Safe without locking: the stdio loop handles one request at a
+        // time.
         HttpClient? client = null;
 
         // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request. An
@@ -54,7 +55,7 @@ sealed class McpMemoryServer(ConfigRoot config, ProfileContext profiles) {
 
             try {
                 client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(config, profiles, baseUrl, autoRetryUnauthorized: false);
-                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, cwdRepoHash, machineId);
+                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, await repository.GetHashAsync(), machineId);
             } catch (Exception ex) {
                 // Unexpected: log the detail to stderr (not to the client, which could leak local
                 // paths from IO errors) and return a generic tool error, keeping the loop alive.
@@ -124,19 +125,6 @@ sealed class McpMemoryServer(ConfigRoot config, ProfileContext profiles) {
         }
 
         return 0;
-    }
-
-    async Task<string?> ResolveCwdRepoHashAsync() {
-        try {
-            var cwd      = Directory.GetCurrentDirectory();
-            var repoInfo = await RepositoryDetection.DetectRepositoryAsync(config, cwd);
-
-            if (repoInfo?.Owner is null || repoInfo.RepoName is null) return null;
-
-            return RepoHashHelper.ComputeRepoHash(repoInfo.Owner, repoInfo.RepoName);
-        } catch {
-            return null;
-        }
     }
 
     async Task<string?> ResolveMachineIdAsync() {

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -18,8 +18,8 @@ sealed class McpSessionsServer(ConfigRoot config, ProfileContext profiles) {
     public async Task<int> RunAsync() {
         var baseUrl = profiles.Resolution.ServerUrl!;
 
-        var cwdRepoHash = await ResolveCwdRepoHashAsync();
-        var tools       = BuildToolsList();
+        var repository = new CwdRepository(config, Directory.GetCurrentDirectory());
+        var tools      = BuildToolsList();
 
         // MCP servers are long-lived and denylisted under the top-level "mcp" command
         // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
@@ -33,13 +33,14 @@ sealed class McpSessionsServer(ConfigRoot config, ProfileContext profiles) {
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
         var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
 
-        // The authenticated client is created on the first tools/call, not at startup:
-        // kcap-sessions auto-registers, so Claude Code spawns `kcap mcp sessions` for every
-        // session — deferring keeps startup local-only (no GET /auth/config, token load, or
-        // stderr) for sessions that never invoke a tool. Created on demand into a nullable field
-        // (rather than a Lazy<Task>) so a transient creation failure leaves it null and the next
-        // call retries, instead of a faulted task sticking for the rest of the session. Safe
-        // without locking: the stdio loop handles one request at a time.
+        // The authenticated client and the cwd repository are resolved on the first tools/call,
+        // not at startup: kcap-sessions auto-registers, so Claude Code spawns `kcap mcp sessions`
+        // for every session — deferring keeps startup local-only (no GET /auth/config, token load,
+        // repo detection, or stderr) for sessions that never invoke a tool. The client is created
+        // on demand into a nullable field (rather than a Lazy<Task>) so a transient creation
+        // failure leaves it null and the next call retries, instead of a faulted task sticking for
+        // the rest of the session. Safe without locking: the stdio loop handles one request at a
+        // time.
         HttpClient? client = null;
 
         // Guarded tool dispatch: never let the stdio JSON-RPC loop die on one bad request. An
@@ -53,7 +54,7 @@ sealed class McpSessionsServer(ConfigRoot config, ProfileContext profiles) {
 
             try {
                 client ??= await HttpClientExtensions.CreateAuthenticatedClientAsync(config, profiles, baseUrl, autoRetryUnauthorized: false);
-                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, cwdRepoHash);
+                return await HandleToolCallAsync(callId, callRequest, client, baseUrl, await repository.GetHashAsync());
             } catch (Exception ex) {
                 // Unexpected: log the detail to stderr (not to the client, which could leak local
                 // paths from IO errors) and return a generic tool error, keeping the loop alive.
@@ -123,19 +124,6 @@ sealed class McpSessionsServer(ConfigRoot config, ProfileContext profiles) {
         }
 
         return 0;
-    }
-
-    async Task<string?> ResolveCwdRepoHashAsync() {
-        try {
-            var cwd      = Directory.GetCurrentDirectory();
-            var repoInfo = await RepositoryDetection.DetectRepositoryAsync(config, cwd);
-
-            if (repoInfo?.Owner is null || repoInfo.RepoName is null) return null;
-
-            return RepoHashHelper.ComputeRepoHash(repoInfo.Owner, repoInfo.RepoName);
-        } catch {
-            return null;
-        }
     }
 
     // Server-level usage preamble (MCP `instructions`) — steers clients toward these tools for

--- a/src/Capacitor.Cli/CwdRepository.cs
+++ b/src/Capacitor.Cli/CwdRepository.cs
@@ -1,0 +1,34 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli;
+
+/// <summary>
+/// The repository a long-lived server's working directory belongs to, resolved on first use and
+/// held for the life of the process. Pull-request detection is skipped: callers need owner and
+/// name only, and the provider round-trip would otherwise run in every agent session that spawns
+/// the server, tool call or not. Not thread-safe; a concurrent first use resolves twice.
+/// </summary>
+sealed class CwdRepository(ConfigRoot config, string cwd, CommandRunner? run = null) {
+    bool               _resolved;
+    RepositoryPayload? _repository;
+
+    /// <summary>Owner, name, host and branch of the checkout, or null outside one.</summary>
+    public async ValueTask<RepositoryPayload?> GetAsync() {
+        if (_resolved) return _repository;
+
+        _repository = await RepositoryDetection.DetectRepositoryAsync(config, cwd, detectPullRequest: false, run: run);
+        _resolved   = true;
+
+        return _repository;
+    }
+
+    /// <summary>The server-side repo hash of the checkout, or null when its origin names no owner.</summary>
+    public async ValueTask<string?> GetHashAsync() {
+        var repo = await GetAsync();
+
+        return repo?.Owner is null || repo.RepoName is null
+            ? null
+            : RepoHashHelper.ComputeRepoHash(repo.Owner, repo.RepoName);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Integration/McpAnalyticsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpAnalyticsServerTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -32,12 +33,12 @@ public class McpAnalyticsServerTests : IDisposable {
         _server.Stop();
     }
 
-    Process SpawnMcpServer(string provider = "None") {
+    Process SpawnMcpServer(string provider = "None", string? workingDirectory = null) {
         _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""{"provider":"{{provider}}"}"""));
 
         var psi = KcapProcess.StartInfo(Daemons.Store, Config.Root, "mcp", "analytics");
-        psi.WorkingDirectory = Tmp.Path;
+        psi.WorkingDirectory = workingDirectory ?? Tmp.Path;
         psi.Environment["KCAP_URL"] = _server.Url!;
 
         var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start kcap process");
@@ -82,6 +83,47 @@ public class McpAnalyticsServerTests : IDisposable {
         }
     }
 
+    /// <summary>
+    /// A repository whose <c>origin</c> points at GitHub, handed to the server as its working
+    /// directory so the cwd-repo scope resolves. No commit is needed: <c>git branch --show-current</c>
+    /// reads the symbolic HEAD ref at zero commits.
+    /// </summary>
+    static GitRepo CwdRepo(string owner, string repoName) {
+        var repo = GitRepo.Create();
+        repo.AddRemote($"https://github.com/{owner}/{repoName}.git");
+        return repo;
+    }
+
+    /// <summary>
+    /// The server is spawned for every agent session, so the working directory's repository is
+    /// resolved by the first tool call, not at startup. Detection is the only startup-time writer
+    /// under the config root's cache directory, so its absence after the handshake proves detection
+    /// never ran; the query that follows then scopes to the repo hash resolved on demand.
+    /// </summary>
+    [Test]
+    public async Task Repository_is_resolved_by_the_first_tool_call_not_at_startup() {
+        using var repo = CwdRepo("acme", "widget");
+
+        _server.Given(Request.Create().WithPath("/api/analytics/query").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody("""{"rows":[]}"""));
+
+        using var proc = SpawnMcpServer(workingDirectory: repo.Path);
+        try {
+            await SendRequest(proc, InitializeRequest(1));
+            await SendRequest(proc, ToolsListRequest(2));
+            await Assert.That(Directory.Exists(Config.Root.Path("cache"))).IsFalse();
+
+            await SendRequest(proc, ToolsCallRequest(3, "query_analytics", new JsonObject { ["sql"] = "select 1" }));
+
+            var hits = _server.FindLogEntries(Request.Create().WithPath("/api/analytics/query").UsingPost());
+            await Assert.That(hits.Count).IsEqualTo(1);
+            await Assert.That(hits[0].RequestMessage.Body ?? "")
+                .Contains(RepoHashHelper.ComputeRepoHash("acme", "widget"));
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
     static async Task<JsonObject> SendRequest(Process proc, JsonObject request, TimeSpan? timeout = null) {
         await proc.StandardInput.WriteLineAsync(request.ToJsonString());
         await proc.StandardInput.FlushAsync();
@@ -120,5 +162,12 @@ public class McpAnalyticsServerTests : IDisposable {
         ["id"]      = id,
         ["method"]  = "tools/list",
         ["params"]  = new JsonObject()
+    };
+
+    static JsonObject ToolsCallRequest(int id, string name, JsonObject arguments) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"]      = id,
+        ["method"]  = "tools/call",
+        ["params"]  = new JsonObject { ["name"] = name, ["arguments"] = arguments }
     };
 }

--- a/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpFlowsServerTests.cs
@@ -157,6 +157,49 @@ public class McpFlowsServerTests : IDisposable {
         }
     };
 
+    /// <summary>
+    /// The server is spawned for every agent session, so the working directory's repository is
+    /// resolved by the first tool call that needs it, not at startup. Detection is the only
+    /// startup-time writer under the config root's cache directory, so its absence after the
+    /// handshake proves detection never ran; the start that follows then names the repo resolved
+    /// on demand.
+    /// </summary>
+    [Test]
+    public async Task Repository_is_resolved_by_the_first_tool_call_not_at_startup() {
+        _server.Given(Request.Create().WithPath("/api/flows/review/start/v2").UsingPost())
+            .RespondWith(
+                Response.Create()
+                    .WithStatusCode(200)
+                    .WithHeader("Content-Type", "application/json")
+                    .WithBody("""{"flow_run_id":"flow-1","round_id":"round-1","round_number":1,"status":"completed","result_kind":"FINDINGS","result_text":"ok","reviewer_agent_id":null,"reviewer_session_id":null}""")
+            );
+
+        using var proc = SpawnMcpServer();
+        try {
+            await SendRequest(proc, InitializeRequest(1));
+            await SendRequest(proc, ToolsListRequest(2));
+            await Assert.That(Directory.Exists(Config.Root.Path("cache"))).IsFalse();
+
+            var args = new JsonObject {
+                ["kind"]         = "spec-review",
+                ["target_kind"]  = "spec",
+                ["target_ref"]   = "docs/feature.md",
+                ["target_title"] = "Feature spec",
+                ["context"]      = "Review."
+            };
+            await SendRequest(proc, ToolsCallRequest(3, "start_review_flow", args));
+
+            var hits = _server.FindLogEntries(Request.Create().WithPath("/api/flows/review/start/v2").UsingPost());
+            await Assert.That(hits.Count).IsEqualTo(1);
+
+            var body = JsonNode.Parse(hits[0].RequestMessage.Body ?? "{}")!.AsObject();
+            await Assert.That(body["repo_owner"]?.GetValue<string>()).IsEqualTo("test-owner");
+            await Assert.That(body["repo_name"]?.GetValue<string>()).IsEqualTo("test-repo");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
     [Test]
     public async Task Initialize_returns_kcap_flows_server_info() {
         using var proc = SpawnMcpServer();

--- a/test/Capacitor.Cli.Tests.Integration/McpMemoryServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpMemoryServerTests.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using Capacitor.Cli.Core;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -34,12 +35,12 @@ public class McpMemoryServerTests : IDisposable {
         _server.Stop();
     }
 
-    Process SpawnMcpServer(string provider = "None") {
+    Process SpawnMcpServer(string provider = "None", string? workingDirectory = null) {
         _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200).WithBody($$"""{"provider":"{{provider}}"}"""));
 
         var psi = KcapProcess.StartInfo(Daemons.Store, Config.Root, "mcp", "memory");
-        psi.WorkingDirectory = Tmp.Path;
+        psi.WorkingDirectory = workingDirectory ?? Tmp.Path;
         psi.Environment["KCAP_URL"] = _server.Url!;
 
         var process = Process.Start(psi) ?? throw new InvalidOperationException("Failed to start kcap process");
@@ -83,6 +84,47 @@ public class McpMemoryServerTests : IDisposable {
         }
     }
 
+    /// <summary>
+    /// A repository whose <c>origin</c> points at GitHub, handed to the server as its working
+    /// directory so the cwd-repo pin resolves. No commit is needed: <c>git branch --show-current</c>
+    /// reads the symbolic HEAD ref at zero commits.
+    /// </summary>
+    static GitRepo CwdRepo(string owner, string repoName) {
+        var repo = GitRepo.Create();
+        repo.AddRemote($"https://github.com/{owner}/{repoName}.git");
+        return repo;
+    }
+
+    /// <summary>
+    /// The server is spawned for every agent session, so the working directory's repository is
+    /// resolved by the first tool call, not at startup. Detection is the only startup-time writer
+    /// under the config root's cache directory, so its absence after the handshake proves detection
+    /// never ran; the search that follows then carries the repo hash resolved on demand.
+    /// </summary>
+    [Test]
+    public async Task Repository_is_resolved_by_the_first_tool_call_not_at_startup() {
+        using var repo = CwdRepo("acme", "widget");
+
+        _server.Given(Request.Create().WithPath("/api/memories/search").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody("[]"));
+
+        using var proc = SpawnMcpServer(workingDirectory: repo.Path);
+        try {
+            await SendRequest(proc, InitializeRequest(1));
+            await SendRequest(proc, ToolsListRequest(2));
+            await Assert.That(Directory.Exists(Config.Root.Path("cache"))).IsFalse();
+
+            await SendRequest(proc, ToolsCallRequest(3, "search_memories", new JsonObject { ["query"] = "anything" }));
+
+            var hits = _server.FindLogEntries(Request.Create().WithPath("/api/memories/search").UsingGet());
+            await Assert.That(hits.Count).IsEqualTo(1);
+            await Assert.That(hits[0].RequestMessage.RawQuery ?? "")
+                .Contains($"repo={RepoHashHelper.ComputeRepoHash("acme", "widget")}");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
     static async Task<JsonObject> SendRequest(Process proc, JsonObject request, TimeSpan? timeout = null) {
         await proc.StandardInput.WriteLineAsync(request.ToJsonString());
         await proc.StandardInput.FlushAsync();
@@ -121,5 +163,12 @@ public class McpMemoryServerTests : IDisposable {
         ["id"]      = id,
         ["method"]  = "tools/list",
         ["params"]  = new JsonObject()
+    };
+
+    static JsonObject ToolsCallRequest(int id, string name, JsonObject arguments) => new() {
+        ["jsonrpc"] = "2.0",
+        ["id"]      = id,
+        ["method"]  = "tools/call",
+        ["params"]  = new JsonObject { ["name"] = name, ["arguments"] = arguments }
     };
 }

--- a/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/McpSessionsServerTests.cs
@@ -96,6 +96,36 @@ public class McpSessionsServerTests : IDisposable {
         }
     }
 
+    /// <summary>
+    /// The server is spawned for every agent session, so the working directory's repository is
+    /// resolved by the first tool call, not at startup. Detection is the only startup-time writer
+    /// under the config root's cache directory, so its absence after the handshake proves detection
+    /// never ran; the search that follows then carries the repo hash resolved on demand.
+    /// </summary>
+    [Test]
+    public async Task Repository_is_resolved_by_the_first_tool_call_not_at_startup() {
+        using var repo = CwdRepo("acme", "widget");
+
+        _server.Given(Request.Create().WithPath("/api/sessions/search").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200).WithHeader("Content-Type", "application/json").WithBody("""{"hits":[]}"""));
+
+        using var proc = SpawnMcpServer(workingDirectory: repo.Path);
+        try {
+            await SendRequest(proc, InitializeRequest(1));
+            await SendRequest(proc, ToolsListRequest(2));
+            await Assert.That(Directory.Exists(Config.Root.Path("cache"))).IsFalse();
+
+            await SendRequest(proc, ToolsCallRequest(3, "search_sessions", new JsonObject { ["query"] = "anything" }));
+
+            var hits = _server.FindLogEntries(Request.Create().WithPath("/api/sessions/search").UsingGet());
+            await Assert.That(hits.Count).IsGreaterThanOrEqualTo(1);
+            await Assert.That(hits[0].RequestMessage.RawQuery ?? "")
+                .Contains($"repo={RepoHashHelper.ComputeRepoHash("acme", "widget")}");
+        } finally {
+            await ShutdownAsync(proc);
+        }
+    }
+
     static async Task<JsonObject> SendRequest(Process proc, JsonObject request, TimeSpan? timeout = null) {
         await proc.StandardInput.WriteLineAsync(request.ToJsonString());
         await proc.StandardInput.FlushAsync();

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/ClaudeHookCommandTests.cs
@@ -530,7 +530,11 @@ public class ClaudeHookCommandTests {
             $$"""{"hook_event_name":"SessionEnd","session_id":"{{Sid}}","transcript_path":"/none","cwd":"/tmp"}""");
         sw.Stop();
         await Assert.That(exit).IsEqualTo(0);
-        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(15)); // did not wait the full 30s
+        // Bounded well clear of the hook's own 15s budget rather than at it: the claim is that the
+        // attempt gave up instead of waiting the server's 30s hold, and a bound equal to the budget
+        // it is measuring has no headroom for a loaded runner (16.2s on a Windows leg, 14.2s alone
+        // on an idle machine).
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(20));
         await Assert.That(fx.SpoolFiles.Any()).IsTrue();
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/CwdRepositoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CwdRepositoryTests.cs
@@ -1,0 +1,84 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.PrDetection;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The repo-aware MCP servers auto-register, so every agent session spawns them whether or not a
+/// tool is ever called. The working directory's repository must therefore cost nothing until a
+/// tool needs it, resolve once, and never make the provider round-trip: only owner and name feed
+/// the repo hash.
+/// </summary>
+public class CwdRepositoryTests {
+    [TempConfigRoot] public required TempConfigRoot Config { get; init; }
+    [TempDir]        public required TempDir        Cwd    { get; init; }
+
+    [Before(Test)]
+    public void Reset() => GitProviderRouter.ResetMemoForTests();
+
+    static CommandRunner RecordingRunner(List<string> commands, string? origin = "git@github.com:acme/widget.git") =>
+        (cmd, args, _, _) => {
+            commands.Add($"{cmd} {args}");
+            string? reply = (cmd, args) switch {
+                ("git", "branch --show-current") => "main",
+                ("git", "config user.name")      => "Tester",
+                ("git", "config user.email")     => "t@example.com",
+                ("git", "remote get-url origin") => origin,
+                _                                => null
+            };
+            return Task.FromResult(reply);
+        };
+
+    [Test]
+    public async Task Construction_spawns_nothing() {
+        var commands = new List<string>();
+
+        _ = new CwdRepository(Config.Root, Cwd.Path, RecordingRunner(commands));
+
+        await Assert.That(commands).IsEmpty();
+    }
+
+    [Test]
+    public async Task Hash_comes_from_origin_without_a_provider_probe() {
+        var commands = new List<string>();
+        var repo     = new CwdRepository(Config.Root, Cwd.Path, RecordingRunner(commands));
+
+        var hash = await repo.GetHashAsync();
+
+        await Assert.That(hash).IsEqualTo(RepoHashHelper.ComputeRepoHash("acme", "widget"));
+        await Assert.That(commands).IsNotEmpty();
+        await Assert.That(commands.All(c => c.StartsWith("git ", StringComparison.Ordinal))).IsTrue();
+    }
+
+    [Test]
+    public async Task Resolution_runs_once_per_instance() {
+        var commands = new List<string>();
+        var repo     = new CwdRepository(Config.Root, Cwd.Path, RecordingRunner(commands));
+
+        await repo.GetHashAsync();
+        var spawned = commands.Count;
+
+        await repo.GetHashAsync();
+        await repo.GetAsync();
+
+        await Assert.That(spawned).IsGreaterThan(0);
+        await Assert.That(commands.Count).IsEqualTo(spawned);
+    }
+
+    [Test]
+    public async Task Outside_a_checkout_there_is_no_repository_and_no_hash() {
+        var repo = new CwdRepository(Config.Root, Cwd.Path, (_, _, _, _) => Task.FromResult<string?>(null));
+
+        await Assert.That(await repo.GetAsync()).IsNull();
+        await Assert.That(await repo.GetHashAsync()).IsNull();
+    }
+
+    [Test]
+    public async Task A_checkout_without_an_origin_remote_has_no_hash() {
+        var commands = new List<string>();
+        var repo     = new CwdRepository(Config.Root, Cwd.Path, RecordingRunner(commands, origin: null));
+
+        await Assert.That(await repo.GetAsync()).IsNotNull();
+        await Assert.That(await repo.GetHashAsync()).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/CwdRepositoryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/CwdRepositoryTests.cs
@@ -13,9 +13,6 @@ public class CwdRepositoryTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
     [TempDir]        public required TempDir        Cwd    { get; init; }
 
-    [Before(Test)]
-    public void Reset() => GitProviderRouter.ResetMemoForTests();
-
     static CommandRunner RecordingRunner(List<string> commands, string? origin = "git@github.com:acme/widget.git") =>
         (cmd, args, _, _) => {
             commands.Add($"{cmd} {args}");


### PR DESCRIPTION
Closes #354 — AI-1500

## What & why

The sessions, memory, analytics and flows MCP servers resolved the working directory's repository at process startup with pull-request detection on, so every agent session on every harness paid a live `gh pr view` / `glab` round-trip per server before any tool was called. None of them reads the PR: they scope requests by owner and name. `CwdRepository` resolves on the first tool call that asks, once per process, with PR detection off; a null result is cached as well, since outside a checkout it cannot change for the life of the process.

## Where to look

The integration pin is indirect: repository detection is the only startup-time writer under the config root's cache directory, so an absent directory after initialize + tools/list proves it never ran, and the tool call that follows carries the repo hash. Flows is the fourth site beyond the three the issue names; the review server keeps PR detection because it needs the PR number.

The session-end hung-server budget test now bounds at 20 s rather than its own 15 s ceiling, mirroring the subagent-stop sibling in the same file. The hook's POST cap is the ceiling less the 1.5 s safety reserve, so a bound at the ceiling has under a second of headroom.

## Verification

- `CwdRepositoryTests`: the provider-probe test fails with PR detection flipped on (the recording runner sees `gh`) and passes with it off.
- The four `Repository_is_resolved_by_the_first_tool_call_not_at_startup` integration tests fail on main at the startup assertion and pass here; the five MCP server integration classes: 57 passed, 0 failed.
- CLI unit suite: 3877 passed, 0 failed. `dotnet publish -c Release`: no IL2026/IL3050.
- `kcap mcp memory` startup with stdin closed measured 0.79 s on this checkout; `gh pr view` alone is 0.77 s of it.
- Windows leg: `session_end_against_hung_server_is_spooled_within_budget` failed twice at 16.2 s and 15.9 s on runners that finished the module in the same 4m22s as main's green runs; alone on an idle Mac it takes 14.2 s.
