### PR TITLE
Spool a 401'd lifecycle payload instead of dropping it

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,6 +58,11 @@ Deliberate choices a change can silently undo — each looks like a bug until yo
 - **Auth commits in one ordered boundary** — claims, then config and provider stamp, then tokens —
   behind a totalized result. `kcap login` never repoints `server_url`; `kcap setup` and the wizard
   adopt it.
+- **A 401 spools; only a rejected payload drops.** Every live hook post and every drain poster
+  classifies a status through `HookSpool.IsRetryable`, where a 401 is retryable like a 5xx: the
+  credential is what `kcap login` repairs, so the event must outlive the lapse. Restating the rule
+  at a call site lets a vendor spool a status the drain then drops — a visible loss turned into a
+  delayed silent one. Retention while the lapse lasts is the spool's own byte cap and 30-day reap.
 - **Secret redaction rewrites decoded JSON string values, never the serialized line.** A pattern run
   over the whole line matches past the value it found into the surrounding structure, and the server
   drops an unparseable line silently. A line the writer refuses is replaced by a placeholder —

--- a/README.md
+++ b/README.md
@@ -138,9 +138,10 @@ server rejects it, or if the token was issued by a different server than the pro
 usable offline. If the server rejects your token while a session is running, Claude Code's hook
 says so as an in-session notice — `[kcap] The server rejected your credentials (HTTP 401) —
 session recording is paused. Run 'kcap login' to resume.` — instead of surfacing an opaque hook
-error, so you no longer have to run `kcap whoami` to work out why recording stopped. Other agents'
-hooks print the same advice to stderr instead of an in-session notice, since not every agent
-surfaces hook output in its UI. `kcap status` prints its own
+error, so you no longer have to run `kcap whoami` to work out why recording stopped. The lifecycle
+event that hit the rejection is not lost: it is spooled like an outage and re-sent on the next hook
+once you have logged in. Other agents' hooks print the same advice to stderr instead of an
+in-session notice, since not every agent surfaces hook output in its UI. `kcap status` prints its own
 **Version** line — the installed CLI version, with an inline `(update available: …)` annotation
 when a newer one is out (capped at your connected server's version, marked `(…, server version)` when
 your tenant trails npm) — see [`kcap update`](#other-commands) for the full opt-out story.
@@ -243,7 +244,7 @@ The `kcap mcp analytics` stdio server lets agents answer analytics questions abo
 Once set up, Capacitor runs silently in the background. Every Claude Code (and Codex CLI, if you installed those hooks) session is captured automatically:
 
 - **Session lifecycle** — start, end, interruptions, context compaction
-- **Durable lifecycle delivery** — if the server is briefly unreachable when a `SessionStart`/`SessionEnd` hook (or a per-subagent `SubagentStop` carrying an `agent_id`) fires (for example during a deploy), the event is spooled to `~/.config/kcap/spool/` and automatically re-sent on the next hook, so sessions don't get stuck "active", lose their start record, or leave subagents stuck "running". No action needed; stale spool entries are reaped after 30 days.
+- **Durable lifecycle delivery** — if the server is briefly unreachable when a `SessionStart`/`SessionEnd` hook (or a per-subagent `SubagentStop` carrying an `agent_id`) fires (for example during a deploy), or rejects your credentials (HTTP 401), the event is spooled to `~/.config/kcap/spool/` and automatically re-sent on the next hook — after `kcap login`, for a rejected credential — so sessions don't get stuck "active", lose their start record, or leave subagents stuck "running". No action needed beyond logging back in; stale spool entries are reaped after 30 days.
 - **Transcript data** — streamed in real time via a background watcher process over SignalR
 - **Subagent activity** — full tree of spawned subagents with their own transcripts
 - **Tool usage** — every tool call with timing and results

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -560,3 +560,24 @@ only for owned review-flow reviewers: bypass silences permission prompts, not qu
 one-time bypass consent dialog, and the multi-CR spray would answer either. The chip is withheld for
 every vendor but Claude, the mode is session-scoped like the effort, and the harness picker no
 longer offers "Remember" — a chosen harness is always persisted for the repository.
+
+## A 401 spools
+
+Every hook path classed an HTTP 401 with the payload-rejecting 4xxs and dropped the event, so a
+credential rejected mid-session lost the lifecycle event that hit it: `kcap login` resumed recording
+from the next event, but a dropped session-start left the session without a server-side record and a
+dropped session-end left it stuck active. A 401 is now retryable, alongside 5xx, 408 and 429.
+
+**The classification is one helper, not eight copies.** The live posts (Claude's three bounded arms,
+`AgentHookPoster.PostOrSpoolAsync` for the other vendors) and the drain posters (`LifecycleSpoolDrain`,
+Claude's and Cursor's inline replays) each restated the rule, and Cursor showed why that cannot hold:
+its live post already spooled any non-2xx, so a 401'd entry survived to the next drain and was dropped
+there — a visible loss turned into a delayed silent one. Spooling at the live post is only safe once
+every drain agrees, so both sides read `HookSpool.IsRetryable`.
+
+**Retention is the spool's own.** A backlog that can only land after a human logs in is bounded the
+way an outage backlog is: the per-session byte cap and the 30-day reap. The pre-flight auth check
+still skips the drain while the token store knows the credential is dead, so a spooled 401 costs
+nothing until the login, and the drain that follows the login replays the backlog in order. On the
+vendor path a server 401 is now `Spooled` rather than `Failed` — the hook exits 0, as Claude's already
+did, and the stderr line still names `kcap login`.

--- a/src/Capacitor.Cli.Core/HookSpool.cs
+++ b/src/Capacitor.Cli.Core/HookSpool.cs
@@ -8,8 +8,8 @@ namespace Capacitor.Cli.Core;
 /// <summary>Result of a single spooled-entry replay attempt.</summary>
 public enum DrainOutcome {
     Delivered,    // POST succeeded — advance past the entry
-    Drop,         // permanent failure (4xx except 408/429) — discard, do not retry
-    TransientStop // server down/timeout/budget — stop draining, keep the remainder
+    Drop,         // the payload itself was rejected (HookSpool.IsRetryable is false) — discard, do not retry
+    TransientStop // server down/timeout/budget/credential lapse — stop draining, keep the remainder
 }
 
 /// <summary>
@@ -27,6 +27,22 @@ public enum DrainOutcome {
 /// </summary>
 public sealed partial class HookSpool(string spoolDir, int capBytes = HookSpool.DefaultCapBytes) {
     public const int DefaultCapBytes = 1_048_576; // 1 MB per session file
+
+    /// <summary>
+    /// Whether a lifecycle POST answered with <paramref name="statusCode"/> is kept for a later
+    /// drain. The one rule every live post and every drain poster shares, so no vendor can spool a
+    /// status the drain then drops. A 401 is retryable: it is a lapsed credential, which
+    /// <c>kcap login</c> repairs, so the payload has to outlive the lapse — a dropped session-start
+    /// leaves the session without a server-side record, a dropped session-end leaves it stuck
+    /// active. Every other 4xx rejects the payload itself, and a replay would be rejected the same
+    /// way. Retention while a lapse lasts is the spool's own: the per-session byte cap and the
+    /// 30-day reap.
+    /// </summary>
+    public static bool IsRetryable(int statusCode) => statusCode is >= 500 or 408 or 429 or 401;
+
+    /// <summary>The drain outcome for a non-success status: retryable stops the pass, anything else drops the entry.</summary>
+    public static DrainOutcome OutcomeOf(int statusCode) =>
+        IsRetryable(statusCode) ? DrainOutcome.TransientStop : DrainOutcome.Drop;
 
     // The subdirectory name belongs to the spool, not to ConfigRoot: a root that enumerated its
     // tenants' directories would change every time one of them gained a file.

--- a/src/Capacitor.Cli.Core/LifecycleSpoolDrain.cs
+++ b/src/Capacitor.Cli.Core/LifecycleSpoolDrain.cs
@@ -103,8 +103,7 @@ public static class LifecycleSpoolDrain {
                 }
                 return DrainOutcome.Delivered;
             }
-            var code = (int)resp.StatusCode;
-            return code is >= 500 or 408 or 429 ? DrainOutcome.TransientStop : DrainOutcome.Drop;
+            return HookSpool.OutcomeOf((int)resp.StatusCode);
         } catch { return DrainOutcome.TransientStop; }
     }
 

--- a/src/Capacitor.Cli/Commands/AgentHookPoster.cs
+++ b/src/Capacitor.Cli/Commands/AgentHookPoster.cs
@@ -27,8 +27,8 @@ internal enum HookPostOutcome {
     /// </summary>
     Failed,
 
-    /// <summary>The POST could not be delivered now (auth lapsed or a transient/unreachable failure) so
-    /// the payload was durably spooled for a later drain pass. NOT delivered — but the caller should still
+    /// <summary>The POST could not be delivered now (auth lapsed, a server 401, or a transient/unreachable
+    /// failure) so the payload was durably spooled for a later drain pass. NOT delivered — but the caller should still
     /// proceed to spawn the watcher (spawn-before-post): capture must not depend on lifecycle delivery.</summary>
     Spooled,
 
@@ -66,8 +66,7 @@ internal sealed class AgentHookPoster(ConfigRoot config, ProfileContext profiles
 
     /// <summary>Auth has genuinely lapsed → any POST would 401. <c>Ok</c> and <c>NoAuthRequired</c> are usable.</summary>
     // Anything that isn't a usable client is a lapse. WrongServer especially: the client carries no
-    // bearer, so posting anyway earns a 401 that the spool would classify as permanent and DROP —
-    // discarding lifecycle/transcript data over a fixable profile mismatch.
+    // bearer, so posting anyway would only earn a 401 for a fixable profile mismatch.
     public static bool IsAuthLapsed(AuthStatus status) =>
         status is AuthStatus.Expired or AuthStatus.NotAuthenticated or AuthStatus.WrongServer;
 
@@ -216,9 +215,8 @@ internal sealed class AgentHookPoster(ConfigRoot config, ProfileContext profiles
     /// on the same gate. This is the Kiro-side analogue of the event-type gate applied to Copilot,
     /// whose per-turn <c>agentStop</c>/<c>notification</c> events skip this call entirely.</para>
     ///
-    /// <para><b>Skips on auth lapse.</b> A POST with no bearer token would 401, and
-    /// <see cref="LifecycleSpoolDrain"/>'s production poster treats a non-timeout/non-5xx status as a
-    /// permanent drop — which would silently discard the very backlog this protects.</para>
+    /// <para><b>Skips on auth lapse.</b> Every POST would 401 and stop the pass at its first entry,
+    /// so the budget is better left to the vendor's own hook; the backlog waits for the login.</para>
     ///
     /// <para><b>Fresh client (review #3 — documented deviation).</b> The brief's Step 3
     /// suggested reusing the vendor's authenticated client, but the drain runs at the top of the
@@ -326,14 +324,15 @@ internal sealed class AgentHookPoster(ConfigRoot config, ProfileContext profiles
 
                 var code = (int)resp.StatusCode;
 
-                // Transient (server down / rate-limit) → spool for retry; a permanent 4xx is a real failure.
-                if (code is >= 500 or 408 or 429) {
-                    return SpoolOrSkip(spool, sessionId, route, body, agentTag);
+                // Before the spool decision, so a 401 still names its fix: an outage spools silently,
+                // but a rejected credential needs the user, and stderr is the only channel here.
+                if (code == 401 || !HookSpool.IsRetryable(code)) {
+                    Console.Error.WriteLine(AuthRejectionNotice.VendorStderrLine(agentTag, endpoint, code));
                 }
 
-                Console.Error.WriteLine(AuthRejectionNotice.VendorStderrLine(agentTag, endpoint, code));
-
-                return HookPostOutcome.Failed;
+                return HookSpool.IsRetryable(code)
+                    ? SpoolOrSkip(spool, sessionId, route, body, agentTag)
+                    : HookPostOutcome.Failed;
             } catch (HttpRequestException) {
                 // Unreachable after retries → transient; spool for a later drain rather than lose it.
                 return SpoolOrSkip(spool, sessionId, route, body, agentTag);

--- a/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
@@ -393,8 +393,8 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
             return 0;
         }
 
-        // Auth lapsed: do not POST (server would 401) and do not drain (a 401 would Drop the
-        // spool backlog). Exit cleanly (0) so Claude shows no per-turn error banner; nudge once on
+        // Auth lapsed: do not POST and do not drain — every request would 401, so the backlog just
+        // waits for the login. Exit cleanly (0) so Claude shows no per-turn error banner; nudge once on
         // session-start via a systemMessage (shown to the user, not injected into the model context).
         if (authStatus is AuthStatus.Expired or AuthStatus.NotAuthenticated or AuthStatus.WrongServer) {
             if (command == "session-start") {
@@ -656,9 +656,9 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
 
             if (resp is null || !resp.IsSuccessStatusCode) {
                 var code      = resp is null ? 0 : (int)resp.StatusCode;
-                var permanent = resp is not null && code is < 500 and not 408 and not 429;
+                var retryable = resp is null || HookSpool.IsRetryable(code);
                 resp?.Dispose();
-                if (!permanent && sessionId is not null) spool.Append(sessionId, "session-start", body);
+                if (retryable && sessionId is not null) spool.Append(sessionId, "session-start", body);
 
                 // The envelope below is built only from a 2xx body, so this is the arm's only
                 // stdout write — without it the start event is dropped in silence.
@@ -780,9 +780,9 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
             } catch { resp = null; }
 
             if (resp is null || !resp.IsSuccessStatusCode) {
-                var permanent = resp is not null && (int)resp.StatusCode is < 500 and not 408 and not 429;
+                var retryable = resp is null || HookSpool.IsRetryable((int)resp.StatusCode);
                 resp?.Dispose();
-                if (!permanent) {
+                if (retryable) {
                     if (sessionId is not null) {
                         spool.Append(sessionId, "session-end", body);
                         await Console.Error.WriteLineAsync($"[kcap] session-end spooled; will retry on the next kcap hook ({sessionId})");
@@ -832,9 +832,9 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
                 } catch { resp = null; }
 
                 if (resp is null || !resp.IsSuccessStatusCode) {
-                    var permanent = resp is not null && (int)resp.StatusCode is < 500 and not 408 and not 429;
+                    var retryable = resp is null || HookSpool.IsRetryable((int)resp.StatusCode);
                     resp?.Dispose();
-                    if (!permanent) {
+                    if (retryable) {
                         spool.Append(sessionId, "subagent-stop", body);
                         await Console.Error.WriteLineAsync($"[kcap] subagent-stop spooled; will retry on the next kcap hook ({sessionId}/{agentId})");
                     }
@@ -1023,10 +1023,7 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
             try {
                 using var content = new StringContent(body, Encoding.UTF8, "application/json");
                 using var resp    = await client.PostOnceAsync($"{Url}/hooks/{route}", content, perAttempt, CancellationToken.None);
-                if (!resp.IsSuccessStatusCode) {
-                    var code = (int)resp.StatusCode;
-                    return code is >= 500 or 408 or 429 ? DrainOutcome.TransientStop : DrainOutcome.Drop;
-                }
+                if (!resp.IsSuccessStatusCode) return HookSpool.OutcomeOf((int)resp.StatusCode);
                 if (route == "session-end") {
                     try {
                         var node = JsonNode.Parse(await resp.Content.ReadAsStringAsync());

--- a/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
@@ -212,9 +212,10 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
     /// </summary>
 
     /// <summary>
-    /// One honest line for a degraded-path spool attempt. An unusable URL routes through the shared
-    /// source-aware diagnostic (which names what to fix and never echoes the URL); a budget overrun
-    /// keeps its existing wording.
+    /// One honest line for a spool attempt, on the degraded path or after a failed live POST:
+    /// "spooled" promises a replay, so it is said only when the append persisted something. An
+    /// unusable URL routes through the shared source-aware diagnostic (which names what to fix and
+    /// never echoes the URL); a budget overrun keeps its existing wording.
     /// </summary>
     async Task ReportSpoolAsync(bool spooled, string route, string key, string reason, bool unusableUrl) {
         var disposition = spooled
@@ -230,6 +231,10 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
 
         await Console.Error.WriteLineAsync($"[kcap] {disposition} ({reason})");
     }
+
+    // Why a bounded live POST left its payload to the spool: the status it got, or no response at all.
+    static string FailureReason(int statusCode) =>
+        statusCode == 0 ? "no response within the hook budget" : $"HTTP {statusCode}";
 
     internal async Task<bool> ShouldSuppressCaptureAsync(
             string? canonicalSessionId, string body, string? command, Profile? activeProfile, HookBudget budget) {
@@ -658,7 +663,10 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
                 var code      = resp is null ? 0 : (int)resp.StatusCode;
                 var retryable = resp is null || HookSpool.IsRetryable(code);
                 resp?.Dispose();
-                if (retryable && sessionId is not null) spool.Append(sessionId, "session-start", body);
+                if (retryable && sessionId is not null) {
+                    await ReportSpoolAsync(spool.Append(sessionId, "session-start", body),
+                                           "session-start", sessionId, FailureReason(code), unusableUrl: false);
+                }
 
                 // The envelope below is built only from a 2xx body, so this is the arm's only
                 // stdout write — without it the start event is dropped in silence.
@@ -780,12 +788,13 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
             } catch { resp = null; }
 
             if (resp is null || !resp.IsSuccessStatusCode) {
-                var retryable = resp is null || HookSpool.IsRetryable((int)resp.StatusCode);
+                var code      = resp is null ? 0 : (int)resp.StatusCode;
+                var retryable = resp is null || HookSpool.IsRetryable(code);
                 resp?.Dispose();
                 if (retryable) {
                     if (sessionId is not null) {
-                        spool.Append(sessionId, "session-end", body);
-                        await Console.Error.WriteLineAsync($"[kcap] session-end spooled; will retry on the next kcap hook ({sessionId})");
+                        await ReportSpoolAsync(spool.Append(sessionId, "session-end", body),
+                                               "session-end", sessionId, FailureReason(code), unusableUrl: false);
                     } else {
                         await Console.Error.WriteLineAsync("[kcap] session-end transient failure but session_id missing — cannot spool; event dropped");
                     }
@@ -832,11 +841,12 @@ public sealed class ClaudeHookCommand(ConfigRoot config, ProfileContext profiles
                 } catch { resp = null; }
 
                 if (resp is null || !resp.IsSuccessStatusCode) {
-                    var retryable = resp is null || HookSpool.IsRetryable((int)resp.StatusCode);
+                    var code      = resp is null ? 0 : (int)resp.StatusCode;
+                    var retryable = resp is null || HookSpool.IsRetryable(code);
                     resp?.Dispose();
                     if (retryable) {
-                        spool.Append(sessionId, "subagent-stop", body);
-                        await Console.Error.WriteLineAsync($"[kcap] subagent-stop spooled; will retry on the next kcap hook ({sessionId}/{agentId})");
+                        await ReportSpoolAsync(spool.Append(sessionId, "subagent-stop", body),
+                                               "subagent-stop", $"{sessionId}/{agentId}", FailureReason(code), unusableUrl: false);
                     }
                     return 0;
                 }

--- a/src/Capacitor.Cli/Commands/Harness/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CursorHookCommand.cs
@@ -111,10 +111,9 @@ public sealed class CursorHookCommand(ConfigRoot config, ProfileContext profiles
         try {
             // Status-returning variant so a lapse doesn't write the per-turn "expired" stderr
             // line CreateAuthenticatedClientAsync would. On a lapse, skip HandleCore entirely:
-            // every POST would 401, and draining the spool would turn its 401s into Drops that
-            // discard the backlog — so leave it intact for replay after the user re-runs
-            // `kcap login`, and exit cleanly. Mirrors the Claude hook (#183); kcap status
-            // surfaces the expired state. Cursor has no user-facing notice channel.
+            // every POST would 401, so the backlog waits intact for the user to re-run
+            // `kcap login`, and exit cleanly. Mirrors the Claude hook; kcap status surfaces the
+            // expired state. Cursor has no user-facing notice channel.
             //
             // Bounded by its OWN Task.WhenAny against the full budget (not merely the linked
             // CancellationToken passed into it) — the one place client creation can be
@@ -403,8 +402,7 @@ public sealed class CursorHookCommand(ConfigRoot config, ProfileContext profiles
                             if (route == "subagent-start") await MaybeSpawnChildWatcherFromPayloadAsync(entryBody);
                             return DrainOutcome.Delivered;
                         }
-                        var code = (int)resp.StatusCode;
-                        return code is >= 500 or 408 or 429 ? DrainOutcome.TransientStop : DrainOutcome.Drop;
+                        return HookSpool.OutcomeOf((int)resp.StatusCode);
                     } catch { return DrainOutcome.TransientStop; }
                 }, budget.Remaining, ct);
             }

--- a/test/Capacitor.Cli.Core.Tests.Unit/HookSpoolTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/HookSpoolTests.cs
@@ -6,6 +6,24 @@ public class HookSpoolTests {
     const string SidA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa";
     const string SidB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb";
 
+    /// <summary>The one classification every live post and drain poster shares. A 401 is retryable
+    /// because <c>kcap login</c> repairs it; a 4xx that rejects the payload itself is not, since a
+    /// replay would be rejected the same way.</summary>
+    [Test]
+    [Arguments(401, true)]
+    [Arguments(408, true)]
+    [Arguments(429, true)]
+    [Arguments(500, true)]
+    [Arguments(503, true)]
+    [Arguments(400, false)]
+    [Arguments(403, false)]
+    [Arguments(404, false)]
+    [Arguments(422, false)]
+    public async Task retryable_statuses_stop_the_drain_and_the_rest_drop(int status, bool retryable) {
+        await Assert.That(HookSpool.IsRetryable(status)).IsEqualTo(retryable);
+        await Assert.That(HookSpool.OutcomeOf(status)).IsEqualTo(retryable ? DrainOutcome.TransientStop : DrainOutcome.Drop);
+    }
+
     [Test]
     public async Task drains_current_session_first_then_others_in_fifo() {
         using var tmp = new TempDir();

--- a/test/Capacitor.Cli.Core.Tests.Unit/LifecycleSpoolDrainTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LifecycleSpoolDrainTests.cs
@@ -70,6 +70,44 @@ public class LifecycleSpoolDrainTests {
         }
     }
 
+    /// <summary>A 401 is a lapsed credential, which <c>kcap login</c> repairs: the backlog must
+    /// outlive it, and a terminal entry that never landed must not mark the session ended.</summary>
+    [Test]
+    public async Task a_401_keeps_the_backlog_and_does_not_mark_the_session_ended() {
+        using var tmp = new TempDir();
+        var life = new HookSpool(tmp.Path);
+        var tx   = new TranscriptSpool(tmp.PathTo("tx"));
+        life.Append(Sid, "session-start/kiro", """{"phase":"start"}""");
+        life.Append(Sid, "session-end/kiro",   """{"phase":"end"}""");
+
+        using var handler = new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.Unauthorized));
+        using var client  = new HttpClient(handler);
+
+        await LifecycleSpoolDrain.RunAsync(Markers, client, "http://s", life, tx, currentSessionId: null,
+            budget: TimeSpan.FromSeconds(5), ct: CancellationToken.None);
+
+        await Assert.That(life.HasBacklog(Sid)).IsTrue();
+        await Assert.That(life.IsMarkedEnded(Sid)).IsFalse();
+    }
+
+    /// <summary>Non-vacuous control: a 4xx that rejects the payload itself is still dropped, so the
+    /// test above proves 401 is singled out rather than that every 4xx is now retained.</summary>
+    [Test]
+    public async Task a_4xx_that_rejects_the_payload_is_still_dropped() {
+        using var tmp = new TempDir();
+        var life = new HookSpool(tmp.Path);
+        var tx   = new TranscriptSpool(tmp.PathTo("tx"));
+        life.Append(Sid, "session-start/kiro", """{"phase":"start"}""");
+
+        using var handler = new StubHandler((_, _) => new HttpResponseMessage(HttpStatusCode.BadRequest));
+        using var client  = new HttpClient(handler);
+
+        await LifecycleSpoolDrain.RunAsync(Markers, client, "http://s", life, tx, currentSessionId: null,
+            budget: TimeSpan.FromSeconds(5), ct: CancellationToken.None);
+
+        await Assert.That(life.HasBacklog(Sid)).IsFalse();
+    }
+
     [Test]
     public async Task drains_start_then_transcript_then_end_for_a_session_with_no_further_hook() {
         using var tmp = new TempDir();

--- a/test/Capacitor.Cli.Tests.Unit/Commands/AgentHookPosterTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/AgentHookPosterTests.cs
@@ -101,10 +101,10 @@ public class AgentHookPosterTests : IDisposable {
     }
 
     /// <summary>
-    /// A 401 must stay <see cref="HookPostOutcome.Failed"/> — the outcome drives the caller's exit
-    /// code and is not part of this change — while the line the user actually reads names the fix.
-    /// These vendors have no user-facing stdout channel (their stdout is a handshake contract the
-    /// vendor parses), so stderr is the only place a nudge can go.
+    /// <c>PostAsync</c> has no spool, so a 401 stays <see cref="HookPostOutcome.Failed"/> here, while
+    /// the line the user actually reads names the fix. These vendors have no user-facing stdout
+    /// channel (their stdout is a handshake contract the vendor parses), so stderr is the only place
+    /// a nudge can go.
     /// </summary>
     // Globally sequential rather than keyed. "ConsoleErrorRedirect" has no other member, so it
     // serialized this Console.Error capture against nothing: Server_error_reports_Failed below
@@ -146,6 +146,53 @@ public class AgentHookPosterTests : IDisposable {
 
         await Assert.That(outcome).IsEqualTo(HookPostOutcome.Spooled);
         await Assert.That(spool.HasBacklog("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).IsTrue();
+    }
+
+    /// <summary>A server-rejected credential is repaired by <c>kcap login</c>, so the payload is kept
+    /// for the drain that follows the login instead of being lost with the turn that hit the 401.</summary>
+    [Test]
+    public async Task PostOrSpool_on_401_spools_and_returns_Spooled() {
+        using var tmp = new TempDir();
+        var spool = new HookSpool(tmp.Path);
+        using var handler = new StubHandler(System.Net.HttpStatusCode.Unauthorized);
+        var outcome = await Poster.PostOrSpoolAsync(
+            () => Task.FromResult<(HttpClient, AuthStatus)>((new HttpClient(handler), AuthStatus.Ok)), "session-start/kiro", """{"session_id":"x"}""",
+            "kiro-hook", spool, sessionId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", route: "session-start/kiro");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.Spooled);
+        await Assert.That(spool.HasBacklog("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).IsTrue();
+    }
+
+    /// <summary>Non-vacuous control: a 4xx that rejects the payload itself still fails outright, so
+    /// the test above proves 401 is singled out rather than that every 4xx now spools.</summary>
+    [Test]
+    public async Task PostOrSpool_on_a_payload_rejecting_4xx_returns_Failed_and_spools_nothing() {
+        using var tmp = new TempDir();
+        var spool = new HookSpool(tmp.Path);
+        using var handler = new StubHandler(System.Net.HttpStatusCode.BadRequest);
+        var outcome = await Poster.PostOrSpoolAsync(
+            () => Task.FromResult<(HttpClient, AuthStatus)>((new HttpClient(handler), AuthStatus.Ok)), "session-start/kiro", """{"session_id":"x"}""",
+            "kiro-hook", spool, sessionId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", route: "session-start/kiro");
+
+        await Assert.That(outcome).IsEqualTo(HookPostOutcome.Failed);
+        await Assert.That(spool.HasBacklog("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")).IsFalse();
+    }
+
+    /// <summary>Spooling a 401 must not silence the nudge: stderr is still the only place these
+    /// vendors can name <c>kcap login</c>. Redirects the process-global Console.Error, so it runs alone.</summary>
+    [Test, NotInParallel]
+    public async Task PostOrSpool_on_401_still_names_kcap_login_on_stderr() {
+        using var tmp = new TempDir();
+        var spool = new HookSpool(tmp.Path);
+        using var handler = new StubHandler(System.Net.HttpStatusCode.Unauthorized);
+        using var capture = ConsoleOutput.StartErrorCapture("\n");
+
+        await Poster.PostOrSpoolAsync(
+            () => Task.FromResult<(HttpClient, AuthStatus)>((new HttpClient(handler), AuthStatus.Ok)), "stop/codex", """{"session_id":"x"}""",
+            "codex-hook", spool, sessionId: "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa", route: "stop/codex");
+
+        await Assert.That(capture.GetCapturedError()).Contains(
+            AuthRejectionNotice.VendorStderrLine("codex-hook", "stop/codex", 401));
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/ClaudeHookCommandTests.cs
@@ -570,6 +570,69 @@ public class ClaudeHookCommandTests {
         await Assert.That(notice!["systemMessage"]!.GetValue<string>()).IsEqualTo(AuthRejectionNotice.RecordingNotice(StoredCredentialState.LooksValid));
     }
 
+    // ── A 401 spools ────────────────────────────────────────────────────────────────────────
+    // A rejected credential is repaired by `kcap login`, so the lifecycle event that hit it is kept
+    // for the drain that follows the login rather than lost with the turn. A dropped session-start
+    // leaves the session with no server-side record; a dropped session-end leaves it stuck "Active".
+
+    [Test]
+    public async Task session_start_on_401_is_spooled_for_replay_after_login() {
+        using var fx = new Fixture(Config.Root, HttpStatusCode.Unauthorized);
+        var stdout = new StringWriter { NewLine = "\n" };
+
+        await new ClaudeHookCommand(Config.Root, Resolutions.At("http://localhost", Config.Root), new HookClock(TimeProvider.System), Home).HandleCore(
+            fx.Client, AuthStatus.Ok, fx.Spool, new StringReader(
+                $$"""{"hook_event_name":"SessionStart","session_id":"{{Sid}}","cwd":"/tmp"}"""),
+            stdout: stdout);
+
+        var files = fx.SpoolFiles.ToList();
+        await Assert.That(files.Count).IsEqualTo(1);
+        await Assert.That(await File.ReadAllTextAsync(files[0])).Contains("\"route\":\"session-start\"");
+    }
+
+    [Test]
+    public async Task session_end_on_401_is_spooled_for_replay_after_login() {
+        using var fx = new Fixture(Config.Root, HttpStatusCode.Unauthorized);
+        await fx.HandleAsync($$"""{"hook_event_name":"SessionEnd","session_id":"{{Sid}}","transcript_path":"/none","cwd":"/tmp"}""");
+        var files = fx.SpoolFiles.ToList();
+        await Assert.That(files.Count).IsEqualTo(1);
+        await Assert.That(await File.ReadAllTextAsync(files[0])).Contains("\"route\":\"session-end\"");
+    }
+
+    [Test]
+    public async Task subagent_stop_on_401_is_spooled_for_replay_after_login() {
+        using var fx = new Fixture(Config.Root, HttpStatusCode.Unauthorized);
+        await fx.HandleAsync($$"""{"hook_event_name":"SubagentStop","session_id":"{{Sid}}","agent_id":"{{AgentId}}","transcript_path":"/none","cwd":"/tmp"}""");
+        var files = fx.SpoolFiles.ToList();
+        await Assert.That(files.Count).IsEqualTo(1);
+        await Assert.That(await File.ReadAllTextAsync(files[0])).Contains("\"route\":\"subagent-stop\"");
+    }
+
+    /// <summary>The drain must classify a 401 as the live post does: an entry that hits one on replay
+    /// stays spooled and lands once the server accepts the credential again. Otherwise spooling at
+    /// the live post only turns a visible loss into a delayed silent one.</summary>
+    [Test]
+    public async Task spooled_entry_that_hits_a_401_on_drain_is_replayed_once_the_server_accepts() {
+        using var rejecting = new Fixture(Config.Root, HttpStatusCode.Unauthorized);
+        using var accepting = new Fixture(Config.Root);
+        rejecting.Spool.Append(Sid, "session-end", $$"""{"session_id":"{{Sid}}"}""");
+        var stdout = new StringWriter { NewLine = "\n" };
+
+        await new ClaudeHookCommand(Config.Root, rejecting.Profiles, new HookClock(TimeProvider.System), Home).HandleCore(
+            rejecting.Client, AuthStatus.Ok, rejecting.Spool, new StringReader(
+                $$"""{"hook_event_name":"Stop","session_id":"{{Sid}}","transcript_path":"/none","cwd":"/tmp"}"""),
+            stdout: stdout);
+        await Assert.That(rejecting.Spool.HasBacklog(Sid)).IsTrue();
+
+        await new ClaudeHookCommand(Config.Root, accepting.Profiles, new HookClock(TimeProvider.System), Home).HandleCore(
+            accepting.Client, AuthStatus.Ok, rejecting.Spool, new StringReader(
+                $$"""{"hook_event_name":"Stop","session_id":"{{Sid}}","transcript_path":"/none","cwd":"/tmp"}"""),
+            stdout: stdout);
+
+        await Assert.That(accepting.RouteOrder).Contains("session-end");
+        await Assert.That(rejecting.Spool.HasBacklog(Sid)).IsFalse();
+    }
+
     [Test]
     public async Task pending_backlog_is_drained_on_next_hook_when_server_up() {
         using var fx = new Fixture(Config.Root); // 200 OK

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/ClaudeHookCommandTests.cs
@@ -608,6 +608,25 @@ public class ClaudeHookCommandTests {
         await Assert.That(await File.ReadAllTextAsync(files[0])).Contains("\"route\":\"subagent-stop\"");
     }
 
+    /// <summary>"Spooled" promises a replay, so the line may only say so when the append persisted
+    /// something; a spool whose directory cannot be created must be reported as a drop. Redirects the
+    /// process-global Console.Error, so it runs alone.</summary>
+    [Test, NotInParallel]
+    public async Task session_end_whose_spool_write_fails_reports_the_drop_not_a_spool() {
+        using var fx  = new Fixture(Config.Root, HttpStatusCode.Unauthorized);
+        using var tmp = new TempDir();
+        tmp.CreateFile("blocker");
+        var unwritable = new HookSpool(tmp.PathTo("blocker", "spool")); // a directory under a file
+        using var capture = ConsoleOutput.StartErrorCapture("\n");
+
+        await new ClaudeHookCommand(Config.Root, fx.Profiles, new HookClock(TimeProvider.System), Home).HandleCore(
+            fx.Client, AuthStatus.Ok, unwritable, new StringReader(
+                $$"""{"hook_event_name":"SessionEnd","session_id":"{{Sid}}","transcript_path":"/none","cwd":"/tmp"}"""));
+
+        await Assert.That(capture.GetCapturedError()).Contains("session-end dropped");
+        await Assert.That(capture.GetCapturedError()).DoesNotContain("session-end spooled");
+    }
+
     /// <summary>The drain must classify a 401 as the live post does: an entry that hits one on replay
     /// stays spooled and lands once the server accepts the credential again. Otherwise spooling at
     /// the live post only turns a visible loss into a delayed silent one.</summary>

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CursorHookCommandTests.cs
@@ -122,6 +122,27 @@ public class CursorHookCommandTests {
         await Assert.That(capture.GetCapturedError()).DoesNotContain("kcap login");
     }
 
+    /// <summary>Cursor's live post already spools any non-2xx, so the drain is where a 401 was lost:
+    /// the replay hit the same 401 and dropped the entry. It must instead stay spooled and land once
+    /// the server accepts the credential again.</summary>
+    [Test]
+    public async Task spooled_entry_that_hits_a_401_on_drain_is_replayed_once_the_server_accepts() {
+        using var rejecting = new Fixture(Config.Root, postStatus: HttpStatusCode.Unauthorized);
+        using var accepting = new Fixture(Config.Root);
+        rejecting.Spool.Append(Sid, "session-start/cursor", $$"""{"hook_event_name":"sessionStart","session_id":"{{Sid}}"}""");
+
+        await rejecting.HandleAsync($$"""{"hook_event_name":"postToolUse","session_id":"{{Sid}}","tool_name":"Glob"}""");
+        await Assert.That(rejecting.Spool.HasBacklog(Sid)).IsTrue();
+
+        await new CursorHookCommand(Config.Root, accepting.Profiles, new HookClock(accepting.Clock), Home).HandleCore(
+            accepting.Client,
+            stdin: new StringReader($$"""{"hook_event_name":"postToolUse","session_id":"{{Sid}}","tool_name":"Glob"}"""),
+            spool: rejecting.Spool);
+
+        await Assert.That(accepting.RouteOrder).Contains("session-start/cursor");
+        await Assert.That(rejecting.Spool.HasBacklog(Sid)).IsFalse();
+    }
+
     [Test]
     public async Task canonical_events_spool_on_POST_failure() {
         using var fx = new Fixture(Config.Root, postStatus: HttpStatusCode.InternalServerError);

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CursorHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CursorHookCommandTests.cs
@@ -122,9 +122,8 @@ public class CursorHookCommandTests {
         await Assert.That(capture.GetCapturedError()).DoesNotContain("kcap login");
     }
 
-    /// <summary>Cursor's live post already spools any non-2xx, so the drain is where a 401 was lost:
-    /// the replay hit the same 401 and dropped the entry. It must instead stay spooled and land once
-    /// the server accepts the credential again.</summary>
+    /// <summary>Cursor's live post spools any non-2xx, so the drain is the only place a 401 can lose an
+    /// entry: it must stay spooled and land once the server accepts the credential again.</summary>
     [Test]
     public async Task spooled_entry_that_hits_a_401_on_drain_is_replayed_once_the_server_accepts() {
         using var rejecting = new Fixture(Config.Root, postStatus: HttpStatusCode.Unauthorized);


### PR DESCRIPTION
Closes #510 — AI-1836

## What & why

Every hook path classed an HTTP 401 with the payload-rejecting 4xxs, so the lifecycle event that hit a rejected credential was dropped and `kcap login` could never recover it: a lost session-start left the session with no server-side record, a lost session-end left it stuck "Active". A 401 is retryable alongside 5xx, 408 and 429, at the live post and in every drain, through one shared helper (`HookSpool.IsRetryable`). Retention while the lapse lasts is the spool's existing byte cap and 30-day reap.

## Where to look

Cursor's live post already spooled any non-2xx, so its 401'd entries were being dropped by the next drain — the case that shows why the live post and the drain must share one rule. A server 401 on the vendor path yields `Spooled`, not `Failed`, so the hook exits 0 as Claude's does, and the stderr line still names `kcap login`.

## Verification

New tests, each watched fail before the fix: the status table, the Core drain keeping a 401'd backlog without marking the session ended, the vendor poster spooling on 401, Claude's three bounded arms spooling on 401, and Claude's and Cursor's drains replaying a 401'd entry once the server accepts. Each has a 400 control that still drops.

| Check | Result |
|---|---|
| `dotnet build Capacitor.slnx` | 0 warnings, 0 errors |
| Capacitor.Cli.Core.Tests.Unit | 2678 passed, 0 failed |
| Capacitor.Cli.Tests.Unit | 3861 passed, 0 failed |
| SpoolOutageRecoveryTests (integration) | 2 passed, 0 failed |
| `dotnet publish -c Release` | exit 0, 0 IL warnings |

🤖 Generated with [Claude Code](https://claude.com/claude-code)