### PR TITLE
Import against the server this run resolved, and relinquish on any exit

### DIFF
--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -1444,9 +1444,9 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
 
     /// <summary>
     /// The profile the import lane runs under. <see cref="ImportCommand"/> reads its base URL from the
-    /// context it is handed, and <c>profiles</c> is the snapshot resolved before Step 1 — on a first run
-    /// that names no server at all, and the one this run chose is not persisted until after this leg
-    /// returns.
+    /// context it is handed, and <c>profiles</c> is resolved at process start, before setup has asked
+    /// for a server — on a first run it names none at all, and the one this run chose is not persisted
+    /// until after this leg returns.
     /// </summary>
     internal static ProfileContext ImportContext(ProfileContext profiles, string serverUrl) =>
         new(profiles.Resolution with { ServerUrl = serverUrl }, profiles.Snapshot);

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -1442,6 +1442,15 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
     /// same as "not found" and draws no alarm on the screen.</summary>
     static readonly TimeSpan LoginShellProbeBudget = TimeSpan.FromSeconds(12);
 
+    /// <summary>
+    /// The profile the import lane runs under. <see cref="ImportCommand"/> reads its base URL from the
+    /// context it is handed, and <c>profiles</c> is the snapshot resolved before Step 1 — on a first run
+    /// that names no server at all, and the one this run chose is not persisted until after this leg
+    /// returns.
+    /// </summary>
+    internal static ProfileContext ImportContext(ProfileContext profiles, string serverUrl) =>
+        new(profiles.Resolution with { ServerUrl = serverUrl }, profiles.Snapshot);
+
     /// <summary>Creates the first-run flow, opens the browser on it, and polls it as itself, returning
     /// the Agents decision for Step 4 to apply. <b>Nothing is configured here</b> — what crosses is
     /// vendor keys and booleans, and the install runs through the same one place the terminal prompt
@@ -1490,7 +1499,7 @@ public sealed class SetupCommand(ConfigRoot config, ProfileContext profiles, IBr
                     config, HarnessRegistry.FromEnvironment(home),
                     Environment.MachineName, await LoginShellFindsCliAsync());
 
-                importing = new SetupImportLane(config, profiles, home, _paths);
+                importing = new SetupImportLane(config, ImportContext(profiles, serverUrl), home, _paths);
 
                 using var progress = new SpectreFirstRunFlowProgress();
 

--- a/src/Capacitor.Cli/InteractiveLifetime.cs
+++ b/src/Capacitor.Cli/InteractiveLifetime.cs
@@ -38,7 +38,7 @@ static class InteractiveLifetime {
     // What an interrupt may spend telling a server the machine has gone. A whole second of an exit
     // the user has already asked for is as much as this is worth: one small POST to a host we are
     // mid-conversation with either lands well inside it or is not going to.
-    static readonly TimeSpan ExitNoticeBudget = TimeSpan.FromSeconds(1);
+    internal static readonly TimeSpan ExitNoticeBudget = TimeSpan.FromSeconds(1);
 
     // PosixSignalRegistration.Create returns an IDisposable that owns the
     // underlying handler slot; if it isn't rooted for the process lifetime the

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -7,6 +7,7 @@ using Capacitor.Cli.Commands.Harness;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.FirstRun;
 using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Core.Telemetry;
 using Capacitor.Cli.Harness.Claude;
@@ -149,6 +150,12 @@ var telemetrySuppressed = CliTelemetry.ConsumeSpawnMarker(
 CliTelemetry.Initialize(command, baseUrl, loggedIn, config, telemetrySuppressed);
 
 AppDomain.CurrentDomain.ProcessExit += (_, _) => {
+    // Environment.Exit runs no `finally` and no `using` disposal, so a leg that ends that way has no
+    // other chance to tell a waiting browser it has stopped. Ahead of the telemetry flush because both
+    // spend the runtime's one exit budget and only this one is holding a page open; the notice claims
+    // once, so a leg that already sent stays silent and a process with none armed is a no-op.
+    FirstRunInterruptRelinquish.RunBeforeExit(InteractiveLifetime.ExitNoticeBudget);
+
     CliTelemetry.RecordCommand(command, args, Environment.ExitCode, CommandTiming.ElapsedMs(commandStart));
     CliTelemetry.FlushAndClose().GetAwaiter().GetResult();
 };

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneConstructionGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneConstructionGuardTests.cs
@@ -5,10 +5,10 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 
 /// <summary>
 /// <see cref="SetupImportLane"/> imports through <c>ImportCommand</c>, which takes its base URL from
-/// the <c>ProfileContext</c> it is handed and from nowhere else. The browser leg's own context is the
-/// snapshot resolved before Step 1, so on a first run it names no server — and <c>setup</c> is exempt
-/// from the entry gate that refuses an unconfigured command, so an unusable URL is caught by nothing
-/// until it reaches the client factory.
+/// the <c>ProfileContext</c> it is handed and from nowhere else. The browser leg's own context is
+/// resolved at process start, before setup has asked for a server, so on a first run it names none —
+/// and <c>setup</c> is exempt from the entry gate that refuses an unconfigured command, so an unusable
+/// URL is caught by nothing until it reaches the client factory.
 ///
 /// <para>A guard rather than a unit test because the defect is in WHICH context the call site passes,
 /// and the call site sits inside an authenticated leg that a unit test cannot reach. Pinning

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneConstructionGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneConstructionGuardTests.cs
@@ -1,0 +1,44 @@
+using System.Runtime.CompilerServices;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>
+/// <see cref="SetupImportLane"/> imports through <c>ImportCommand</c>, which takes its base URL from
+/// the <c>ProfileContext</c> it is handed and from nowhere else. The browser leg's own context is the
+/// snapshot resolved before Step 1, so on a first run it names no server — and <c>setup</c> is exempt
+/// from the entry gate that refuses an unconfigured command, so an unusable URL is caught by nothing
+/// until it reaches the client factory.
+///
+/// <para>A guard rather than a unit test because the defect is in WHICH context the call site passes,
+/// and the call site sits inside an authenticated leg that a unit test cannot reach. Pinning
+/// <see cref="SetupCommand.ImportContext"/> alone would pass with nothing calling it.</para>
+/// </summary>
+public class SetupImportLaneConstructionGuardTests {
+    /// <summary>Walks up from this file to the repo-root marker, so the test runner's working
+    /// directory is irrelevant.</summary>
+    static string RepoRoot([CallerFilePath] string here = "") {
+        var dir = Path.GetDirectoryName(here);
+        while (dir is not null && !File.Exists(Path.Combine(dir, "Capacitor.slnx")))
+            dir = Path.GetDirectoryName(dir);
+
+        return dir ?? throw new InvalidOperationException($"Could not locate repo root walking up from {here}");
+    }
+
+    [Test]
+    public async Task Every_construction_of_the_lane_names_the_server_this_run_resolved() {
+        var sites = Directory
+            .EnumerateFiles(Path.Combine(RepoRoot(), "src"), "*.cs", SearchOption.AllDirectories)
+            .SelectMany(f => File.ReadAllLines(f).Select((line, i) => (File: Path.GetFileName(f), No: i + 1, line)))
+            .Where(l => l.line.Contains("new SetupImportLane(", StringComparison.Ordinal))
+            .ToList();
+
+        await Assert.That(sites).IsNotEmpty()
+                    .Because("a rename that empties this scan would make the guard pass for the wrong reason");
+
+        foreach (var site in sites) {
+            await Assert.That(site.line).Contains("ImportContext(")
+                        .Because($"{site.File}:{site.No} hands the lane a context that need not name a server");
+        }
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneTests.cs
@@ -417,9 +417,9 @@ public class SetupImportLaneTests {
 
     /// <summary>
     /// The lane imports through <see cref="ImportCommand"/>, which takes its base URL from the context
-    /// it is handed — so the one this run resolved has to reach it. The leg's own context is the
-    /// snapshot from before Step 1, and on a first run that names no server at all: `setup` is exempt
-    /// from the entry gate that refuses an unconfigured command, so nothing downstream would catch it.
+    /// it is handed — so the one this run resolved has to reach it. The leg's own context is resolved at
+    /// process start, before setup has asked for a server, and on a first run it names none: `setup` is
+    /// exempt from the entry gate that refuses an unconfigured command, so nothing downstream catches it.
     /// </summary>
     [Test]
     public async Task The_import_context_names_the_server_this_run_resolved() {

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupImportLaneTests.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.FirstRun;
 using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Harness.Claude;
@@ -412,5 +413,34 @@ public class SetupImportLaneTests {
             CancellationToken.None);
 
         await Assert.That(totals).IsNotNull();
+    }
+
+    /// <summary>
+    /// The lane imports through <see cref="ImportCommand"/>, which takes its base URL from the context
+    /// it is handed — so the one this run resolved has to reach it. The leg's own context is the
+    /// snapshot from before Step 1, and on a first run that names no server at all: `setup` is exempt
+    /// from the entry gate that refuses an unconfigured command, so nothing downstream would catch it.
+    /// </summary>
+    [Test]
+    public async Task The_import_context_names_the_server_this_run_resolved() {
+        var beforeSetup = new ProfileContext(new(null, "default", null, null), new ProfileConfig());
+
+        var forImport = SetupCommand.ImportContext(beforeSetup, "https://tenant.kcap.ai");
+
+        await Assert.That(forImport.Resolution.ServerUrl).IsEqualTo("https://tenant.kcap.ai");
+    }
+
+    /// <summary>Only the server moves: the profile the run is configuring still decides everything the
+    /// import reads off it, visibility included.</summary>
+    [Test]
+    public async Task The_import_context_keeps_the_rest_of_the_resolution() {
+        var profile     = new Profile { ServerUrl = "https://stale.kcap.ai", DefaultVisibility = "org_public" };
+        var beforeSetup = new ProfileContext(new("https://stale.kcap.ai", "work", profile, null), new ProfileConfig());
+
+        var forImport = SetupCommand.ImportContext(beforeSetup, "https://tenant.kcap.ai");
+
+        await Assert.That(forImport.Resolution.ProfileName).IsEqualTo("work");
+        await Assert.That(forImport.Resolution.Profile).IsSameReferenceAs(profile);
+        await Assert.That(forImport.Snapshot).IsSameReferenceAs(beforeSetup.Snapshot);
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/FirstRunExitNoticeGuardTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/FirstRunExitNoticeGuardTests.cs
@@ -1,0 +1,39 @@
+using System.Runtime.CompilerServices;
+using System.Text.RegularExpressions;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// A leg waiting on the browser owes it a relinquish, and <c>Environment.Exit</c> pays nothing on the
+/// way out: no <c>finally</c>, no <c>using</c> disposal, no <c>catch</c>. The signal handlers reach the
+/// notice themselves; every other exit reaches it only through <c>AppDomain.ProcessExit</c>, which
+/// <c>Environment.Exit</c> does raise.
+///
+/// <para>Pinned as a guard because the failure is silent and remote — the process ends cleanly, the
+/// terminal looks finished, and what breaks is a page on another machine that never stops waiting.
+/// Nothing in the CLI's own output would show it.</para>
+/// </summary>
+public class FirstRunExitNoticeGuardTests {
+    static string RepoRoot([CallerFilePath] string here = "") {
+        var dir = Path.GetDirectoryName(here);
+        while (dir is not null && !File.Exists(Path.Combine(dir, "Capacitor.slnx")))
+            dir = Path.GetDirectoryName(dir);
+
+        return dir ?? throw new InvalidOperationException($"Could not locate repo root walking up from {here}");
+    }
+
+    [Test]
+    public async Task The_process_exit_handler_sends_the_pending_relinquish() {
+        var program = await File.ReadAllTextAsync(
+            Path.Combine(RepoRoot(), "src", "Capacitor.Cli", "Program.cs"));
+
+        var handler = Regex.Match(
+            program, @"AppDomain\.CurrentDomain\.ProcessExit\s*\+=.*?\n\};", RegexOptions.Singleline);
+
+        await Assert.That(handler.Success).IsTrue()
+                    .Because("no ProcessExit handler means no exit path reaches the notice at all");
+
+        await Assert.That(handler.Value).Contains("FirstRunInterruptRelinquish.RunBeforeExit")
+                    .Because("an Environment.Exit anywhere in the CLI otherwise leaves the browser waiting");
+    }
+}


### PR DESCRIPTION
AI-2482, AI-2483 — no GitHub issue; both were found in-house and filed in Linear only.

## What & why

`kcap setup`'s browser leg imports nothing on a first run, and then ends the process without telling the browser, which holds its step until the flow's twelve-hour lifetime expires.

The lane is handed `profiles`, the context resolved before Step 1, and `ImportCommand` reads its base URL from whatever context it gets. On a first run that names no server, and `setup` is one of the commands exempt from the entry gate that refuses an unconfigured command — so nothing between the two catches it. It now gets a context carrying the URL this run resolved, which is what the flow client one call earlier already used.

The empty URL then reaches `EnsureAbsolute`, which under `FailFast` writes a hint and calls `Environment.Exit(2)`. That runs no `finally` and disposes nothing, so the relinquish notice the leg armed is never sent. `Environment.Exit` does raise `AppDomain.ProcessExit`, and this file already leans on that to flush telemetry, so the notice now goes out from there too — covering every `Environment.Exit` in the CLI, not just this one.

## Where to look

The notice is claimed once, so a leg that settled normally sends nothing on the way out and a process with none armed is a no-op. It goes ahead of the telemetry flush because both spend the runtime's single exit budget and only one of them is holding a page open.

Making the exit itself catchable is the wider change, tracked separately as AI-2486; it needs an audit of every broad `catch` on a request path and is deliberately not here.

## Verification

Reproduced the exit in the devcontainer with a schemeless `KCAP_URL`, matching the reported run on all three counts:

```
server_url is missing a scheme. Run: kcap config set server_url https://<host>
exit=2
crash log: none
```

Both guards were confirmed to fail without their fix:

| Guard | Without the fix |
| --- | --- |
| `SetupImportLaneConstructionGuardTests` | `SetupCommand.cs:1502 hands the lane a context that need not name a server` |
| `FirstRunExitNoticeGuardTests` | `Expected to contain "FirstRunInterruptRelinquish.RunBeforeExit"` |

`Capacitor.Cli.Tests.Unit` 3984 and `Capacitor.Cli.Core.Tests.Unit` 2953, 0 failed. `dotnet publish -c Release` clean of IL2026/IL3050.
