### PR TITLE
Polish the desktop app launcher, sign-in, chat tools, and workspace chrome

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ riderModule.iml
 .worktrees/
 logs/
 .publish/
+.dev/
 **/.DS_Store
 .superpowers/
 **/data/capacitor.db

--- a/src/Capacitor.App/App.axaml
+++ b/src/Capacitor.App/App.axaml
@@ -1,21 +1,28 @@
 <Application xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              x:Class="Capacitor.App.App"
-             RequestedThemeVariant="Default">
+             RequestedThemeVariant="Dark">
     <Application.Resources>
         <!-- The Home surface's design palette. Kcap-prefixed keys so these never
              shadow a FluentTheme resource of the same short name — MainWindow's existing controls
-             stay on FluentTheme defaults untouched. -->
+             stay on FluentTheme defaults untouched. ThemeVariant is Dark because every Kcap*
+             brush is a dark-canvas token: Fluent's light ButtonBackgroundPointerOver would paint
+             a near-white fill under our light Foreground and the control vanishes on hover. -->
         <ResourceDictionary>
             <SolidColorBrush x:Key="KcapCanvasBrush" Color="#0B0D12" />
             <SolidColorBrush x:Key="KcapSurfaceBrush" Color="#12151D" />
             <SolidColorBrush x:Key="KcapSurfaceRaisedBrush" Color="#191D27" />
             <SolidColorBrush x:Key="KcapBorderBrush" Color="#2A3040" />
             <SolidColorBrush x:Key="KcapTextBrush" Color="#F1F3F7" />
-            <SolidColorBrush x:Key="KcapMutedBrush" Color="#9299AA" />
-            <SolidColorBrush x:Key="KcapFaintBrush" Color="#6F7687" />
-            <SolidColorBrush x:Key="KcapAccentBrush" Color="#5BE0B3" />
-            <SolidColorBrush x:Key="KcapAccentDimBrush" Color="#173F36" />
+            <!-- Secondary / tertiary body text: both clear AA (≥4.5:1) on Canvas→Border.
+                 Faint was #6F7687 (~3.7:1 on Raised) — too dim for real copy. -->
+            <SolidColorBrush x:Key="KcapMutedBrush" Color="#B0B7C6" />
+            <SolidColorBrush x:Key="KcapFaintBrush" Color="#949BAA" />
+            <!-- Primary CTAs: near-white fill. Green (KcapSuccess*) is status/selection only. -->
+            <SolidColorBrush x:Key="KcapPrimaryBrush" Color="#F1F3F7" />
+            <SolidColorBrush x:Key="KcapOnPrimaryBrush" Color="#0B0D12" />
+            <SolidColorBrush x:Key="KcapSuccessBrush" Color="#5BE0B3" />
+            <SolidColorBrush x:Key="KcapSuccessDimBrush" Color="#173F36" />
             <SolidColorBrush x:Key="KcapWarningBrush" Color="#F4B860" />
             <SolidColorBrush x:Key="KcapWarningDimBrush" Color="#45351E" />
             <SolidColorBrush x:Key="KcapPurpleBrush" Color="#A994FF" />
@@ -26,19 +33,62 @@
     <Application.Styles>
         <FluentTheme />
         <!-- Popup panels drawn on our tokens: the flyout presenter IS the panel (no inner Border
-             fighting the theme's own chrome). Opted into per flyout via FlyoutPresenterClasses. -->
+             fighting the theme's own chrome). Opted into per flyout via FlyoutPresenterClasses.
+             Fluent's ControlTheme defaults ScrollViewer.HorizontalScrollBarVisibility=Auto on the
+             presenter's OWN ScrollViewer — that is the horizontal bar on Activity, not the inner
+             one. Content that needs to scroll owns its own ScrollViewer. -->
         <Style Selector="FlyoutPresenter.kcapPanel">
             <Setter Property="Background" Value="{StaticResource KcapSurfaceBrush}" />
             <Setter Property="BorderBrush" Value="{StaticResource KcapBorderBrush}" />
             <Setter Property="BorderThickness" Value="1" />
             <Setter Property="CornerRadius" Value="12" />
             <Setter Property="Padding" Value="0" />
+            <Setter Property="MaxWidth" Value="10000" />
+            <Setter Property="MaxHeight" Value="10000" />
+            <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+            <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
         </Style>
         <!-- A TextBox inside one of our cards: the card is its boundary, so the theme's focused
-             ring and fill would read as a second box. -->
+             ring and fill would read as a second box. Fluent's default placeholder follows the
+             system theme and goes near-black on our dark surfaces — pin a readable muted tone. -->
+        <Style Selector="TextBox.kcapEmbedded">
+            <Setter Property="PlaceholderForeground" Value="{StaticResource KcapMutedBrush}" />
+        </Style>
         <Style Selector="TextBox.kcapEmbedded:focus /template/ Border#PART_BorderElement, TextBox.kcapEmbedded:pointerover /template/ Border#PART_BorderElement">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderThickness" Value="0" />
+        </Style>
+        <!-- Fluent paints hover/pressed on PART_ContentPresenter, not the Button.Background local
+             value — so a chip that sets its own fill still gets a theme fill that clashes with
+             KcapTextBrush. These classes pin the template chrome to our tokens (same footgun
+             HomeView.sessionCard / SessionRail.railRow already call out). -->
+        <Style Selector="Button.kcapChip:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.kcapChip:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapBorderBrush}" />
+            <Setter Property="BorderBrush" Value="{StaticResource KcapBorderBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+        </Style>
+        <Style Selector="Button.kcapPrimary">
+            <Setter Property="Background" Value="{StaticResource KcapPrimaryBrush}" />
+            <Setter Property="BorderBrush" Value="{StaticResource KcapPrimaryBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapOnPrimaryBrush}" />
+        </Style>
+        <Style Selector="Button.kcapPrimary:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.kcapPrimary:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapPrimaryBrush}" />
+            <Setter Property="BorderBrush" Value="{StaticResource KcapPrimaryBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapOnPrimaryBrush}" />
+        </Style>
+        <Style Selector="Button.kcapPrimary:disabled /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapBorderBrush}" />
+            <Setter Property="BorderBrush" Value="{StaticResource KcapBorderBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapFaintBrush}" />
+        </Style>
+        <Style Selector="Button.kcapGhost:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.kcapGhost:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
         </Style>
     </Application.Styles>
 </Application>

--- a/src/Capacitor.App/App.axaml
+++ b/src/Capacitor.App/App.axaml
@@ -90,5 +90,21 @@
             <Setter Property="BorderBrush" Value="Transparent" />
             <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
         </Style>
+        <!-- Live tool-call status: a soft pulse so an in-flight row is never a blank gap. -->
+        <Style Selector="Border.toolRunning">
+            <Style.Animations>
+                <Animation Duration="0:0:1.1" IterationCount="Infinite">
+                    <KeyFrame Cue="0%">
+                        <Setter Property="Opacity" Value="0.35" />
+                    </KeyFrame>
+                    <KeyFrame Cue="50%">
+                        <Setter Property="Opacity" Value="1" />
+                    </KeyFrame>
+                    <KeyFrame Cue="100%">
+                        <Setter Property="Opacity" Value="0.35" />
+                    </KeyFrame>
+                </Animation>
+            </Style.Animations>
+        </Style>
     </Application.Styles>
 </Application>

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -346,7 +346,8 @@ public partial class App : Application {
                 lifecycleStatus, launch, _navigation, _workspaceTeardown.Track, BuildWorkspace,
                 // The tenant slug the rail footer shows — profiles are named after it at sign-in.
                 tenantName: profiles?.Resolution?.ProfileName, agentsWithPending: permissions.AgentsWithPending,
-                requestSignIn: requestSignIn),
+                requestSignIn: requestSignIn,
+                lifecycleAttention: lifecycleAttention),
             // Both close paths release the workspace: hide-to-tray keeps the window (and its
             // attach) alive, a real close discards the window the next Show() would rebuild.
             releaseWorkspace: window => (window.DataContext as MainWindowViewModel)?.CloseWorkspace());
@@ -718,7 +719,8 @@ public partial class App : Application {
             IObservable<string?>? lifecycleStatus = null, ILaunchClient? launch = null,
             NavigationGate? navigation = null, Action<Func<Task>>? trackWorkspaceTeardown = null,
             Func<string, WorkspaceViewModel>? workspaceFactory = null, string? tenantName = null,
-            IObservable<IReadOnlySet<string>>? agentsWithPending = null, Action? requestSignIn = null) {
+            IObservable<IReadOnlySet<string>>? agentsWithPending = null, Action? requestSignIn = null,
+            IObservable<string?>? lifecycleAttention = null) {
         // Notifier is set on the WINDOW (spec §11 toast overlay), not the ViewModel — the toast
         // is a View-level concern (WindowNotificationManager lives on MainWindow) independent of
         // the VM's WhenActivated-scoped projections.
@@ -750,7 +752,7 @@ public partial class App : Application {
         vm = new MainWindowViewModel(
             service, shutdownToken, activity, startAction, lifecycleStatus, home: home,
             navigation: navigation, trackWorkspaceTeardown: trackWorkspaceTeardown, workspaceFactory: workspaceFactory,
-            rail: rail, tenantName: tenantName);
+            rail: rail, tenantName: tenantName, lifecycleAttention: lifecycleAttention);
         var window = new MainWindow {
             DataContext = vm,
             Notifier = notifier,

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -1039,6 +1039,12 @@ public partial class App : Application {
         "stale_txn_marker"
             => "A previous daemon setup didn't finish. Press Start daemon to try again.",
 
+        "running_without_daemon_pid"
+            => "The daemon service is loaded but no process is attached. Press Start daemon to repair.",
+
+        "daemon_running_outside_service"
+            => "A daemon is running outside the service. Press Start daemon to repair.",
+
         "ownership_mismatch" or "ownership_unknown" or "instance_pid_mismatch"
             or "instance_changed_during_classification" or "unreachable_with_recorded_owner"
             => "Another daemon may already be running for this name. Stop it, then press Start daemon.",

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -386,7 +386,7 @@ public partial class App : Application {
         // Reachable in the carve-out arm (gate Incomplete after an abandoned wizard), where the
         // rail can show disconnected with no server to re-auth against.
         if (profiles?.Resolution.ServerUrl is not { } serverUrl || !OnboardingGate.ValidServerUrl(serverUrl)) {
-            notifier.Notify("No server is configured — run kcap setup first.");
+            notifier.Notify("No server is configured. Run kcap setup first.");
             return;
         }
 
@@ -399,10 +399,11 @@ public partial class App : Application {
             WizardComposition.NewOperation);
         var window = new SignInWindow { DataContext = graph.SignIn };
 
-        // A committed sign-in closes the dialog itself; Closed below is the ONE finish path, so
-        // both the auto-close and the user's own close cancel/quiesce identically.
+        // Hold the dialog on success so "Signed in…" is readable, refresh app state in parallel,
+        // then close. Closed below is still the ONE finish path for cancel/quiesce.
         void OnSignInChanged(object? _, PropertyChangedEventArgs e) {
-            if (e.PropertyName == nameof(SignInStepViewModel.Satisfied) && graph.SignIn.Satisfied) window.Close();
+            if (e.PropertyName == nameof(SignInStepViewModel.Satisfied) && graph.SignIn.Satisfied)
+                _ = CloseSignInAfterSuccessAsync(window);
         }
 
         graph.SignIn.PropertyChanged += OnSignInChanged;
@@ -416,15 +417,37 @@ public partial class App : Application {
         window.Show();
     }
 
+    /// How long a successful re-auth keeps the dialog open so the success line is not a flash.
+    internal static readonly TimeSpan SignInSuccessHold = TimeSpan.FromMilliseconds(1600);
+
+    async Task CloseSignInAfterSuccessAsync(Window window) {
+        var refresh = RefreshAfterReauthAsync();
+        try {
+            await Task.WhenAll(refresh, Task.Delay(SignInSuccessHold)).ConfigureAwait(true);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: post-sign-in refresh failed: {ex.Message}");
+        }
+
+        if (ReferenceEquals(_signInWindow, window)) window.Close();
+    }
+
+    /// Clears the launcher's expired/disconnected sign-in banner path, drops a stale launch hub,
+    /// nudges work-context refresh, and kicks attach so snapshots catch up sooner after new tokens land.
+    async Task RefreshAfterReauthAsync() {
+        _home?.NotifySignInCompleted();
+        _serverClients?.NotifySignInCompleted();
+        if (_launch is not null) await _launch.InvalidateAsync().ConfigureAwait(true);
+        if (_service is not null) await _service.RestartLoopAsync().ConfigureAwait(true);
+    }
+
     /// Fire-and-forget from the dialog's Closed handler — nothing may block the UI close. The
     /// quiesce is what stops a still-running attempt from committing after the window is gone.
     async Task FinishSignInAsync(ReauthGraph graph) {
         try {
             await graph.CloseAsync(CancellationToken.None);
-            if (graph.SignIn.Satisfied) {
-                _home?.NotifySignInCompleted();
-                _serverClients?.NotifySignInCompleted();
-            }
+            // Success path already refreshed before close; call again so a manual close after
+            // Satisfied still clears the banner if the hold was interrupted.
+            if (graph.SignIn.Satisfied) await RefreshAfterReauthAsync();
         } catch (Exception ex) {
             Console.Error.WriteLine($"kcap: sign-in dialog teardown failed: {ex.Message}");
         }

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -101,6 +101,7 @@ public partial class App : Application {
     // holder on both teardown paths, after _home — never before, or a launch still in flight would
     // lose its transport mid-invoke.
     ServerClients? _serverClients;
+    ServerLaunchClient? _launch;
     TrayViewModel? _trayVm;
     TrayIconManager? _tray;
     // No disposal needed — RefCount tears its Interval down with its last subscriber, and every
@@ -329,6 +330,7 @@ public partial class App : Application {
         var launch = new ServerLaunchClient(_config, profiles);
         var workContext = new ServerWorkContextSource(_config, profiles);
         var serverClients = new ServerClients(launch, workContext);
+        _launch = launch;
         _serverClients = serverClients;
 
         // One attach client per attempt, dialed at the daemon's own control socket; 80x24 is a

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -990,14 +990,22 @@ public partial class App : Application {
                 break;
             }
             case RecoverySurface.Reinstall:
-                surface.Attention($"kcap needs to be reinstalled to continue ({named}).");
+                // Token stays in the log for support; the banner names the action, not the wire code.
+                Console.Error.WriteLine($"kcap: daemon package inconsistent ({named}) — reinstall needed");
+                surface.Attention("This kcap install looks broken. Reinstall kcap, then try again.");
                 markPresented?.Invoke();
                 break;
             case RecoverySurface.Attention:
-            case RecoverySurface.Storage:
-                surface.Attention($"A daemon mutation needs attention ({named}).");
+            case RecoverySurface.Storage: {
+                if (AttentionCopyFor(named) is { } copy) {
+                    surface.Attention(copy);
+                } else {
+                    // Opaque tokens are for the log — a bare "needs attention (token)" banner helps nobody.
+                    Console.Error.WriteLine($"kcap: daemon mutation needs attention ({named}) — not shown in the UI");
+                }
                 markPresented?.Invoke();
                 break;
+            }
         }
     }
 
@@ -1008,6 +1016,37 @@ public partial class App : Application {
         MutationVerb.StartVerified => "verified start",
         MutationVerb.DetachedStart => "daemon start",
         _                          => verb.ToString(),
+    };
+
+    /// User-facing line for Attention/Storage outcomes. Null means log-only — never surface a
+    /// machine token the operator cannot act on.
+    internal static string? AttentionCopyFor(string token) => token switch {
+        "cli_not_found"            => "kcap CLI not found. Can't manage the daemon from this app.",
+        // App↔CLI floor — never "for the daemon"; this gate runs before any daemon contact.
+        "cli_below_floor"          => "This kcap is too old for this app. Update kcap, then press Start daemon.",
+        "no_server_configured"     => "No server is configured. Sign in or run setup first.",
+        "consent_seed_unwritable"  => "Couldn't write consent data. Check permissions on the kcap config directory.",
+        "internal_error"           => "Couldn't finish daemon setup. Press Start daemon to try again.",
+
+        "verify_viability" or "verify_hello_validation" or "verify_start_gate" or "verify_start_gate_drift"
+            or "daemon_start_gate"
+            => "The daemon didn't come up cleanly. Press Start daemon to try again.",
+
+        "verify_readiness_timeout" or "verify_contended" or "verify_rollback_budget"
+            or "verify_restore_verification" or "verify_stop_unconfirmed" or "verify_bootout_unknown"
+            => "Daemon setup didn't finish in time. Press Start daemon to try again.",
+
+        "stale_txn_marker"
+            => "A previous daemon setup didn't finish. Press Start daemon to try again.",
+
+        "ownership_mismatch" or "ownership_unknown" or "instance_pid_mismatch"
+            or "instance_changed_during_classification" or "unreachable_with_recorded_owner"
+            => "Another daemon may already be running for this name. Stop it, then press Start daemon.",
+
+        "server_or_name_mismatch" or "identity_inconsistent"
+            => "This daemon doesn't match the configured server or name. Check setup, then press Start daemon.",
+
+        _ => null,
     };
 
     // spec §10 invariant: only these AttentionSkew tokens route to Takeover; every other AttentionSkew/AttentionRepair stays Attention.

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -640,33 +640,37 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
             var lct = linked.Token;
 
             if (_cli.CliPath is null) {
-                _surface.Status("kcap CLI not found — can't start the daemon service.");
+                _surface.Status("kcap CLI not found. Can't start the daemon service.");
                 return;
             }
 
-            if (!await TryAcquireGateAsync(lct).ConfigureAwait(false)) return;
+            if (!await TryAcquireGateAsync(lct).ConfigureAwait(false)) {
+                _surface.Status("Couldn't start the daemon. Try again.");
+                return;
+            }
             try {
                 // Fresh evidence every call — a Start racing an in-flight mutation blocks on the
                 // gate above and, once it clears, re-queries rather than acting on anything it
                 // might have observed before the wait.
                 var snap = await QueryStatusForActionAsync(lct).ConfigureAwait(false);
-                if (snap is null) return; // unknown — already surfaced, no action (spec §6)
+                if (snap is null) return; // unknown — already surfaced, no action
 
                 var state = ServiceStateClassifier.Parse(snap.State);
                 if (state == ServiceState.Unknown) {
-                    _surface.Status("Daemon service reported an unrecognized state — skipping this action.");
+                    _surface.Status("Daemon service reported an unrecognized state. Skipping this action.");
                     Console.Error.WriteLine($"kcap: daemon lifecycle start action saw an unrecognized service state: {snap.State}");
                     return;
                 }
 
                 if (state == ServiceState.Running) {
+                    _surface.Status("Daemon service is already running. Reconnecting…");
                     _ = _client.RestartLoopAsync();
                     return;
                 }
 
                 if (state == ServiceState.Installed) {
                     if (snap.UnitPresent && snap.DaemonPid is null)
-                        await RunLaneMutationAsync(MutationVerb.StartVerified, lct).ConfigureAwait(false);
+                        await ReportStartMutationAsync(MutationVerb.StartVerified, lct).ConfigureAwait(false);
                     else
                         await OfferRepairAsync(snap, lct).ConfigureAwait(false); // orphan label or coexistence
                     return;
@@ -675,13 +679,13 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
                 // state == ServiceState.NotInstalled: no loaded label.
                 if (snap.UnitPresent) {
                     if (snap.DaemonPid is null)
-                        await RunLaneMutationAsync(MutationVerb.StartVerified, lct).ConfigureAwait(false); // bootstrap the stopped unit
+                        await ReportStartMutationAsync(MutationVerb.StartVerified, lct).ConfigureAwait(false); // bootstrap the stopped unit
                     else
                         await OfferRepairAsync(snap, lct).ConfigureAwait(false); // a manual daemon owns the name
                     return;
                 }
 
-                await RunLaneMutationAsync(MutationVerb.DetachedStart, lct).ConfigureAwait(false); // nothing at all — no unit to rewrite
+                await ReportStartMutationAsync(MutationVerb.DetachedStart, lct).ConfigureAwait(false); // nothing at all — no unit to rewrite
             } finally {
                 _gate.Release();
             }
@@ -691,6 +695,16 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
             _surface.Status("Starting the daemon failed unexpectedly.");
             Console.Error.WriteLine($"kcap: daemon lifecycle start action failed unexpectedly: {ex.Message}");
         }
+    }
+
+    /// Start-click feedback after a lane mutation: success and failure both write Status so the
+    /// launcher banner is never left on a mute "Starting…" with no follow-up. Failure detail may
+    /// also arrive later via Attention (outcome consumer); that overwrites this one-liner.
+    async Task ReportStartMutationAsync(MutationVerb verb, CancellationToken ct) {
+        var ok = await RunLaneMutationAsync(verb, ct).ConfigureAwait(false);
+        _surface.Status(ok
+            ? "Daemon start requested. Waiting to connect…"
+            : "Daemon start did not finish. Press Retry.");
     }
 
     /// §4.4 repair affordance: the SAME dialoged operation as skew's takeover

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -49,6 +49,11 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     internal const string TakeoverDisclosure =
         "This replaces the existing daemon service and re-captures its settings; a failed replacement leaves it uninstalled rather than restored.";
 
+    /// Status when Start finds a live service and only kicks reattach. MainWindow replaces this
+    /// (and its own Retry reconnect copy) if attach lands Unreachable again.
+    internal const string AlreadyRunningReconnectStatus =
+        "Daemon service is already running. Reconnecting…";
+
     internal static readonly TimeSpan TxnActiveRequeryDelay = TimeSpan.FromSeconds(2);
 
     readonly IDaemonClientService _client;
@@ -663,7 +668,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
                 }
 
                 if (state == ServiceState.Running) {
-                    _surface.Status("Daemon service is already running. Reconnecting…");
+                    _surface.Status(AlreadyRunningReconnectStatus);
                     _ = _client.RestartLoopAsync();
                     return;
                 }

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -365,7 +365,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
 
     void AttentionCoexistence(int daemonPid) =>
         _surface.Attention(
-            $"A daemon is already running (pid {daemonPid}) alongside the installed service — not starting a second one.");
+            $"A daemon is already running (PID {daemonPid}) alongside the installed service — not starting a second one.");
 
     /// §4.1 preconditions, install-only — start performs no viability check (spec §3.4), so this
     /// is never called on a start row. Returns the honest line to surface on failure, or null
@@ -572,7 +572,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         if (attached) {
             if (snap.JobPid is not null && snap.DaemonPid is not null && snap.JobPid != snap.DaemonPid)
                 _surface.Attention(
-                    $"The daemon service job (pid {snap.JobPid}) does not match the attached daemon (pid {snap.DaemonPid}).");
+                    $"The daemon service job (PID {snap.JobPid}) does not match the attached daemon (PID {snap.DaemonPid}).");
             else if (state == ServiceState.Running && snap.DaemonPid is null)
                 _surface.Attention("The service reports its job running, but no attached-daemon evidence backs it.");
         }
@@ -585,7 +585,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
 
         if (attached && snap.UnitPresent && state == ServiceState.NotInstalled && snap.DaemonPid is not null)
             _surface.Attention(
-                $"A daemon is running outside the installed service — the service is stopped while a manual daemon (pid {snap.DaemonPid}) owns the name.");
+                $"A daemon is running outside the installed service — the service is stopped while a manual daemon (PID {snap.DaemonPid}) owns the name.");
     }
 
     // The inline, AWAITED building block: used by RunStartupBranchAsync, which already holds the

--- a/src/Capacitor.App/Services/HostedHarnessCatalog.cs
+++ b/src/Capacitor.App/Services/HostedHarnessCatalog.cs
@@ -83,10 +83,10 @@ public static class HostedHarnessCatalog {
         ModelChoices.TryGetValue(vendor, out var models) ? models : [];
 
     /// Chip wording for a model selection: the curated label when known, the raw slug otherwise,
-    /// "default" for the "" sentinel.
+    /// "Default" for the "" sentinel (same word the effort/agent pickers use for "harness chooses").
     public static string ModelLabelFor(string vendor, string model) =>
         string.IsNullOrWhiteSpace(model)
-            ? "default"
+            ? EffortDefaultLabel
             : ModelChoicesFor(vendor).FirstOrDefault(m => string.Equals(m.Slug, model, StringComparison.OrdinalIgnoreCase))?.Label ?? model;
 
     /// The effort ladder the daemon passes through verbatim (codex maps max→xhigh itself); the
@@ -94,6 +94,23 @@ public static class HostedHarnessCatalog {
     /// beside the model catalog so the launch vocabularies have one authority.
     public static readonly IReadOnlyList<string> EffortLadder = ["low", "medium", "high", "xhigh"];
 
+    /// Shared chip/flyout word for "omit from the wire — let the harness decide". Not "Auto":
+    /// that label is Claude's permission mode, a different control.
+    public const string EffortDefaultLabel = "Default";
+
+    /// Sentence-case display for an effort wire token; unknown tokens pass through unchanged.
+    public static string EffortLabelFor(string? token) => token switch {
+        null or "" => EffortDefaultLabel,
+        "low"      => "Low",
+        "medium"   => "Medium",
+        "high"     => "High",
+        "xhigh"    => "Max",
+        _          => token,
+    };
+
+    /// Claude permission modes, most → least prompting. Manual is the product default and is
+    /// omitted from the launch payload (same "harness default" idea as Effort's Default); the
+    /// rows below it are escalations, so the flyout keeps a separator after Manual.
     public static readonly IReadOnlyList<PermissionModeChoice> PermissionModes = [
         new(ClaudePermissionModes.Manual, "Manual"),
         new(ClaudePermissionModes.AcceptEdits, "Accept edits"),
@@ -130,7 +147,7 @@ public static class HostedHarnessCatalog {
     public static (string Glyph, string Color) TileFor(string vendor) =>
         VendorTiles.TryGetValue(vendor, out var tile)
             ? tile
-            : (vendor.Length > 0 ? vendor[..1].ToUpperInvariant() : "?", "#9299AA");
+            : (vendor.Length > 0 ? vendor[..1].ToUpperInvariant() : "?", "#B0B7C6");
 
     /// Display label for a vendor token: the option's Label when the list carries one, the raw
     /// token otherwise (before the first daemon snapshot, or a token this build has never heard

--- a/src/Capacitor.App/Services/ServerLaunchClient.cs
+++ b/src/Capacitor.App/Services/ServerLaunchClient.cs
@@ -85,6 +85,20 @@ public sealed class ServerLaunchClient(ConfigRoot config, ProfileContext? profil
     }
 
     /// Takes the gate first: disposing it out from under an in-flight launch would fault that
+    /// launch's Release. Next StartAsync rebuilds the hub so a fresh AccessTokenProvider reads
+    /// tokens written by a just-finished sign-in.
+    public async Task InvalidateAsync(CancellationToken ct = default) {
+        await _gate.WaitAsync(ct).ConfigureAwait(false);
+        try {
+            if (_hub is null) return;
+            await _hub.DisposeAsync().ConfigureAwait(false);
+            _hub = null;
+        } finally {
+            _gate.Release();
+        }
+    }
+
+    /// Takes the gate first: disposing it out from under an in-flight launch would fault that
     /// launch's Release. A launch arriving after this point fails with ObjectDisposedException,
     /// which StartAsync already turns into a failed LaunchOutcome.
     public async ValueTask DisposeAsync() {

--- a/src/Capacitor.App/ViewModels/ActivityViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ActivityViewModel.cs
@@ -8,11 +8,11 @@ using ReactiveUI;
 
 namespace Capacitor.App.ViewModels;
 
-/// One row of the decision log, projected for display (spec §7). Time is local
-/// ("yyyy-MM-dd HH:mm:ss"); an unparseable decided_at renders verbatim rather than throwing.
-/// IsAllowed drives the outcome badge color; Outcome carries the raw wire value.
+/// One row of the decision log, projected for display. Time is a short local clock for the
+/// table; TimeTip carries the full local stamp for hover. An unparseable decided_at renders
+/// verbatim in both rather than throwing. IsAllowed drives the outcome color.
 public sealed record ActivityRow(
-    string Time, string Outcome, bool IsAllowed, string Requester, string KindLabel,
+    string Time, string TimeTip, string Outcome, bool IsAllowed, string Requester, string KindLabel,
     string RepoLeaf, string RepoFull, string Vendor, string SourceLabel);
 
 /// Renders the consent decision log as the Activity tab (spec §7): pure file I/O via the injected
@@ -154,10 +154,13 @@ public sealed class ActivityViewModel : ReactiveObject, IDisposable {
         IsEmpty = _rowsSource.Count == 0;
     }
 
-    static ActivityRow ToRow(ConsentDecisionRecord r) => new(
-        FormatTime(r.DecidedAt), r.Outcome, r.Outcome == "allowed", RequesterOf(r),
-        ConsentPromptViewModel.KindLabelOf(r.Kind), RepoLabel.Leaf(r.RepoPath), r.RepoPath, r.Vendor,
-        SourceLabelOf(r.Source));
+    static ActivityRow ToRow(ConsentDecisionRecord r) {
+        var (time, tip) = FormatTime(r.DecidedAt);
+        return new(
+            time, tip, r.Outcome, r.Outcome == "allowed", RequesterOf(r),
+            ConsentPromptViewModel.KindLabelOf(r.Kind), RepoLabel.Leaf(r.RepoPath), r.RepoPath, r.Vendor,
+            SourceLabelOf(r.Source));
+    }
 
     static string RequesterOf(ConsentDecisionRecord r) =>
         !string.IsNullOrWhiteSpace(r.RequesterDisplay) ? r.RequesterDisplay
@@ -166,11 +169,14 @@ public sealed class ActivityViewModel : ReactiveObject, IDisposable {
 
     // RoundtripKind, matching ConsentService.DeadlineFor: both parse the same daemon-written ISO
     // stamps, and one parse style across the app is one behavior to reason about.
-    static string FormatTime(string decidedAt) =>
-        DateTimeOffset.TryParse(decidedAt, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed)
-            ? parsed.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture)
-            : decidedAt; // unparseable — rendered verbatim rather than thrown
-
+    static (string Display, string Tip) FormatTime(string decidedAt) {
+        if (!DateTimeOffset.TryParse(decidedAt, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out var parsed))
+            return (decidedAt, decidedAt);
+        var local = parsed.ToLocalTime();
+        return (
+            local.ToString("MMM d HH:mm", CultureInfo.InvariantCulture),
+            local.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture));
+    }
     internal static string SourceLabelOf(string source) => source switch {
         "owner"          => "owner",
         "default"        => "default policy",

--- a/src/Capacitor.App/ViewModels/ChatItems.cs
+++ b/src/Capacitor.App/ViewModels/ChatItems.cs
@@ -28,6 +28,12 @@ public sealed class ToolCallItem(string name, string detail, ToolCategory catego
     public string Detail { get; } = detail;
     public ToolCategory Category { get; } = category;
 
+    /// What the row shows: the human detail when present, otherwise the tool name.
+    public string LineText => string.IsNullOrEmpty(Detail) ? Name : Detail;
+
+    /// True when the transcript carried a useful detail — the row paints that brighter than a bare name.
+    public bool HasDetail => !string.IsNullOrEmpty(Detail);
+
     ToolOutcome _outcome;
     /// Flipped in place when the matching tool_result arrives; a result is terminal.
     public ToolOutcome Outcome {
@@ -39,6 +45,7 @@ public sealed class ToolCallItem(string name, string detail, ToolCategory catego
             this.RaisePropertyChanged(nameof(OutcomeGlyph));
             this.RaisePropertyChanged(nameof(IsError));
             this.RaisePropertyChanged(nameof(IsSettled));
+            this.RaisePropertyChanged(nameof(IsRunning));
         }
     }
 
@@ -51,28 +58,45 @@ public sealed class ToolCallItem(string name, string detail, ToolCategory catego
             _isAwaitingPermission = value;
             this.RaisePropertyChanged();
             this.RaisePropertyChanged(nameof(OutcomeGlyph));
+            this.RaisePropertyChanged(nameof(IsRunning));
         }
     }
 
     public bool IsSettled => _outcome != ToolOutcome.Running;
     public bool IsError => _outcome == ToolOutcome.Error;
+    /// True while the call is in flight and not waiting on a permission prompt — drives the
+    /// pulsing status pill so a live row is never blank.
+    public bool IsRunning => _outcome == ToolOutcome.Running && !_isAwaitingPermission;
     public string OutcomeGlyph => _outcome switch {
         ToolOutcome.Done  => "✓",
         ToolOutcome.Error => "✕",
         _                 => _isAwaitingPermission ? "?" : "",
     };
+
+    bool _showRowStatus = true;
+    /// False on a lone-call card: status sits in the kind-chip header instead of trailing the detail.
+    public bool ShowRowStatus {
+        get => _showRowStatus;
+        set {
+            if (_showRowStatus == value) return;
+            _showRowStatus = value;
+            this.RaisePropertyChanged();
+        }
+    }
 }
 
-/// A run of consecutive tool calls. Settled calls fold into Summary; live ones stay listed.
-/// VisibleCalls is the one list the view binds, swapped on toggle so a folded group holds no
-/// containers for its settled rows.
+/// A run of consecutive tool calls. Settled calls fold into Summary when there are two or more
+/// calls in the group; a lone call stays a single row with no "Ran a command" chrome.
+/// VisibleCalls is the one list the view binds, swapped on toggle so a folded multi-call group
+/// holds no containers for its settled rows.
 public sealed class ToolGroupItem : ChatItemViewModel {
     readonly AvaloniaList<ToolCallItem> _calls = new();
     readonly AvaloniaList<ToolCallItem> _live = new();
 
     public IAvaloniaReadOnlyList<ToolCallItem> Calls => _calls;
     public IAvaloniaReadOnlyList<ToolCallItem> LiveCalls => _live;
-    public IAvaloniaReadOnlyList<ToolCallItem> VisibleCalls => _isExpanded ? _calls : _live;
+    public IAvaloniaReadOnlyList<ToolCallItem> VisibleCalls =>
+        _calls.Count <= 1 || _isExpanded ? _calls : _live;
 
     bool _isExpanded;
     public bool IsExpanded {
@@ -82,6 +106,7 @@ public sealed class ToolGroupItem : ChatItemViewModel {
             _isExpanded = value;
             this.RaisePropertyChanged();
             this.RaisePropertyChanged(nameof(VisibleCalls));
+            this.RaisePropertyChanged(nameof(SummaryLine));
         }
     }
 
@@ -90,8 +115,30 @@ public sealed class ToolGroupItem : ChatItemViewModel {
     string _summary = "";
     public string Summary { get => _summary; private set => this.RaiseAndSetIfChanged(ref _summary, value); }
 
+    /// What the header shows: the category phrase, plus a peek at the first settled detail while
+    /// folded so the useful bit is visible without expanding.
+    public string SummaryLine {
+        get {
+            if (_summary.Length == 0) return "";
+            if (_isExpanded || PeekDetail() is not { Length: > 0 } peek) return _summary;
+            return $"{_summary} · {peek}";
+        }
+    }
+
     bool _hasSummary;
     public bool HasSummary { get => _hasSummary; private set => this.RaiseAndSetIfChanged(ref _hasSummary, value); }
+
+    /// Summary chrome only when folding would hide something — a single call is the row itself.
+    public bool ShowsSummaryHeader => _hasSummary && _calls.Count > 1;
+
+    /// Lone-call cards have no summary phrase, so a kind chip names what the callout is.
+    public bool ShowsKindChip => _calls.Count == 1;
+
+    public string KindChip =>
+        _calls.Count == 1 ? ToolSummary.ChipLabel(_calls[0].Category) : "";
+
+    /// The single call on a lone card — header status binds here.
+    public ToolCallItem? LoneCall => _calls.Count == 1 ? _calls[0] : null;
 
     bool _hasFailure;
     public bool HasFailure { get => _hasFailure; private set => this.RaiseAndSetIfChanged(ref _hasFailure, value); }
@@ -104,9 +151,21 @@ public sealed class ToolGroupItem : ChatItemViewModel {
 
     public void Add(ToolCallItem call) {
         _calls.Add(call);
+        RefreshLoneChrome();
+        this.RaisePropertyChanged(nameof(ShowsSummaryHeader));
+        this.RaisePropertyChanged(nameof(VisibleCalls));
+        this.RaisePropertyChanged(nameof(SummaryLine));
         if (call.IsSettled) { Recompute(); return; }
         _live.Add(call);
         call.PropertyChanged += OnCallChanged;
+    }
+
+    void RefreshLoneChrome() {
+        var lone = _calls.Count == 1;
+        foreach (var c in _calls) c.ShowRowStatus = !lone;
+        this.RaisePropertyChanged(nameof(ShowsKindChip));
+        this.RaisePropertyChanged(nameof(KindChip));
+        this.RaisePropertyChanged(nameof(LoneCall));
     }
 
     void OnCallChanged(object? sender, PropertyChangedEventArgs e) {
@@ -121,5 +180,17 @@ public sealed class ToolGroupItem : ChatItemViewModel {
         Summary = ToolSummary.Describe(settled.Select(c => c.Category));
         HasFailure = settled.Any(c => c.IsError);
         HasSummary = settled.Count > 0;
+        this.RaisePropertyChanged(nameof(ShowsSummaryHeader));
+        this.RaisePropertyChanged(nameof(VisibleCalls));
+        this.RaisePropertyChanged(nameof(SummaryLine));
+    }
+
+    /// First settled call's line, capped so the header stays one scannable row.
+    string? PeekDetail() {
+        var first = _calls.FirstOrDefault(c => c.IsSettled);
+        if (first is null) return null;
+        var text = first.LineText;
+        const int cap = 56;
+        return text.Length <= cap ? text : text[..(cap - 1)] + "…";
     }
 }

--- a/src/Capacitor.App/ViewModels/ChatItems.cs
+++ b/src/Capacitor.App/ViewModels/ChatItems.cs
@@ -28,10 +28,10 @@ public sealed class ToolCallItem(string name, string detail, ToolCategory catego
     public string Detail { get; } = detail;
     public ToolCategory Category { get; } = category;
 
-    /// What the row shows: the human detail when present, otherwise the tool name.
+    /// What the row shows: detail when present, otherwise the tool name.
     public string LineText => string.IsNullOrEmpty(Detail) ? Name : Detail;
 
-    /// True when the transcript carried a useful detail — the row paints that brighter than a bare name.
+    /// True when the transcript carried a useful detail (brighter paint than a bare name).
     public bool HasDetail => !string.IsNullOrEmpty(Detail);
 
     ToolOutcome _outcome;

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -132,8 +132,9 @@ public sealed class ChatTabViewModel : ReactiveObject {
 
     /// The hint is built from the terminal's own availability, so it is true in the windows
     /// where State alone would lie (a reattach or detach under way while State reads Attached).
-    internal static string HintFor(SendAvailability availability, TerminalSessionState state, string vendorLabel) => availability switch {
-        SendAvailability.Ready         => $"Reply to {vendorLabel} · Enter sends · Shift+Enter for a new line",
+    /// Ready omits the harness name — the workspace chip already names it.
+    internal static string HintFor(SendAvailability availability, TerminalSessionState state) => availability switch {
+        SendAvailability.Ready         => "Enter sends · Shift+Enter for a new line",
         SendAvailability.Sending       => "Sending…",
         SendAvailability.Transitioning => "Updating the terminal connection…",
         SendAvailability.ReadOnly      => $"Read-only: {state.Detail}",
@@ -222,10 +223,9 @@ public sealed class ChatTabViewModel : ReactiveObject {
         // goes blank there instead of offering a reply that can never be sent.
         _composerHint = Observable.CombineLatest(
                 terminal.WhenAnyValue(t => t.SendAvailability, t => t.State, (availability, state) => (availability, state)),
-                this.WhenAnyValue(x => x.VendorLabel),
                 this.WhenAnyValue(x => x.IsReadOnlyParticipant),
-                (t, label, readOnly) => readOnly ? "" : HintFor(t.availability, t.state, label))
-            .ToProperty(this, x => x.ComposerHint, HintFor(terminal.SendAvailability, terminal.State, ""))
+                (t, readOnly) => readOnly ? "" : HintFor(t.availability, t.state))
+            .ToProperty(this, x => x.ComposerHint, HintFor(terminal.SendAvailability, terminal.State))
             .DisposeWith(_disposables);
 
         var canSend = Observable.CombineLatest(

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -92,6 +92,11 @@ public sealed class ChatTabViewModel : ReactiveObject {
     readonly ObservableAsPropertyHelper<string> _composerHint;
     public string ComposerHint => _composerHint.Value;
 
+    readonly ObservableAsPropertyHelper<bool> _showsComposer;
+    /// Input + Send stay in the tree only while messaging is still possible. An ended session
+    /// hides them and leaves the hint — a greyed empty box is the wrong affordance.
+    public bool ShowsComposer => _showsComposer.Value;
+
     string _vendor = "";
     IReadOnlyList<HarnessOption> _options = HostedHarnessCatalog.Build(null);
 
@@ -226,6 +231,14 @@ public sealed class ChatTabViewModel : ReactiveObject {
                 this.WhenAnyValue(x => x.IsReadOnlyParticipant),
                 (t, readOnly) => readOnly ? "" : HintFor(t.availability, t.state))
             .ToProperty(this, x => x.ComposerHint, HintFor(terminal.SendAvailability, terminal.State))
+            .DisposeWith(_disposables);
+
+        _showsComposer = Observable.CombineLatest(
+                terminal.WhenAnyValue(t => t.SendAvailability),
+                this.WhenAnyValue(x => x.IsReadOnlyParticipant),
+                (availability, readOnly) => !readOnly && availability != SendAvailability.Ended)
+            .ToProperty(this, x => x.ShowsComposer,
+                initialValue: !IsReadOnlyParticipant && terminal.SendAvailability != SendAvailability.Ended)
             .DisposeWith(_disposables);
 
         var canSend = Observable.CombineLatest(

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -50,6 +50,8 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     public const string UnusableIdMessage = "Launched, but the session id was unusable. Open it from the session list.";
 
     internal const string ConnectingNotice     = "Connecting to the server…";
+    internal const string FinishingSignInNotice =
+        "Finishing sign-in. Reconnecting to the server…";
     internal const string DaemonDownNotice     =
         "The daemon isn't running. Start it to launch sessions. If it should already be up, press Retry.";
     internal const string DaemonIncompatibleNotice =
@@ -128,6 +130,9 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// property read via WhenAnyValue) so the ctor can compose it — see SessionRailViewModel's
     /// _selectedAgentIdChanges for why WhenAnyValue is avoided in constructors here.
     readonly BehaviorSubject<bool> _signInRequired = new(false);
+    /// True after a successful re-auth until the daemon reports server-connected (or goes down).
+    /// Keeps the banner from still asking to Sign in while the daemon catches up.
+    readonly BehaviorSubject<bool> _awaitingServerAfterSignIn = new(false);
     readonly Action? _requestSignIn;
 
     readonly ObservableAsPropertyHelper<string?> _connectionNotice;
@@ -254,12 +259,16 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
                 .ObserveOn(RxSchedulers.MainThreadScheduler));
 
         var signInState = availability
-            .CombineLatest(_signInRequired, (a, expired) => (Availability: a, Expired: expired))
+            .CombineLatest(
+                _signInRequired,
+                _awaitingServerAfterSignIn,
+                (a, expired, awaiting) => (Availability: a, Expired: expired, Awaiting: awaiting))
             .ObserveOn(RxSchedulers.MainThreadScheduler);
         var notices = daemon.Status
             .CombineLatest(
                 daemon.Snapshots.Select(s => s.Daemon.Connection).StartWith(""),
                 _signInRequired,
+                _awaitingServerAfterSignIn,
                 NoticeFor)
             .ObserveOn(RxSchedulers.MainThreadScheduler);
         _connectionNotice = notices
@@ -270,8 +279,13 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
             .ToProperty(this, x => x.ConnectionBannerVisible, initialValue: false)
             .DisposeWith(_disposables);
         _signInVisible = signInState
-            .Select(t => t.Expired || t.Availability == LaunchAvailability.ServerDisconnected)
+            .Select(t => !t.Awaiting && (t.Expired || t.Availability == LaunchAvailability.ServerDisconnected))
             .ToProperty(this, x => x.SignInVisible, initialValue: false)
+            .DisposeWith(_disposables);
+
+        availability
+            .Where(a => a is LaunchAvailability.Ready or LaunchAvailability.DaemonUnavailable)
+            .Subscribe(_ => _awaitingServerAfterSignIn.OnNext(false))
             .DisposeWith(_disposables);
 
         _startButtonTip = _selectedRepoPathChanges
@@ -307,9 +321,12 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
             .DisposeWith(_disposables);
     }
 
-    /// The re-auth dialog's success lands here (App wires it): the expired flag lifts without
-    /// waiting for the next launch attempt to re-prove it.
-    public void NotifySignInCompleted() => _signInRequired.OnNext(false);
+    /// The re-auth dialog's success lands here (App wires it): clears the expired flag and holds a
+    /// finishing notice until the daemon reports the server is connected again.
+    public void NotifySignInCompleted() {
+        _signInRequired.OnNext(false);
+        _awaitingServerAfterSignIn.OnNext(true);
+    }
 
     /// Local attach state is checked FIRST — the upstream word is only meaningful once the attach
     /// is Connected (a stale retained snapshot might carry any word). Unknown upstream words read
@@ -324,12 +341,16 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         },
     };
 
-    internal static string? NoticeFor(AttachStatus status, string daemonConnection, bool signInExpired) {
+    internal static string? NoticeFor(
+            AttachStatus status, string daemonConnection, bool signInExpired, bool awaitingServer = false) {
         if (signInExpired) return SignInExpiredNotice;
         if (status.State == AttachState.Unreachable) {
             return status.Reason == IncompatibleReason ? DaemonIncompatibleNotice : DaemonDownNotice;
         }
-        return AvailabilityFor(status, daemonConnection) switch {
+        var availability = AvailabilityFor(status, daemonConnection);
+        if (awaitingServer && availability is LaunchAvailability.ServerDisconnected or LaunchAvailability.Pending)
+            return FinishingSignInNotice;
+        return availability switch {
             LaunchAvailability.Ready             => null,
             LaunchAvailability.Pending           => ConnectingNotice,
             LaunchAvailability.DaemonUnavailable => DaemonDownNotice,

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -47,12 +47,17 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// A launch that started but handed back an id nothing can open. The session is real and running
     /// — it just has to be reached from the session list, so this is a launch-succeeded wording, not
     /// a failure one (spec §3, entry-point guards).
-    public const string UnusableIdMessage = "Launched, but the session id was unusable — open it from the session list.";
+    public const string UnusableIdMessage = "Launched, but the session id was unusable. Open it from the session list.";
 
     internal const string ConnectingNotice     = "Connecting to the server…";
-    internal const string DaemonDownNotice     = "The daemon isn't running — start it to launch sessions.";
-    internal const string ServerLostNotice     = "Not connected to the server — sign in again to reconnect.";
-    internal const string SignInExpiredNotice  = "Your sign-in has expired — sign in again.";
+    internal const string DaemonDownNotice     =
+        "The daemon isn't running. Start it to launch sessions. If it should already be up, press Retry.";
+    internal const string DaemonIncompatibleNotice =
+        "App and daemon are incompatible. Update both to matching versions, then press Retry.";
+    internal const string ServerLostNotice     = "Not connected to the server. Sign in again to reconnect.";
+    internal const string SignInExpiredNotice  = "Your sign-in has expired. Sign in again.";
+
+    const string IncompatibleReason = "daemon_incompatible";
 
     readonly IDaemonClientService _daemon;
     readonly IAppStateStore _state;
@@ -130,8 +135,29 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// wins over the connection-derived one — it is the more specific diagnosis.
     public string? ConnectionNotice => _connectionNotice.Value;
 
+    readonly ObservableAsPropertyHelper<bool> _connectionBannerVisible;
+    /// Same connection/sign-in/daemon banner the launcher shows above the composer.
+    public bool ConnectionBannerVisible => _connectionBannerVisible.Value;
+
     readonly ObservableAsPropertyHelper<bool> _signInVisible;
     public bool SignInVisible => _signInVisible.Value;
+
+    ObservableAsPropertyHelper<bool>? _daemonStartVisible;
+    public bool DaemonStartVisible => _daemonStartVisible?.Value ?? false;
+
+    ObservableAsPropertyHelper<bool>? _daemonRetryVisible;
+    public bool DaemonRetryVisible => _daemonRetryVisible?.Value ?? false;
+
+    ObservableAsPropertyHelper<string?>? _daemonStartMessage;
+    /// Start-daemon failure text mirrored from MainWindow (cleared on Connected / new attempt).
+    public string? DaemonStartMessage => _daemonStartMessage?.Value;
+
+    /// Shared with MainWindowViewModel so the banner's Start daemon button is the same command
+    /// lifecycle / startAction already owns. Null until AttachDaemonRecovery runs.
+    public ReactiveCommand<Unit, Unit>? StartDaemonCommand { get; private set; }
+
+    /// Shared with MainWindowViewModel.RetryCommand. Null until AttachDaemonRecovery runs.
+    public ReactiveCommand<Unit, Unit>? RetryDaemonCommand { get; private set; }
 
     readonly ObservableAsPropertyHelper<string> _startButtonTip;
     /// Hover tip for Start: names the gate that keeps it disabled (no repo, or ConnectionNotice),
@@ -230,8 +256,18 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         var signInState = availability
             .CombineLatest(_signInRequired, (a, expired) => (Availability: a, Expired: expired))
             .ObserveOn(RxSchedulers.MainThreadScheduler);
-        _connectionNotice = signInState.Select(t => NoticeFor(t.Availability, t.Expired))
+        var notices = daemon.Status
+            .CombineLatest(
+                daemon.Snapshots.Select(s => s.Daemon.Connection).StartWith(""),
+                _signInRequired,
+                NoticeFor)
+            .ObserveOn(RxSchedulers.MainThreadScheduler);
+        _connectionNotice = notices
             .ToProperty(this, x => x.ConnectionNotice, ConnectingNotice)
+            .DisposeWith(_disposables);
+        _connectionBannerVisible = notices
+            .Select(notice => notice is not null)
+            .ToProperty(this, x => x.ConnectionBannerVisible, initialValue: false)
             .DisposeWith(_disposables);
         _signInVisible = signInState
             .Select(t => t.Expired || t.Availability == LaunchAvailability.ServerDisconnected)
@@ -239,11 +275,36 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
             .DisposeWith(_disposables);
 
         _startButtonTip = _selectedRepoPathChanges
-            .CombineLatest(signInState.Select(t => NoticeFor(t.Availability, t.Expired)), TipFor)
+            .CombineLatest(notices, TipFor)
             .ToProperty(this, x => x.StartButtonTip, TipFor(SelectedRepoPath, ConnectingNotice))
             .DisposeWith(_disposables);
 
         SignInCommand = ReactiveCommand.Create(() => { _requestSignIn?.Invoke(); });
+    }
+
+    /// MainWindow owns Start/Retry (lifecycle startAction + shutdown token). The launcher banner
+    /// reuses those commands and the start-message lane so chrome and pane never diverge.
+    public void AttachDaemonRecovery(
+            ReactiveCommand<Unit, Unit> startDaemon,
+            ReactiveCommand<Unit, Unit> retry,
+            IObservable<bool> startVisible,
+            IObservable<bool> retryVisible,
+            IObservable<string?> startMessage) {
+        StartDaemonCommand = startDaemon;
+        RetryDaemonCommand = retry;
+        this.RaisePropertyChanged(nameof(StartDaemonCommand));
+        this.RaisePropertyChanged(nameof(RetryDaemonCommand));
+
+        _daemonStartVisible = startVisible
+            .ToProperty(this, x => x.DaemonStartVisible, initialValue: false)
+            .DisposeWith(_disposables);
+        _daemonRetryVisible = retryVisible
+            .ToProperty(this, x => x.DaemonRetryVisible, initialValue: false)
+            .DisposeWith(_disposables);
+        _daemonStartMessage = startMessage
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .ToProperty(this, x => x.DaemonStartMessage, (string?)null)
+            .DisposeWith(_disposables);
     }
 
     /// The re-auth dialog's success lands here (App wires it): the expired flag lifts without
@@ -263,6 +324,20 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         },
     };
 
+    internal static string? NoticeFor(AttachStatus status, string daemonConnection, bool signInExpired) {
+        if (signInExpired) return SignInExpiredNotice;
+        if (status.State == AttachState.Unreachable) {
+            return status.Reason == IncompatibleReason ? DaemonIncompatibleNotice : DaemonDownNotice;
+        }
+        return AvailabilityFor(status, daemonConnection) switch {
+            LaunchAvailability.Ready             => null,
+            LaunchAvailability.Pending           => ConnectingNotice,
+            LaunchAvailability.DaemonUnavailable => DaemonDownNotice,
+            _                                    => ServerLostNotice,
+        };
+    }
+
+    /// Back-compat for callers that already classified availability.
     internal static string? NoticeFor(LaunchAvailability availability, bool signInExpired) =>
         signInExpired ? SignInExpiredNotice
         : availability switch {

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -64,9 +64,15 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     readonly CompositeDisposable _disposables = new();
 
     string _selectedRepoPath = ScratchRepoPath;
+    // Subject (not WhenAnyValue) so the ctor can compose StartButtonTip — same reason as
+    // _signInRequired above.
+    readonly BehaviorSubject<string> _selectedRepoPathChanges = new(ScratchRepoPath);
     public string SelectedRepoPath {
         get => _selectedRepoPath;
-        set => this.RaiseAndSetIfChanged(ref _selectedRepoPath, value);
+        set {
+            this.RaiseAndSetIfChanged(ref _selectedRepoPath, value);
+            _selectedRepoPathChanges.OnNext(value);
+        }
     }
 
     string _selectedVendor = DefaultVendor;
@@ -126,6 +132,11 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
 
     readonly ObservableAsPropertyHelper<bool> _signInVisible;
     public bool SignInVisible => _signInVisible.Value;
+
+    readonly ObservableAsPropertyHelper<string> _startButtonTip;
+    /// Hover tip for Start: names the gate that keeps it disabled (no repo, or ConnectionNotice),
+    /// else plain "Start". Bound with ToolTip.ShowOnDisabled so a disabled button still explains.
+    public string StartButtonTip => _startButtonTip.Value;
 
     public ReactiveCommand<Unit, Unit> SignInCommand { get; }
 
@@ -227,6 +238,11 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
             .ToProperty(this, x => x.SignInVisible, initialValue: false)
             .DisposeWith(_disposables);
 
+        _startButtonTip = _selectedRepoPathChanges
+            .CombineLatest(signInState.Select(t => NoticeFor(t.Availability, t.Expired)), TipFor)
+            .ToProperty(this, x => x.StartButtonTip, TipFor(SelectedRepoPath, ConnectingNotice))
+            .DisposeWith(_disposables);
+
         SignInCommand = ReactiveCommand.Create(() => { _requestSignIn?.Invoke(); });
     }
 
@@ -255,6 +271,11 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
             LaunchAvailability.DaemonUnavailable => DaemonDownNotice,
             _                                    => ServerLostNotice,
         };
+
+    /// Repo gate first (IsEnabled), then the connection/sign-in notice StartCommand also gates on.
+    internal static string TipFor(string? repoPath, string? connectionNotice) =>
+        string.IsNullOrEmpty(repoPath) ? "Select a repository to start"
+        : connectionNotice ?? "Start";
 
     // Constructor-scoped (like TrayViewModel/ActivityViewModel), not WhenActivated — the OAPH and
     // the Agents subscription above run for this object's whole lifetime, not a window's.

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -47,7 +47,7 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// A launch that started but handed back an id nothing can open. The session is real and running
     /// — it just has to be reached from the session list, so this is a launch-succeeded wording, not
     /// a failure one (spec §3, entry-point guards).
-    public const string UnusableIdMessage = "Launched, but the session id was unusable. Open it from the session list.";
+    public const string UnusableIdMessage = "Launched, but the session ID was unusable. Open it from the session list.";
 
     internal const string ConnectingNotice     = "Connecting to the server…";
     internal const string FinishingSignInNotice =

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -400,7 +400,9 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         var seen = new HashSet<string>(PathComparer);
         var paths = new List<string>();
         void Add(string? path) {
-            if (!string.IsNullOrEmpty(path) && seen.Add(path)) paths.Add(path);
+            if (string.IsNullOrEmpty(path)) return;
+            var normalized = PlatformPaths.Normalize(path);
+            if (seen.Add(normalized)) paths.Add(normalized);
         }
 
         foreach (var key in byRepo?.Keys ?? [])
@@ -429,9 +431,9 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// Sets the repository and restores that repository's remembered harness, or DefaultVendor
     /// when none — never the vendor a DIFFERENT repository had selected.
     public async Task SelectRepositoryAsync(string repoPath) {
-        SelectedRepoPath = repoPath;
+        SelectedRepoPath = repoPath.Length == 0 ? ScratchRepoPath : PlatformPaths.Normalize(repoPath);
         var saved = await _state.LoadAsync();
-        SetVendor(Lookup(saved.HarnessByRepo, repoPath) ?? DefaultVendor);
+        SetVendor(Lookup(saved.HarnessByRepo, SelectedRepoPath) ?? DefaultVendor);
     }
 
     /// The one place a vendor change lands, so the model-reset invariant (ids are
@@ -506,16 +508,17 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     }
 
     /// Replaces any entry whose key matches under PathComparer, so re-choosing a harness for the
-    /// same repository reached under different casing overwrites rather than accumulating a
-    /// second, shadowing entry.
+    /// same repository reached under different casing or a trailing separator overwrites rather
+    /// than accumulating a second, shadowing entry.
     static IReadOnlyDictionary<string, string> WithEntry(IReadOnlyDictionary<string, string>? existing, string key, string value) {
+        var normalized = key.Length == 0 ? key : PlatformPaths.Normalize(key);
         var next = new Dictionary<string, string>();
         if (existing is not null)
             foreach (var entry in existing)
-                if (!PathComparer.Equals(entry.Key, key))
+                if (!PathComparer.Equals(entry.Key, normalized))
                     next[entry.Key] = entry.Value;
 
-        next[key] = value;
+        next[normalized] = value;
         return next;
     }
 }

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -294,6 +294,10 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
             .DisposeWith(_disposables);
 
         SignInCommand = ReactiveCommand.Create(() => { _requestSignIn?.Invoke(); });
+
+        // Adopt a recent known repo when the launcher starts empty — fire-and-forget; the picker
+        // also calls EnsureDefaultRepositoryAsync before listing.
+        _ = EnsureDefaultRepositoryAsync();
     }
 
     /// MainWindow owns Start/Retry (lifecycle startAction + shutdown token). The launcher banner
@@ -391,9 +395,12 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// known repos (what the server's launch dialog sees), and the current selection (a
     /// picker-added repo with no remembered harness and no agent yet lives nowhere else).
     /// Deduped under PathComparer with remembered keys added first, so where two casings are one
-    /// repository the casing the user picked is the one displayed. Scratch is always last; the
-    /// view renders it separated.
+    /// repository the casing the user picked is the one displayed. Scratch ("No repository") is
+    /// offered only when that list is empty — with real repos, an empty selection adopts the
+    /// most recently used known path instead.
     public async Task<IReadOnlyList<RepositoryOption>> ListRepositoriesAsync() {
+        await EnsureDefaultRepositoryAsync();
+
         var byRepo = (await _state.LoadAsync()).HarnessByRepo;
         var known = await _knownRepos();
 
@@ -423,9 +430,38 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
             .Select(p => new RepositoryOption(p, Lookup(byRepo, p) ?? DefaultVendor, PathComparer.Equals(p, selected)))
             .ToList();
 
-        options.Add(new RepositoryOption(
-            ScratchRepoPath, Lookup(byRepo, ScratchRepoPath) ?? DefaultVendor, selected.Length == 0));
+        if (paths.Count == 0)
+            options.Add(new RepositoryOption(
+                ScratchRepoPath, Lookup(byRepo, ScratchRepoPath) ?? DefaultVendor, selected.Length == 0));
         return options;
+    }
+
+    /// When nothing is selected, adopt the most recently used known repository (then a remembered
+    /// harness key, then an agent root). No-op when a selection already exists or nothing is known.
+    public async Task EnsureDefaultRepositoryAsync() {
+        if (SelectedRepoPath.Length > 0) return;
+        if (await PreferRecentRepositoryAsync() is not { Length: > 0 } recent) return;
+        await SelectRepositoryAsync(recent);
+    }
+
+    async Task<string?> PreferRecentRepositoryAsync() {
+        foreach (var path in await _knownRepos()) {
+            var normalized = PlatformPaths.Normalize(path);
+            if (normalized.Length > 0) return normalized;
+        }
+
+        foreach (var key in (await _state.LoadAsync()).HarnessByRepo?.Keys ?? []) {
+            var normalized = PlatformPaths.Normalize(key);
+            if (normalized.Length > 0) return normalized;
+        }
+
+        foreach (var agent in _daemon.Agents.Items) {
+            if (agent.RepoPath is not { Length: > 0 } repoPath) continue;
+            var normalized = PlatformPaths.Normalize(GitRepository.ResolveMainRepoRoot(repoPath));
+            if (normalized.Length > 0) return normalized;
+        }
+
+        return null;
     }
 
     /// Sets the repository and restores that repository's remembered harness, or DefaultVendor

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -53,9 +53,9 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     internal const string FinishingSignInNotice =
         "Finishing sign-in. Reconnecting to the server…";
     internal const string DaemonDownNotice     =
-        "The daemon isn't running. Start it to launch sessions. If it should already be up, press Retry.";
+        "The daemon isn't running. Press Start daemon to launch sessions.";
     internal const string DaemonIncompatibleNotice =
-        "App and daemon are incompatible. Update both to matching versions, then press Retry.";
+        "App and daemon are incompatible. Update both to matching versions, then press Reconnect.";
     internal const string ServerLostNotice     = "Not connected to the server. Sign in again to reconnect.";
     internal const string SignInExpiredNotice  = "Your sign-in has expired. Sign in again.";
 
@@ -140,6 +140,11 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// wins over the connection-derived one — it is the more specific diagnosis.
     public string? ConnectionNotice => _connectionNotice.Value;
 
+    readonly ObservableAsPropertyHelper<string?> _bannerMessage;
+    /// Single banner body: a start/lifecycle message wins over the generic connection notice so
+    /// Unreachable + "kcap too old" does not stack two lines that both say press Start daemon.
+    public string? BannerMessage => _bannerMessage.Value;
+
     readonly ObservableAsPropertyHelper<bool> _connectionBannerVisible;
     /// Same connection/sign-in/daemon banner the launcher shows above the composer.
     public bool ConnectionBannerVisible => _connectionBannerVisible.Value;
@@ -156,6 +161,9 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     ObservableAsPropertyHelper<string?>? _daemonStartMessage;
     /// Start-daemon failure text mirrored from MainWindow (cleared on Connected / new attempt).
     public string? DaemonStartMessage => _daemonStartMessage?.Value;
+
+    // Feeds BannerMessage before AttachDaemonRecovery runs (null) and after (lifecycle lane).
+    readonly BehaviorSubject<string?> _daemonStartMessageFeed = new(null);
 
     /// Shared with MainWindowViewModel so the banner's Start daemon button is the same command
     /// lifecycle / startAction already owns. Null until AttachDaemonRecovery runs.
@@ -274,8 +282,12 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         _connectionNotice = notices
             .ToProperty(this, x => x.ConnectionNotice, ConnectingNotice)
             .DisposeWith(_disposables);
-        _connectionBannerVisible = notices
-            .Select(notice => notice is not null)
+        var bannerMessages = notices.CombineLatest(_daemonStartMessageFeed, BannerMessageFor);
+        _bannerMessage = bannerMessages
+            .ToProperty(this, x => x.BannerMessage, ConnectingNotice)
+            .DisposeWith(_disposables);
+        _connectionBannerVisible = bannerMessages
+            .Select(message => message is not null)
             .ToProperty(this, x => x.ConnectionBannerVisible, initialValue: false)
             .DisposeWith(_disposables);
         _signInVisible = signInState
@@ -300,7 +312,7 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         _ = EnsureDefaultRepositoryAsync();
     }
 
-    /// MainWindow owns Start/Retry (lifecycle startAction + shutdown token). The launcher banner
+    /// MainWindow owns Start/Reconnect (lifecycle startAction + shutdown token). The launcher banner
     /// reuses those commands and the start-message lane so chrome and pane never diverge.
     public void AttachDaemonRecovery(
             ReactiveCommand<Unit, Unit> startDaemon,
@@ -319,11 +331,19 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         _daemonRetryVisible = retryVisible
             .ToProperty(this, x => x.DaemonRetryVisible, initialValue: false)
             .DisposeWith(_disposables);
+        startMessage
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(_daemonStartMessageFeed)
+            .DisposeWith(_disposables);
         _daemonStartMessage = startMessage
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .ToProperty(this, x => x.DaemonStartMessage, (string?)null)
             .DisposeWith(_disposables);
     }
+
+    /// Prefer the actionable start/lifecycle line when present; otherwise the connection notice.
+    internal static string? BannerMessageFor(string? connectionNotice, string? startMessage) =>
+        !string.IsNullOrEmpty(startMessage) ? startMessage : connectionNotice;
 
     /// The re-auth dialog's success lands here (App wires it): clears the expired flag and holds a
     /// finishing notice until the daemon reports the server is connected again.
@@ -379,7 +399,10 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
 
     // Constructor-scoped (like TrayViewModel/ActivityViewModel), not WhenActivated — the OAPH and
     // the Agents subscription above run for this object's whole lifetime, not a window's.
-    public void Dispose() => _disposables.Dispose();
+    public void Dispose() {
+        _disposables.Dispose();
+        _daemonStartMessageFeed.Dispose();
+    }
 
     /// Sets the selection and persists it for SelectedRepoPath.
     public async Task ChooseHarnessAsync(string vendor) {

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -382,16 +382,6 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         };
     }
 
-    /// Back-compat for callers that already classified availability.
-    internal static string? NoticeFor(LaunchAvailability availability, bool signInExpired) =>
-        signInExpired ? SignInExpiredNotice
-        : availability switch {
-            LaunchAvailability.Ready             => null,
-            LaunchAvailability.Pending           => ConnectingNotice,
-            LaunchAvailability.DaemonUnavailable => DaemonDownNotice,
-            _                                    => ServerLostNotice,
-        };
-
     /// Repo gate first (IsEnabled), then the connection/sign-in notice StartCommand also gates on.
     internal static string TipFor(string? repoPath, string? connectionNotice) =>
         string.IsNullOrEmpty(repoPath) ? "Select a repository to start"
@@ -464,6 +454,8 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     public async Task EnsureDefaultRepositoryAsync() {
         if (SelectedRepoPath.Length > 0) return;
         if (await PreferRecentRepositoryAsync() is not { Length: > 0 } recent) return;
+        // PreferRecent can await file I/O — a pick made while that ran must win.
+        if (SelectedRepoPath.Length > 0) return;
         await SelectRepositoryAsync(recent);
     }
 

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -44,9 +44,8 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     /// a storage key only.
     public const string ScratchRepoPath = "";
 
-    /// A launch that started but handed back an id nothing can open. The session is real and running
-    /// — it just has to be reached from the session list, so this is a launch-succeeded wording, not
-    /// a failure one (spec §3, entry-point guards).
+    /// A launch that started but handed back an id nothing can open. The session is real — open
+    /// it from the session list rather than treating this as a launch failure.
     public const string UnusableIdMessage = "Launched, but the session ID was unusable. Open it from the session list.";
 
     internal const string ConnectingNotice     = "Connecting to the server…";
@@ -158,23 +157,15 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
     ObservableAsPropertyHelper<bool>? _daemonRetryVisible;
     public bool DaemonRetryVisible => _daemonRetryVisible?.Value ?? false;
 
-    ObservableAsPropertyHelper<string?>? _daemonStartMessage;
-    /// Start-daemon failure text mirrored from MainWindow (cleared on Connected / new attempt).
-    public string? DaemonStartMessage => _daemonStartMessage?.Value;
-
     // Feeds BannerMessage before AttachDaemonRecovery runs (null) and after (lifecycle lane).
     readonly BehaviorSubject<string?> _daemonStartMessageFeed = new(null);
 
-    /// Shared with MainWindowViewModel so the banner's Start daemon button is the same command
-    /// lifecycle / startAction already owns. Null until AttachDaemonRecovery runs.
+    /// Wired by AttachDaemonRecovery to MainWindow's Start/Reconnect commands.
     public ReactiveCommand<Unit, Unit>? StartDaemonCommand { get; private set; }
-
-    /// Shared with MainWindowViewModel.RetryCommand. Null until AttachDaemonRecovery runs.
     public ReactiveCommand<Unit, Unit>? RetryDaemonCommand { get; private set; }
 
     readonly ObservableAsPropertyHelper<string> _startButtonTip;
-    /// Hover tip for Start: names the gate that keeps it disabled (no repo, or ConnectionNotice),
-    /// else plain "Start". Bound with ToolTip.ShowOnDisabled so a disabled button still explains.
+    /// Tip when Start is disabled (no repo / connection gate). ToolTip.ShowOnDisabled is required.
     public string StartButtonTip => _startButtonTip.Value;
 
     public ReactiveCommand<Unit, Unit> SignInCommand { get; }
@@ -334,10 +325,6 @@ public sealed class HomeViewModel : ReactiveObject, IDisposable {
         startMessage
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(_daemonStartMessageFeed)
-            .DisposeWith(_disposables);
-        _daemonStartMessage = startMessage
-            .ObserveOn(RxSchedulers.MainThreadScheduler)
-            .ToProperty(this, x => x.DaemonStartMessage, (string?)null)
             .DisposeWith(_disposables);
     }
 

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -13,7 +13,7 @@ namespace Capacitor.App.ViewModels;
 /// Sessions view.
 public enum ShellView { Home, Sessions }
 
-/// Projects IDaemonClientService.Status/Snapshots into display text and drives Start/Retry.
+/// Projects IDaemonClientService.Status/Snapshots into display text and drives Start/Reconnect.
 /// All display projections are activation-scoped (WhenActivated) — the service outlives this
 /// ViewModel and owns its subjects (spec §5), so nothing here disposes the service itself.
 /// DEVIATION: StartDaemonCommand/RetryCommand and their canExecute pipelines are built in the
@@ -22,7 +22,8 @@ public enum ShellView { Home, Sessions }
 /// service's own long-lived subjects, not resources the VM needs to scope to a window's
 /// lifetime. StartVisible/RetryVisible mirror that same constructor scoping (spec: presentation
 /// visibility must track the identical state predicate the command's own canExecute uses,
-/// independent of activation too).
+/// independent of activation too). One primary action at a time: Start when the daemon looks
+/// down; Reconnect when attaching or skewed (never both).
 public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel {
     const string IncompatibleReason = "daemon_incompatible";
     const string UnreachableReason  = "daemon_unreachable";
@@ -38,7 +39,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     /// click is never silent even when the start action itself has nothing further to say.
     internal const string StartingMessage = "Starting the daemon…";
 
-    /// Shown the moment Retry is pressed. Cleared on Connected; replaced if attach stays unreachable.
+    /// Shown the moment Reconnect is pressed. Cleared on Connected; replaced if attach stays unreachable.
     internal const string ReconnectingMessage = "Reconnecting…";
 
     internal const string ReconnectFailedMessage =
@@ -271,11 +272,15 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
         // IsEnabled write, onto that same background thread, tripping Avalonia's dispatcher
         // thread-affinity check. These stay constructor-scoped (not inside WhenActivated) since
         // commands must exist and be assertable pre-activation — see the class doc comment.
+        // One primary action at a time: Start when nothing is listening (spawn/reattach via the
+        // lifecycle); Reconnect when Start is not the right next step (skew, or still connecting).
         var canStart = service.Status
             .Select(s => s.State == AttachState.Unreachable && s.Reason == UnreachableReason)
             .ObserveOn(RxSchedulers.MainThreadScheduler);
         var canRetry = service.Status
-            .Select(s => s.State != AttachState.Connected)
+            .Select(s =>
+                s.State == AttachState.Connecting
+                || (s.State == AttachState.Unreachable && s.Reason != UnreachableReason))
             .ObserveOn(RxSchedulers.MainThreadScheduler);
 
         var start = startAction ?? RunStartAsync;
@@ -296,13 +301,10 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .ToProperty(this, x => x.RecoveryVisible, initialValue: false);
 
-        // Launcher banner owns the chrome; share the same Start/Retry commands and start-message
+        // Launcher banner owns the chrome; share the same Start/Reconnect commands and start-message
         // lane so the pane never drifts from what MainWindow already drives.
-        var daemonRetryVisible = service.Status
-            .Select(s => s.State == AttachState.Unreachable)
-            .ObserveOn(RxSchedulers.MainThreadScheduler);
         home?.AttachDaemonRecovery(
-            StartDaemonCommand, RetryCommand, canStart, daemonRetryVisible, _startMessageChanges);
+            StartDaemonCommand, RetryCommand, canStart, canRetry, _startMessageChanges);
 
         this.WhenActivated(disposables => {
             var status    = service.Status.ObserveOn(RxSchedulers.MainThreadScheduler);

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -14,16 +14,10 @@ namespace Capacitor.App.ViewModels;
 public enum ShellView { Home, Sessions }
 
 /// Projects IDaemonClientService.Status/Snapshots into display text and drives Start/Reconnect.
-/// All display projections are activation-scoped (WhenActivated) — the service outlives this
-/// ViewModel and owns its subjects (spec §5), so nothing here disposes the service itself.
-/// DEVIATION: StartDaemonCommand/RetryCommand and their canExecute pipelines are built in the
-/// CONSTRUCTOR, not inside WhenActivated — commands must exist (and be assertable via
-/// CanExecute) independent of window activation; service.Status/service.Snapshots are the
-/// service's own long-lived subjects, not resources the VM needs to scope to a window's
-/// lifetime. StartVisible/RetryVisible mirror that same constructor scoping (spec: presentation
-/// visibility must track the identical state predicate the command's own canExecute uses,
-/// independent of activation too). One primary action at a time: Start when the daemon looks
-/// down; Reconnect when attaching or skewed (never both).
+/// Display projections are activation-scoped (WhenActivated). StartDaemonCommand/RetryCommand and
+/// their canExecute pipelines are built in the constructor so they exist pre-activation.
+/// StartVisible/RetryVisible track the same predicates (one primary action: Start when down;
+/// Reconnect when connecting or skewed). The service outlives this VM and owns its subjects.
 public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel {
     const string IncompatibleReason = "daemon_incompatible";
     const string UnreachableReason  = "daemon_unreachable";
@@ -95,9 +89,8 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     ObservableAsPropertyHelper<IBrush>? _statusDotBrush;
     public IBrush StatusDotBrush => _statusDotBrush?.Value ?? DotBrush(StatusColors.Unavailable);
 
-    // "n of m agents" only while Connected (spec §1.5: active_agents is a display count, never
-    // a free-slots/launch-capacity claim) — "—" otherwise, even though the last-known snapshot
-    // (and the Agents cache) is retained by the service across disconnects.
+    // "n of m agents" only while Connected — active_agents is a display count, never capacity.
+    // "—" otherwise; the service still retains the last snapshot across disconnects.
     ObservableAsPropertyHelper<string>? _agentCountText;
     public string AgentCountText => _agentCountText?.Value ?? "—";
 
@@ -110,15 +103,9 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     public string? Reason => _reason?.Value;
 
     readonly BehaviorSubject<string?> _startMessageChanges = new(null);
-    readonly ObservableAsPropertyHelper<bool> _recoveryVisible;
-    /// Recovery chrome (banner + Start/Retry): Unreachable attach, or a failed start message still
-    /// on screen — so the user always has a next step, not a dead end.
-    public bool RecoveryVisible => _recoveryVisible.Value;
 
-
-    /// The Activity feed (spec §7) — constructed once at the composition root, same instance the
-    /// prompt window's onConcluded callback nudges, so this is a plain ctor-injected reference,
-    /// not something built here.
+    /// Constructed once at the composition root; the prompt window's onConcluded callback nudges
+    /// the same instance.
     public ActivityViewModel Activity { get; }
 
     /// The Home surface's launcher and cards — constructed at the composition root over the SAME
@@ -134,7 +121,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     WorkspaceViewModel? _currentWorkspace;
     /// null = the Sessions surface shows its placeholder pane; non-null = that session's workspace.
     /// Exactly one workspace at a time, and this VM owns it: every swap starts the outgoing one's
-    /// tracked teardown (spec §3).
+    /// tracked teardown.
     public WorkspaceViewModel? CurrentWorkspace {
         get => _currentWorkspace;
         private set => this.RaiseAndSetIfChanged(ref _currentWorkspace, value);
@@ -175,8 +162,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     public ReactiveCommand<Unit, Unit> CloseWorkspaceCommand { get; }
 
     string? _startMessage;
-    // Start-daemon failure text. Cleared on every new start attempt AND on any transition to
-    // Connected (spec §5); set only when a start attempt actually fails.
+    // Cleared on every new start attempt and on Connected; set when a start attempt fails.
     public string? StartMessage {
         get => _startMessage;
         private set {
@@ -188,11 +174,8 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     public ReactiveCommand<Unit, Unit> StartDaemonCommand { get; }
     public ReactiveCommand<Unit, Unit> RetryCommand { get; }
 
-    // Button IsVisible projections (spec: "shows ONLY when its action is meaningful"). Deliberately
-    // NOT ReactiveCommand.CanExecute — that ANDs in "not currently executing", which would hide the
-    // button mid-attempt instead of just disabling it. These track the exact same state predicate
-    // (canStart/canRetry below) the commands' own canExecute pipelines use, ctor-scoped for the
-    // same reason those pipelines are (see class doc comment).
+    // Visibility tracks "action is meaningful", not CanExecute — CanExecute also ANDs "not
+    // executing", which would hide the button mid-attempt instead of only disabling it.
     readonly ObservableAsPropertyHelper<bool> _startVisible;
     public bool StartVisible => _startVisible.Value;
 
@@ -202,27 +185,20 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     readonly TimeProvider _time;
 
     /// <param name="shutdownToken">
-    /// Abandons StartDaemonAsync's WAIT (never the spawned daemon) on app shutdown. MUST be a
-    /// token linked to the app lifetime — never CancellationToken.None (Task 4 carry-note: an
-    /// unbounded wait would survive app exit).
+    /// Abandons StartDaemonAsync's WAIT (never the spawned daemon) on app shutdown. Must be linked
+    /// to the app lifetime — never CancellationToken.None (an unbounded wait would survive exit).
     /// </param>
     /// <param name="startAction">
-    /// spec §4.4: the service-aware Start action (DaemonLifecycleController.StartActionAsync).
-    /// Null falls back to the plain detached `StartDaemonAsync` RunStartAsync always used —
-    /// preserved so a caller without a live controller (most existing tests) keeps today's
-    /// behavior verbatim.
+    /// Service-aware Start (DaemonLifecycleController.StartActionAsync). Null falls back to plain
+    /// StartDaemonAsync — for callers without a live controller (most unit tests).
     /// </param>
     /// <param name="lifecycleStatus">
-    /// ILifecycleSurface.Status one-liners (e.g. "daemon started, app not yet
-    /// attached — retrying", a coded transaction failure) ride the SAME start-message lane
-    /// RunStartAsync already uses — one place near the Start button for "why isn't this working",
-    /// cleared by the identical Connected-transition rule below. Null (most existing tests, and
-    /// any caller without a live lifecycle controller) means this lane never receives anything.
+    /// ILifecycleSurface.Status one-liners ride the same StartMessage lane as start failures.
+    /// Null means this lane never receives anything.
     /// </param>
     /// <param name="lifecycleAttention">
-    /// ILifecycleSurface.Attention lines (mutation failures presented by the outcome consumer).
-    /// Same StartMessage lane as lifecycleStatus — otherwise a Start daemon click that fails in
-    /// the mutation lane only updates the menu-bar icon and the banner stays mute.
+    /// ILifecycleSurface.Attention lines on the same StartMessage lane — otherwise a mutation-lane
+    /// Start failure only updates the tray and the banner stays mute.
     /// </param>
     /// <param name="navigation">
     /// The composition root's app-lifetime NavigationGate. Null builds a private one, so
@@ -299,11 +275,6 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
         // behavior. Ctor-scoped for the same reason as the commands themselves.
         _startVisible = canStart.ToProperty(this, x => x.StartVisible, initialValue: false);
         _retryVisible = canRetry.ToProperty(this, x => x.RetryVisible, initialValue: false);
-        _recoveryVisible = service.Status
-            .CombineLatest(_startMessageChanges, (s, msg) =>
-                s.State == AttachState.Unreachable || !string.IsNullOrEmpty(msg))
-            .ObserveOn(RxSchedulers.MainThreadScheduler)
-            .ToProperty(this, x => x.RecoveryVisible, initialValue: false);
 
         // Launcher banner owns the chrome; share the same Start/Reconnect commands and start-message
         // lane so the pane never drifts from what MainWindow already drives.
@@ -391,9 +362,8 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
         });
     }
 
-    /// Card and rail click: swaps the window to this session's workspace on the Sessions surface,
-    /// starting the tracked teardown of whatever it replaces. Refused once shutdown has latched — a
-    /// new workspace is a new attach, and quiesce/disposal is already running (spec §3).
+    /// Card and rail click: swaps to this session's workspace. Refused once shutdown has latched —
+    /// a new workspace is a new attach, and quiesce is already running.
     public void OpenSession(string agentId) {
         if (_navigation.ShutdownLatched || _workspaceFactory is null) return;
         CurrentView = ShellView.Sessions;
@@ -417,10 +387,9 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     /// open must still retire an in-flight launch's captured generation.
     public void CloseWorkspace() => SwapTo(null);
 
-    /// The first shutdown pass, synchronously: unhook the live workspace and register its teardown
-    /// BEFORE the drain seals the tracker, then latch the gate so no later window can open another
-    /// one. A workspace that never went through a close or close-to-hide would otherwise register
-    /// its teardown after the drain, against already-disposed dependencies (spec §3).
+    /// First shutdown pass: unhook the live workspace and register its teardown before the drain
+    /// seals the tracker, then latch so no later window opens another. A workspace that never
+    /// closed would otherwise register teardown after drain against already-disposed deps.
     public void LatchShutdown() {
         var live = CurrentWorkspace;
         CurrentWorkspace = null;

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -45,7 +45,11 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     internal const string ReconnectFailedMessage =
         "Could not reconnect. If the daemon isn't running, press Start daemon.";
 
-    // StatusColors (shared with TrayIconRenderer's tray-icon overlay, spec §4) is hex-only
+    internal static bool IsInFlightReconnectMessage(string? message) =>
+        message == ReconnectingMessage
+        || message == DaemonLifecycleController.AlreadyRunningReconnectStatus;
+
+    // StatusColors (shared with TrayIconRenderer's tray-icon overlay) is hex-only
     // constants (plain strings, not Brush instances). A Brush is an AvaloniaObject with UI-thread
     // affinity enforced the moment the renderer references it; caching one as a shared
     // `static readonly` field would tie its affinity to whichever thread happens to trigger this
@@ -364,11 +368,12 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
                 .Subscribe(_ => StartMessage = null)
                 .DisposeWith(disposables);
 
-            // Retry only kicks reattach. If we land Unreachable again while still showing the
-            // in-flight reconnect copy, replace it so the click does not leave a forever-pending line.
+            // Reconnect / already-running kicks only reattach. If we land Unreachable again while
+            // still showing an in-flight reconnect copy, replace it so the banner does not claim
+            // reconnect forever.
             status.Where(s => s.State == AttachState.Unreachable)
                 .Subscribe(_ => {
-                    if (StartMessage == ReconnectingMessage)
+                    if (IsInFlightReconnectMessage(StartMessage))
                         StartMessage = ReconnectFailedMessage;
                 })
                 .DisposeWith(disposables);

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -157,7 +157,8 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     public SessionRailViewModel? Rail { get; }
 
     /// The active profile's name — the tenant slug (profiles are named after it at sign-in).
-    /// "" for a caller without one (tests, pre-onboarding); the footer binding tolerates it.
+    /// "" when absent or when the name is the literal built-in "default" (hiding that segment
+    /// so the rail footer does not read as a second "Default" next to connection state).
     public string TenantName { get; }
 
     /// The launch auto-open's staleness token — see NavigationGate. Read from the SHARED gate, not
@@ -253,7 +254,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
         _trackTeardown = trackWorkspaceTeardown ?? RunUntracked;
         _workspaceFactory = workspaceFactory;
         Rail = rail;
-        TenantName = tenantName ?? "";
+        TenantName = ProfileLabelForRail(tenantName);
         CloseWorkspaceCommand = ReactiveCommand.Create(CloseWorkspace);
         ShowHomeCommand = ReactiveCommand.Create(() => { CurrentView = ShellView.Home; });
         ShowSessionsCommand = ReactiveCommand.Create(() => { CurrentView = ShellView.Sessions; });
@@ -458,6 +459,14 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     }
 
     static string Capitalize(string word) => word.Length == 0 ? word : char.ToUpperInvariant(word[0]) + word[1..];
+
+    /// Named profiles stay visible beside Connected; the built-in "default" profile does not —
+    /// that word collides with the model/effort "Default" elsewhere in the chrome.
+    internal static string ProfileLabelForRail(string? profileName) =>
+        string.IsNullOrWhiteSpace(profileName)
+        || string.Equals(profileName, "default", StringComparison.OrdinalIgnoreCase)
+            ? ""
+            : profileName;
 
     // Single word for the merged status line. Local attach State is checked FIRST — the daemon's
     // own upstream Connection word is only meaningful once State is Connected (see the

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -1,6 +1,7 @@
 using System.Reactive;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using Avalonia.Media;
 using Capacitor.App.Services;
 using ReactiveUI;
@@ -26,10 +27,22 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     const string IncompatibleReason = "daemon_incompatible";
     const string UnreachableReason  = "daemon_unreachable";
 
-    // Neutral wording (spec §5): §4.2's incompatibility classification is a broad heuristic —
-    // an unexpected frame can equally mean the APP is the older side — so the UI must not
-    // prescribe an upgrade direction.
-    const string SkewMessage = "app and daemon are incompatible — make sure both are up to date";
+    // Neutral wording: incompatibility classification is a broad heuristic — an unexpected frame
+    // can equally mean the APP is the older side — so the UI must not prescribe an upgrade direction.
+    // User-facing copy lives on HomeViewModel (launcher banner); Reason mirrors it for tests/tray.
+
+    /// User-facing copy when the daemon isn't attached. Never the wire token (daemon_unreachable).
+    internal static string UnreachableMessage => HomeViewModel.DaemonDownNotice;
+
+    /// Shown the moment Start daemon is pressed, before the lifecycle/CLI work returns, so a
+    /// click is never silent even when the start action itself has nothing further to say.
+    internal const string StartingMessage = "Starting the daemon…";
+
+    /// Shown the moment Retry is pressed. Cleared on Connected; replaced if attach stays unreachable.
+    internal const string ReconnectingMessage = "Reconnecting…";
+
+    internal const string ReconnectFailedMessage =
+        "Could not reconnect. If the daemon isn't running, press Start daemon.";
 
     // StatusColors (shared with TrayIconRenderer's tray-icon overlay, spec §4) is hex-only
     // constants (plain strings, not Brush instances). A Brush is an AvaloniaObject with UI-thread
@@ -86,11 +99,17 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     ObservableAsPropertyHelper<AttachState>? _state;
     public AttachState State => _state?.Value ?? AttachState.Connecting;
 
-    // Display text for why we're not connected: the raw wire reason for daemon_unreachable, but
-    // the NEUTRAL skew message (never an upgrade-direction verdict) for daemon_incompatible; null
-    // outside Unreachable.
+    // Display text for why we're not connected: friendly copy only — never a raw wire token
+    // like daemon_unreachable. Null outside Unreachable.
     ObservableAsPropertyHelper<string?>? _reason;
     public string? Reason => _reason?.Value;
+
+    readonly BehaviorSubject<string?> _startMessageChanges = new(null);
+    readonly ObservableAsPropertyHelper<bool> _recoveryVisible;
+    /// Recovery chrome (banner + Start/Retry): Unreachable attach, or a failed start message still
+    /// on screen — so the user always has a next step, not a dead end.
+    public bool RecoveryVisible => _recoveryVisible.Value;
+
 
     /// The Activity feed (spec §7) — constructed once at the composition root, same instance the
     /// prompt window's onConcluded callback nudges, so this is a plain ctor-injected reference,
@@ -154,7 +173,10 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     // Connected (spec §5); set only when a start attempt actually fails.
     public string? StartMessage {
         get => _startMessage;
-        private set => this.RaiseAndSetIfChanged(ref _startMessage, value);
+        private set {
+            this.RaiseAndSetIfChanged(ref _startMessage, value);
+            _startMessageChanges.OnNext(value);
+        }
     }
 
     public ReactiveCommand<Unit, Unit> StartDaemonCommand { get; }
@@ -185,14 +207,19 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     /// behavior verbatim.
     /// </param>
     /// <param name="lifecycleStatus">
-    /// spec §6: ILifecycleSurface.Status one-liners (e.g. "daemon started, app not yet
+    /// ILifecycleSurface.Status one-liners (e.g. "daemon started, app not yet
     /// attached — retrying", a coded transaction failure) ride the SAME start-message lane
     /// RunStartAsync already uses — one place near the Start button for "why isn't this working",
     /// cleared by the identical Connected-transition rule below. Null (most existing tests, and
     /// any caller without a live lifecycle controller) means this lane never receives anything.
     /// </param>
+    /// <param name="lifecycleAttention">
+    /// ILifecycleSurface.Attention lines (mutation failures presented by the outcome consumer).
+    /// Same StartMessage lane as lifecycleStatus — otherwise a Start daemon click that fails in
+    /// the mutation lane only updates the menu-bar icon and the banner stays mute.
+    /// </param>
     /// <param name="navigation">
-    /// The composition root's app-lifetime NavigationGate (spec §3). Null builds a private one, so
+    /// The composition root's app-lifetime NavigationGate. Null builds a private one, so
     /// a caller with no navigation of its own (most existing tests) still gets a working VM — but
     /// only a SHARED gate makes the shutdown latch reach a window built after shutdown began.
     /// </param>
@@ -217,7 +244,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
             IObservable<string?>? lifecycleStatus = null, TimeProvider? time = null, HomeViewModel? home = null,
             NavigationGate? navigation = null, Action<Func<Task>>? trackWorkspaceTeardown = null,
             Func<string, WorkspaceViewModel>? workspaceFactory = null, SessionRailViewModel? rail = null,
-            string? tenantName = null) {
+            string? tenantName = null, IObservable<string?>? lifecycleAttention = null) {
         _service = service;
         _time = time ?? TimeProvider.System;
         Activity = activity;
@@ -251,8 +278,9 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
             .ObserveOn(RxSchedulers.MainThreadScheduler);
 
         var start = startAction ?? RunStartAsync;
-        StartDaemonCommand = ReactiveCommand.CreateFromTask(() => start(shutdownToken), canStart);
-        RetryCommand        = ReactiveCommand.CreateFromTask(service.RestartLoopAsync, canRetry);
+        StartDaemonCommand = ReactiveCommand.CreateFromTask(
+            () => InvokeStartAsync(start, shutdownToken), canStart);
+        RetryCommand = ReactiveCommand.CreateFromTask(InvokeRetryAsync, canRetry);
 
         // Independent subscriptions to the SAME canStart/canRetry state predicates the commands
         // above were built from (service.Status is hot/multicast, so a second subscriber replays
@@ -261,6 +289,19 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
         // behavior. Ctor-scoped for the same reason as the commands themselves.
         _startVisible = canStart.ToProperty(this, x => x.StartVisible, initialValue: false);
         _retryVisible = canRetry.ToProperty(this, x => x.RetryVisible, initialValue: false);
+        _recoveryVisible = service.Status
+            .CombineLatest(_startMessageChanges, (s, msg) =>
+                s.State == AttachState.Unreachable || !string.IsNullOrEmpty(msg))
+            .ObserveOn(RxSchedulers.MainThreadScheduler)
+            .ToProperty(this, x => x.RecoveryVisible, initialValue: false);
+
+        // Launcher banner owns the chrome; share the same Start/Retry commands and start-message
+        // lane so the pane never drifts from what MainWindow already drives.
+        var daemonRetryVisible = service.Status
+            .Select(s => s.State == AttachState.Unreachable)
+            .ObserveOn(RxSchedulers.MainThreadScheduler);
+        home?.AttachDaemonRecovery(
+            StartDaemonCommand, RetryCommand, canStart, daemonRetryVisible, _startMessageChanges);
 
         this.WhenActivated(disposables => {
             var status    = service.Status.ObserveOn(RxSchedulers.MainThreadScheduler);
@@ -320,10 +361,25 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
                 .Subscribe(_ => StartMessage = null)
                 .DisposeWith(disposables);
 
-            lifecycleStatus?.ObserveOn(RxSchedulers.MainThreadScheduler)
-                .Where(msg => msg is not null)
-                .Subscribe(msg => StartMessage = msg)
+            // Retry only kicks reattach. If we land Unreachable again while still showing the
+            // in-flight reconnect copy, replace it so the click does not leave a forever-pending line.
+            status.Where(s => s.State == AttachState.Unreachable)
+                .Subscribe(_ => {
+                    if (StartMessage == ReconnectingMessage)
+                        StartMessage = ReconnectFailedMessage;
+                })
                 .DisposeWith(disposables);
+
+            // Status (start-action one-liners) and Attention (mutation-outcome presentation) both
+            // land on StartMessage so the launcher banner is never mute after a Start daemon click.
+            void BindStartMessage(IObservable<string?>? source) =>
+                source?.ObserveOn(RxSchedulers.MainThreadScheduler)
+                    .Where(msg => msg is not null)
+                    .Subscribe(msg => StartMessage = msg)
+                    .DisposeWith(disposables);
+
+            BindStartMessage(lifecycleStatus);
+            BindStartMessage(lifecycleAttention);
         });
     }
 
@@ -388,8 +444,8 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     }
 
     static string? ReasonText(AttachStatus status) => status.State switch {
-        AttachState.Unreachable when status.Reason == IncompatibleReason => SkewMessage,
-        AttachState.Unreachable => status.Reason,
+        AttachState.Unreachable when status.Reason == IncompatibleReason => HomeViewModel.DaemonIncompatibleNotice,
+        AttachState.Unreachable => HomeViewModel.DaemonDownNotice,
         _ => null,
     };
 
@@ -431,15 +487,25 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
         };
     }
 
+    async Task InvokeStartAsync(Func<CancellationToken, Task> start, CancellationToken ct) {
+        StartMessage = StartingMessage;
+        await start(ct);
+    }
+
+    async Task InvokeRetryAsync() {
+        StartMessage = ReconnectingMessage;
+        await _service.RestartLoopAsync();
+    }
+
     async Task RunStartAsync(CancellationToken ct) {
-        StartMessage = null; // clear on every new attempt
         try {
             var result = await _service.StartDaemonAsync(ct);
             if (!result.Ok) StartMessage = result.Message;
+            else StartMessage = "Daemon start requested. Waiting to connect…";
         } catch (OperationCanceledException) {
             // App is quitting: OnShutdownRequested cancelled `ct` while this start was still in
-            // flight, and StartDaemonAsync deliberately rethrows OCE for exactly that case (spec
-            // §5 — ct abandons the WAIT, not the started daemon). Nothing subscribes to
+            // flight, and StartDaemonAsync deliberately rethrows OCE for exactly that case —
+            // ct abandons the WAIT, not the started daemon. Nothing subscribes to
             // StartDaemonCommand.ThrownExceptions, so letting this escape would have ReactiveUI's
             // default handler reschedule an UnhandledErrorException onto the still-alive
             // dispatcher. The app is exiting — there is nothing left to render.

--- a/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
@@ -311,13 +311,13 @@ public sealed class DaemonStepViewModel : ReactiveObject, IWizardStep {
         if (matched) {
             // Not enablement: a manual daemon dies at logout and no later startup phase repairs it.
             Set(DaemonRow.ManualIdentityMatch,
-                $"A daemon is already running outside the service (pid {daemonPid}) — it stops at logout unless kcap manages it.",
+                $"A daemon is already running outside the service (PID {daemonPid}) — it stops at logout unless kcap manages it.",
                 DaemonAffordance.Takeover);
             return;
         }
 
         Set(DaemonRow.ManualIdentityMismatch,
-            $"{DescribeForeign(_evidence)} is already running under this name (pid {daemonPid}) — kcap changed nothing.",
+            $"{DescribeForeign(_evidence)} is already running under this name (PID {daemonPid}) — kcap changed nothing.",
             DaemonAffordance.Takeover);
     }
 

--- a/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
@@ -103,8 +103,7 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
             Append(line);
         };
         bridges.Progress.ErrorReceived += line => {
-            // Headline + StatusDetail carry the failure. Do not also Append — that duplicated the
-            // same line under the progress log.
+            // Headline + StatusDetail only — Append would double the line in the progress log.
             var detail = FormatErrorDetail(line);
             _lastReport  = detail;
             StatusDetail = detail;

--- a/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
@@ -428,7 +428,7 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
                 SetStatus(
                     CommittedStatus(committed),
                     isError: false,
-                    "You're signed in. Updating the app…");
+                    "You're signed in. Refreshing…");
 
                 break;
             case AuthResult.Cancelled:

--- a/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
@@ -103,9 +103,11 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
             Append(line);
         };
         bridges.Progress.ErrorReceived += line => {
-            _lastReport  = line;
-            StatusDetail = line;
-            Append(line);
+            // Headline + StatusDetail carry the failure. Do not also Append — that duplicated the
+            // same line under the progress log.
+            var detail = FormatErrorDetail(line);
+            _lastReport  = detail;
+            StatusDetail = detail;
         };
         bridges.Progress.BrowserOpened      += url => {
             BrowserUrl = url;
@@ -146,7 +148,7 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
             ConfirmVisible = true;
         }, () => ConfirmVisible = false, ct);
         provisioner.PollProgress = (attempt, max) =>
-            _post(() => ProvisioningProgress = $"Setting up your workspace — this can take a few minutes… ({attempt}/{max})");
+            _post(() => ProvisioningProgress = $"Setting up your workspace. This can take a few minutes… ({attempt}/{max})");
 
         SignInCommand = ReactiveCommand.CreateFromTask(SignInAsync);
         CancelCommand = ReactiveCommand.Create(() => _attempt?.Cancel());
@@ -217,10 +219,16 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
 
     public bool StatusIsError {
         get => _statusIsError;
-        private set => this.RaiseAndSetIfChanged(ref _statusIsError, value);
+        private set {
+            this.RaiseAndSetIfChanged(ref _statusIsError, value);
+            this.RaisePropertyChanged(nameof(PrimaryActionLabel));
+        }
     }
 
-    /// The last error line the façade rendered — the detail behind the generic failure headline.
+    /// "Try again" after a failure so the primary action is not another "Sign in" next to the title.
+    public string PrimaryActionLabel => StatusIsError ? "Try again" : "Sign in";
+
+    /// The last error line the façade rendered. Detail behind the generic failure headline.
     public string? StatusDetail {
         get => _statusDetail;
         private set => this.RaiseAndSetIfChanged(ref _statusDetail, value);
@@ -231,6 +239,7 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         private set {
             this.RaiseAndSetIfChanged(ref _busy, value);
             this.RaisePropertyChanged(nameof(Idle));
+            this.RaisePropertyChanged(nameof(ShowPrimaryAction));
         }
     }
 
@@ -238,8 +247,14 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
 
     public bool Satisfied {
         get => _satisfied;
-        private set => this.RaiseAndSetIfChanged(ref _satisfied, value);
+        private set {
+            this.RaiseAndSetIfChanged(ref _satisfied, value);
+            this.RaisePropertyChanged(nameof(ShowPrimaryAction));
+        }
     }
+
+    /// Hidden once sign-in committed — the status line is the success state, not another Sign in.
+    public bool ShowPrimaryAction => Idle && !Satisfied;
 
     public string? DeviceCode {
         get => _deviceCode;
@@ -374,7 +389,7 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         SetStatus(
             "Waiting for your browser…",
             isError: false,
-            "Complete authorization there, then return here — this window updates on its own.");
+            "Complete authorization there, then return here. This window updates on its own.");
 
         AuthAttempt attempt;
 
@@ -382,7 +397,7 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
             attempt = _service.Begin(intent);
         } catch (InvalidOperationException) {
             Busy = false;
-            SetStatus("Finishing the previous attempt — try again in a moment.", isError: false);
+            SetStatus("Finishing the previous attempt. Try again in a moment.", isError: false);
 
             return;
         }
@@ -410,7 +425,10 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         switch (result) {
             case AuthResult.Committed committed:
                 Satisfied = true;
-                SetStatus(CommittedStatus(committed), isError: false);
+                SetStatus(
+                    CommittedStatus(committed),
+                    isError: false,
+                    "You're signed in. Updating the app…");
 
                 break;
             case AuthResult.Cancelled:
@@ -516,7 +534,7 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
     void SetStatus(string text, bool isError, string? detail = null) {
         Status        = text;
         StatusIsError = isError;
-        StatusDetail  = detail;
+        StatusDetail  = detail is null ? null : FormatErrorDetail(detail);
     }
 
     void Append(string line) {
@@ -540,5 +558,16 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         var note = code.IndexOf("  (copied", StringComparison.Ordinal);
 
         return note < 0 ? code.Trim() : code[..note].Trim();
+    }
+
+    /// Progress sink lines often start with "Error: "; the failure headline already says that.
+    internal static string FormatErrorDetail(string line) {
+        const string prefix = "Error: ";
+        var text = line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase)
+            ? line[prefix.Length..].TrimStart()
+            : line.Trim();
+        if (text.Length == 0) return text;
+
+        return char.ToUpperInvariant(text[0]) + text[1..];
     }
 }

--- a/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
@@ -109,7 +109,10 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         };
         bridges.Progress.BrowserOpened      += url => {
             BrowserUrl = url;
-            Append($"Opening your browser. If it doesn't open, visit: {url}");
+            // StatusDetail survives here: SetStatus only clears it on the next non-error headline.
+            StatusDetail = "Finish authorization in the browser, then return here. This window updates when you're done.";
+            WaitingText  = "Waiting for you to authorize…";
+            Append("Opened the sign-in page in your browser.");
         };
         bridges.Progress.DeviceCodeReceived += (code, verificationUri, prefilled) => {
             DeviceCode      = StripClipboardNote(code);
@@ -324,7 +327,7 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
     }
 
     public Task OnEnterAsync(CancellationToken ct) {
-        if (!Satisfied && !Busy) SetStatus(ReadyStatus(), isError: false);
+        if (!Satisfied && !Busy) SetStatus(ReadyStatus(), isError: false, ReadyDetail());
 
         return Task.CompletedTask;
     }
@@ -368,7 +371,10 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         ResetForRun(intent);
         Busy = true;
         // Before Begin: a synchronously-rendered error must not have its detail wiped by this.
-        SetStatus("Signing in…", isError: false);
+        SetStatus(
+            "Waiting for your browser…",
+            isError: false,
+            "Complete authorization there, then return here — this window updates on its own.");
 
         AuthAttempt attempt;
 
@@ -420,17 +426,13 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
             // Provisioning outran its poll window. Sign-in itself succeeded and the workspace is on its
             // way, so headlining a failure here would tell the user something untrue.
             case AuthResult.Failed { Reason: AuthFailureReason.ProvisioningInProgress } pending:
-                SetStatus(pending.Message, isError: false);
-                // The headline is the fact; the sink's line is what to do about it, and SetStatus
-                // drops the detail on a non-error.
-                StatusDetail ??= _lastReport;
+                SetStatus(pending.Message, isError: false, _lastReport);
 
                 break;
-            // Already rendered through the sink; the last reported line stands in when none was an error.
+            // Already rendered through the sink; prefer the last reported line over in-flight
+            // guidance (StatusDetail holds browser-wait copy until an ErrorReceived overwrites it).
             default:
-                Status        = "Sign-in failed.";
-                StatusIsError = true;
-                StatusDetail ??= _lastReport;
+                SetStatus("Sign-in failed.", isError: true, _lastReport ?? StatusDetail);
 
                 break;
         }
@@ -442,12 +444,23 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
             : committed.Username is { Length: > 0 } username ? $"Signed in as {username}" : "Signed in.";
 
     string ReadyStatus() => _connect.Intent switch {
-        ConnectIntent.Paste paste       => $"Ready to sign in to {paste.ServerInput}.",
+        // Destination only — the window title already says "Sign in"; detail explains what happens.
+        ConnectIntent.Paste paste       => paste.ServerInput,
         ConnectIntent.Discover discover => discover.Provider == AuthProvider.WorkOS
-            ? "Ready to find your workspaces with single sign-on."
-            : "Ready to find your workspaces with GitHub.",
-        ConnectIntent.Create => "Ready to create a workspace.",
-        _                    => "Choose how to connect on the Connect step."
+            ? "Find your workspaces with single sign-on"
+            : "Find your workspaces with GitHub",
+        ConnectIntent.Create => "Create a workspace",
+        _                    => "Choose how to connect on the Connect step.",
+    };
+
+    string ReadyDetail() => _connect.Intent switch {
+        ConnectIntent.Paste =>
+            "Opens your browser to authorize this machine and stores a token for launching hosted agents.",
+        ConnectIntent.Discover =>
+            "Opens your browser, then lists the workspaces your account can access.",
+        ConnectIntent.Create =>
+            "Walks you through setup, then authorizes this machine for the new workspace.",
+        _ => "Pick a connection option on the Connect step, then come back here.",
     };
 
     async Task SurfaceQuarantineAsync() {
@@ -500,10 +513,10 @@ public sealed class SignInStepViewModel : ReactiveObject, IWizardStep {
         ConfirmVisible       = false;
     }
 
-    void SetStatus(string text, bool isError) {
+    void SetStatus(string text, bool isError, string? detail = null) {
         Status        = text;
         StatusIsError = isError;
-        StatusDetail  = isError ? StatusDetail : null;
+        StatusDetail  = detail;
     }
 
     void Append(string line) {

--- a/src/Capacitor.App/ViewModels/SessionRailViewModel.cs
+++ b/src/Capacitor.App/ViewModels/SessionRailViewModel.cs
@@ -106,15 +106,16 @@ public sealed class SessionRailViewModel : ReactiveObject, IDisposable {
     }
 
     internal static string WorktreeKeyFor(AgentStatusDto dto) =>
-        CheckoutLabel.CheckoutPathFor(dto) ?? dto.RepoPath ?? "";
+        PlatformPaths.Normalize(CheckoutLabel.CheckoutPathFor(dto) ?? dto.RepoPath ?? "");
 
     // Memoized: ResolveMainRepoRoot reads .git files — cheap once, not per-changeset cheap; a
     // path's resolution never changes within a daemon's lifetime. A current daemon already sends
-    // the repository, so this only ever rewrites an older daemon's checkout path.
+    // the repository, so this only ever rewrites an older daemon's checkout path. The stored
+    // root is separator-normalized so `/repo` and `/repo/` never become two rail groups.
     string RepoRootFor(AgentStatusDto dto) {
         if (dto.RepoPath is not { Length: > 0 } path) return "";
         if (_rootByPath.TryGetValue(path, out var root)) return root;
-        root = _resolveRepoRoot(path);
+        root = PlatformPaths.Normalize(_resolveRepoRoot(path));
         _rootByPath[path] = root;
         return root;
     }

--- a/src/Capacitor.App/ViewModels/SessionStatusDots.cs
+++ b/src/Capacitor.App/ViewModels/SessionStatusDots.cs
@@ -24,4 +24,7 @@ public static class SessionStatusDots {
     /// The needs-you pip's status rule, held beside the dot vocabulary so the two can never
     /// disagree.
     public static bool NeedsAttention(string status) => status == "Failed";
+
+    /// Process is gone — Completed/Failed stay in the snapshot until teardown removes the agent.
+    public static bool IsTerminal(string? status) => status is "Completed" or "Failed";
 }

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -286,21 +286,24 @@ public sealed class TerminalTabViewModel : ReactiveObject {
                     HandleDtoObserved(change.Current);
                     break;
                 case ChangeReason.Remove:
-                    HandleAgentRemoved();
+                    HandleAgentEnded();
                     break;
             }
         }
     }
 
     void HandleDtoObserved(AgentStatusDto dto) {
-        // Only the FIRST observation is a resolve-gate event; a later update (status text, etc.)
-        // after the gate already decided is not re-run through it.
-        if (Interlocked.CompareExchange(ref _resolveState, ResolveDtoWon, ResolvePending) != ResolvePending) return;
-
-        _resolveTimer?.Dispose();
-        _resolveTimer = null;
-
-        PendingResolveWorkForTesting = RunResolveWorkAsync(dto);
+        // First observation wins the resolve gate; later updates only matter when the agent has
+        // already finished (Completed/Failed stay in the cache until teardown removes them).
+        var prior = Interlocked.CompareExchange(ref _resolveState, ResolveDtoWon, ResolvePending);
+        if (prior == ResolvePending) {
+            _resolveTimer?.Dispose();
+            _resolveTimer = null;
+            PendingResolveWorkForTesting = RunResolveWorkAsync(dto);
+            return;
+        }
+        if (prior == ResolveDtoWon && SessionStatusDots.IsTerminal(dto.Status))
+            HandleAgentEnded();
     }
 
     /// Fault-observing wrapper around ApplyResolvedDtoAsync: this Task is fire-and-forget from
@@ -324,12 +327,13 @@ public sealed class TerminalTabViewModel : ReactiveObject {
         }
     }
 
-    void HandleAgentRemoved() {
+    void HandleAgentEnded() {
         // Meaningful only once resolved via a DTO (not a pending or timed-out gate, which have
         // their own terminal renderings already).
         if (Volatile.Read(ref _resolveState) != ResolveDtoWon) return;
-        // Signal precedence: the run's own Exited/Failed verdict outranks a cache removal.
-        if (State.Phase is TerminalSessionPhase.Exited or TerminalSessionPhase.Failed) return;
+        // Signal precedence: the run's own Exited/Failed verdict outranks a cache end.
+        if (State.Phase is TerminalSessionPhase.Exited or TerminalSessionPhase.Failed
+            or TerminalSessionPhase.SessionEnded) return;
 
         Publish(TerminalSessionState.SessionEnded, null);
     }

--- a/src/Capacitor.App/ViewModels/ToolSummary.cs
+++ b/src/Capacitor.App/ViewModels/ToolSummary.cs
@@ -81,6 +81,22 @@ public static class ToolSummary {
         return sb.ToString();
     }
 
+    /// Short noun for a lone-call card chip — the detail line is not enough when the kind is
+    /// ambiguous (a Task prompt reads like prose without this).
+    public static string ChipLabel(ToolCategory category) => category switch {
+        ToolCategory.Read      => "Read",
+        ToolCategory.Edit      => "Edit",
+        ToolCategory.Command   => "Command",
+        ToolCategory.Search    => "Search",
+        ToolCategory.WebSearch => "Web",
+        ToolCategory.Fetch     => "Fetch",
+        ToolCategory.Skill     => "Skill",
+        ToolCategory.Agent     => "Task",
+        ToolCategory.Plan      => "Plan",
+        ToolCategory.Question  => "Question",
+        _                      => "Tool",
+    };
+
     static bool IsSkillFile(string? path) =>
         path is not null && (path == "SKILL.md" || path.EndsWith("/SKILL.md", StringComparison.Ordinal));
 

--- a/src/Capacitor.App/ViewModels/TrayModels.cs
+++ b/src/Capacitor.App/ViewModels/TrayModels.cs
@@ -18,8 +18,7 @@ public static class CheckoutLabel {
     public static string? CheckoutPathFor(AgentStatusDto dto) => dto.BorrowedFrom ?? dto.WorktreePath;
 
     public static bool IsMain(string checkout, string repoRoot) =>
-        PlatformPaths.Comparer.Equals(
-            Path.TrimEndingDirectorySeparator(checkout), Path.TrimEndingDirectorySeparator(repoRoot));
+        PlatformPaths.Comparer.Equals(checkout, repoRoot);
 
     public static string Format(string checkout, string repoRoot) =>
         IsMain(checkout, repoRoot) ? "main checkout" : PlatformPaths.Leaf(checkout);
@@ -30,13 +29,35 @@ public static class CheckoutLabel {
 public static class PlatformPaths {
     /// Repo paths compare the way the filesystem underneath them does: case-insensitively on
     /// Windows and macOS, case-sensitively on Linux where two checkouts differing only in case
-    /// are genuinely different repositories.
-    public static readonly StringComparer Comparer =
-        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase;
+    /// are genuinely different repositories. Trailing directory separators are ignored — `/a`
+    /// and `/a/` are one repository.
+    public static readonly StringComparer Comparer = new TrailingSeparatorComparer(
+        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+
+    /// Drops a trailing directory separator so list/group keys share one spelling.
+    public static string Normalize(string path) =>
+        string.IsNullOrEmpty(path) ? path : Path.TrimEndingDirectorySeparator(path);
 
     /// The path's own last segment, verbatim.
-    public static string Leaf(string path) =>
-        Path.GetFileName(Path.TrimEndingDirectorySeparator(path));
+    public static string Leaf(string path) => Path.GetFileName(Normalize(path));
+
+    sealed class TrailingSeparatorComparer(StringComparer inner) : StringComparer {
+        public override int Compare(string? x, string? y) {
+            if (ReferenceEquals(x, y)) return 0;
+            if (x is null) return -1;
+            if (y is null) return 1;
+            return inner.Compare(Normalize(x), Normalize(y));
+        }
+
+        public override bool Equals(string? x, string? y) {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+            return inner.Equals(Normalize(x), Normalize(y));
+        }
+
+        public override int GetHashCode(string obj) =>
+            inner.GetHashCode(Normalize(obj));
+    }
 }
 
 // StopEnabled: false while AgentActionService.StopsInFlight contains Id. Kind is the wire

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
@@ -3,6 +3,7 @@ using System.Reactive.Concurrency;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.LocalIpc;
@@ -106,11 +107,14 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
         }
     }
     bool _hasSession;
+    // Subject, not WhenAnyValue — same RxAppBuilder init trap as SessionRailViewModel.SelectedAgentId.
+    readonly BehaviorSubject<bool> _hasSessionChanges = new(false);
     public bool HasSession {
         get => _hasSession;
         private set {
             if (_hasSession == value) return;
             this.RaiseAndSetIfChanged(ref _hasSession, value);
+            _hasSessionChanges.OnNext(value);
             this.RaisePropertyChanged(nameof(RefreshTip));
         }
     }
@@ -132,6 +136,7 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
         _source = source;
         _opener = opener;
         InitializeProjections();
+        _disposables.Add(_hasSessionChanges);
 
         // Enabled for any known session id. A click while a read is in flight queues one follow-up
         // (RefreshPending) instead of disabling the control — a greyed icon looked broken and ate
@@ -142,7 +147,7 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
                 if (_current.IsReading) _current.RefreshPending = true;
                 else StartRead(_current);
             },
-            this.WhenAnyValue(x => x.HasSession));
+            _hasSessionChanges);
         _disposables.Add(RefreshCommand);
         SignInCommand = ReactiveCommand.Create(() => { requestSignIn?.Invoke(); });
         _disposables.Add(SignInCommand);

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
@@ -97,9 +97,28 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
     bool _isStale;
     public bool IsStale { get => _isStale; private set => this.RaiseAndSetIfChanged(ref _isStale, value); }
     bool _isReading;
-    public bool IsReading { get => _isReading; private set => this.RaiseAndSetIfChanged(ref _isReading, value); }
+    public bool IsReading {
+        get => _isReading;
+        private set {
+            if (_isReading == value) return;
+            this.RaiseAndSetIfChanged(ref _isReading, value);
+            this.RaisePropertyChanged(nameof(RefreshTip));
+        }
+    }
     bool _hasSession;
-    public bool HasSession { get => _hasSession; private set => this.RaiseAndSetIfChanged(ref _hasSession, value); }
+    public bool HasSession {
+        get => _hasSession;
+        private set {
+            if (_hasSession == value) return;
+            this.RaiseAndSetIfChanged(ref _hasSession, value);
+            this.RaisePropertyChanged(nameof(RefreshTip));
+        }
+    }
+
+    /// Tip on the header refresh control — bound with ShowOnDisabled so a greyed icon still explains itself.
+    public string RefreshTip => HasSession
+        ? IsReading ? "Refreshing…" : "Refresh"
+        : "Waiting for the session ID";
 
     public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
     public ReactiveCommand<Unit, Unit> SignInCommand { get; }
@@ -114,9 +133,16 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
         _opener = opener;
         InitializeProjections();
 
+        // Enabled for any known session id. A click while a read is in flight queues one follow-up
+        // (RefreshPending) instead of disabling the control — a greyed icon looked broken and ate
+        // the click with no feedback.
         RefreshCommand = ReactiveCommand.Create(
-            () => { if (_current is { IsReading: false } lease) StartRead(lease); },
-            this.WhenAnyValue(x => x.HasSession, x => x.IsReading, (has, reading) => has && !reading));
+            () => {
+                if (_current is null) return;
+                if (_current.IsReading) _current.RefreshPending = true;
+                else StartRead(_current);
+            },
+            this.WhenAnyValue(x => x.HasSession));
         _disposables.Add(RefreshCommand);
         SignInCommand = ReactiveCommand.Create(() => { requestSignIn?.Invoke(); });
         _disposables.Add(SignInCommand);

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -33,8 +33,8 @@ public enum WorkspaceTab { Chat, Terminal }
 ///
 /// A removed agent id freezes its LAST known dto rather than blanking the header back to
 /// placeholders -- SessionEnded flips (sticky, mirroring TerminalTabViewModel's own
-/// Exited/Failed stickiness) but Title/IdentitySubtitle/etc keep identifying the session
-/// that just ended instead of reverting to "— · —".
+/// Exited/Failed stickiness) but Title/RepoLabelText/etc keep identifying the session
+/// that just ended instead of reverting to "—".
 public sealed class WorkspaceViewModel : ReactiveObject {
     const string UnresolvedKind = "unresolved";
 
@@ -46,12 +46,8 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     public string Title => _title.Value;
 
     readonly ObservableAsPropertyHelper<string> _repoLabelText;
-    /// Checkout path only (`repo / worktree`); tests and Stop labels use this without harness meta.
+    /// Checkout under the title (`repo / worktree`); harness/transport live in the work-context pane.
     public string RepoLabelText => _repoLabelText.Value;
-
-    readonly ObservableAsPropertyHelper<string> _identitySubtitle;
-    /// Quiet meta under the title: checkout · transport · vendor (model).
-    public string IdentitySubtitle => _identitySubtitle.Value;
 
     readonly ObservableAsPropertyHelper<bool> _showsTerminalTab;
     public bool ShowsTerminalTab => _showsTerminalTab.Value;
@@ -126,9 +122,6 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         _repoLabelText = presence.Select(p => CheckoutLabelFor(p.Dto))
             .ToProperty(this, x => x.RepoLabelText, CheckoutLabelFor(null))
             .DisposeWith(_disposables);
-        _identitySubtitle = presence.Select(p => IdentitySubtitleFor(p.Dto))
-            .ToProperty(this, x => x.IdentitySubtitle, IdentitySubtitleFor(null))
-            .DisposeWith(_disposables);
         _showsTerminalTab = presence.Select(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
             .ToProperty(this, x => x.ShowsTerminalTab, initialValue: false)
             .DisposeWith(_disposables);
@@ -192,24 +185,6 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     }
 
     static string TitleFor(AgentStatusDto? dto) => dto?.Title ?? RepoLabel.Leaf(dto?.RepoPath);
-
-    /// Checkout, then transport family and vendor/model — one scannable meta line under the title.
-    internal static string IdentitySubtitleFor(AgentStatusDto? dto) {
-        var checkout = CheckoutLabelFor(dto);
-        if (dto is null) return checkout;
-        var family = HostedHarnessCatalog.EffectiveFamily(dto.HasTerminal, dto.Vendor);
-        var vendor = VendorLabelFor(dto);
-        return string.IsNullOrEmpty(family)
-            ? $"{checkout} · {vendor}"
-            : $"{checkout} · {family} · {vendor}";
-    }
-
-    static string VendorLabelFor(AgentStatusDto? dto) {
-        if (dto is null) return "—";
-        // Empty model is the harness default — name the vendor only; a concrete model rides beside it.
-        if (string.IsNullOrWhiteSpace(dto.Model)) return dto.Vendor;
-        return $"{dto.Vendor} ({HostedHarnessCatalog.ModelLabelFor(dto.Vendor, dto.Model)})";
-    }
 
     /// Disposes this workspace's own daemon-cache projections, then tears down Chat (if built), the
     /// work-context pane, and Terminal last -- the caller that closes a workspace tab calls this once.

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -195,11 +195,14 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         return dto.WorkLocation == WorkLocationText.Borrowed ? $"{label} · borrowed" : label;
     }
 
-    static string TitleFor(AgentStatusDto? dto) => dto?.Title ?? $"{RepoLabel.Leaf(dto?.RepoPath)} · {dto?.Vendor ?? "—"}";
+    static string TitleFor(AgentStatusDto? dto) => dto?.Title ?? RepoLabel.Leaf(dto?.RepoPath);
 
     static string VendorChipFor(AgentStatusDto? dto) {
         if (dto is null) return "—";
-        return dto.Model is null ? dto.Vendor : $"{dto.Vendor} ({dto.Model})";
+        // Empty model is the harness default — the chip names the vendor only; a concrete model
+        // rides beside it. Curated label when known, raw slug otherwise.
+        if (string.IsNullOrWhiteSpace(dto.Model)) return dto.Vendor;
+        return $"{dto.Vendor} ({HostedHarnessCatalog.ModelLabelFor(dto.Vendor, dto.Model)})";
     }
 
     /// Disposes this workspace's own daemon-cache projections, then tears down Chat (if built), the

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -31,8 +31,8 @@ public enum WorkspaceTab { Chat, Terminal }
 /// subscriber is exactly correct, unlike replaying a raw changeset to a fresh DynamicData query
 /// aggregator would be.
 ///
-/// A removed agent id freezes its LAST known dto rather than blanking the header back to
-/// placeholders -- SessionEnded flips (sticky, mirroring TerminalTabViewModel's own
+/// A removed or terminal-status agent freezes its LAST known dto rather than blanking the header
+/// back to placeholders -- SessionEnded flips (sticky, mirroring TerminalTabViewModel's own
 /// Exited/Failed stickiness) but Title/RepoLabelText/etc keep identifying the session
 /// that just ended instead of reverting to "—".
 public sealed class WorkspaceViewModel : ReactiveObject {
@@ -150,6 +150,8 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         OpenInWebCommand = ReactiveCommand.Create(() => actions.OpenInWeb(agentId));
         _disposables.Add(OpenInWebCommand);
 
+        var canStop = presence.Select(p => !p.SessionEnded)
+            .CombineLatest(actions.StopsInFlight, (alive, inFlight) => alive && !inFlight.Contains(agentId));
         StopCommand = ReactiveCommand.Create(() => {
             var dto = _latestDto;
             // UnresolvedKind fails safe as protected (AgentActionService.IsProtectedKind treats
@@ -159,7 +161,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
             var kind = dto?.Kind ?? UnresolvedKind;
             var label = dto is null ? agentId : $"{dto.Kind} · {dto.Vendor} · {RepoLabel.Leaf(dto.RepoPath)}";
             actions.RequestStop(agentId, label, kind);
-        });
+        }, canStop);
         _disposables.Add(StopCommand);
     }
 
@@ -169,6 +171,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         foreach (var change in changes) {
             if (change.Reason == ChangeReason.Remove) { ended = true; continue; } // dto stays frozen
             dto = change.Current;
+            if (SessionStatusDots.IsTerminal(dto.Status)) ended = true;
         }
         return new AgentPresence(dto, ended);
     }

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -33,7 +33,7 @@ public enum WorkspaceTab { Chat, Terminal }
 ///
 /// A removed agent id freezes its LAST known dto rather than blanking the header back to
 /// placeholders -- SessionEnded flips (sticky, mirroring TerminalTabViewModel's own
-/// Exited/Failed stickiness) but Title/RepoLabelText/VendorChip/etc keep identifying the session
+/// Exited/Failed stickiness) but Title/IdentitySubtitle/etc keep identifying the session
 /// that just ended instead of reverting to "— · —".
 public sealed class WorkspaceViewModel : ReactiveObject {
     const string UnresolvedKind = "unresolved";
@@ -46,13 +46,12 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     public string Title => _title.Value;
 
     readonly ObservableAsPropertyHelper<string> _repoLabelText;
+    /// Checkout path only (`repo / worktree`); tests and Stop labels use this without harness meta.
     public string RepoLabelText => _repoLabelText.Value;
 
-    readonly ObservableAsPropertyHelper<string> _vendorChip;
-    public string VendorChip => _vendorChip.Value;
-
-    readonly ObservableAsPropertyHelper<string> _familyDot;
-    public string FamilyDot => _familyDot.Value;
+    readonly ObservableAsPropertyHelper<string> _identitySubtitle;
+    /// Quiet meta under the title: checkout · transport · vendor (model).
+    public string IdentitySubtitle => _identitySubtitle.Value;
 
     readonly ObservableAsPropertyHelper<bool> _showsTerminalTab;
     public bool ShowsTerminalTab => _showsTerminalTab.Value;
@@ -127,11 +126,8 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         _repoLabelText = presence.Select(p => CheckoutLabelFor(p.Dto))
             .ToProperty(this, x => x.RepoLabelText, CheckoutLabelFor(null))
             .DisposeWith(_disposables);
-        _vendorChip = presence.Select(p => VendorChipFor(p.Dto))
-            .ToProperty(this, x => x.VendorChip, VendorChipFor(null))
-            .DisposeWith(_disposables);
-        _familyDot = presence.Select(p => p.Dto is null ? "" : HostedHarnessCatalog.EffectiveFamily(p.Dto.HasTerminal, p.Dto.Vendor))
-            .ToProperty(this, x => x.FamilyDot, "")
+        _identitySubtitle = presence.Select(p => IdentitySubtitleFor(p.Dto))
+            .ToProperty(this, x => x.IdentitySubtitle, IdentitySubtitleFor(null))
             .DisposeWith(_disposables);
         _showsTerminalTab = presence.Select(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
             .ToProperty(this, x => x.ShowsTerminalTab, initialValue: false)
@@ -197,10 +193,20 @@ public sealed class WorkspaceViewModel : ReactiveObject {
 
     static string TitleFor(AgentStatusDto? dto) => dto?.Title ?? RepoLabel.Leaf(dto?.RepoPath);
 
-    static string VendorChipFor(AgentStatusDto? dto) {
+    /// Checkout, then transport family and vendor/model — one scannable meta line under the title.
+    internal static string IdentitySubtitleFor(AgentStatusDto? dto) {
+        var checkout = CheckoutLabelFor(dto);
+        if (dto is null) return checkout;
+        var family = HostedHarnessCatalog.EffectiveFamily(dto.HasTerminal, dto.Vendor);
+        var vendor = VendorLabelFor(dto);
+        return string.IsNullOrEmpty(family)
+            ? $"{checkout} · {vendor}"
+            : $"{checkout} · {family} · {vendor}";
+    }
+
+    static string VendorLabelFor(AgentStatusDto? dto) {
         if (dto is null) return "—";
-        // Empty model is the harness default — the chip names the vendor only; a concrete model
-        // rides beside it. Curated label when known, raw slug otherwise.
+        // Empty model is the harness default — name the vendor only; a concrete model rides beside it.
         if (string.IsNullOrWhiteSpace(dto.Model)) return dto.Vendor;
         return $"{dto.Vendor} ({HostedHarnessCatalog.ModelLabelFor(dto.Vendor, dto.Model)})";
     }

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -90,7 +90,7 @@
                     <ItemsControl ItemsSource="{Binding PendingCards}">
                         <ItemsControl.DataTemplates>
                             <DataTemplate x:DataType="vm:PermissionCardViewModel">
-                                <Border Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapAccentBrush}"
+                                <Border Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapSuccessBrush}"
                                         BorderThickness="1" CornerRadius="10" Padding="13,10" Margin="0,0,0,6">
                                     <StackPanel Spacing="6">
                                         <TextBlock Text="{Binding ToolName}" FontWeight="SemiBold" FontSize="13" Foreground="{StaticResource KcapTextBrush}" />
@@ -103,17 +103,17 @@
                                             <Button Content="Allow always" Command="{Binding AllowAlwaysCommand}" IsVisible="{Binding ShowsAllowAlways}"
                                                     Background="Transparent" BorderBrush="Transparent" Foreground="{StaticResource KcapMutedBrush}" Padding="10,4" FontSize="12" CornerRadius="7" />
                                             <Button Content="Allow" Command="{Binding AllowCommand}" Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
-                                                    Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                                                    Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" />
                                         </StackPanel>
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>
                             <DataTemplate x:DataType="vm:QuestionCardViewModel">
-                                <Border Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapAccentBrush}"
+                                <Border Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapSuccessBrush}"
                                         BorderThickness="1" CornerRadius="10" Padding="13,10" Margin="0,0,0,6">
                                     <Border.Styles>
                                         <Style Selector="Button.selected">
-                                            <Setter Property="BorderBrush" Value="{StaticResource KcapAccentBrush}" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapSuccessBrush}" />
                                         </Style>
                                     </Border.Styles>
                                     <StackPanel Spacing="8" IsEnabled="{Binding !IsBusy}">
@@ -160,7 +160,7 @@
                                                             <Button DockPanel.Dock="Right" Content="Answer" Command="{Binding EnterCommand}"
                                                                     IsVisible="{Binding ShowsOtherAnswer}" Margin="6,0,0,0"
                                                                     Padding="10,4" FontSize="12" CornerRadius="7"
-                                                                    Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                                                                    Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" />
                                                             <TextBox Text="{Binding OtherText}" PlaceholderText="Other…" MaxLength="{Binding MaxOtherLength}"
                                                                      AcceptsReturn="False" FontSize="12" MinHeight="30">
                                                                 <TextBox.KeyBindings>
@@ -176,7 +176,7 @@
                                                    IsVisible="{Binding ErrorText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                         <Button Content="Submit" Command="{Binding SubmitCommand}" IsVisible="{Binding ShowsSubmit}"
                                                 HorizontalAlignment="Right" Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
-                                                Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" />
+                                                Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" />
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>
@@ -209,9 +209,9 @@
                     <Ellipse Grid.Column="2" Width="7" Height="7" Fill="{Binding StatusDot}" VerticalAlignment="Center" Margin="12,0,6,0" />
                     <TextBlock Grid.Column="3" Text="{Binding StatusText}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
                                VerticalAlignment="Center" />
-                    <Button x:Name="SendButton" Grid.Column="4" Content="Send" Command="{Binding SendCommand}" Margin="12,0,0,0"
+                    <Button x:Name="SendButton" Grid.Column="4" Classes="kcapPrimary" Content="Send" Command="{Binding SendCommand}" Margin="12,0,0,0"
                             Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
-                            Background="{StaticResource KcapAccentBrush}" Foreground="#07120E"
+                            Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
                             IsVisible="{Binding !IsReadOnlyParticipant}" />
                 </Grid>
             </StackPanel>

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -101,8 +101,8 @@
                                 </Panel>
                             </Grid>
                             <Button Classes="toolSummary" IsVisible="{Binding ShowsSummaryHeader}" Command="{Binding ToggleCommand}"
-                                    Background="Transparent" BorderBrush="Transparent" Padding="0" Cursor="Hand"
-                                    HorizontalAlignment="Left">
+                                    Background="Transparent" BorderBrush="Transparent" Padding="0,4" MinHeight="28" Cursor="Hand"
+                                    HorizontalAlignment="Left" HorizontalContentAlignment="Left">
                                 <StackPanel Orientation="Horizontal" Spacing="9">
                                     <Panel Width="12" Height="12" VerticalAlignment="Center">
                                         <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.8"

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -201,15 +201,10 @@
                     <TextBlock Text="{Binding ReadOnlyNotice, StringFormat='Read-only: {0}'}"
                                Foreground="{StaticResource KcapWarningBrush}" TextWrapping="Wrap" />
                 </Border>
-                <Grid ColumnDefinitions="*,Auto,Auto,Auto,Auto">
+                <Grid ColumnDefinitions="*,Auto">
                     <TextBlock Text="{Binding ComposerHint}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
                                VerticalAlignment="Center" TextTrimming="CharacterEllipsis" />
-                    <TextBlock Grid.Column="1" Text="{Binding ModelLabel}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
-                               VerticalAlignment="Center" Margin="12,0,0,0" />
-                    <Ellipse Grid.Column="2" Width="7" Height="7" Fill="{Binding StatusDot}" VerticalAlignment="Center" Margin="12,0,6,0" />
-                    <TextBlock Grid.Column="3" Text="{Binding StatusText}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
-                               VerticalAlignment="Center" />
-                    <Button x:Name="SendButton" Grid.Column="4" Classes="kcapPrimary" Content="Send" Command="{Binding SendCommand}" Margin="12,0,0,0"
+                    <Button x:Name="SendButton" Grid.Column="1" Classes="kcapPrimary" Content="Send" Command="{Binding SendCommand}" Margin="12,0,0,0"
                             Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
                             Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
                             IsVisible="{Binding !IsReadOnlyParticipant}" />

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -240,7 +240,7 @@
             <StackPanel Spacing="6">
                 <TextBox x:Name="ComposerInput" Classes="kcapEmbedded" Text="{Binding ComposerText}" AcceptsReturn="True" TextWrapping="Wrap"
                          MinHeight="38" MaxHeight="160" Background="Transparent" BorderThickness="0"
-                         PlaceholderText="Write a message" IsVisible="{Binding !IsReadOnlyParticipant}" />
+                         PlaceholderText="Write a message" IsVisible="{Binding ShowsComposer}" />
                 <!-- A flow participant is addressed through the flow protocol, never messaged
                      directly, so the banner replaces the input rather than overlaying a dead one. -->
                 <Border x:Name="ReadOnlyBanner" IsVisible="{Binding IsReadOnlyParticipant}"
@@ -255,7 +255,7 @@
                     <Button x:Name="SendButton" Grid.Column="1" Classes="kcapPrimary" Content="Send" Command="{Binding SendCommand}" Margin="12,0,0,0"
                             Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
                             Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
-                            IsVisible="{Binding !IsReadOnlyParticipant}" />
+                            IsVisible="{Binding ShowsComposer}" />
                 </Grid>
             </StackPanel>
         </Border>

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -43,37 +43,85 @@
                     </Border>
                 </DataTemplate>
                 <DataTemplate x:DataType="vm:ToolCallItem">
-                    <StackPanel Orientation="Horizontal" Spacing="9" Margin="0,0,0,6">
-                        <TextBlock Text="›" FontSize="13" Foreground="{StaticResource KcapFaintBrush}" VerticalAlignment="Center" />
-                        <TextBlock Text="{Binding Name}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
-                        <TextBlock Text="{Binding Detail}" FontSize="11" Foreground="{StaticResource KcapFaintBrush}"
-                                   TextTrimming="CharacterEllipsis" MaxWidth="480" VerticalAlignment="Center" />
-                        <TextBlock Text="{Binding OutcomeGlyph}" FontSize="11" VerticalAlignment="Center"
-                                   Foreground="{Binding IsError, Converter={x:Static views:ToolOutcomeBrushConverter.Instance}}" />
-                    </StackPanel>
+                    <Grid x:Name="ToolCallRow" ColumnDefinitions="*,Auto" Margin="0,0,0,4" MinHeight="18">
+                        <!-- Detail is the useful bit (command, path); paint it brighter. A bare tool
+                             name is fallback chrome only, so it stays muted. Selectable so a command
+                             can be copied without retyping. -->
+                        <SelectableTextBlock Text="{Binding Detail}" FontSize="12" LineHeight="16"
+                                   FontFamily="Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace"
+                                   Foreground="{StaticResource KcapTextBrush}"
+                                   TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                                   IsVisible="{Binding HasDetail}" />
+                        <SelectableTextBlock Text="{Binding Name}" FontSize="12" LineHeight="16"
+                                   FontFamily="Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace"
+                                   Foreground="{StaticResource KcapMutedBrush}"
+                                   TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                                   IsVisible="{Binding !HasDetail}" />
+                        <Panel Grid.Column="1" IsVisible="{Binding ShowRowStatus}">
+                            <Border x:Name="ToolStatusPill" Classes="toolStatus" Width="14" Height="8"
+                                    CornerRadius="4" Margin="8,0,0,0" VerticalAlignment="Center"
+                                    IsVisible="{Binding IsSettled}"
+                                    Background="{Binding IsError, Converter={x:Static views:ToolOutcomeBrushConverter.Instance}}" />
+                            <Border Classes="toolRunning toolStatus" Width="14" Height="8"
+                                    CornerRadius="4" Margin="8,0,0,0" VerticalAlignment="Center"
+                                    IsVisible="{Binding IsRunning}"
+                                    Background="{StaticResource KcapWarningBrush}" />
+                            <TextBlock Text="?" FontSize="11" Margin="8,0,0,0"
+                                       VerticalAlignment="Center"
+                                       IsVisible="{Binding IsAwaitingPermission}"
+                                       Foreground="{Binding IsError, Converter={x:Static views:ToolOutcomeBrushConverter.Instance}}" />
+                        </Panel>
+                    </Grid>
                 </DataTemplate>
                 <DataTemplate x:DataType="vm:ToolGroupItem">
-                    <StackPanel>
-                        <Button Classes="toolSummary" IsVisible="{Binding HasSummary}" Command="{Binding ToggleCommand}"
-                                Background="Transparent" BorderBrush="Transparent" Padding="0" Margin="0,0,0,6" Cursor="Hand"
-                                HorizontalAlignment="Left">
-                            <StackPanel Orientation="Horizontal" Spacing="9">
-                                <!-- Stroked chevron, not a text glyph — the 9px ▸ rendered as a dot. -->
-                                <Panel Width="12" Height="12" VerticalAlignment="Center">
-                                    <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.8"
-                                          StrokeLineCap="Round" StrokeJoin="Round"
-                                          Data="M3,4.5 L6,7.5 L9,4.5" IsVisible="{Binding IsExpanded}" />
-                                    <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.8"
-                                          StrokeLineCap="Round" StrokeJoin="Round"
-                                          Data="M4.5,3 L7.5,6 L4.5,9" IsVisible="{Binding !IsExpanded}" />
+                    <!-- Stretch to the chat column (capped like assistant text) so lone cards are
+                         not content-width pills. -->
+                    <Border MaxWidth="660" MinWidth="320" Margin="0,4,0,22" Padding="12,10" CornerRadius="10"
+                            Background="{StaticResource KcapSurfaceBrush}"
+                            BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                            HorizontalAlignment="Stretch">
+                        <StackPanel Spacing="6">
+                            <!-- Lone call: kind label + status on one header row; detail below.
+                                 Plain text (no chip chrome) so it lines up with the detail. -->
+                            <Grid ColumnDefinitions="*,Auto" IsVisible="{Binding ShowsKindChip}">
+                                <TextBlock Classes="toolKindChip" Text="{Binding KindChip}"
+                                           FontSize="10" FontWeight="SemiBold"
+                                           Foreground="{StaticResource KcapMutedBrush}"
+                                           VerticalAlignment="Center" />
+                                <Panel Grid.Column="1" DataContext="{Binding LoneCall}" VerticalAlignment="Center">
+                                    <Border Classes="toolStatus" Width="14" Height="8" CornerRadius="4"
+                                            VerticalAlignment="Center" IsVisible="{Binding IsSettled}"
+                                            Background="{Binding IsError, Converter={x:Static views:ToolOutcomeBrushConverter.Instance}}" />
+                                    <Border Classes="toolRunning toolStatus" Width="14" Height="8" CornerRadius="4"
+                                            VerticalAlignment="Center" IsVisible="{Binding IsRunning}"
+                                            Background="{StaticResource KcapWarningBrush}" />
+                                    <TextBlock Text="?" FontSize="11" VerticalAlignment="Center"
+                                               IsVisible="{Binding IsAwaitingPermission}"
+                                               Foreground="{Binding IsError, Converter={x:Static views:ToolOutcomeBrushConverter.Instance}}" />
                                 </Panel>
-                                <TextBlock Text="{Binding Summary}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
-                                <TextBlock Text="✕" FontSize="11" Foreground="{StaticResource KcapDangerBrush}"
-                                           IsVisible="{Binding HasFailure}" VerticalAlignment="Center" />
-                            </StackPanel>
-                        </Button>
-                        <ItemsControl ItemsSource="{Binding VisibleCalls}" />
-                    </StackPanel>
+                            </Grid>
+                            <Button Classes="toolSummary" IsVisible="{Binding ShowsSummaryHeader}" Command="{Binding ToggleCommand}"
+                                    Background="Transparent" BorderBrush="Transparent" Padding="0" Cursor="Hand"
+                                    HorizontalAlignment="Left">
+                                <StackPanel Orientation="Horizontal" Spacing="9">
+                                    <Panel Width="12" Height="12" VerticalAlignment="Center">
+                                        <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.8"
+                                              StrokeLineCap="Round" StrokeJoin="Round"
+                                              Data="M3,4.5 L6,7.5 L9,4.5" IsVisible="{Binding IsExpanded}" />
+                                        <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.8"
+                                              StrokeLineCap="Round" StrokeJoin="Round"
+                                              Data="M4.5,3 L7.5,6 L4.5,9" IsVisible="{Binding !IsExpanded}" />
+                                    </Panel>
+                                    <TextBlock Text="{Binding SummaryLine}" FontSize="12" Foreground="{StaticResource KcapMutedBrush}"
+                                               TextTrimming="CharacterEllipsis" MaxWidth="560" VerticalAlignment="Center" />
+                                    <Border Classes="toolStatus" Width="14" Height="8" CornerRadius="4"
+                                            Background="{StaticResource KcapDangerBrush}"
+                                            IsVisible="{Binding HasFailure}" VerticalAlignment="Center" />
+                                </StackPanel>
+                            </Button>
+                            <ItemsControl ItemsSource="{Binding VisibleCalls}" />
+                        </StackPanel>
+                    </Border>
                 </DataTemplate>
             </ItemsControl.DataTemplates>
         </ItemsControl>

--- a/src/Capacitor.App/Views/Converters.cs
+++ b/src/Capacitor.App/Views/Converters.cs
@@ -1,7 +1,7 @@
 using System.Globalization;
-using Avalonia.Controls;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
+using Avalonia.Media.Immutable;
 
 namespace Capacitor.App.Views;
 
@@ -17,15 +17,15 @@ public sealed class UppercaseConverter : IValueConverter {
         throw new NotSupportedException();
 }
 
-/// Activity row outcome badge (spec §7): green for allowed, red for denied. ActivityRow stays a
-/// plain record (no Avalonia types, so its mapping can construct off any thread) — the color
-/// lives here rather than as a cached Brush field, for the same UI-thread-affinity reason
-/// MainWindowViewModel.DotBrush documents.
+/// Activity row outcome badge (spec §7): the same Connected/Disrupted greens and reds as the
+/// status dots, so "allowed" matches a live session indicator rather than a darker Material green.
+/// ActivityRow stays a plain record (no Avalonia types) — color lives here for the same
+/// UI-thread-affinity reason MainWindowViewModel.DotBrush documents.
 public sealed class OutcomeBrushConverter : IValueConverter {
     public static readonly OutcomeBrushConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        new SolidColorBrush(Color.Parse(value is true ? "#2E7D32" : "#D32F2F"));
+        new SolidColorBrush(Color.Parse(value is true ? StatusColors.Connected : StatusColors.Disrupted));
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();
@@ -55,13 +55,16 @@ public sealed class OffscreenWhenInactiveConverter : IValueConverter {
         throw new NotSupportedException();
 }
 
-/// The tool-call outcome glyph's colour, resolved off the app palette at bind time for the same
-/// UI-thread-affinity reason OutcomeBrushConverter documents.
+/// Tool-call outcome colour: the same Connected/Disrupted greens and reds as the status dots
+/// and Activity "allowed"/"denied", so a settled tool never invents a second success green.
 public sealed class ToolOutcomeBrushConverter : IValueConverter {
     public static readonly ToolOutcomeBrushConverter Instance = new();
 
+    static readonly IBrush Success = new ImmutableSolidColorBrush(Color.Parse(StatusColors.Connected));
+    static readonly IBrush Failure = new ImmutableSolidColorBrush(Color.Parse(StatusColors.Disrupted));
+
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        Avalonia.Application.Current?.FindResource(value is true ? "KcapDangerBrush" : "KcapSuccessBrush");
+        value is true ? Failure : Success;
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/Converters.cs
+++ b/src/Capacitor.App/Views/Converters.cs
@@ -61,7 +61,7 @@ public sealed class ToolOutcomeBrushConverter : IValueConverter {
     public static readonly ToolOutcomeBrushConverter Instance = new();
 
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        Avalonia.Application.Current?.FindResource(value is true ? "KcapDangerBrush" : "KcapAccentBrush");
+        Avalonia.Application.Current?.FindResource(value is true ? "KcapDangerBrush" : "KcapSuccessBrush");
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/Converters.cs
+++ b/src/Capacitor.App/Views/Converters.cs
@@ -17,8 +17,8 @@ public sealed class UppercaseConverter : IValueConverter {
         throw new NotSupportedException();
 }
 
-/// Activity row outcome badge (spec §7): the same Connected/Disrupted greens and reds as the
-/// status dots, so "allowed" matches a live session indicator rather than a darker Material green.
+/// Activity row outcome badge: the same Connected/Disrupted greens and reds as the status dots,
+/// so "allowed" matches a live session indicator rather than a darker Material green.
 /// ActivityRow stays a plain record (no Avalonia types) — color lives here for the same
 /// UI-thread-affinity reason MainWindowViewModel.DotBrush documents.
 public sealed class OutcomeBrushConverter : IValueConverter {

--- a/src/Capacitor.App/Views/HomeView.axaml.cs
+++ b/src/Capacitor.App/Views/HomeView.axaml.cs
@@ -21,13 +21,14 @@ public partial class HomeView : UserControl {
     }
 }
 
-/// RepositoryChip's label: the repo leaf name, or "No repository" for HomeViewModel.ScratchRepoPath
-/// ("") — RepoLabel.Leaf("") returns "" (there is no leaf), not the sentinel this chip needs.
+/// RepositoryChip's label: always "Repo · …" so the chip's job stays readable next to
+/// Effort/Permissions — leaf name, or "No repository" for HomeViewModel.ScratchRepoPath
+/// ("" — RepoLabel.Leaf("") returns "", not the sentinel this chip needs).
 public sealed class RepositoryLabelConverter : IValueConverter {
     public static readonly RepositoryLabelConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is string { Length: > 0 } path ? RepoLabel.Leaf(path) : "No repository";
+        value is string { Length: > 0 } path ? $"Repo · {RepoLabel.Leaf(path)}" : "Repo · No repository";
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/HomeView.axaml.cs
+++ b/src/Capacitor.App/Views/HomeView.axaml.cs
@@ -39,9 +39,20 @@ public sealed class RepositoryLabelConverter : IValueConverter {
 public sealed class CountIsZeroConverter : IValueConverter {
     public static readonly CountIsZeroConverter Instance = new();
 
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is int count && count == 0;
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is int n && n == 0;
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Inverse of CountIsZeroConverter — progress logs and similar, visible only while there is content.
+public sealed class CountIsNotZeroConverter : IValueConverter {
+    public static readonly CountIsNotZeroConverter Instance = new();
+
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is int n && n != 0;
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();
 }

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml
@@ -6,93 +6,105 @@
              x:DataType="vm:HomeViewModel">
     <!-- The Sessions surface's empty state: launching IS the pane, T3-style — a headline naming
          the selected repository over one big composer. DataContext is a HomeViewModel supplied
-         externally (MainWindow binds Home), same contract as HomeView. -->
-    <StackPanel VerticalAlignment="Center" HorizontalAlignment="Stretch" MaxWidth="680"
-                Spacing="20" Margin="24,0">
-        <TextBlock FontSize="26" FontWeight="SemiBold" Foreground="{StaticResource KcapTextBrush}"
-                   HorizontalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center"
-                   Text="{Binding SelectedRepoPath, Converter={x:Static views:LauncherHeadlineConverter.Instance}}" />
-
-        <Border Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                BorderThickness="1" CornerRadius="12" Padding="14">
-            <StackPanel Spacing="12">
-                <TextBox x:Name="GoalInput" Classes="kcapEmbedded" Text="{Binding Goal}"
-                         PlaceholderText="What should we build? Type a goal or paste an issue, PR, or work-item URL…"
-                         Background="Transparent" Foreground="{StaticResource KcapTextBrush}"
-                         BorderThickness="0" MinHeight="72" TextWrapping="Wrap" FontSize="14"
-                         VerticalContentAlignment="Top" AcceptsReturn="False" />
-
-                <Grid ColumnDefinitions="*,Auto">
-                    <WrapPanel ItemSpacing="8" LineSpacing="8" VerticalAlignment="Center">
-                        <Button x:Name="RepositoryChip" Click="OnRepositoryChipClick"
-                                Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                                Content="{Binding SelectedRepoPath, Converter={x:Static views:RepositoryLabelConverter.Instance}}"
-                                ToolTip.Tip="{Binding SelectedRepoPath}" />
-
-                        <!-- One picker for harness AND model (T3-style): searchable, grouped by
-                             vendor, with a per-vendor default row and a typed-custom escape hatch —
-                             built per open in code-behind, like the repository picker. -->
-                        <Button x:Name="AgentChip" Click="OnAgentChipClick"
-                                Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                                ToolTip.Tip="Harness and model">
-                            <StackPanel Orientation="Horizontal" Spacing="7">
-                                <ContentControl VerticalAlignment="Center"
-                                                Content="{Binding SelectedVendor, Converter={x:Static views:VendorGlyphConverter.Instance}, ConverterParameter=13}" />
-                                <TextBlock VerticalAlignment="Center">
-                                    <TextBlock.Text>
-                                        <MultiBinding Converter="{x:Static views:AgentChipTextConverter.Instance}">
-                                            <Binding Path="Harnesses" />
-                                            <Binding Path="SelectedVendor" />
-                                            <Binding Path="SelectedModel" />
-                                        </MultiBinding>
-                                    </TextBlock.Text>
-                                </TextBlock>
-                            </StackPanel>
-                        </Button>
-
-                        <Button x:Name="EffortChip" Click="OnEffortChipClick"
-                                Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                                Content="{Binding SelectedEffort, Converter={x:Static views:EffortChipTextConverter.Instance}}"
-                                ToolTip.Tip="Reasoning effort — Default lets the harness decide" />
-
-                        <Button x:Name="PermissionChip" Click="OnPermissionChipClick"
-                                Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                                Content="{Binding SelectedPermissionMode, Converter={x:Static views:PermissionChipTextConverter.Instance}}"
-                                IsVisible="{Binding SelectedVendor, Converter={x:Static views:PermissionChipVisibleConverter.Instance}}"
-                                ToolTip.Tip="Permission mode — how much Claude asks before acting" />
-                    </WrapPanel>
-
-                    <Button Grid.Column="1" x:Name="StartButton" Command="{Binding StartCommand}"
-                            Background="{StaticResource KcapAccentBrush}" Width="36" Height="36" CornerRadius="18"
-                            Padding="0" Margin="12,0,0,0" VerticalAlignment="Bottom"
-                            HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                            ToolTip.Tip="Start" AutomationProperties.Name="Start"
-                            IsEnabled="{Binding SelectedRepoPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                        <Path Data="M8,13.5 L8,3 M3.5,7.5 L8,3 L12.5,7.5" Stroke="#07120E" StrokeThickness="2"
-                              StrokeLineCap="Round" StrokeJoin="Round" Width="16" Height="16" />
-                    </Button>
-                </Grid>
-
-                <TextBlock x:Name="StartErrorText" Text="{Binding StartError}" Foreground="{StaticResource KcapDangerBrush}"
-                           TextWrapping="Wrap"
-                           IsVisible="{Binding StartError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-
-                <StackPanel Orientation="Horizontal" Spacing="10"
-                            IsVisible="{Binding ConnectionNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                    <TextBlock x:Name="ConnectionNoticeText" Text="{Binding ConnectionNotice}"
-                               Foreground="{StaticResource KcapMutedBrush}" TextWrapping="Wrap"
-                               VerticalAlignment="Center"
-                               IsVisible="{Binding ConnectionNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                    <Button x:Name="HomeSignInButton" Content="Sign in" Command="{Binding SignInCommand}"
-                            Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" FontWeight="SemiBold"
-                            CornerRadius="7" Padding="12,5"
-                            IsVisible="{Binding SignInVisible}" />
-                </StackPanel>
-            </StackPanel>
+         externally (MainWindow binds Home), same contract as HomeView. Connection / sign-in
+         status sits ABOVE the composer card as chrome, not inside the goal field. -->
+    <DockPanel Margin="24,0">
+        <Border DockPanel.Dock="Top" Margin="0,0,0,16" Padding="14,10" CornerRadius="10"
+                HorizontalAlignment="Stretch" MaxWidth="680"
+                Background="{StaticResource KcapWarningDimBrush}"
+                BorderBrush="{StaticResource KcapWarningBrush}" BorderThickness="1"
+                IsVisible="{Binding ConnectionNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBlock x:Name="ConnectionNoticeText" Text="{Binding ConnectionNotice}"
+                           Foreground="{StaticResource KcapWarningBrush}" FontSize="13"
+                           TextWrapping="Wrap" VerticalAlignment="Center" />
+                <Button Grid.Column="1" x:Name="HomeSignInButton" Classes="kcapPrimary"
+                        Content="Sign in" Command="{Binding SignInCommand}"
+                        Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
+                        FontWeight="SemiBold" CornerRadius="7" Padding="14,6" Margin="16,0,0,0"
+                        VerticalAlignment="Center"
+                        IsVisible="{Binding SignInVisible}" />
+            </Grid>
         </Border>
-    </StackPanel>
+
+        <StackPanel VerticalAlignment="Center" HorizontalAlignment="Stretch" MaxWidth="680"
+                    Spacing="20">
+            <TextBlock FontSize="26" FontWeight="SemiBold" Foreground="{StaticResource KcapTextBrush}"
+                       HorizontalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center"
+                       Text="{Binding SelectedRepoPath, Converter={x:Static views:LauncherHeadlineConverter.Instance}}" />
+
+            <Border Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                    BorderThickness="1" CornerRadius="12" Padding="14">
+                <StackPanel Spacing="12">
+                    <TextBox x:Name="GoalInput" Classes="kcapEmbedded" Text="{Binding Goal}"
+                             PlaceholderText="What should we build? Type a goal or paste an issue, PR, or work-item URL…"
+                             Background="Transparent" Foreground="{StaticResource KcapTextBrush}"
+                             BorderThickness="0" MinHeight="72" TextWrapping="Wrap" FontSize="14"
+                             VerticalContentAlignment="Top" AcceptsReturn="False" />
+
+                    <Grid ColumnDefinitions="*,Auto">
+                        <WrapPanel ItemSpacing="8" LineSpacing="8" VerticalAlignment="Center">
+                            <Button x:Name="RepositoryChip" Classes="kcapChip" Click="OnRepositoryChipClick"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                    Content="{Binding SelectedRepoPath, Converter={x:Static views:RepositoryLabelConverter.Instance}}"
+                                    ToolTip.Tip="Repository for the new session" />
+
+                            <!-- One picker for harness AND model (T3-style): searchable, grouped by
+                                 vendor, with a per-vendor default row and a typed-custom escape hatch —
+                                 built per open in code-behind, like the repository picker. -->
+                            <Button x:Name="AgentChip" Classes="kcapChip" Click="OnAgentChipClick"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                    ToolTip.Tip="Harness and model">
+                                <StackPanel Orientation="Horizontal" Spacing="7">
+                                    <ContentControl VerticalAlignment="Center"
+                                                    Content="{Binding SelectedVendor, Converter={x:Static views:VendorGlyphConverter.Instance}, ConverterParameter=13}" />
+                                    <TextBlock VerticalAlignment="Center">
+                                        <TextBlock.Text>
+                                            <MultiBinding Converter="{x:Static views:AgentChipTextConverter.Instance}">
+                                                <Binding Path="Harnesses" />
+                                                <Binding Path="SelectedVendor" />
+                                                <Binding Path="SelectedModel" />
+                                            </MultiBinding>
+                                        </TextBlock.Text>
+                                    </TextBlock>
+                                </StackPanel>
+                            </Button>
+
+                            <Button x:Name="EffortChip" Classes="kcapChip" Click="OnEffortChipClick"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                    Content="{Binding SelectedEffort, Converter={x:Static views:EffortChipTextConverter.Instance}}"
+                                    ToolTip.Tip="Reasoning effort — Default lets the harness decide" />
+
+                            <Button x:Name="PermissionChip" Classes="kcapChip" Click="OnPermissionChipClick"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                    Content="{Binding SelectedPermissionMode, Converter={x:Static views:PermissionChipTextConverter.Instance}}"
+                                    IsVisible="{Binding SelectedVendor, Converter={x:Static views:PermissionChipVisibleConverter.Instance}}"
+                                    ToolTip.Tip="Permission mode — how much Claude asks before acting" />
+                        </WrapPanel>
+
+                        <Button Grid.Column="1" x:Name="StartButton" Classes="kcapPrimary" Command="{Binding StartCommand}"
+                                Background="{StaticResource KcapPrimaryBrush}" Width="36" Height="36" CornerRadius="18"
+                                Padding="0" Margin="12,0,0,0" VerticalAlignment="Bottom"
+                                HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                                ToolTip.Tip="{Binding StartButtonTip}"
+                                ToolTip.ShowOnDisabled="True"
+                                AutomationProperties.Name="Start"
+                                IsEnabled="{Binding SelectedRepoPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                            <Path Data="M8,13.5 L8,3 M3.5,7.5 L8,3 L12.5,7.5"
+                                  Stroke="{StaticResource KcapOnPrimaryBrush}" StrokeThickness="2"
+                                  StrokeLineCap="Round" StrokeJoin="Round" Width="16" Height="16" />
+                        </Button>
+                    </Grid>
+
+                    <TextBlock x:Name="StartErrorText" Text="{Binding StartError}" Foreground="{StaticResource KcapDangerBrush}"
+                               TextWrapping="Wrap"
+                               IsVisible="{Binding StartError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                </StackPanel>
+            </Border>
+        </StackPanel>
+    </DockPanel>
 </UserControl>

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml
@@ -15,22 +15,17 @@
                 BorderBrush="{StaticResource KcapWarningBrush}" BorderThickness="1"
                 IsVisible="{Binding ConnectionBannerVisible}">
             <StackPanel Spacing="12">
-                <StackPanel Spacing="6">
-                    <TextBlock x:Name="ConnectionNoticeText" Text="{Binding ConnectionNotice}"
-                               Foreground="{StaticResource KcapWarningBrush}" FontSize="13" LineHeight="20"
-                               TextWrapping="Wrap" />
-                    <TextBlock x:Name="DaemonStartMessageText" Text="{Binding DaemonStartMessage}"
-                               Foreground="{StaticResource KcapDangerBrush}" FontSize="12.5" LineHeight="18"
-                               TextWrapping="Wrap"
-                               IsVisible="{Binding DaemonStartMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                </StackPanel>
+                <TextBlock x:Name="BannerMessageText" Text="{Binding BannerMessage}"
+                           Foreground="{StaticResource KcapWarningBrush}" FontSize="13" LineHeight="20"
+                           TextWrapping="Wrap"
+                           IsVisible="{Binding BannerMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Left">
                     <Button x:Name="StartDaemonButton" Classes="kcapPrimary" Content="Start daemon"
                             Command="{Binding StartDaemonCommand}" IsVisible="{Binding DaemonStartVisible}"
                             Background="{StaticResource KcapPrimaryBrush}"
                             Foreground="{StaticResource KcapOnPrimaryBrush}"
                             FontWeight="SemiBold" CornerRadius="7" Padding="14,6" />
-                    <Button x:Name="RetryDaemonButton" Classes="kcapChip" Content="Retry"
+                    <Button x:Name="RetryDaemonButton" Classes="kcapChip" Content="Reconnect"
                             Command="{Binding RetryDaemonCommand}" IsVisible="{Binding DaemonRetryVisible}"
                             Background="{StaticResource KcapSurfaceRaisedBrush}"
                             BorderBrush="{StaticResource KcapBorderBrush}"

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml
@@ -4,8 +4,8 @@
              xmlns:views="clr-namespace:Capacitor.App.Views"
              x:Class="Capacitor.App.Views.LauncherPaneView"
              x:DataType="vm:HomeViewModel">
-    <!-- The Sessions surface's empty state: launching IS the pane, T3-style — a headline naming
-         the selected repository over one big composer. DataContext is a HomeViewModel supplied
+    <!-- The Sessions surface's empty state: launching IS the pane — a fixed question over an
+         optional repo subtitle, then one big composer. DataContext is a HomeViewModel supplied
          externally (MainWindow binds Home), same contract as HomeView. Connection / sign-in
          status sits ABOVE the composer card as chrome, not inside the goal field. -->
     <DockPanel Margin="24,16,24,0">
@@ -47,9 +47,22 @@
 
         <StackPanel VerticalAlignment="Center" HorizontalAlignment="Stretch" MaxWidth="680"
                     Spacing="20">
-            <TextBlock FontSize="26" FontWeight="SemiBold" Foreground="{StaticResource KcapTextBrush}"
-                       HorizontalAlignment="Center" TextWrapping="Wrap" TextAlignment="Center"
-                       Text="{Binding SelectedRepoPath, Converter={x:Static views:LauncherHeadlineConverter.Instance}}" />
+            <!-- Question is fixed; the leaf sits on its own line so a long name never blows out
+                 the 26px sentence or fights the chip row. -->
+            <StackPanel Spacing="6" HorizontalAlignment="Center">
+                <TextBlock x:Name="LauncherHeadline" Text="What should we build?"
+                           FontSize="26" FontWeight="SemiBold" LineHeight="32" LetterSpacing="-0.3"
+                           Foreground="{StaticResource KcapTextBrush}"
+                           HorizontalAlignment="Center" TextAlignment="Center" />
+                <TextBlock x:Name="LauncherRepoSubtitle"
+                           Text="{Binding SelectedRepoPath, Converter={x:Static views:LauncherRepoSubtitleConverter.Instance}}"
+                           FontSize="15" FontWeight="Medium" LineHeight="22" LetterSpacing="0.2"
+                           Foreground="{StaticResource KcapMutedBrush}"
+                           HorizontalAlignment="Center" TextAlignment="Center"
+                           TextTrimming="CharacterEllipsis" MaxWidth="640"
+                           ToolTip.Tip="{Binding SelectedRepoPath}"
+                           IsVisible="{Binding SelectedRepoPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+            </StackPanel>
 
             <Border Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                     BorderThickness="1" CornerRadius="12" Padding="14">
@@ -60,63 +73,71 @@
                              BorderThickness="0" MinHeight="72" TextWrapping="Wrap" FontSize="14"
                              VerticalContentAlignment="Top" AcceptsReturn="False" />
 
-                    <Grid ColumnDefinitions="*,Auto">
-                        <WrapPanel ItemSpacing="8" LineSpacing="8" VerticalAlignment="Center">
-                            <Button x:Name="RepositoryChip" Classes="kcapChip" Click="OnRepositoryChipClick"
-                                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                    Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                                    Content="{Binding SelectedRepoPath, Converter={x:Static views:RepositoryLabelConverter.Instance}}"
-                                    ToolTip.Tip="Repository for the new session" />
-
-                            <!-- One picker for harness AND model (T3-style): searchable, grouped by
-                                 vendor, with a per-vendor default row and a typed-custom escape hatch —
-                                 built per open in code-behind, like the repository picker. -->
-                            <Button x:Name="AgentChip" Classes="kcapChip" Click="OnAgentChipClick"
-                                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                    Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                                    ToolTip.Tip="Harness and model">
-                                <StackPanel Orientation="Horizontal" Spacing="7">
-                                    <ContentControl VerticalAlignment="Center"
-                                                    Content="{Binding SelectedVendor, Converter={x:Static views:VendorGlyphConverter.Instance}, ConverterParameter=13}" />
-                                    <TextBlock VerticalAlignment="Center">
-                                        <TextBlock.Text>
-                                            <MultiBinding Converter="{x:Static views:AgentChipTextConverter.Instance}">
-                                                <Binding Path="Harnesses" />
-                                                <Binding Path="SelectedVendor" />
-                                                <Binding Path="SelectedModel" />
-                                            </MultiBinding>
-                                        </TextBlock.Text>
-                                    </TextBlock>
-                                </StackPanel>
-                            </Button>
-
-                            <Button x:Name="EffortChip" Classes="kcapChip" Click="OnEffortChipClick"
-                                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                    Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                                    Content="{Binding SelectedEffort, Converter={x:Static views:EffortChipTextConverter.Instance}}"
-                                    ToolTip.Tip="Reasoning effort. Default lets the harness decide" />
-
-                            <Button x:Name="PermissionChip" Classes="kcapChip" Click="OnPermissionChipClick"
-                                    Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                    Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
-                                    Content="{Binding SelectedPermissionMode, Converter={x:Static views:PermissionChipTextConverter.Instance}}"
-                                    IsVisible="{Binding SelectedVendor, Converter={x:Static views:PermissionChipVisibleConverter.Instance}}"
-                                    ToolTip.Tip="Permission mode. How much Claude asks before acting" />
-                        </WrapPanel>
-
-                        <Button Grid.Column="1" x:Name="StartButton" Classes="kcapPrimary" Command="{Binding StartCommand}"
-                                Background="{StaticResource KcapPrimaryBrush}" Width="36" Height="36" CornerRadius="18"
-                                Padding="0" Margin="12,0,0,0" VerticalAlignment="Bottom"
-                                HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
-                                ToolTip.Tip="{Binding StartButtonTip}"
-                                ToolTip.ShowOnDisabled="True"
-                                AutomationProperties.Name="Start"
-                                IsEnabled="{Binding SelectedRepoPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                            <Path Data="M8,13.5 L8,3 M3.5,7.5 L8,3 L12.5,7.5"
-                                  Stroke="{StaticResource KcapOnPrimaryBrush}" StrokeThickness="2"
-                                  StrokeLineCap="Round" StrokeJoin="Round" Width="16" Height="16" />
+                    <!-- Repo on its own row (capped width + ellipsis); settings + Start below so a
+                         long leaf never orphans Permissions alone under the repo pill. -->
+                    <StackPanel Spacing="8">
+                        <Button x:Name="RepositoryChip" Classes="kcapChip" Click="OnRepositoryChipClick"
+                                HorizontalAlignment="Left" MaxWidth="460"
+                                Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                ToolTip.Tip="{Binding SelectedRepoPath, Converter={x:Static views:RepositoryChipTipConverter.Instance}}">
+                            <TextBlock Text="{Binding SelectedRepoPath, Converter={x:Static views:RepositoryLabelConverter.Instance}}"
+                                       TextTrimming="CharacterEllipsis"
+                                       Foreground="{StaticResource KcapTextBrush}" />
                         </Button>
-                    </Grid>
+
+                        <Grid ColumnDefinitions="*,Auto">
+                            <WrapPanel ItemSpacing="8" LineSpacing="8" VerticalAlignment="Center">
+                                <!-- One picker for harness AND model (T3-style): searchable, grouped by
+                                     vendor, with a per-vendor default row and a typed-custom escape hatch —
+                                     built per open in code-behind, like the repository picker. -->
+                                <Button x:Name="AgentChip" Classes="kcapChip" Click="OnAgentChipClick"
+                                        Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                        Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                        ToolTip.Tip="Harness and model">
+                                    <StackPanel Orientation="Horizontal" Spacing="7">
+                                        <ContentControl VerticalAlignment="Center"
+                                                        Content="{Binding SelectedVendor, Converter={x:Static views:VendorGlyphConverter.Instance}, ConverterParameter=13}" />
+                                        <TextBlock VerticalAlignment="Center">
+                                            <TextBlock.Text>
+                                                <MultiBinding Converter="{x:Static views:AgentChipTextConverter.Instance}">
+                                                    <Binding Path="Harnesses" />
+                                                    <Binding Path="SelectedVendor" />
+                                                    <Binding Path="SelectedModel" />
+                                                </MultiBinding>
+                                            </TextBlock.Text>
+                                        </TextBlock>
+                                    </StackPanel>
+                                </Button>
+
+                                <Button x:Name="EffortChip" Classes="kcapChip" Click="OnEffortChipClick"
+                                        Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                        Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                        Content="{Binding SelectedEffort, Converter={x:Static views:EffortChipTextConverter.Instance}}"
+                                        ToolTip.Tip="Reasoning effort. Default lets the harness decide" />
+
+                                <Button x:Name="PermissionChip" Classes="kcapChip" Click="OnPermissionChipClick"
+                                        Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
+                                        Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
+                                        Content="{Binding SelectedPermissionMode, Converter={x:Static views:PermissionChipTextConverter.Instance}}"
+                                        IsVisible="{Binding SelectedVendor, Converter={x:Static views:PermissionChipVisibleConverter.Instance}}"
+                                        ToolTip.Tip="Permission mode. How much Claude asks before acting" />
+                            </WrapPanel>
+
+                            <Button Grid.Column="1" x:Name="StartButton" Classes="kcapPrimary" Command="{Binding StartCommand}"
+                                    Background="{StaticResource KcapPrimaryBrush}" Width="36" Height="36" CornerRadius="18"
+                                    Padding="0" Margin="12,0,0,0" VerticalAlignment="Center"
+                                    HorizontalContentAlignment="Center" VerticalContentAlignment="Center"
+                                    ToolTip.Tip="{Binding StartButtonTip}"
+                                    ToolTip.ShowOnDisabled="True"
+                                    AutomationProperties.Name="Start"
+                                    IsEnabled="{Binding SelectedRepoPath, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                                <Path Data="M8,13.5 L8,3 M3.5,7.5 L8,3 L12.5,7.5"
+                                      Stroke="{StaticResource KcapOnPrimaryBrush}" StrokeThickness="2"
+                                      StrokeLineCap="Round" StrokeJoin="Round" Width="16" Height="16" />
+                            </Button>
+                        </Grid>
+                    </StackPanel>
 
                     <TextBlock x:Name="StartErrorText" Text="{Binding StartError}" Foreground="{StaticResource KcapDangerBrush}"
                                TextWrapping="Wrap"

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml
@@ -17,8 +17,7 @@
             <StackPanel Spacing="12">
                 <TextBlock x:Name="BannerMessageText" Text="{Binding BannerMessage}"
                            Foreground="{StaticResource KcapWarningBrush}" FontSize="13" LineHeight="20"
-                           TextWrapping="Wrap"
-                           IsVisible="{Binding BannerMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                           TextWrapping="Wrap" />
                 <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Left">
                     <Button x:Name="StartDaemonButton" Classes="kcapPrimary" Content="Start daemon"
                             Command="{Binding StartDaemonCommand}" IsVisible="{Binding DaemonStartVisible}"
@@ -83,9 +82,7 @@
 
                         <Grid ColumnDefinitions="*,Auto">
                             <WrapPanel ItemSpacing="8" LineSpacing="8" VerticalAlignment="Center">
-                                <!-- One picker for harness AND model (T3-style): searchable, grouped by
-                                     vendor, with a per-vendor default row and a typed-custom escape hatch —
-                                     built per open in code-behind, like the repository picker. -->
+                                <!-- Harness + model picker: built per open in code-behind, like the repo menu. -->
                                 <Button x:Name="AgentChip" Classes="kcapChip" Click="OnAgentChipClick"
                                         Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                                         Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml
@@ -8,23 +8,41 @@
          the selected repository over one big composer. DataContext is a HomeViewModel supplied
          externally (MainWindow binds Home), same contract as HomeView. Connection / sign-in
          status sits ABOVE the composer card as chrome, not inside the goal field. -->
-    <DockPanel Margin="24,0">
-        <Border DockPanel.Dock="Top" Margin="0,0,0,16" Padding="14,10" CornerRadius="10"
+    <DockPanel Margin="24,16,24,0">
+        <Border DockPanel.Dock="Top" Margin="0,0,0,16" Padding="14,12" CornerRadius="10"
                 HorizontalAlignment="Stretch" MaxWidth="680"
                 Background="{StaticResource KcapWarningDimBrush}"
                 BorderBrush="{StaticResource KcapWarningBrush}" BorderThickness="1"
-                IsVisible="{Binding ConnectionNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-            <Grid ColumnDefinitions="*,Auto">
-                <TextBlock x:Name="ConnectionNoticeText" Text="{Binding ConnectionNotice}"
-                           Foreground="{StaticResource KcapWarningBrush}" FontSize="13"
-                           TextWrapping="Wrap" VerticalAlignment="Center" />
-                <Button Grid.Column="1" x:Name="HomeSignInButton" Classes="kcapPrimary"
-                        Content="Sign in" Command="{Binding SignInCommand}"
-                        Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
-                        FontWeight="SemiBold" CornerRadius="7" Padding="14,6" Margin="16,0,0,0"
-                        VerticalAlignment="Center"
-                        IsVisible="{Binding SignInVisible}" />
-            </Grid>
+                IsVisible="{Binding ConnectionBannerVisible}">
+            <StackPanel Spacing="12">
+                <StackPanel Spacing="6">
+                    <TextBlock x:Name="ConnectionNoticeText" Text="{Binding ConnectionNotice}"
+                               Foreground="{StaticResource KcapWarningBrush}" FontSize="13" LineHeight="20"
+                               TextWrapping="Wrap" />
+                    <TextBlock x:Name="DaemonStartMessageText" Text="{Binding DaemonStartMessage}"
+                               Foreground="{StaticResource KcapDangerBrush}" FontSize="12.5" LineHeight="18"
+                               TextWrapping="Wrap"
+                               IsVisible="{Binding DaemonStartMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                </StackPanel>
+                <StackPanel Orientation="Horizontal" Spacing="8" HorizontalAlignment="Left">
+                    <Button x:Name="StartDaemonButton" Classes="kcapPrimary" Content="Start daemon"
+                            Command="{Binding StartDaemonCommand}" IsVisible="{Binding DaemonStartVisible}"
+                            Background="{StaticResource KcapPrimaryBrush}"
+                            Foreground="{StaticResource KcapOnPrimaryBrush}"
+                            FontWeight="SemiBold" CornerRadius="7" Padding="14,6" />
+                    <Button x:Name="RetryDaemonButton" Classes="kcapChip" Content="Retry"
+                            Command="{Binding RetryDaemonCommand}" IsVisible="{Binding DaemonRetryVisible}"
+                            Background="{StaticResource KcapSurfaceRaisedBrush}"
+                            BorderBrush="{StaticResource KcapBorderBrush}"
+                            Foreground="{StaticResource KcapTextBrush}"
+                            CornerRadius="7" Padding="14,6" />
+                    <Button x:Name="HomeSignInButton" Classes="kcapPrimary"
+                            Content="Sign in" Command="{Binding SignInCommand}"
+                            Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
+                            FontWeight="SemiBold" CornerRadius="7" Padding="14,6"
+                            IsVisible="{Binding SignInVisible}" />
+                </StackPanel>
+            </StackPanel>
         </Border>
 
         <StackPanel VerticalAlignment="Center" HorizontalAlignment="Stretch" MaxWidth="680"
@@ -76,14 +94,14 @@
                                     Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                                     Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
                                     Content="{Binding SelectedEffort, Converter={x:Static views:EffortChipTextConverter.Instance}}"
-                                    ToolTip.Tip="Reasoning effort — Default lets the harness decide" />
+                                    ToolTip.Tip="Reasoning effort. Default lets the harness decide" />
 
                             <Button x:Name="PermissionChip" Classes="kcapChip" Click="OnPermissionChipClick"
                                     Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                                     Foreground="{StaticResource KcapTextBrush}" CornerRadius="999" Padding="11,5"
                                     Content="{Binding SelectedPermissionMode, Converter={x:Static views:PermissionChipTextConverter.Instance}}"
                                     IsVisible="{Binding SelectedVendor, Converter={x:Static views:PermissionChipVisibleConverter.Instance}}"
-                                    ToolTip.Tip="Permission mode — how much Claude asks before acting" />
+                                    ToolTip.Tip="Permission mode. How much Claude asks before acting" />
                         </WrapPanel>
 
                         <Button Grid.Column="1" x:Name="StartButton" Classes="kcapPrimary" Command="{Binding StartCommand}"

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
@@ -467,13 +467,34 @@ public sealed class PermissionChipVisibleConverter : IValueConverter {
         throw new NotSupportedException();
 }
 
-/// The pane's headline names the selected repository the way T3's new-thread screen does; the
-/// scratch workspace ("") gets the plain question rather than a fake repo name.
+/// Fixed launcher question — the selected leaf lives on the subtitle line, not inside this string.
 public sealed class LauncherHeadlineConverter : IValueConverter {
     public static readonly LauncherHeadlineConverter Instance = new();
+    public const string Question = "What should we build?";
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => Question;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Leaf under the fixed question; empty when nothing is selected (the subtitle is then hidden).
+public sealed class LauncherRepoSubtitleConverter : IValueConverter {
+    public static readonly LauncherRepoSubtitleConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is string { Length: > 0 } path ? $"What should we build in {RepoLabel.Leaf(path)}?" : "What should we build?";
+        value is string { Length: > 0 } path ? RepoLabel.Leaf(path) : "";
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// Repo chip tip: full path when selected, otherwise the control's job label.
+public sealed class RepositoryChipTipConverter : IValueConverter {
+    public static readonly RepositoryChipTipConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        value is string { Length: > 0 } path ? path : "Repository for the new session";
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
@@ -1,7 +1,10 @@
 using System.Globalization;
+using System.Reactive.Linq;
+using System.Windows.Input;
 using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Data.Converters;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Media;
 using Avalonia.Platform.Storage;
@@ -13,7 +16,24 @@ namespace Capacitor.App.Views;
 /// The launcher pane: DataContext is supplied externally (a plainly-constructed HomeViewModel),
 /// same contract as HomeView — this view never builds its own ViewModel.
 public partial class LauncherPaneView : UserControl {
-    public LauncherPaneView() => InitializeComponent();
+    public LauncherPaneView() {
+        InitializeComponent();
+        // Tunnel, not bubble: TextBox can still mark Enter handled on the bubble route even when
+        // AcceptsReturn is false, so Start must see the key on the way down.
+        GoalInput.AddHandler(KeyDownEvent, OnGoalKeyDown, RoutingStrategies.Tunnel);
+    }
+
+    /// Bare Enter starts a session when Start can run; otherwise the key is consumed so it does
+    /// not leave a stray newline. Mirrors the Start button: connection readiness from CanExecute,
+    /// repository from SelectedRepoPath (the button's IsEnabled binding).
+    void OnGoalKeyDown(object? sender, KeyEventArgs e) {
+        if (e.Key != Key.Enter) return;
+        e.Handled = true;
+        if (DataContext is not HomeViewModel vm) return;
+        if (string.IsNullOrEmpty(vm.SelectedRepoPath)) return;
+        if (!((ICommand)vm.StartCommand).CanExecute(null)) return;
+        vm.StartCommand.Execute().Subscribe();
+    }
 
     // Repository picker: one flyout item per ListRepositoriesAsync entry — leaf name over full
     // path, remembered-harness pill on the right, per the settled design. The scratch entry and

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
@@ -17,58 +17,81 @@ public partial class LauncherPaneView : UserControl {
 
     // Repository picker: one flyout item per ListRepositoriesAsync entry — leaf name over full
     // path, remembered-harness pill on the right, per the settled design. The scratch entry and
-    // the folder-picker affordance sit last, each behind a separator.
+    // the folder-picker affordance sit last, each behind a separator. Built as a kcapPanel Flyout
+    // (same shape as the agent picker) rather than MenuFlyout — Fluent's radio MenuItem chrome
+    // fights the dark palette.
     async void OnRepositoryChipClick(object? sender, RoutedEventArgs e) {
         if (DataContext is not HomeViewModel vm || sender is not Control anchor) return;
 
-        var flyout = new MenuFlyout();
-        foreach (var option in await vm.ListRepositoriesAsync()) {
-            if (option.RepoPath.Length == 0) flyout.Items.Add(new Separator());
-            flyout.Items.Add(RepositoryItem(vm, option));
-        }
-        flyout.Items.Add(new Separator());
+        var muted = Brush("KcapMutedBrush");
+        var rows = new StackPanel { Spacing = 2, Margin = new Thickness(6) };
 
-        var add = new MenuItem { Header = "Add repository…" };
-        add.Click += async (_, _) => await AddRepositoryAsync(vm);
-        flyout.Items.Add(add);
+        var flyout = PanelFlyout(rows, minWidth: 300);
+        foreach (var option in await vm.ListRepositoriesAsync()) {
+            // Scratch ("No repository") is listed after real repos — the separator is only the
+            // break between those two groups, never a stray rule above the first row.
+            if (option.RepoPath.Length == 0 && rows.Children.Count > 0)
+                rows.Children.Add(ChoiceSeparator());
+            rows.Children.Add(RepositoryRow(vm, option, muted, flyout));
+        }
+        rows.Children.Add(ChoiceSeparator());
+        rows.Children.Add(ChoiceRow("Add repository…", selected: false, () => {
+            flyout.Hide();
+            _ = AddRepositoryAsync(vm);
+        }));
 
         flyout.ShowAt(anchor);
     }
 
-    MenuItem RepositoryItem(HomeViewModel vm, RepositoryOption option) {
+    Button RepositoryRow(HomeViewModel vm, RepositoryOption option, IBrush muted, Flyout flyout) {
         var isScratch = option.RepoPath.Length == 0;
-        var muted = (IBrush)this.FindResource("KcapMutedBrush")!;
-
-        var left = new StackPanel { Spacing = 2, VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center };
-        left.Children.Add(new TextBlock {
+        var title = new TextBlock {
             Text = isScratch ? "No repository" : RepoLabel.Leaf(option.RepoPath),
-        });
-        if (!isScratch)
-            left.Children.Add(new TextBlock { Text = option.RepoPath, FontSize = 10.5, Foreground = muted });
+            FontSize = 13.5,
+            FontWeight = option.Selected ? FontWeight.SemiBold : FontWeight.Normal,
+            Foreground = Brush("KcapTextBrush"),
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+        };
 
+        // Pill sits on the title row only (not vertically centered on title+path), so every
+        // repo's badge lines up with "No repository"'s badge.
         var pill = new Border {
-            Background = (IBrush)this.FindResource("KcapSurfaceRaisedBrush")!,
-            CornerRadius = new CornerRadius(999), Padding = new Thickness(7, 2),
-            Margin = new Thickness(12, 0, 0, 0), VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
+            Background = Brush("KcapMutedBrush"), CornerRadius = new CornerRadius(999),
+            Padding = new Thickness(8, 3), Margin = new Thickness(12, 0, 0, 0),
+            VerticalAlignment = Avalonia.Layout.VerticalAlignment.Center,
             Child = new TextBlock {
                 Text = HostedHarnessCatalog.LabelFor(vm.Harnesses, option.Vendor),
-                FontSize = 10, Foreground = muted,
+                FontSize = 11, FontWeight = FontWeight.SemiBold,
+                Foreground = Brush("KcapOnPrimaryBrush"),
             },
         };
 
-        var header = new Grid { ColumnDefinitions = new ColumnDefinitions("*,Auto"), MinWidth = 260 };
-        header.Children.Add(left);
-        Grid.SetColumn(pill, 1);
-        header.Children.Add(pill);
-
-        var item = new MenuItem {
-            Header = header,
-            ToggleType = MenuItemToggleType.Radio,
-            IsChecked = option.Selected,
+        var grid = new Grid {
+            ColumnDefinitions = new ColumnDefinitions("*,Auto"),
+            RowDefinitions = new RowDefinitions("Auto,Auto"),
+            MinWidth = 260,
+            // Stretch so the * column eats leftover width and the pill stays right-aligned
+            // across one-line and two-line rows alike.
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
         };
-        var path = option.RepoPath;
-        item.Click += async (_, _) => await vm.SelectRepositoryAsync(path);
-        return item;
+        grid.Children.Add(title);
+        Grid.SetColumn(pill, 1);
+        grid.Children.Add(pill);
+
+        if (!isScratch) {
+            var path = new TextBlock {
+                Text = option.RepoPath, FontSize = 10.5, Foreground = muted,
+                Margin = new Thickness(0, 2, 0, 0),
+            };
+            Grid.SetRow(path, 1);
+            grid.Children.Add(path);
+        }
+
+        var repoPath = option.RepoPath;
+        return ChoiceButton(grid, () => {
+            flyout.Hide();
+            _ = vm.SelectRepositoryAsync(repoPath);
+        });
     }
 
     // "Add one" via a native folder picker — SelectRepositoryAsync then treats the choice like
@@ -88,24 +111,24 @@ public partial class LauncherPaneView : UserControl {
 
     // Effort picker over HostedHarnessCatalog.EffortLadder; Default hands the choice back to the
     // harness. A wrong value for a given vendor surfaces as that session's own launch error, same
-    // as the CLI's --effort.
+    // as the CLI's --effort. Separator after Default matches Permissions (base vs escalations).
     void OnEffortChipClick(object? sender, RoutedEventArgs e) {
         if (DataContext is not HomeViewModel vm || sender is not Control anchor) return;
 
-        var flyout = new MenuFlyout();
-        var byDefault = new MenuItem {
-            Header = "Default", ToggleType = MenuItemToggleType.Radio, IsChecked = vm.SelectedEffort is null,
-        };
-        byDefault.Click += (_, _) => vm.SelectedEffort = null;
-        flyout.Items.Add(byDefault);
-        flyout.Items.Add(new Separator());
+        var rows = new StackPanel { Spacing = 2, Margin = new Thickness(6) };
+        var flyout = PanelFlyout(rows, minWidth: 180);
+
+        rows.Children.Add(ChoiceRow(HostedHarnessCatalog.EffortDefaultLabel, vm.SelectedEffort is null, () => {
+            vm.SelectedEffort = null;
+            flyout.Hide();
+        }));
+        rows.Children.Add(ChoiceSeparator());
         foreach (var effort in HostedHarnessCatalog.EffortLadder) {
-            var item = new MenuItem {
-                Header = effort, ToggleType = MenuItemToggleType.Radio, IsChecked = vm.SelectedEffort == effort,
-            };
             var value = effort;
-            item.Click += (_, _) => vm.SelectedEffort = value;
-            flyout.Items.Add(item);
+            rows.Children.Add(ChoiceRow(HostedHarnessCatalog.EffortLabelFor(value), vm.SelectedEffort == effort, () => {
+                vm.SelectedEffort = value;
+                flyout.Hide();
+            }));
         }
         flyout.ShowAt(anchor);
     }
@@ -113,18 +136,66 @@ public partial class LauncherPaneView : UserControl {
     void OnPermissionChipClick(object? sender, RoutedEventArgs e) {
         if (DataContext is not HomeViewModel vm || sender is not Control anchor) return;
 
-        var flyout = new MenuFlyout();
+        var rows = new StackPanel { Spacing = 2, Margin = new Thickness(6) };
+        var flyout = PanelFlyout(rows, minWidth: 200);
+
+        // Manual first (omit-from-wire default), then separator, then escalations — same shape as Effort.
         foreach (var mode in HostedHarnessCatalog.PermissionModes) {
-            var item = new MenuItem {
-                Header = mode.Label, ToggleType = MenuItemToggleType.Radio,
-                IsChecked = string.Equals(vm.SelectedPermissionMode, mode.Token, StringComparison.Ordinal),
-            };
+            if (rows.Children.Count == 1)
+                rows.Children.Add(ChoiceSeparator());
+
             var token = mode.Token;
-            item.Click += (_, _) => vm.SelectedPermissionMode = token;
-            flyout.Items.Add(item);
+            var selected = string.Equals(vm.SelectedPermissionMode, token, StringComparison.Ordinal);
+            rows.Children.Add(ChoiceRow(mode.Label, selected, () => {
+                vm.SelectedPermissionMode = token;
+                flyout.Hide();
+            }));
         }
         flyout.ShowAt(anchor);
     }
+
+    // Shared chip-picker chrome: kcapPanel Flyout + ghost rows; selection is weight, not green.
+    static Flyout PanelFlyout(Control content, double minWidth) {
+        var host = new Border { Child = content, MinWidth = minWidth };
+        var flyout = new Flyout {
+            Placement = PlacementMode.Bottom, Content = host,
+            // A few pixels of air between the chip and the panel — flush looks glued on.
+            VerticalOffset = 6,
+        };
+        flyout.FlyoutPresenterClasses.Add("kcapPanel");
+        return flyout;
+    }
+
+    Button ChoiceRow(string label, bool selected, Action pick) {
+        var body = new TextBlock {
+            Text = label, FontSize = 13.5,
+            FontWeight = selected ? FontWeight.SemiBold : FontWeight.Normal,
+            Foreground = Brush("KcapTextBrush"),
+        };
+        return ChoiceButton(body, pick);
+    }
+
+    static Button ChoiceButton(object content, Action pick) {
+        var row = new Button {
+            Content = content,
+            HorizontalAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
+            // Stretch: left-aligned content stays content-sized and never pushes a trailing pill
+            // to the row's right edge (repo list badges).
+            HorizontalContentAlignment = Avalonia.Layout.HorizontalAlignment.Stretch,
+            Background = Brushes.Transparent, BorderThickness = new Thickness(0),
+            CornerRadius = new CornerRadius(8), Padding = new Thickness(10, 8),
+        };
+        row.Classes.Add("kcapGhost");
+        row.Click += (_, _) => pick();
+        return row;
+    }
+
+    Border ChoiceSeparator() => new() {
+        Height = 1, Margin = new Thickness(8, 4),
+        Background = Brush("KcapBorderBrush"),
+    };
+
+    IBrush Brush(string key) => (IBrush)this.FindResource(key)!;
 
     /// The vendor's mark at a given size: the brand path when VendorIcons carries one, the tinted
     /// monogram otherwise (both from HostedHarnessCatalog.TileFor). UI-thread only (constructs
@@ -155,7 +226,7 @@ public partial class LauncherPaneView : UserControl {
         var text = (IBrush)this.FindResource("KcapTextBrush")!;
         var muted = (IBrush)this.FindResource("KcapMutedBrush")!;
         var faint = (IBrush)this.FindResource("KcapFaintBrush")!;
-        var accent = (IBrush)this.FindResource("KcapAccentBrush")!;
+        var success = (IBrush)this.FindResource("KcapSuccessBrush")!;
         var raised = (IBrush)this.FindResource("KcapSurfaceRaisedBrush")!;
         var border = (IBrush)this.FindResource("KcapBorderBrush")!;
 
@@ -196,7 +267,9 @@ public partial class LauncherPaneView : UserControl {
         Grid.SetColumn(right, 1);
         root.Children.Add(right);
 
-        var flyout = new Flyout { Placement = PlacementMode.Bottom, Content = root };
+        var flyout = new Flyout {
+            Placement = PlacementMode.Bottom, Content = root, VerticalOffset = 6,
+        };
         flyout.FlyoutPresenterClasses.Add("kcapPanel");
 
         async void Pick(string vendor, string slug) {
@@ -216,7 +289,7 @@ public partial class LauncherPaneView : UserControl {
             var body = new StackPanel();
             body.Children.Add(new TextBlock {
                 Text = label, FontSize = 13.5, FontWeight = FontWeight.SemiBold,
-                Foreground = selected ? accent : enabled ? text : faint,
+                Foreground = selected ? success : enabled ? text : faint,
             });
             body.Children.Add(sub);
 
@@ -227,6 +300,7 @@ public partial class LauncherPaneView : UserControl {
                 Background = Brushes.Transparent, BorderThickness = new Thickness(0),
                 CornerRadius = new CornerRadius(8), Padding = new Thickness(10, 7),
             };
+            row.Classes.Add("kcapGhost");
             row.Click += (_, _) => pick();
             return row;
         }
@@ -293,6 +367,7 @@ public partial class LauncherPaneView : UserControl {
                     CornerRadius = new CornerRadius(9),
                     Opacity = option.Available ? 1 : 0.4,
                 };
+                tile.Classes.Add(active ? "kcapChip" : "kcapGhost");
                 ToolTip.SetTip(tile, $"{option.Label} — {HostedHarnessCatalog.DescriptionFor(option)}");
                 tile.Click += (_, _) => {
                     currentTab = vendor;
@@ -304,8 +379,6 @@ public partial class LauncherPaneView : UserControl {
         }
 
         searchBox.TextChanged += (_, _) => RebuildRows();
-        searchBox.GotFocus += (_, _) => underline.Background = accent;
-        searchBox.LostFocus += (_, _) => underline.Background = border;
         RebuildTabs();
         RebuildRows();
         flyout.ShowAt(anchor);
@@ -328,7 +401,7 @@ public sealed class VendorGlyphConverter : IValueConverter {
 }
 
 /// AgentChip's label: "Claude · Fable 5" — vendor label plus the model's curated label (raw slug
-/// when uncurated, "default" for the "" sentinel).
+/// when uncurated, "Default" for the "" sentinel). Same "left · right" shape as Effort/Permissions.
 public sealed class AgentChipTextConverter : IMultiValueConverter {
     public static readonly AgentChipTextConverter Instance = new();
 
@@ -338,22 +411,27 @@ public sealed class AgentChipTextConverter : IMultiValueConverter {
             : "";
 }
 
-/// EffortChip's label: the chosen rung, or the default wording for null.
+/// EffortChip's label: always "Effort · …" — Default when null, otherwise the chosen rung's
+/// sentence-case label. Keeps the category visible after a pick.
 public sealed class EffortChipTextConverter : IValueConverter {
     public static readonly EffortChipTextConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is string { Length: > 0 } effort ? $"Effort: {effort}" : "Default effort";
+        $"Effort · {HostedHarnessCatalog.EffortLabelFor(value as string)}";
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();
 }
 
+/// PermissionChip's label: always "Permissions · …" so a bare "Manual" is not mistaken for an
+/// effort or harness setting.
 public sealed class PermissionChipTextConverter : IValueConverter {
     public static readonly PermissionChipTextConverter Instance = new();
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        value is string token ? HostedHarnessCatalog.PermissionModeLabelFor(token) : "";
+        value is string token
+            ? $"Permissions · {HostedHarnessCatalog.PermissionModeLabelFor(token)}"
+            : "Permissions · Manual";
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
@@ -477,17 +477,6 @@ public sealed class PermissionChipVisibleConverter : IValueConverter {
         throw new NotSupportedException();
 }
 
-/// Fixed launcher question — the selected leaf lives on the subtitle line, not inside this string.
-public sealed class LauncherHeadlineConverter : IValueConverter {
-    public static readonly LauncherHeadlineConverter Instance = new();
-    public const string Question = "What should we build?";
-
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) => Question;
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotSupportedException();
-}
-
 /// Leaf under the fixed question; empty when nothing is selected (the subtitle is then hidden).
 public sealed class LauncherRepoSubtitleConverter : IValueConverter {
     public static readonly LauncherRepoSubtitleConverter Instance = new();

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
@@ -110,8 +110,18 @@ public partial class LauncherPaneView : UserControl {
         var repoPath = option.RepoPath;
         return ChoiceButton(grid, () => {
             flyout.Hide();
-            _ = vm.SelectRepositoryAsync(repoPath);
+            _ = SelectRepositoryObservedAsync(vm, repoPath);
         });
+    }
+
+    // ChoiceButton's click is sync; keep flyout-close immediate and observe the async load so a
+    // failed state read is not an unobserved task.
+    static async Task SelectRepositoryObservedAsync(HomeViewModel vm, string repoPath) {
+        try {
+            await vm.SelectRepositoryAsync(repoPath);
+        } catch (Exception ex) {
+            Console.Error.WriteLine($"kcap: select repository failed: {ex}");
+        }
     }
 
     // "Add one" via a native folder picker — SelectRepositoryAsync then treats the choice like

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
@@ -48,8 +48,8 @@ public partial class LauncherPaneView : UserControl {
 
         var flyout = PanelFlyout(rows, minWidth: 300);
         foreach (var option in await vm.ListRepositoriesAsync()) {
-            // Scratch ("No repository") is listed after real repos — the separator is only the
-            // break between those two groups, never a stray rule above the first row.
+            // Scratch is only listed when there are no real repos — still separate it visually
+            // if it ever shares the menu with another row.
             if (option.RepoPath.Length == 0 && rows.Children.Count > 0)
                 rows.Children.Add(ChoiceSeparator());
             rows.Children.Add(RepositoryRow(vm, option, muted, flyout));

--- a/src/Capacitor.App/Views/MainWindow.axaml
+++ b/src/Capacitor.App/Views/MainWindow.axaml
@@ -11,20 +11,12 @@
                      Width="1200" MinWidth="1200" Height="760" MinHeight="560"
                      Background="{StaticResource KcapCanvasBrush}"
                      ExtendClientAreaToDecorationsHint="True">
-    <!-- The window lives on the Sessions surface (spec §3, revised): rail | workspace, where the
-         right pane's EMPTY state is the launcher (LauncherPaneView) — asking for a new session
-         and having none selected are the same screen. The Home surface stays in the tree but
-         hidden: nothing navigates to it for now (ShowHomeCommand still exists), and its launcher
-         card moved to the pane. CurrentWorkspace only means anything inside Sessions, and the
-         workspace side is a ContentControl over a template rather than an always-present
-         WorkspaceView, so the terminal control is CONSTRUCTED only once a session is opened
-         instead of sitting hidden in every window that never opens one.
-
-         The client area extends into the title bar (design canvas: the dark surfaces reach the
-         top, the native caption buttons sit over the content — Avalonia 12 keeps system chrome
-         itself; the ChromeHints knob no longer exists). The strip below is the
-         bottom-most child, so it only receives presses where no surface content is hit-testable —
-         the rail and workspace headers carry their own drag handlers. -->
+    <!-- Sessions is the home surface: rail | launcher-or-workspace. The right pane's empty state
+         IS the launcher. Home stays in the tree but hidden (ShowHomeCommand still exists).
+         Workspace content is a template so the terminal is only built once a session opens.
+         ExtendClientAreaToDecorationsHint paints into the title bar; the transparent strip below
+         only receives presses where no surface content is hit-testable — rail and workspace
+         headers carry their own drag handlers. -->
     <Panel>
         <Border Height="40" VerticalAlignment="Top" Background="Transparent"
                 PointerPressed="OnChromePointerPressed" />

--- a/src/Capacitor.App/Views/MainWindow.axaml
+++ b/src/Capacitor.App/Views/MainWindow.axaml
@@ -60,9 +60,10 @@
                             <Button.Flyout>
                                 <Flyout Placement="BottomEdgeAlignedRight" VerticalOffset="6"
                                         FlyoutPresenterClasses="kcapPanel">
-                                    <!-- Fixed width so star columns never spill into a horizontal scrollbar;
-                                         empty state stays compact instead of stretching to MaxHeight. -->
-                                    <Border Width="520" MaxHeight="400" Padding="16,14">
+                                    <!-- Fixed width + fixed column widths so header and rows share
+                                         one grid; vertical scroll after MaxHeight; horizontal only
+                                         if content truly overflows (presenter H-scroll stays off). -->
+                                    <Border Width="720" MaxHeight="420" Padding="14,12">
                                         <Grid>
                                             <StackPanel IsVisible="{Binding Activity.IsEmpty}"
                                                         Spacing="6" Margin="0,28"
@@ -76,13 +77,13 @@
                                                            TextAlignment="Center" HorizontalAlignment="Center" />
                                             </StackPanel>
 
-                                            <ScrollViewer IsVisible="{Binding !Activity.IsEmpty}"
-                                                          VerticalScrollBarVisibility="Auto"
-                                                          HorizontalScrollBarVisibility="Disabled">
-                                                <StackPanel>
+                                            <DockPanel IsVisible="{Binding !Activity.IsEmpty}">
+                                                <Border DockPanel.Dock="Top"
+                                                        BorderBrush="{StaticResource KcapBorderBrush}"
+                                                        BorderThickness="0,0,0,1" Padding="4,0,4,8" Margin="0,0,0,2">
                                                     <Grid x:Name="ActivityHeader"
-                                                          ColumnDefinitions="1.6*,0.8*,1.3*,0.9*,1.4*,0.9*,1*"
-                                                          Margin="0,0,0,8">
+                                                          ColumnDefinitions="118,76,128,78,*,78,96"
+                                                          ColumnSpacing="10">
                                                         <TextBlock Grid.Column="0" Text="Time" FontSize="11" FontWeight="SemiBold"
                                                                    Foreground="{StaticResource KcapMutedBrush}" />
                                                         <TextBlock Grid.Column="1" Text="Outcome" FontSize="11" FontWeight="SemiBold"
@@ -98,40 +99,57 @@
                                                         <TextBlock Grid.Column="6" Text="Source" FontSize="11" FontWeight="SemiBold"
                                                                    Foreground="{StaticResource KcapMutedBrush}" />
                                                     </Grid>
+                                                </Border>
 
-                                                    <ItemsControl x:Name="ActivityItems" ItemsSource="{Binding Activity.Rows}">
+                                                <ScrollViewer VerticalScrollBarVisibility="Auto"
+                                                              HorizontalScrollBarVisibility="Auto">
+                                                    <ItemsControl x:Name="ActivityItems" ItemsSource="{Binding Activity.Rows}"
+                                                                  HorizontalAlignment="Stretch">
+                                                        <!-- ContentPresenter defaults to Left; without Stretch each row
+                                                             sizes to its text and columns drift off the header. -->
+                                                        <ItemsControl.Styles>
+                                                            <Style Selector="ItemsControl > ContentPresenter">
+                                                                <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                                            </Style>
+                                                        </ItemsControl.Styles>
                                                         <ItemsControl.ItemTemplate>
                                                             <DataTemplate x:DataType="vm:ActivityRow">
-                                                                <Grid ColumnDefinitions="1.6*,0.8*,1.3*,0.9*,1.4*,0.9*,1*"
-                                                                      Margin="0,3">
-                                                                    <TextBlock Grid.Column="0" Text="{Binding Time}" FontSize="12.5"
-                                                                               Foreground="{StaticResource KcapTextBrush}"
-                                                                               TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="1" Text="{Binding Outcome}" FontSize="12.5"
-                                                                               TextTrimming="CharacterEllipsis"
-                                                                               Foreground="{Binding IsAllowed, Converter={x:Static views:OutcomeBrushConverter.Instance}}" />
-                                                                    <TextBlock Grid.Column="2" Text="{Binding Requester}" FontSize="12.5"
-                                                                               Foreground="{StaticResource KcapTextBrush}"
-                                                                               TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="3" Text="{Binding KindLabel}" FontSize="12.5"
-                                                                               Foreground="{StaticResource KcapTextBrush}"
-                                                                               TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="4" Text="{Binding RepoLeaf}" FontSize="12.5"
-                                                                               Foreground="{StaticResource KcapTextBrush}"
-                                                                               ToolTip.Tip="{Binding RepoFull}"
-                                                                               TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="5" Text="{Binding Vendor}" FontSize="12.5"
-                                                                               Foreground="{StaticResource KcapTextBrush}"
-                                                                               TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="6" Text="{Binding SourceLabel}" FontSize="12.5"
-                                                                               Foreground="{StaticResource KcapTextBrush}"
-                                                                               TextTrimming="CharacterEllipsis" />
-                                                                </Grid>
+                                                                <Border BorderBrush="{StaticResource KcapBorderBrush}"
+                                                                        BorderThickness="0,0,0,1" Padding="4,8">
+                                                                    <Grid ColumnDefinitions="118,76,128,78,*,78,96"
+                                                                          ColumnSpacing="10">
+                                                                        <TextBlock Grid.Column="0" Text="{Binding Time}" FontSize="12.5"
+                                                                                   Foreground="{StaticResource KcapTextBrush}"
+                                                                                   ToolTip.Tip="{Binding TimeTip}"
+                                                                                   TextTrimming="CharacterEllipsis" />
+                                                                        <TextBlock Grid.Column="1" Text="{Binding Outcome}" FontSize="12.5"
+                                                                                   TextTrimming="CharacterEllipsis"
+                                                                                   Foreground="{Binding IsAllowed, Converter={x:Static views:OutcomeBrushConverter.Instance}}" />
+                                                                        <TextBlock Grid.Column="2" Text="{Binding Requester}" FontSize="12.5"
+                                                                                   Foreground="{StaticResource KcapTextBrush}"
+                                                                                   ToolTip.Tip="{Binding Requester}"
+                                                                                   TextTrimming="CharacterEllipsis" />
+                                                                        <TextBlock Grid.Column="3" Text="{Binding KindLabel}" FontSize="12.5"
+                                                                                   Foreground="{StaticResource KcapTextBrush}"
+                                                                                   TextTrimming="CharacterEllipsis" />
+                                                                        <TextBlock Grid.Column="4" Text="{Binding RepoLeaf}" FontSize="12.5"
+                                                                                   Foreground="{StaticResource KcapTextBrush}"
+                                                                                   ToolTip.Tip="{Binding RepoFull}"
+                                                                                   TextTrimming="CharacterEllipsis" />
+                                                                        <TextBlock Grid.Column="5" Text="{Binding Vendor}" FontSize="12.5"
+                                                                                   Foreground="{StaticResource KcapTextBrush}"
+                                                                                   TextTrimming="CharacterEllipsis" />
+                                                                        <TextBlock Grid.Column="6" Text="{Binding SourceLabel}" FontSize="12.5"
+                                                                                   Foreground="{StaticResource KcapTextBrush}"
+                                                                                   ToolTip.Tip="{Binding SourceLabel}"
+                                                                                   TextTrimming="CharacterEllipsis" />
+                                                                    </Grid>
+                                                                </Border>
                                                             </DataTemplate>
                                                         </ItemsControl.ItemTemplate>
                                                     </ItemsControl>
-                                                </StackPanel>
-                                            </ScrollViewer>
+                                                </ScrollViewer>
+                                            </DockPanel>
                                         </Grid>
                                     </Border>
                                 </Flyout>

--- a/src/Capacitor.App/Views/MainWindow.axaml
+++ b/src/Capacitor.App/Views/MainWindow.axaml
@@ -8,7 +8,7 @@
                      x:DataType="vm:MainWindowViewModel"
                      Title="Kurrent Capacitor Desktop"
                      Icon="avares://Kurrent Capacitor/Assets/kcap-icon.png"
-                     Width="1200" MinWidth="1200" Height="760"
+                     Width="1200" MinWidth="1200" Height="760" MinHeight="560"
                      Background="{StaticResource KcapCanvasBrush}"
                      ExtendClientAreaToDecorationsHint="True">
     <!-- The window lives on the Sessions surface (spec §3, revised): rail | workspace, where the
@@ -42,39 +42,20 @@
             <Panel Grid.Column="1">
                 <!-- The launcher pane: daemon status top-left, Activity top-right, the composer
                      centered. Visible exactly while no workspace is open. -->
-                <Grid x:Name="LauncherPane" RowDefinitions="Auto,*" Margin="24,12,24,24"
+                <Grid x:Name="LauncherPane" RowDefinitions="Auto,*" Margin="24,20,24,24"
                       IsVisible="{Binding CurrentWorkspace, Converter={x:Static ObjectConverters.IsNull}}">
                     <Grid Grid.Row="0" ColumnDefinitions="*,Auto" Background="Transparent"
                           PointerPressed="OnChromePointerPressed">
-                        <!-- Daemon identity lives in the rail footer (and its tooltip) now; only
-                             the recovery affordances remain here, each self-hiding while healthy. -->
-                        <StackPanel Spacing="10">
-                            <StackPanel Spacing="8">
-                                <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <Button x:Name="StartButton" Classes="kcapPrimary" Content="Start daemon" Command="{Binding StartDaemonCommand}" IsVisible="{Binding StartVisible}"
-                                            Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" FontWeight="SemiBold"
-                                            CornerRadius="7" Padding="13,6" />
-                                    <Button x:Name="RetryButton" Classes="kcapChip" Content="Retry" Command="{Binding RetryCommand}" IsVisible="{Binding RetryVisible}"
-                                            Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
-                                            Foreground="{StaticResource KcapTextBrush}" CornerRadius="7" Padding="13,6" />
-                                </StackPanel>
-
-                                <TextBlock x:Name="StartMessageText" Text="{Binding StartMessage}"
-                                           Foreground="{StaticResource KcapDangerBrush}" FontSize="12"
-                                           IsVisible="{Binding StartMessage, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                                <TextBlock x:Name="ReasonText" Text="{Binding Reason}"
-                                           Foreground="{StaticResource KcapWarningBrush}" FontSize="12"
-                                           IsVisible="{Binding Reason, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                            </StackPanel>
-                        </StackPanel>
+                        <!-- Daemon recovery sits in LauncherPaneView's connection banner (same
+                             place as sign-in), not here in the chrome. -->
 
                         <!-- The consent-decision feed, as a transient panel off this chip rather
                              than a section in the page flow. Opened/Closed drive the polling gate
                              in code-behind, and opening a workspace closes it. -->
                         <Button Grid.Column="1" x:Name="ActivityButton" Classes="kcapChip" VerticalAlignment="Top"
+                                HorizontalAlignment="Right"
                                 Background="{StaticResource KcapSurfaceRaisedBrush}"
-                                BorderBrush="{StaticResource KcapBorderBrush}" CornerRadius="7" Padding="12,6">
-                            <TextBlock Text="Activity" FontSize="12.5" FontWeight="SemiBold"
+                                BorderBrush="{StaticResource KcapBorderBrush}" CornerRadius="7" Padding="12,6">                            <TextBlock Text="Activity" FontSize="12.5" FontWeight="SemiBold"
                                        Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
                             <Button.Flyout>
                                 <Flyout Placement="BottomEdgeAlignedRight" VerticalOffset="6"

--- a/src/Capacitor.App/Views/MainWindow.axaml
+++ b/src/Capacitor.App/Views/MainWindow.axaml
@@ -51,10 +51,10 @@
                         <StackPanel Spacing="10">
                             <StackPanel Spacing="8">
                                 <StackPanel Orientation="Horizontal" Spacing="8">
-                                    <Button x:Name="StartButton" Content="Start daemon" Command="{Binding StartDaemonCommand}" IsVisible="{Binding StartVisible}"
-                                            Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" FontWeight="SemiBold"
+                                    <Button x:Name="StartButton" Classes="kcapPrimary" Content="Start daemon" Command="{Binding StartDaemonCommand}" IsVisible="{Binding StartVisible}"
+                                            Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" FontWeight="SemiBold"
                                             CornerRadius="7" Padding="13,6" />
-                                    <Button x:Name="RetryButton" Content="Retry" Command="{Binding RetryCommand}" IsVisible="{Binding RetryVisible}"
+                                    <Button x:Name="RetryButton" Classes="kcapChip" Content="Retry" Command="{Binding RetryCommand}" IsVisible="{Binding RetryVisible}"
                                             Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                                             Foreground="{StaticResource KcapTextBrush}" CornerRadius="7" Padding="13,6" />
                                 </StackPanel>
@@ -71,46 +71,80 @@
                         <!-- The consent-decision feed, as a transient panel off this chip rather
                              than a section in the page flow. Opened/Closed drive the polling gate
                              in code-behind, and opening a workspace closes it. -->
-                        <Button Grid.Column="1" x:Name="ActivityButton" VerticalAlignment="Top"
+                        <Button Grid.Column="1" x:Name="ActivityButton" Classes="kcapChip" VerticalAlignment="Top"
                                 Background="{StaticResource KcapSurfaceRaisedBrush}"
                                 BorderBrush="{StaticResource KcapBorderBrush}" CornerRadius="7" Padding="12,6">
                             <TextBlock Text="Activity" FontSize="12.5" FontWeight="SemiBold"
                                        Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
                             <Button.Flyout>
-                                <Flyout Placement="BottomEdgeAlignedRight">
-                                    <Border Background="{StaticResource KcapSurfaceBrush}" MinWidth="480" MaxWidth="840"
-                                            MaxHeight="440" Padding="14">
-                                        <Grid RowDefinitions="Auto,*">
-                                            <TextBlock x:Name="ActivityEmptyText" Text="No decisions yet"
-                                                       Foreground="{StaticResource KcapFaintBrush}"
-                                                       IsVisible="{Binding Activity.IsEmpty}" HorizontalAlignment="Center" Margin="0,10" />
+                                <Flyout Placement="BottomEdgeAlignedRight" VerticalOffset="6"
+                                        FlyoutPresenterClasses="kcapPanel">
+                                    <!-- Fixed width so star columns never spill into a horizontal scrollbar;
+                                         empty state stays compact instead of stretching to MaxHeight. -->
+                                    <Border Width="520" MaxHeight="400" Padding="16,14">
+                                        <Grid>
+                                            <StackPanel IsVisible="{Binding Activity.IsEmpty}"
+                                                        Spacing="6" Margin="0,28"
+                                                        HorizontalAlignment="Center" VerticalAlignment="Center">
+                                                <TextBlock x:Name="ActivityEmptyText" Text="No decisions yet"
+                                                           Foreground="{StaticResource KcapMutedBrush}"
+                                                           FontSize="13.5" HorizontalAlignment="Center" />
+                                                <TextBlock Text="Allow and deny choices from consent prompts show up here."
+                                                           Foreground="{StaticResource KcapFaintBrush}"
+                                                           FontSize="12" TextWrapping="Wrap" MaxWidth="300"
+                                                           TextAlignment="Center" HorizontalAlignment="Center" />
+                                            </StackPanel>
 
-                                            <ScrollViewer Grid.Row="1"
-                                                          VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Auto">
+                                            <ScrollViewer IsVisible="{Binding !Activity.IsEmpty}"
+                                                          VerticalScrollBarVisibility="Auto"
+                                                          HorizontalScrollBarVisibility="Disabled">
                                                 <StackPanel>
-                                                    <Grid x:Name="ActivityHeader" ColumnDefinitions="150,70,120,90,140,90,110" Margin="0,0,0,4"
-                                                          IsVisible="{Binding !Activity.IsEmpty}">
-                                                        <TextBlock Grid.Column="0" Text="Time" FontWeight="Bold" Opacity="0.7" />
-                                                        <TextBlock Grid.Column="1" Text="Outcome" FontWeight="Bold" Opacity="0.7" />
-                                                        <TextBlock Grid.Column="2" Text="Requester" FontWeight="Bold" Opacity="0.7" />
-                                                        <TextBlock Grid.Column="3" Text="Kind" FontWeight="Bold" Opacity="0.7" />
-                                                        <TextBlock Grid.Column="4" Text="Repo" FontWeight="Bold" Opacity="0.7" />
-                                                        <TextBlock Grid.Column="5" Text="Vendor" FontWeight="Bold" Opacity="0.7" />
-                                                        <TextBlock Grid.Column="6" Text="Source" FontWeight="Bold" Opacity="0.7" />
+                                                    <Grid x:Name="ActivityHeader"
+                                                          ColumnDefinitions="1.6*,0.8*,1.3*,0.9*,1.4*,0.9*,1*"
+                                                          Margin="0,0,0,8">
+                                                        <TextBlock Grid.Column="0" Text="Time" FontSize="11" FontWeight="SemiBold"
+                                                                   Foreground="{StaticResource KcapMutedBrush}" />
+                                                        <TextBlock Grid.Column="1" Text="Outcome" FontSize="11" FontWeight="SemiBold"
+                                                                   Foreground="{StaticResource KcapMutedBrush}" />
+                                                        <TextBlock Grid.Column="2" Text="Requester" FontSize="11" FontWeight="SemiBold"
+                                                                   Foreground="{StaticResource KcapMutedBrush}" />
+                                                        <TextBlock Grid.Column="3" Text="Kind" FontSize="11" FontWeight="SemiBold"
+                                                                   Foreground="{StaticResource KcapMutedBrush}" />
+                                                        <TextBlock Grid.Column="4" Text="Repo" FontSize="11" FontWeight="SemiBold"
+                                                                   Foreground="{StaticResource KcapMutedBrush}" />
+                                                        <TextBlock Grid.Column="5" Text="Vendor" FontSize="11" FontWeight="SemiBold"
+                                                                   Foreground="{StaticResource KcapMutedBrush}" />
+                                                        <TextBlock Grid.Column="6" Text="Source" FontSize="11" FontWeight="SemiBold"
+                                                                   Foreground="{StaticResource KcapMutedBrush}" />
                                                     </Grid>
 
                                                     <ItemsControl x:Name="ActivityItems" ItemsSource="{Binding Activity.Rows}">
                                                         <ItemsControl.ItemTemplate>
                                                             <DataTemplate x:DataType="vm:ActivityRow">
-                                                                <Grid ColumnDefinitions="150,70,120,90,140,90,110" Margin="0,2">
-                                                                    <TextBlock Grid.Column="0" Text="{Binding Time}" TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="1" Text="{Binding Outcome}" TextTrimming="CharacterEllipsis"
+                                                                <Grid ColumnDefinitions="1.6*,0.8*,1.3*,0.9*,1.4*,0.9*,1*"
+                                                                      Margin="0,3">
+                                                                    <TextBlock Grid.Column="0" Text="{Binding Time}" FontSize="12.5"
+                                                                               Foreground="{StaticResource KcapTextBrush}"
+                                                                               TextTrimming="CharacterEllipsis" />
+                                                                    <TextBlock Grid.Column="1" Text="{Binding Outcome}" FontSize="12.5"
+                                                                               TextTrimming="CharacterEllipsis"
                                                                                Foreground="{Binding IsAllowed, Converter={x:Static views:OutcomeBrushConverter.Instance}}" />
-                                                                    <TextBlock Grid.Column="2" Text="{Binding Requester}" TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="3" Text="{Binding KindLabel}" TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="4" Text="{Binding RepoLeaf}" ToolTip.Tip="{Binding RepoFull}" TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="5" Text="{Binding Vendor}" TextTrimming="CharacterEllipsis" />
-                                                                    <TextBlock Grid.Column="6" Text="{Binding SourceLabel}" TextTrimming="CharacterEllipsis" />
+                                                                    <TextBlock Grid.Column="2" Text="{Binding Requester}" FontSize="12.5"
+                                                                               Foreground="{StaticResource KcapTextBrush}"
+                                                                               TextTrimming="CharacterEllipsis" />
+                                                                    <TextBlock Grid.Column="3" Text="{Binding KindLabel}" FontSize="12.5"
+                                                                               Foreground="{StaticResource KcapTextBrush}"
+                                                                               TextTrimming="CharacterEllipsis" />
+                                                                    <TextBlock Grid.Column="4" Text="{Binding RepoLeaf}" FontSize="12.5"
+                                                                               Foreground="{StaticResource KcapTextBrush}"
+                                                                               ToolTip.Tip="{Binding RepoFull}"
+                                                                               TextTrimming="CharacterEllipsis" />
+                                                                    <TextBlock Grid.Column="5" Text="{Binding Vendor}" FontSize="12.5"
+                                                                               Foreground="{StaticResource KcapTextBrush}"
+                                                                               TextTrimming="CharacterEllipsis" />
+                                                                    <TextBlock Grid.Column="6" Text="{Binding SourceLabel}" FontSize="12.5"
+                                                                               Foreground="{StaticResource KcapTextBrush}"
+                                                                               TextTrimming="CharacterEllipsis" />
                                                                 </Grid>
                                                             </DataTemplate>
                                                         </ItemsControl.ItemTemplate>

--- a/src/Capacitor.App/Views/MarkdownBlocks.cs
+++ b/src/Capacitor.App/Views/MarkdownBlocks.cs
@@ -157,7 +157,7 @@ public static class MarkdownBlocks {
         FontSize = fontSize,
         FontWeight = weight,
         Cursor = new Cursor(StandardCursorType.Hand),
-        Foreground = Brush("KcapAccentBrush"),
+        Foreground = Brush("KcapSuccessBrush"),
         VerticalAlignment = VerticalAlignment.Center,
     };
 

--- a/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml
+++ b/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml
@@ -6,125 +6,271 @@
              x:DataType="vm:SignInStepViewModel">
     <!-- Shared between the onboarding wizard's Sign-in step and the steady-state re-auth dialog
          (SignInWindow) — one rendering of SignInStepViewModel, so the two can never drift. -->
-    <Grid RowDefinitions="Auto,Auto,Auto,Auto,*">
-        <StackPanel Grid.Row="0" Spacing="4">
+    <UserControl.Styles>
+        <Style Selector="TextBox.kcapField">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+            <Setter Property="BorderBrush" Value="{StaticResource KcapBorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Padding" Value="12,9" />
+            <Setter Property="PlaceholderForeground" Value="{StaticResource KcapMutedBrush}" />
+        </Style>
+        <Style Selector="ListBox.kcapList">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="BorderBrush" Value="{StaticResource KcapBorderBrush}" />
+            <Setter Property="BorderThickness" Value="1" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+        </Style>
+    </UserControl.Styles>
+
+    <DockPanel>
+        <StackPanel DockPanel.Dock="Top" Spacing="10" Margin="0,0,0,20">
+            <TextBlock Text="Sign in" FontSize="22" FontWeight="SemiBold"
+                       Foreground="{StaticResource KcapTextBrush}" />
             <TextBlock x:Name="SignInStatusText" Text="{Binding Status}" TextWrapping="Wrap"
+                       FontSize="14" LineHeight="22" Foreground="{StaticResource KcapMutedBrush}"
                        Classes.failed="{Binding StatusIsError}">
                 <TextBlock.Styles>
                     <!-- Only a failure is coloured: a cancelled sign-in is not an error. -->
                     <Style Selector="TextBlock.failed">
-                        <Setter Property="Foreground" Value="#E53935" />
+                        <Setter Property="Foreground" Value="{StaticResource KcapDangerBrush}" />
                     </Style>
                 </TextBlock.Styles>
             </TextBlock>
-            <TextBlock x:Name="SignInDetailText" Text="{Binding StatusDetail}" TextWrapping="Wrap" Opacity="0.7"
+            <TextBlock x:Name="SignInDetailText" Text="{Binding StatusDetail}" TextWrapping="Wrap"
+                       FontSize="12.5" LineHeight="20" Foreground="{StaticResource KcapFaintBrush}"
                        IsVisible="{Binding StatusDetail, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
         </StackPanel>
 
-        <StackPanel Grid.Row="1" Orientation="Horizontal" Spacing="8" Margin="0,10,0,0">
-            <Button x:Name="SignInButton" Content="Sign in" Command="{Binding SignInCommand}"
-                    IsEnabled="{Binding Idle}" />
-            <Button x:Name="CancelSignInButton" Content="Cancel" Command="{Binding CancelCommand}"
-                    IsVisible="{Binding Busy}" />
-        </StackPanel>
-
-        <StackPanel Grid.Row="2" Spacing="6" Margin="0,10,0,0">
-            <Button x:Name="OpenSignInUrlButton" Content="Open the sign-in page"
-                    Command="{Binding OpenSignInUrlCommand}"
-                    IsVisible="{Binding BrowserUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-
-            <StackPanel Spacing="4"
-                        IsVisible="{Binding DeviceCode, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                <TextBlock Text="Enter this code to finish signing in:" />
-                <TextBlock x:Name="DeviceCodeText" Text="{Binding DeviceCode}" FontSize="22" FontWeight="Bold" />
-                <Button x:Name="OpenVerificationUriButton" Content="{Binding VerificationUri}"
-                        Command="{Binding OpenVerificationUriCommand}" />
-            </StackPanel>
-
-            <TextBlock x:Name="WaitingText" Text="{Binding WaitingText}" Opacity="0.7"
-                       IsVisible="{Binding WaitingText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-            <TextBlock x:Name="ProvisioningText" Text="{Binding ProvisioningProgress}" TextWrapping="Wrap"
-                       IsVisible="{Binding ProvisioningProgress, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-        </StackPanel>
-
-        <StackPanel Grid.Row="3" Spacing="8" Margin="0,10,0,0">
-            <StackPanel Spacing="6" IsVisible="{Binding TenantPickerVisible}">
-                <TextBlock Text="Which workspace would you like to use?" />
-                <ListBox x:Name="TenantList" MaxHeight="120" ItemsSource="{Binding Tenants}"
-                         SelectedItem="{Binding SelectedTenant, Mode=TwoWay}">
-                    <ListBox.ItemTemplate>
-                        <DataTemplate x:DataType="auth:DiscoveredTenant">
-                            <TextBlock Text="{Binding Origin}" TextTrimming="CharacterEllipsis" />
-                        </DataTemplate>
-                    </ListBox.ItemTemplate>
-                </ListBox>
+        <!-- Browser fallback lives at the foot: open + selectable URL, not buried in the log. -->
+        <Border DockPanel.Dock="Bottom" Margin="0,16,0,0"
+                Background="{StaticResource KcapSurfaceBrush}"
+                BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                CornerRadius="12" Padding="16,14"
+                IsVisible="{Binding BrowserUrl, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <StackPanel Spacing="10">
+                <TextBlock Text="Finish in your browser"
+                           FontSize="13.5" FontWeight="SemiBold"
+                           Foreground="{StaticResource KcapTextBrush}" />
+                <TextBlock x:Name="WaitingText" Text="{Binding WaitingText}" TextWrapping="Wrap"
+                           FontSize="12.5" Foreground="{StaticResource KcapMutedBrush}"
+                           IsVisible="{Binding WaitingText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                <TextBlock Text="If a browser window didn't open, use the link below."
+                           TextWrapping="Wrap" FontSize="12"
+                           Foreground="{StaticResource KcapFaintBrush}" />
+                <SelectableTextBlock x:Name="SignInBrowserUrlText" Text="{Binding BrowserUrl}"
+                                     TextWrapping="Wrap" FontSize="11.5"
+                                     Foreground="{StaticResource KcapTextBrush}" />
                 <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button x:Name="ConfirmTenantButton" Content="Use this workspace"
-                            Command="{Binding ConfirmTenantCommand}" />
-                    <Button x:Name="CancelTenantButton" Content="Back" Command="{Binding CancelTenantCommand}" />
+                    <Button x:Name="OpenSignInUrlButton" Classes="kcapChip"
+                            Content="Open the sign-in page"
+                            Command="{Binding OpenSignInUrlCommand}"
+                            Background="{StaticResource KcapSurfaceRaisedBrush}"
+                            BorderBrush="{StaticResource KcapBorderBrush}"
+                            Foreground="{StaticResource KcapTextBrush}"
+                            CornerRadius="8" Padding="14,8" FontSize="13" />
+                    <Button x:Name="CopySignInUrlButton" Classes="kcapChip"
+                            Content="Copy link" Click="OnCopySignInUrlClick"
+                            Background="{StaticResource KcapSurfaceRaisedBrush}"
+                            BorderBrush="{StaticResource KcapBorderBrush}"
+                            Foreground="{StaticResource KcapTextBrush}"
+                            CornerRadius="8" Padding="14,8" FontSize="13" />
                 </StackPanel>
             </StackPanel>
+        </Border>
 
-            <StackPanel Spacing="6" IsVisible="{Binding ModeChoiceVisible}">
-                <TextBlock Text="No workspace was found for your account. How would you like to continue?"
-                           TextWrapping="Wrap" />
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button x:Name="CreateWorkspaceButton" Content="Create a workspace"
-                            Command="{Binding CreateWorkspaceCommand}" />
-                    <TextBox x:Name="ExistingWorkspaceBox" Width="180" PlaceholderText="acme"
-                             Text="{Binding ExistingWorkspaceInput, Mode=TwoWay}" />
-                    <Button x:Name="UseExistingWorkspaceButton" Content="I already have one"
-                            Command="{Binding UseExistingWorkspaceCommand}" />
-                    <Button x:Name="CancelWorkspaceButton" Content="Cancel"
-                            Command="{Binding CancelWorkspaceCommand}" />
-                </StackPanel>
-            </StackPanel>
-
-            <StackPanel Spacing="6" IsVisible="{Binding OrgNamePromptVisible}">
-                <TextBlock Text="Organization name" />
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <TextBox x:Name="OrgNameBox" Width="220" Text="{Binding OrgName, Mode=TwoWay}" />
-                    <Button x:Name="SubmitOrgNameButton" Content="Continue" Command="{Binding SubmitOrgNameCommand}" />
-                    <Button x:Name="CancelOrgNameButton" Content="Cancel" Command="{Binding CancelOrgNameCommand}" />
-                </StackPanel>
-            </StackPanel>
-
-            <StackPanel Spacing="6" IsVisible="{Binding SlugPromptVisible}">
-                <TextBlock Text="Workspace address" />
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <TextBox x:Name="SlugBox" Width="220" Text="{Binding Slug, Mode=TwoWay}" />
-                    <TextBlock Text=".kcap.ai" VerticalAlignment="Center" Opacity="0.7" />
-                    <Button x:Name="SubmitSlugButton" Content="Continue" Command="{Binding SubmitSlugCommand}" />
-                    <Button x:Name="CancelSlugButton" Content="Cancel" Command="{Binding CancelSlugCommand}" />
-                </StackPanel>
-                <TextBlock x:Name="SlugErrorText" Text="{Binding SlugError}" TextWrapping="Wrap" Foreground="#E53935"
-                           IsVisible="{Binding SlugError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-            </StackPanel>
-
-            <StackPanel Spacing="6" IsVisible="{Binding ConfirmVisible}">
-                <TextBlock x:Name="ConfirmCreateText" Text="{Binding ConfirmText}" TextWrapping="Wrap" />
-                <StackPanel Orientation="Horizontal" Spacing="8">
-                    <Button x:Name="ConfirmCreateButton" Content="Create" Command="{Binding ConfirmCreateCommand}" />
-                    <Button x:Name="DeclineCreateButton" Content="Not now" Command="{Binding DeclineCreateCommand}" />
-                </StackPanel>
-            </StackPanel>
-
-            <StackPanel Spacing="6"
-                        IsVisible="{Binding QuarantineNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                <TextBlock x:Name="QuarantineNoticeText" Text="{Binding QuarantineNotice}" TextWrapping="Wrap" />
-                <Button x:Name="AcknowledgeQuarantineButton" Content="Acknowledge"
-                        Command="{Binding AcknowledgeQuarantineCommand}" HorizontalAlignment="Left" />
-            </StackPanel>
-        </StackPanel>
-
-        <ScrollViewer Grid.Row="4" Margin="0,10,0,0" VerticalScrollBarVisibility="Auto">
+        <!-- Progress log: quiet trailing detail above the browser card. -->
+        <ScrollViewer DockPanel.Dock="Bottom" Margin="0,16,0,0" MaxHeight="88"
+                      VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
             <ItemsControl x:Name="SignInLog" ItemsSource="{Binding Log}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="x:String">
-                        <TextBlock Text="{Binding}" FontSize="12" Opacity="0.7" TextWrapping="Wrap" />
+                        <TextBlock Text="{Binding}" FontSize="11.5"
+                                   Foreground="{StaticResource KcapFaintBrush}" TextWrapping="Wrap"
+                                   Margin="0,2" />
                     </DataTemplate>
                 </ItemsControl.ItemTemplate>
             </ItemsControl>
         </ScrollViewer>
-    </Grid>
+
+        <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Spacing="16">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <Button x:Name="SignInButton" Classes="kcapPrimary" Content="Sign in"
+                            Command="{Binding SignInCommand}" IsEnabled="{Binding Idle}"
+                            Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
+                            FontWeight="SemiBold" CornerRadius="8" Padding="18,9"
+                            FontSize="13.5" />
+                    <Button x:Name="CancelSignInButton" Classes="kcapChip" Content="Cancel"
+                            Command="{Binding CancelCommand}" IsVisible="{Binding Busy}"
+                            Background="{StaticResource KcapSurfaceRaisedBrush}"
+                            BorderBrush="{StaticResource KcapBorderBrush}"
+                            Foreground="{StaticResource KcapTextBrush}"
+                            CornerRadius="8" Padding="16,9" FontSize="13.5" />
+                </StackPanel>
+
+                <StackPanel Spacing="10">
+                    <Border Background="{StaticResource KcapSurfaceBrush}"
+                            BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
+                            CornerRadius="12" Padding="16,14"
+                            IsVisible="{Binding DeviceCode, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                        <StackPanel Spacing="10">
+                            <TextBlock Text="Enter this code to finish signing in"
+                                       Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5" />
+                            <TextBlock x:Name="DeviceCodeText" Text="{Binding DeviceCode}"
+                                       FontSize="28" FontWeight="Bold" LetterSpacing="2"
+                                       Foreground="{StaticResource KcapTextBrush}" />
+                            <Button x:Name="OpenVerificationUriButton" Classes="kcapChip"
+                                    Content="{Binding VerificationUri}"
+                                    Command="{Binding OpenVerificationUriCommand}"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}"
+                                    BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}"
+                                    CornerRadius="8" Padding="12,7" HorizontalAlignment="Left"
+                                    FontSize="12" />
+                        </StackPanel>
+                    </Border>
+
+                    <TextBlock x:Name="ProvisioningText" Text="{Binding ProvisioningProgress}"
+                               TextWrapping="Wrap" Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5"
+                               IsVisible="{Binding ProvisioningProgress, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                </StackPanel>
+
+                <StackPanel Spacing="12">
+                    <StackPanel Spacing="10" IsVisible="{Binding TenantPickerVisible}">
+                        <TextBlock Text="Which workspace would you like to use?"
+                                   Foreground="{StaticResource KcapTextBrush}" FontSize="13.5" />
+                        <ListBox x:Name="TenantList" Classes="kcapList" MaxHeight="140"
+                                 ItemsSource="{Binding Tenants}"
+                                 SelectedItem="{Binding SelectedTenant, Mode=TwoWay}">
+                            <ListBox.ItemTemplate>
+                                <DataTemplate x:DataType="auth:DiscoveredTenant">
+                                    <TextBlock Text="{Binding Origin}" TextTrimming="CharacterEllipsis"
+                                               Foreground="{StaticResource KcapTextBrush}" Margin="4,6" />
+                                </DataTemplate>
+                            </ListBox.ItemTemplate>
+                        </ListBox>
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button x:Name="ConfirmTenantButton" Classes="kcapPrimary"
+                                    Content="Use this workspace"
+                                    Command="{Binding ConfirmTenantCommand}"
+                                    Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
+                                    FontWeight="SemiBold" CornerRadius="8" Padding="14,8" />
+                            <Button x:Name="CancelTenantButton" Classes="kcapChip" Content="Back"
+                                    Command="{Binding CancelTenantCommand}"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}"
+                                    BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}"
+                                    CornerRadius="8" Padding="14,8" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="10" IsVisible="{Binding ModeChoiceVisible}">
+                        <TextBlock Text="No workspace was found for your account. How would you like to continue?"
+                                   TextWrapping="Wrap" Foreground="{StaticResource KcapTextBrush}" FontSize="13.5" />
+                        <StackPanel Spacing="8">
+                            <Button x:Name="CreateWorkspaceButton" Classes="kcapPrimary"
+                                    Content="Create a workspace"
+                                    Command="{Binding CreateWorkspaceCommand}"
+                                    Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
+                                    FontWeight="SemiBold" CornerRadius="8" Padding="14,8"
+                                    HorizontalAlignment="Left" />
+                            <StackPanel Orientation="Horizontal" Spacing="8">
+                                <TextBox x:Name="ExistingWorkspaceBox" Classes="kcapField" Width="180"
+                                         PlaceholderText="acme"
+                                         Text="{Binding ExistingWorkspaceInput, Mode=TwoWay}" />
+                                <Button x:Name="UseExistingWorkspaceButton" Classes="kcapChip"
+                                        Content="I already have one"
+                                        Command="{Binding UseExistingWorkspaceCommand}"
+                                        Background="{StaticResource KcapSurfaceRaisedBrush}"
+                                        BorderBrush="{StaticResource KcapBorderBrush}"
+                                        Foreground="{StaticResource KcapTextBrush}"
+                                        CornerRadius="8" Padding="14,8" />
+                            </StackPanel>
+                            <Button x:Name="CancelWorkspaceButton" Classes="kcapChip" Content="Cancel"
+                                    Command="{Binding CancelWorkspaceCommand}"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}"
+                                    BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}"
+                                    CornerRadius="8" Padding="14,8" HorizontalAlignment="Left" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="8" IsVisible="{Binding OrgNamePromptVisible}">
+                        <TextBlock Text="Organization name" Foreground="{StaticResource KcapMutedBrush}"
+                                   FontSize="12.5" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBox x:Name="OrgNameBox" Classes="kcapField" Width="240"
+                                     Text="{Binding OrgName, Mode=TwoWay}" />
+                            <Button x:Name="SubmitOrgNameButton" Classes="kcapPrimary" Content="Continue"
+                                    Command="{Binding SubmitOrgNameCommand}"
+                                    Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
+                                    FontWeight="SemiBold" CornerRadius="8" Padding="14,8" />
+                            <Button x:Name="CancelOrgNameButton" Classes="kcapChip" Content="Cancel"
+                                    Command="{Binding CancelOrgNameCommand}"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}"
+                                    BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}"
+                                    CornerRadius="8" Padding="14,8" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="8" IsVisible="{Binding SlugPromptVisible}">
+                        <TextBlock Text="Workspace address" Foreground="{StaticResource KcapMutedBrush}"
+                                   FontSize="12.5" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <TextBox x:Name="SlugBox" Classes="kcapField" Width="200"
+                                     Text="{Binding Slug, Mode=TwoWay}" />
+                            <TextBlock Text=".kcap.ai" VerticalAlignment="Center"
+                                       Foreground="{StaticResource KcapFaintBrush}" />
+                            <Button x:Name="SubmitSlugButton" Classes="kcapPrimary" Content="Continue"
+                                    Command="{Binding SubmitSlugCommand}"
+                                    Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
+                                    FontWeight="SemiBold" CornerRadius="8" Padding="14,8" />
+                            <Button x:Name="CancelSlugButton" Classes="kcapChip" Content="Cancel"
+                                    Command="{Binding CancelSlugCommand}"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}"
+                                    BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}"
+                                    CornerRadius="8" Padding="14,8" />
+                        </StackPanel>
+                        <TextBlock x:Name="SlugErrorText" Text="{Binding SlugError}" TextWrapping="Wrap"
+                                   Foreground="{StaticResource KcapDangerBrush}" FontSize="12.5"
+                                   IsVisible="{Binding SlugError, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                    </StackPanel>
+
+                    <StackPanel Spacing="10" IsVisible="{Binding ConfirmVisible}">
+                        <TextBlock x:Name="ConfirmCreateText" Text="{Binding ConfirmText}" TextWrapping="Wrap"
+                                   Foreground="{StaticResource KcapTextBrush}" FontSize="13.5" />
+                        <StackPanel Orientation="Horizontal" Spacing="8">
+                            <Button x:Name="ConfirmCreateButton" Classes="kcapPrimary" Content="Create"
+                                    Command="{Binding ConfirmCreateCommand}"
+                                    Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
+                                    FontWeight="SemiBold" CornerRadius="8" Padding="14,8" />
+                            <Button x:Name="DeclineCreateButton" Classes="kcapChip" Content="Not now"
+                                    Command="{Binding DeclineCreateCommand}"
+                                    Background="{StaticResource KcapSurfaceRaisedBrush}"
+                                    BorderBrush="{StaticResource KcapBorderBrush}"
+                                    Foreground="{StaticResource KcapTextBrush}"
+                                    CornerRadius="8" Padding="14,8" />
+                        </StackPanel>
+                    </StackPanel>
+
+                    <StackPanel Spacing="10"
+                                IsVisible="{Binding QuarantineNotice, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+                        <TextBlock x:Name="QuarantineNoticeText" Text="{Binding QuarantineNotice}"
+                                   TextWrapping="Wrap" Foreground="{StaticResource KcapWarningBrush}" />
+                        <Button x:Name="AcknowledgeQuarantineButton" Classes="kcapPrimary"
+                                Content="Acknowledge"
+                                Command="{Binding AcknowledgeQuarantineCommand}"
+                                Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
+                                FontWeight="SemiBold" CornerRadius="8" Padding="14,8"
+                                HorizontalAlignment="Left" />
+                    </StackPanel>
+                </StackPanel>
+            </StackPanel>
+        </ScrollViewer>
+    </DockPanel>
 </UserControl>

--- a/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml
+++ b/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml
@@ -2,6 +2,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:auth="clr-namespace:Capacitor.Cli.Core.Auth;assembly=Capacitor.Cli.Core"
              xmlns:vm="clr-namespace:Capacitor.App.ViewModels.Onboarding"
+             xmlns:views="clr-namespace:Capacitor.App.Views"
              x:Class="Capacitor.App.Views.Onboarding.SignInStepView"
              x:DataType="vm:SignInStepViewModel">
     <!-- Shared between the onboarding wizard's Sign-in step and the steady-state re-auth dialog
@@ -26,11 +27,12 @@
     </UserControl.Styles>
 
     <DockPanel>
-        <StackPanel DockPanel.Dock="Top" Spacing="10" Margin="0,0,0,20">
-            <TextBlock Text="Sign in" FontSize="22" FontWeight="SemiBold"
-                       Foreground="{StaticResource KcapTextBrush}" />
+        <StackPanel DockPanel.Dock="Top" Spacing="8" Margin="0,0,0,20">
+            <!-- No page title here: the wizard step chrome and SignInWindow title already name
+                 the surface. Status is the first thing the user needs. -->
             <TextBlock x:Name="SignInStatusText" Text="{Binding Status}" TextWrapping="Wrap"
-                       FontSize="14" LineHeight="22" Foreground="{StaticResource KcapMutedBrush}"
+                       FontSize="18" FontWeight="SemiBold" LineHeight="26"
+                       Foreground="{StaticResource KcapTextBrush}"
                        Classes.failed="{Binding StatusIsError}">
                 <TextBlock.Styles>
                     <!-- Only a failure is coloured: a cancelled sign-in is not an error. -->
@@ -40,7 +42,7 @@
                 </TextBlock.Styles>
             </TextBlock>
             <TextBlock x:Name="SignInDetailText" Text="{Binding StatusDetail}" TextWrapping="Wrap"
-                       FontSize="12.5" LineHeight="20" Foreground="{StaticResource KcapFaintBrush}"
+                       FontSize="13.5" LineHeight="21" Foreground="{StaticResource KcapMutedBrush}"
                        IsVisible="{Binding StatusDetail, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
         </StackPanel>
 
@@ -81,9 +83,11 @@
             </StackPanel>
         </Border>
 
-        <!-- Progress log: quiet trailing detail above the browser card. -->
+        <!-- Progress log: quiet trailing detail above the browser card. Hidden when empty so a
+             failure does not leave a second copy of the same error under the actions. -->
         <ScrollViewer DockPanel.Dock="Bottom" Margin="0,16,0,0" MaxHeight="88"
-                      VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+                      VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled"
+                      IsVisible="{Binding Log.Count, Converter={x:Static views:CountIsNotZeroConverter.Instance}}">
             <ItemsControl x:Name="SignInLog" ItemsSource="{Binding Log}">
                 <ItemsControl.ItemTemplate>
                     <DataTemplate x:DataType="x:String">
@@ -98,8 +102,9 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
             <StackPanel Spacing="16">
                 <StackPanel Orientation="Horizontal" Spacing="10">
-                    <Button x:Name="SignInButton" Classes="kcapPrimary" Content="Sign in"
+                    <Button x:Name="SignInButton" Classes="kcapPrimary" Content="{Binding PrimaryActionLabel}"
                             Command="{Binding SignInCommand}" IsEnabled="{Binding Idle}"
+                            IsVisible="{Binding ShowPrimaryAction}"
                             Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
                             FontWeight="SemiBold" CornerRadius="8" Padding="18,9"
                             FontSize="13.5" />

--- a/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml.cs
+++ b/src/Capacitor.App/Views/Onboarding/SignInStepView.axaml.cs
@@ -1,7 +1,17 @@
 using Avalonia.Controls;
+using Avalonia.Input.Platform;
+using Avalonia.Interactivity;
+using Capacitor.App.ViewModels.Onboarding;
 
 namespace Capacitor.App.Views.Onboarding;
 
 public partial class SignInStepView : UserControl {
     public SignInStepView() => InitializeComponent();
+
+    async void OnCopySignInUrlClick(object? sender, RoutedEventArgs e) {
+        if (DataContext is not SignInStepViewModel { BrowserUrl: { Length: > 0 } url }) return;
+        var clipboard = TopLevel.GetTopLevel(this)?.Clipboard;
+        if (clipboard is null) return;
+        await clipboard.SetTextAsync(url);
+    }
 }

--- a/src/Capacitor.App/Views/SessionRailView.axaml
+++ b/src/Capacitor.App/Views/SessionRailView.axaml
@@ -20,6 +20,18 @@
         <Style Selector="Button.selected, Button.holdsSelected">
             <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
         </Style>
+        <Style Selector="Button.railRow:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.railRow:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+        </Style>
+        <Style Selector="Button.selected:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.holdsSelected:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.selected:pressed /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.holdsSelected:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+        </Style>
 
     </UserControl.Styles>
 
@@ -33,7 +45,7 @@
                 <Grid Height="44" Background="Transparent" PointerPressed="OnChromePointerPressed" />
 
                 <!-- Deselects the workspace: the pane's empty state IS the launcher. -->
-                <Button x:Name="RailNewSessionButton" HorizontalAlignment="Stretch" Margin="10,0,10,10"
+                <Button x:Name="RailNewSessionButton" Classes="kcapChip" HorizontalAlignment="Stretch" Margin="10,0,10,10"
                         Command="{Binding CloseWorkspaceCommand}"
                         Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                         BorderThickness="1" CornerRadius="7" Padding="11,7">
@@ -42,7 +54,7 @@
                                    Foreground="{StaticResource KcapFaintBrush}" VerticalAlignment="Center" />
                         <StackPanel Orientation="Horizontal" Spacing="8">
                             <TextBlock Text="+" FontSize="15" FontWeight="SemiBold"
-                                       Foreground="{StaticResource KcapAccentBrush}" VerticalAlignment="Center" />
+                                       Foreground="{StaticResource KcapTextBrush}" VerticalAlignment="Center" />
                             <TextBlock Text="New session" FontSize="13" FontWeight="SemiBold"
                                        Foreground="{StaticResource KcapTextBrush}" VerticalAlignment="Center" />
                         </StackPanel>

--- a/src/Capacitor.App/Views/SignInWindow.axaml
+++ b/src/Capacitor.App/Views/SignInWindow.axaml
@@ -6,8 +6,11 @@
         x:DataType="vm:SignInStepViewModel"
         Title="Sign in"
         Icon="avares://Kurrent Capacitor/Assets/kcap-icon.png"
-        Width="560" Height="420">
+        Width="480" Height="560"
+        MinWidth="420" MinHeight="480"
+        Background="{StaticResource KcapCanvasBrush}"
+        CanResize="False">
     <!-- The steady-state re-auth dialog: the wizard's sign-in step view over a ReauthComposition
          graph pinned to the configured server. App owns opening/closing it. -->
-    <onboarding:SignInStepView Margin="16" />
+    <onboarding:SignInStepView Margin="32,28" />
 </Window>

--- a/src/Capacitor.App/Views/WorkContextView.axaml
+++ b/src/Capacitor.App/Views/WorkContextView.axaml
@@ -94,10 +94,11 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel Margin="16,18,16,18" Spacing="0">
 
-                <!-- Header: eyebrow + Refresh, shared mid-line (the icon button is taller than the type). -->
-                <Grid ColumnDefinitions="*,Auto" MinHeight="30">
-                    <TextBlock Grid.Column="0" Text="ABOUT THIS WORK" Classes="eyebrow" Background="Transparent"
-                               VerticalAlignment="Center" PointerPressed="OnHeaderPointerPressed" />
+                <!-- Header: full-width drag chrome; refresh stays a button (handler skips Buttons). -->
+                <Grid ColumnDefinitions="*,Auto" MinHeight="30" Background="Transparent"
+                      PointerPressed="OnHeaderPointerPressed">
+                    <TextBlock Grid.Column="0" Text="ABOUT THIS WORK" Classes="eyebrow"
+                               VerticalAlignment="Center" />
                     <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
                         <Ellipse x:Name="StaleDot" Width="6" Height="6" Fill="{StaticResource KcapWarningBrush}"
                                  IsVisible="{Binding IsStale}" ToolTip.Tip="Last refresh failed; showing the previous result"

--- a/src/Capacitor.App/Views/WorkContextView.axaml
+++ b/src/Capacitor.App/Views/WorkContextView.axaml
@@ -124,7 +124,7 @@
                         <!-- Ready body. -->
                         <StackPanel IsVisible="{Binding IsReady}">
                             <TextBlock x:Name="WorkContextKey" Text="{Binding Key}" FontSize="12" FontWeight="Bold"
-                                       Foreground="{StaticResource KcapAccentBrush}" Margin="0,8,0,0"
+                                       Foreground="{StaticResource KcapSuccessBrush}" Margin="0,8,0,0"
                                        IsVisible="{Binding Key, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                             <TextBlock x:Name="WorkContextTitle" Text="{Binding Title}" FontSize="12.5" LineHeight="18"
                                        Foreground="{StaticResource KcapTextBrush}" TextWrapping="Wrap" Margin="0,4,0,0" />
@@ -152,7 +152,7 @@
                                         <StackPanel Orientation="Horizontal" Spacing="9" Margin="0,0,0,7">
                                             <Panel Width="12" Height="12" VerticalAlignment="Center">
                                                 <Ellipse Width="12" Height="12" Stroke="{StaticResource KcapBorderBrush}" StrokeThickness="1.5" IsVisible="{Binding !IsThisSession}" />
-                                                <Ellipse Width="12" Height="12" Fill="{StaticResource KcapAccentBrush}" IsVisible="{Binding IsThisSession}" />
+                                                <Ellipse Width="12" Height="12" Fill="{StaticResource KcapSuccessBrush}" IsVisible="{Binding IsThisSession}" />
                                                 <Path Stroke="#07120E" StrokeThickness="1.6" StrokeLineCap="Round" StrokeJoin="Round"
                                                       Data="M3,6 L5.2,8.2 L9,4" IsVisible="{Binding IsThisSession}" />
                                             </Panel>
@@ -188,7 +188,7 @@
                             <TextBlock x:Name="PhaseNoteText" Text="{Binding PhaseNote}" FontSize="11.5" LineHeight="16"
                                        Foreground="{StaticResource KcapMutedBrush}" TextWrapping="Wrap" />
                             <Button x:Name="SignInButton" Content="Sign in" Command="{Binding SignInCommand}" IsVisible="{Binding ShowsSignIn}"
-                                    Background="{StaticResource KcapAccentBrush}" Foreground="#07120E" FontWeight="SemiBold"
+                                    Background="{StaticResource KcapSuccessBrush}" Foreground="#07120E" FontWeight="SemiBold"
                                     CornerRadius="7" Padding="13,5" HorizontalAlignment="Left" />
                             <Button x:Name="RetryButton" Content="Retry" Command="{Binding RefreshCommand}" IsVisible="{Binding ShowsRetry}"
                                     Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
@@ -206,7 +206,7 @@
                                     <StackPanel Spacing="6">
                                         <TextBlock Text="{Binding Eyebrow}" Classes="cardEyebrow" />
                                         <StackPanel Orientation="Horizontal" Spacing="8">
-                                            <TextBlock Text="{Binding Key}" FontSize="11.5" FontWeight="Bold" Foreground="{StaticResource KcapAccentBrush}" VerticalAlignment="Center" />
+                                            <TextBlock Text="{Binding Key}" FontSize="11.5" FontWeight="Bold" Foreground="{StaticResource KcapSuccessBrush}" VerticalAlignment="Center" />
                                             <TextBlock Text="{Binding Title}" FontSize="11.5" Foreground="{StaticResource KcapTextBrush}" TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
                                         </StackPanel>
                                     </StackPanel>
@@ -234,8 +234,8 @@
                     </DockPanel>
                 </Button>
                 <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
-                    <Border Width="24" Height="24" CornerRadius="999" Background="{StaticResource KcapAccentDimBrush}">
-                        <TextBlock Text="{Binding RequesterInitial}" FontSize="10.5" FontWeight="Bold" Foreground="{StaticResource KcapAccentBrush}"
+                    <Border Width="24" Height="24" CornerRadius="999" Background="{StaticResource KcapSuccessDimBrush}">
+                        <TextBlock Text="{Binding RequesterInitial}" FontSize="10.5" FontWeight="Bold" Foreground="{StaticResource KcapSuccessBrush}"
                                    HorizontalAlignment="Center" VerticalAlignment="Center" />
                     </Border>
                     <StackPanel VerticalAlignment="Center" IsVisible="{Binding PeopleExpanded}">

--- a/src/Capacitor.App/Views/WorkContextView.axaml
+++ b/src/Capacitor.App/Views/WorkContextView.axaml
@@ -32,12 +32,48 @@
             <Setter Property="LetterSpacing" Value="0.6" />
             <Setter Property="Foreground" Value="{StaticResource KcapPurpleBrush}" />
         </Style>
+        <!-- Transparent stretch wrapper for cards / nested chrome — not a hit-target of its own. -->
         <Style Selector="Button.toggle">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Padding" Value="0" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        </Style>
+        <!-- Section rows (Who's on it / Session): real padding so hover and click aren't tight to glyphs. -->
+        <Style Selector="Button.sectionHeader">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="8,10" />
+            <Setter Property="Margin" Value="-8,0" />
+            <Setter Property="CornerRadius" Value="8" />
+            <Setter Property="HorizontalAlignment" Value="Stretch" />
+            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        </Style>
+        <Style Selector="Button.sectionHeader:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.sectionHeader:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+        </Style>
+        <!-- Header refresh: a square hit target, not a 13px orphan path. -->
+        <Style Selector="Button.iconButton">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderThickness" Value="0" />
+            <Setter Property="Padding" Value="7" />
+            <Setter Property="MinWidth" Value="30" />
+            <Setter Property="MinHeight" Value="30" />
+            <Setter Property="CornerRadius" Value="7" />
+            <Setter Property="HorizontalContentAlignment" Value="Center" />
+            <Setter Property="VerticalContentAlignment" Value="Center" />
+        </Style>
+        <Style Selector="Button.iconButton:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.iconButton:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="BorderBrush" Value="Transparent" />
+        </Style>
+        <Style Selector="Button.iconButton:disabled /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="Opacity" Value="0.4" />
         </Style>
         <Style Selector="Border.card">
             <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
@@ -58,19 +94,23 @@
         <ScrollViewer VerticalScrollBarVisibility="Auto">
             <StackPanel Margin="16,18,16,18" Spacing="0">
 
-                <!-- Header: eyebrow, the stale dot, Refresh. Also the pane's drag strip, like the
-                     workspace header on the other side of the split (see WindowChrome). -->
-                <DockPanel Background="Transparent" PointerPressed="OnHeaderPointerPressed">
-                    <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="8">
+                <!-- Header: eyebrow + Refresh, shared mid-line (the icon button is taller than the type). -->
+                <Grid ColumnDefinitions="*,Auto" MinHeight="30">
+                    <TextBlock Grid.Column="0" Text="ABOUT THIS WORK" Classes="eyebrow" Background="Transparent"
+                               VerticalAlignment="Center" PointerPressed="OnHeaderPointerPressed" />
+                    <StackPanel Grid.Column="1" Orientation="Horizontal" Spacing="6" VerticalAlignment="Center">
                         <Ellipse x:Name="StaleDot" Width="6" Height="6" Fill="{StaticResource KcapWarningBrush}"
-                                 IsVisible="{Binding IsStale}" ToolTip.Tip="Last refresh failed; showing the previous result" />
-                        <Button x:Name="RefreshButton" Command="{Binding RefreshCommand}" Classes="toggle" ToolTip.Tip="Refresh">
-                            <Path Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.6" StrokeLineCap="Round" Width="13" Height="13" Stretch="Uniform"
+                                 IsVisible="{Binding IsStale}" ToolTip.Tip="Last refresh failed; showing the previous result"
+                                 VerticalAlignment="Center" Margin="0,0,2,0" />
+                        <Button x:Name="RefreshButton" Command="{Binding RefreshCommand}" Classes="iconButton"
+                                VerticalAlignment="Center"
+                                ToolTip.Tip="{Binding RefreshTip}" ToolTip.ShowOnDisabled="True">
+                            <Path Width="14" Height="14" Stretch="Uniform"
+                                  Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.6" StrokeLineCap="Round"
                                   Data="M11.5,6.5 A5,5 0 1 1 10,3 M10,0.5 L10,3 L7.5,3" />
                         </Button>
                     </StackPanel>
-                    <TextBlock Text="ABOUT THIS WORK" Classes="eyebrow" />
-                </DockPanel>
+                </Grid>
 
                 <!-- Work item card. -->
                 <Border Classes="card" Margin="0,12,0,0">
@@ -92,7 +132,7 @@
                                        IsVisible="{Binding PartOfTitle, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
 
                             <!-- Parts: header toggle, then one row per part. -->
-                            <Button x:Name="PartsToggle" Command="{Binding TogglePartsCommand}" Classes="toggle" Margin="0,12,0,0">
+                            <Button x:Name="PartsToggle" Command="{Binding TogglePartsCommand}" Classes="sectionHeader" Margin="-8,8,-8,0">
                                 <DockPanel>
                                     <Border DockPanel.Dock="Right" Classes="soon"><TextBlock /></Border>
                                     <StackPanel Orientation="Horizontal" Spacing="7">
@@ -182,17 +222,17 @@
                 </Border>
 
                 <!-- Who's on it. -->
-                <Button x:Name="WhoToggle" Command="{Binding TogglePeopleCommand}" Classes="toggle" Margin="0,20,0,0">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="WHO'S ON IT" Classes="eyebrow" />
-                        <Border Classes="soon"><TextBlock /></Border>
-                        <Panel Width="12" Height="12" VerticalAlignment="Center">
+                <Button x:Name="WhoToggle" Command="{Binding TogglePeopleCommand}" Classes="sectionHeader" Margin="-8,16,-8,0">
+                    <DockPanel>
+                        <Panel DockPanel.Dock="Right" Width="12" Height="12" VerticalAlignment="Center">
                             <Path Classes="chevron" Data="M3,4.5 L6,7.5 L9,4.5" IsVisible="{Binding PeopleExpanded}" />
                             <Path Classes="chevron" Data="M4.5,3 L7.5,6 L4.5,9" IsVisible="{Binding !PeopleExpanded}" />
                         </Panel>
-                    </StackPanel>
+                        <Border DockPanel.Dock="Right" Classes="soon" Margin="0,0,10,0"><TextBlock /></Border>
+                        <TextBlock Text="WHO'S ON IT" Classes="eyebrow" />
+                    </DockPanel>
                 </Button>
-                <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,11,0,0">
+                <StackPanel Orientation="Horizontal" Spacing="10" Margin="0,10,0,0">
                     <Border Width="24" Height="24" CornerRadius="999" Background="{StaticResource KcapAccentDimBrush}">
                         <TextBlock Text="{Binding RequesterInitial}" FontSize="10.5" FontWeight="Bold" Foreground="{StaticResource KcapAccentBrush}"
                                    HorizontalAlignment="Center" VerticalAlignment="Center" />
@@ -203,21 +243,21 @@
                     </StackPanel>
                 </StackPanel>
 
-                <Border Height="1" Background="{StaticResource KcapBorderBrush}" Margin="0,20,0,16" />
+                <Border Height="1" Background="{StaticResource KcapBorderBrush}" Margin="0,16,0,12" />
 
                 <!-- Session facts. -->
-                <Button x:Name="SessionToggle" Command="{Binding ToggleSessionCommand}" Classes="toggle">
-                    <StackPanel Orientation="Horizontal" Spacing="8">
-                        <TextBlock Text="SESSION" Classes="eyebrow" />
-                        <Panel Width="12" Height="12" VerticalAlignment="Center">
+                <Button x:Name="SessionToggle" Command="{Binding ToggleSessionCommand}" Classes="sectionHeader">
+                    <DockPanel>
+                        <Panel DockPanel.Dock="Right" Width="12" Height="12" VerticalAlignment="Center">
                             <Path Classes="chevron" Data="M3,4.5 L6,7.5 L9,4.5" IsVisible="{Binding SessionExpanded}" />
                             <Path Classes="chevron" Data="M4.5,3 L7.5,6 L4.5,9" IsVisible="{Binding !SessionExpanded}" />
                         </Panel>
-                    </StackPanel>
+                        <TextBlock Text="SESSION" Classes="eyebrow" />
+                    </DockPanel>
                 </Button>
                 <TextBlock x:Name="SessionSummaryText" Text="{Binding SessionSummaryLine}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
                            Margin="0,10,0,0" IsVisible="{Binding !SessionExpanded}" />
-                <Grid x:Name="SessionFacts" ColumnDefinitions="96,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,11,0,0"
+                <Grid x:Name="SessionFacts" ColumnDefinitions="108,*" RowDefinitions="Auto,Auto,Auto,Auto,Auto,Auto" Margin="0,10,0,0"
                       IsVisible="{Binding SessionExpanded}">
                     <Grid.Styles>
                         <Style Selector="TextBlock.factLabel">
@@ -225,14 +265,16 @@
                             <Setter Property="FontWeight" Value="Bold" />
                             <Setter Property="LetterSpacing" Value="0.8" />
                             <Setter Property="Foreground" Value="{StaticResource KcapFaintBrush}" />
-                            <Setter Property="Margin" Value="0,0,0,11" />
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                            <Setter Property="Margin" Value="0,0,12,12" />
                         </Style>
                         <Style Selector="SelectableTextBlock.factValue">
                             <Setter Property="FontSize" Value="11" />
                             <Setter Property="LineHeight" Value="15" />
                             <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
                             <Setter Property="TextWrapping" Value="Wrap" />
-                            <Setter Property="Margin" Value="0,0,0,11" />
+                            <Setter Property="VerticalAlignment" Value="Center" />
+                            <Setter Property="Margin" Value="0,0,0,12" />
                         </Style>
                     </Grid.Styles>
                     <TextBlock Grid.Row="0" Grid.Column="0" Text="REPOSITORY" Classes="factLabel" />

--- a/src/Capacitor.App/Views/WorkContextView.axaml.cs
+++ b/src/Capacitor.App/Views/WorkContextView.axaml.cs
@@ -1,4 +1,7 @@
+using Avalonia;
 using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.VisualTree;
 
 namespace Capacitor.App.Views;
 
@@ -9,6 +12,10 @@ public partial class WorkContextView : UserControl {
         InitializeComponent();
     }
 
-    void OnHeaderPointerPressed(object? sender, Avalonia.Input.PointerPressedEventArgs e) =>
+    // Drag only from empty chrome — never from the refresh button (or any other Button in the strip).
+    void OnHeaderPointerPressed(object? sender, PointerPressedEventArgs e) {
+        if (e.Source is Visual source && source.FindAncestorOfType<Button>(includeSelf: true) is not null)
+            return;
         WindowChrome.BeginDrag(this, e);
+    }
 }

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -37,14 +37,14 @@
          terminal keeps its own column, so the size it reports to the PTY is the real center width. -->
     <Grid ColumnDefinitions="*,400">
     <Grid Grid.Column="0" RowDefinitions="56,42,*">
-        <!-- Header: title over quiet identity meta · spacer · actions.
-             Leaving the workspace is the rail's job, not a Back button's. -->
+        <!-- Header: title over checkout · spacer · actions.
+             Harness/transport live in the work-context pane; leaving is the rail's job. -->
         <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto" Margin="20,0,16,0"
               Background="Transparent" PointerPressed="OnHeaderPointerPressed">
             <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center" Margin="0,0,16,0">
                 <TextBlock x:Name="WorkspaceTitle" Text="{Binding Title}" FontWeight="SemiBold" FontSize="14.5"
                            Foreground="{StaticResource KcapTextBrush}" TextTrimming="CharacterEllipsis" />
-                <TextBlock x:Name="WorkspaceSubtitle" Text="{Binding IdentitySubtitle}" FontSize="11.5"
+                <TextBlock x:Name="WorkspaceSubtitle" Text="{Binding RepoLabelText}" FontSize="11.5"
                            Foreground="{StaticResource KcapMutedBrush}" TextTrimming="CharacterEllipsis" />
             </StackPanel>
 

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -20,6 +20,17 @@
             <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
             <Setter Property="FontWeight" Value="SemiBold" />
         </Style>
+        <!-- Fluent hover paints PART_ContentPresenter; keep tab chrome on our tokens. -->
+        <Style Selector="Button.tab:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.tab:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+        </Style>
+        <Style Selector="Button.tab.active:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.tab.active:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+        </Style>
     </UserControl.Styles>
 
     <!-- Two columns: the workspace proper, and the work-context pane at its fixed width. The
@@ -91,7 +102,7 @@
                                        Opacity="{Binding IsTerminalActive, Converter={x:Static views:BoolToOpacityConverter.Instance}}"
                                        AutomationProperties.IsOffscreenBehavior="{Binding IsTerminalActive, Converter={x:Static views:OffscreenWhenInactiveConverter.Instance}}"
                                        FontFamily="Menlo,Monaco,Consolas,Cascadia Mono,DejaVu Sans Mono,monospace"
-                                       CaretBrush="{StaticResource KcapAccentBrush}"
+                                       CaretBrush="{StaticResource KcapTextBrush}"
                                        Model="{Binding Terminal.Surface, Converter={x:Static views:TerminalSurfaceModelConverter.Instance}}" />
 
             <!-- A session with no tabs at all has no Terminal tab to activate, and these banners
@@ -132,7 +143,7 @@
                         <TextBlock Text="{Binding Terminal.State, Converter={x:Static views:TerminalDetachedOrFailedMessageConverter.Instance}}"
                                    Foreground="{StaticResource KcapTextBrush}" HorizontalAlignment="Center" TextWrapping="Wrap" MaxWidth="380" />
                         <Button x:Name="ReattachButton" Content="Reattach" Command="{Binding Terminal.ReattachCommand}"
-                                HorizontalAlignment="Center" Background="{StaticResource KcapAccentBrush}" Foreground="#07120E"
+                                HorizontalAlignment="Center" Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}"
                                 FontWeight="SemiBold" Padding="16,5" />
                     </StackPanel>
                 </Border>

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -37,35 +37,21 @@
          terminal keeps its own column, so the size it reports to the PTY is the real center width. -->
     <Grid ColumnDefinitions="*,400">
     <Grid Grid.Column="0" RowDefinitions="56,42,*">
-        <!-- Header: identity on the left (title/repo + pty/vendor chip) · spacer · actions.
+        <!-- Header: title over quiet identity meta · spacer · actions.
              Leaving the workspace is the rail's job, not a Back button's. -->
-        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,*,Auto,Auto" Margin="20,0,16,0"
+        <Grid Grid.Row="0" ColumnDefinitions="*,Auto,Auto" Margin="20,0,16,0"
               Background="Transparent" PointerPressed="OnHeaderPointerPressed">
-            <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center" Margin="0,0,12,0">
+            <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center" Margin="0,0,16,0">
                 <TextBlock x:Name="WorkspaceTitle" Text="{Binding Title}" FontWeight="SemiBold" FontSize="14.5"
                            Foreground="{StaticResource KcapTextBrush}" TextTrimming="CharacterEllipsis" />
-                <TextBlock x:Name="WorkspaceRepo" Text="{Binding RepoLabelText}" FontSize="11.5"
-                           Foreground="{StaticResource KcapPurpleBrush}" TextTrimming="CharacterEllipsis" />
+                <TextBlock x:Name="WorkspaceSubtitle" Text="{Binding IdentitySubtitle}" FontSize="11.5"
+                           Foreground="{StaticResource KcapMutedBrush}" TextTrimming="CharacterEllipsis" />
             </StackPanel>
 
-            <Border Grid.Column="1" Background="{StaticResource KcapSurfaceRaisedBrush}"
-                    BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1" CornerRadius="7"
-                    Padding="10,5" VerticalAlignment="Center">
-                <StackPanel Orientation="Horizontal" Spacing="7">
-                    <Border Background="{StaticResource KcapCanvasBrush}" CornerRadius="999" Padding="6,1"
-                            VerticalAlignment="Center"
-                            IsVisible="{Binding FamilyDot, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                        <TextBlock Text="{Binding FamilyDot}" FontSize="9" Foreground="{StaticResource KcapMutedBrush}" />
-                    </Border>
-                    <TextBlock x:Name="WorkspaceVendorChip" Text="{Binding VendorChip}" FontSize="12" FontWeight="SemiBold"
-                               Foreground="{StaticResource KcapTextBrush}" VerticalAlignment="Center" />
-                </StackPanel>
-            </Border>
-
-            <Button Grid.Column="3" Content="Open in web" Command="{Binding OpenInWebCommand}"
+            <Button Grid.Column="1" Content="Open in web" Command="{Binding OpenInWebCommand}"
                     Background="Transparent" BorderBrush="Transparent" CornerRadius="7"
                     Foreground="{StaticResource KcapMutedBrush}" Padding="10,5" FontSize="12.5" Margin="0,0,4,0" />
-            <Button Grid.Column="4" Content="Stop" Command="{Binding StopCommand}"
+            <Button Grid.Column="2" Content="Stop" Command="{Binding StopCommand}"
                     Background="Transparent" BorderBrush="Transparent" CornerRadius="7"
                     Foreground="{StaticResource KcapDangerBrush}" Padding="10,5" FontSize="12.5" />
         </Grid>

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -37,20 +37,20 @@
          terminal keeps its own column, so the size it reports to the PTY is the real center width. -->
     <Grid ColumnDefinitions="*,400">
     <Grid Grid.Column="0" RowDefinitions="56,42,*">
-        <!-- Header: title over repo leaf · spacer · vendor chip with its family badge ·
-             Open-in-web/Stop. Leaving the workspace is the rail's job, not a Back button's. -->
-        <Grid Grid.Row="0" ColumnDefinitions="Auto,*,Auto,Auto,Auto" Margin="20,0,16,0"
+        <!-- Header: identity on the left (title/repo + pty/vendor chip) · spacer · actions.
+             Leaving the workspace is the rail's job, not a Back button's. -->
+        <Grid Grid.Row="0" ColumnDefinitions="Auto,Auto,*,Auto,Auto" Margin="20,0,16,0"
               Background="Transparent" PointerPressed="OnHeaderPointerPressed">
-            <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center">
+            <StackPanel Grid.Column="0" Spacing="2" VerticalAlignment="Center" Margin="0,0,12,0">
                 <TextBlock x:Name="WorkspaceTitle" Text="{Binding Title}" FontWeight="SemiBold" FontSize="14.5"
                            Foreground="{StaticResource KcapTextBrush}" TextTrimming="CharacterEllipsis" />
                 <TextBlock x:Name="WorkspaceRepo" Text="{Binding RepoLabelText}" FontSize="11.5"
                            Foreground="{StaticResource KcapPurpleBrush}" TextTrimming="CharacterEllipsis" />
             </StackPanel>
 
-            <Border Grid.Column="2" Background="{StaticResource KcapSurfaceRaisedBrush}"
+            <Border Grid.Column="1" Background="{StaticResource KcapSurfaceRaisedBrush}"
                     BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1" CornerRadius="7"
-                    Padding="10,5" Margin="0,0,10,0" VerticalAlignment="Center">
+                    Padding="10,5" VerticalAlignment="Center">
                 <StackPanel Orientation="Horizontal" Spacing="7">
                     <Border Background="{StaticResource KcapCanvasBrush}" CornerRadius="999" Padding="6,1"
                             VerticalAlignment="Center"

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -845,7 +845,7 @@ public static class OAuthLoginFlow {
             json = await CorrectWorkOSOrgAsync(http, apiBase, clientId, json, organizationId, ct);
 
             if (json is null) {
-                progress.Error("Error: signed in to the wrong workspace. Re-run `kcap login` and choose the one this server belongs to.");
+                progress.Error("Error: Signed in to the wrong workspace. Sign in again and choose the one this server belongs to.");
 
                 return null;
             }

--- a/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ActivityViewModelTests.cs
@@ -79,8 +79,9 @@ public class ActivityViewModelTests {
     [NotInParallel("AvaloniaSession")]
     public async Task Rows_map_records_with_fallbacks_and_source_labels() {
         const string decidedAt = "2026-08-08T12:34:56.0000000+00:00";
-        var expectedTime = DateTimeOffset.Parse(decidedAt, CultureInfo.InvariantCulture)
-            .ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+        var local = DateTimeOffset.Parse(decidedAt, CultureInfo.InvariantCulture).ToLocalTime();
+        var expectedTime = local.ToString("MMM d HH:mm", CultureInfo.InvariantCulture);
+        var expectedTip = local.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
 
         var records = new[] {
             Rec(decidedAt: decidedAt, requester: "github:1", requesterDisplay: "Ada Lovelace",
@@ -101,6 +102,7 @@ public class ActivityViewModelTests {
         });
 
         await Assert.That(first.Time).IsEqualTo(expectedTime);
+        await Assert.That(first.TimeTip).IsEqualTo(expectedTip);
         await Assert.That(first.Requester).IsEqualTo("Ada Lovelace");
         await Assert.That(first.KindLabel).IsEqualTo("Review flow");
         // A consent record carries the launch request's path verbatim, with no repository behind

--- a/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
@@ -199,6 +199,21 @@ public class AppMutationLaneWiringTests {
     }
 
     [Test]
+    [Arguments("running_without_daemon_pid")]
+    [Arguments("daemon_running_outside_service")]
+    public async Task AttentionRepair_uses_human_copy_for_service_ownership_tokens(string token) {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.AttentionRepair(token));
+
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
+
+        await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
+        await Assert.That(surface.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor(token)!);
+        await Assert.That(surface.AttentionMessages[0]).DoesNotContain(token);
+    }
+
+    [Test]
     public async Task Unknown_attention_token_is_acked_but_not_shown_in_the_banner() {
         var surface = new FakeLifecycleSurface();
         var presented = false;

--- a/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
@@ -130,7 +130,7 @@ public class AppMutationLaneWiringTests {
     // ---- PresentOutcomeAsync: Reinstall/Attention/Storage ----
 
     [Test]
-    public async Task Reinstall_surface_is_an_attention_line_naming_the_token_no_dialog_no_status() {
+    public async Task Reinstall_surface_is_an_attention_line_without_a_dialog() {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.Failed(28, "package_inconsistent", RecoverySurface.Reinstall));
 
@@ -140,11 +140,12 @@ public class AppMutationLaneWiringTests {
         await Assert.That(surface.Prompts).IsEmpty();
         await Assert.That(surface.StatusMessages).IsEmpty(); // Reinstall never writes Status
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
-        await Assert.That(surface.AttentionMessages[0]).Contains("package_inconsistent");
+        await Assert.That(surface.AttentionMessages[0]).Contains("Reinstall", StringComparison.OrdinalIgnoreCase);
+        await Assert.That(surface.AttentionMessages[0]).DoesNotContain("package_inconsistent");
     }
 
     [Test]
-    public async Task Attention_surface_names_the_token() {
+    public async Task Attention_surface_uses_human_copy_not_the_wire_token() {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.Failed(1, "internal_error", RecoverySurface.Attention));
 
@@ -152,13 +153,14 @@ public class AppMutationLaneWiringTests {
             surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
-        await Assert.That(surface.AttentionMessages[0]).Contains("internal_error");
+        await Assert.That(surface.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor("internal_error")!);
+        await Assert.That(surface.AttentionMessages[0]).DoesNotContain("internal_error");
         await Assert.That(surface.Prompts).IsEmpty();
         await Assert.That(surface.StatusMessages).IsEmpty();
     }
 
     [Test]
-    public async Task Storage_surface_also_reads_as_attention_and_names_the_token() {
+    public async Task Storage_surface_uses_human_copy_not_the_wire_token() {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.Refused("consent_seed_unwritable", RecoverySurface.Storage));
 
@@ -166,11 +168,12 @@ public class AppMutationLaneWiringTests {
             surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
-        await Assert.That(surface.AttentionMessages[0]).Contains("consent_seed_unwritable");
+        await Assert.That(surface.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor("consent_seed_unwritable")!);
+        await Assert.That(surface.AttentionMessages[0]).DoesNotContain("consent_seed_unwritable");
     }
 
     [Test]
-    public async Task AttentionSkew_always_reads_as_attention_naming_its_own_detail() {
+    public async Task AttentionSkew_uses_human_copy_for_known_ownership_tokens() {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.AttentionSkew("ownership_mismatch"));
 
@@ -178,11 +181,12 @@ public class AppMutationLaneWiringTests {
             surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
-        await Assert.That(surface.AttentionMessages[0]).Contains("ownership_mismatch");
+        await Assert.That(surface.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor("ownership_mismatch")!);
+        await Assert.That(surface.AttentionMessages[0]).DoesNotContain("ownership_mismatch");
     }
 
     [Test]
-    public async Task AttentionRepair_always_reads_as_attention_naming_its_own_detail() {
+    public async Task AttentionRepair_uses_human_copy_for_stale_txn_marker() {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.AttentionRepair("stale_txn_marker"));
 
@@ -190,7 +194,24 @@ public class AppMutationLaneWiringTests {
             surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
-        await Assert.That(surface.AttentionMessages[0]).Contains("stale_txn_marker");
+        await Assert.That(surface.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor("stale_txn_marker")!);
+        await Assert.That(surface.AttentionMessages[0]).DoesNotContain("stale_txn_marker");
+    }
+
+    [Test]
+    public async Task Unknown_attention_token_is_acked_but_not_shown_in_the_banner() {
+        var surface = new FakeLifecycleSurface();
+        var presented = false;
+        var envelope = Envelope(new MutationOutcome.Failed(1, "some_future_token", RecoverySurface.Attention));
+
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None,
+            markPresented: () => presented = true);
+
+        await Assert.That(presented).IsTrue();
+        await Assert.That(surface.AttentionMessages).IsEmpty();
+        await Assert.That(surface.StatusMessages).IsEmpty();
+        await Assert.That(surface.Prompts).IsEmpty();
     }
 
     // UnconfirmedNoAttach is actionable: one attention presentation naming the verb
@@ -233,7 +254,8 @@ public class AppMutationLaneWiringTests {
         await AppUnderTest.PresentOutcomeAsync(
             surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
-        await Assert.That(surface.AttentionMessages[0]).Contains("verify_readiness_timeout");
+        await Assert.That(surface.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor("verify_readiness_timeout")!);
+        await Assert.That(surface.AttentionMessages[0]).DoesNotContain("verify_readiness_timeout");
     }
 
     // DigestGate (43) is DaemonCommands' own gate, not a ServiceVerify exit code, but it still
@@ -247,7 +269,8 @@ public class AppMutationLaneWiringTests {
         await AppUnderTest.PresentOutcomeAsync(
             surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
 
-        await Assert.That(surface.AttentionMessages[0]).Contains("daemon_start_gate");
+        await Assert.That(surface.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor("daemon_start_gate")!);
+        await Assert.That(surface.AttentionMessages[0]).DoesNotContain("daemon_start_gate");
     }
 
     // ---- ClassifyForPresentation (the pure routing table, standalone) ----
@@ -330,8 +353,7 @@ public class AppMutationLaneWiringTests {
     [Arguments("server_or_name_mismatch")]
     [Arguments("ownership_mismatch")]
     [Arguments("unreachable_with_recorded_owner")]
-    [Arguments("some_unknown_future_token")]
-    public async Task AttentionSkew_other_token_is_attention_only_no_dialog(string token) {
+    public async Task AttentionSkew_known_attention_token_is_human_copy_no_dialog(string token) {
         var surface = new FakeLifecycleSurface();
         var envelope = Envelope(new MutationOutcome.AttentionSkew(token));
 
@@ -340,7 +362,20 @@ public class AppMutationLaneWiringTests {
 
         await Assert.That(surface.Prompts).IsEmpty();
         await Assert.That(surface.AttentionMessages.Count).IsEqualTo(1);
-        await Assert.That(surface.AttentionMessages[0]).Contains(token);
+        await Assert.That(surface.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor(token)!);
+        await Assert.That(surface.AttentionMessages[0]).DoesNotContain(token);
+    }
+
+    [Test]
+    public async Task AttentionSkew_unknown_token_is_acked_but_not_shown() {
+        var surface = new FakeLifecycleSurface();
+        var envelope = Envelope(new MutationOutcome.AttentionSkew("some_unknown_future_token"));
+
+        await AppUnderTest.PresentOutcomeAsync(
+            surface, envelope, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, CancellationToken.None);
+
+        await Assert.That(surface.Prompts).IsEmpty();
+        await Assert.That(surface.AttentionMessages).IsEmpty();
     }
 
     // ---- ConsumeMutationOutcomesAsync ----
@@ -371,18 +406,19 @@ public class AppMutationLaneWiringTests {
         var consumerTask = AppUnderTest.ConsumeMutationOutcomesAsync(
             channel, surface, NeverRunMutation, FixedTerminalPath("/usr/bin"), () => null, cts.Token);
 
-        channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(1, "boom1", RecoverySurface.Attention)));
+        // Known tokens so presentation still calls Attention (unknown tokens are log-only).
+        channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(1, "internal_error", RecoverySurface.Attention)));
 
         // The first attempt throws (pre-presentation) and is requeued at the front, not skipped —
         // the retry succeeds (ThrowOnceOnAttentionSurface only throws once) and is what actually
         // reaches the surface.
         await WaitUntilAsync(() => inner.AttentionMessages.Count == 1, what: "the requeued retry's presentation");
-        await Assert.That(inner.AttentionMessages[0]).Contains("boom1");
+        await Assert.That(inner.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor("internal_error")!);
 
         // Channel remains functional afterward: a fresh envelope still presents normally.
-        channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(2, "boom2", RecoverySurface.Attention)));
+        channel.Enqueue(new OutcomeEnvelope(Req(), new MutationOutcome.Failed(2, "stale_txn_marker", RecoverySurface.Attention)));
         await WaitUntilAsync(() => inner.AttentionMessages.Count == 2, what: "the next envelope's presentation");
-        await Assert.That(inner.AttentionMessages[1]).Contains("boom2");
+        await Assert.That(inner.AttentionMessages[1]).IsEqualTo(AppUnderTest.AttentionCopyFor("stale_txn_marker")!);
 
         cts.Cancel();
         // The loop's own outer catch swallows shutdown's OperationCanceledException by design

--- a/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
@@ -68,6 +68,7 @@ public class ChatComposerTests {
             // a detach lands SessionEnded — and the hint follows the terminal there too.
             daemon.Agents.Remove("a1");
             await Assert.That(chat.ComposerHint).IsEqualTo("This session has ended");
+            await Assert.That(chat.ShowsComposer).IsFalse();
 
             var attached = TerminalSessionState.Attached(null);
             await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Transitioning, attached)).IsEqualTo("Updating the terminal connection…");
@@ -75,6 +76,22 @@ public class ChatComposerTests {
             await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Connecting, TerminalSessionState.Connecting)).IsEqualTo("Connecting to the terminal…");
             await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Ended, TerminalSessionState.SessionEnded)).IsEqualTo("This session has ended");
             await Assert.That(ChatTabViewModel.HintFor(SendAvailability.NoTerminal, TerminalSessionState.NotFound)).IsEqualTo("No terminal to send to");
+            await chat.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Composer_hides_when_agent_status_becomes_Failed() {
+        await RunOnUiAsync(async () => {
+            var (daemon, _, _, chat, _, _) = await BuildAttachedAsync();
+            await Assert.That(chat.ShowsComposer).IsTrue();
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo") with { Status = "Failed" });
+            await Assert.That(chat.ComposerHint).IsEqualTo("This session has ended");
+            await Assert.That(chat.ShowsComposer).IsFalse();
+            chat.ComposerText = "too late";
+            await Assert.That(await chat.SendCommand.CanExecute.FirstAsync()).IsFalse();
             await chat.TeardownAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
@@ -54,11 +54,11 @@ public class ChatComposerTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Hint_follows_send_availability_and_the_vendor_label() {
+    public async Task Hint_follows_send_availability() {
         await RunOnUiAsync(async () => {
             var (daemon, _, terminal, chat, client, _) = await BuildAttachedAsync();
             await Assert.That(chat.VendorLabel).IsEqualTo("Claude Code");
-            await Assert.That(chat.ComposerHint).IsEqualTo("Reply to Claude Code · Enter sends · Shift+Enter for a new line");
+            await Assert.That(chat.ComposerHint).IsEqualTo("Enter sends · Shift+Enter for a new line");
 
             client.Result.SetResult(new AttachOutcome.Detached());
             await terminal.CurrentRunForTesting!;
@@ -70,11 +70,11 @@ public class ChatComposerTests {
             await Assert.That(chat.ComposerHint).IsEqualTo("This session has ended");
 
             var attached = TerminalSessionState.Attached(null);
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Transitioning, attached, "Claude Code")).IsEqualTo("Updating the terminal connection…");
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.ReadOnly, TerminalSessionState.Attached("review"), "x")).IsEqualTo("Read-only: review");
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Connecting, TerminalSessionState.Connecting, "x")).IsEqualTo("Connecting to the terminal…");
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Ended, TerminalSessionState.SessionEnded, "x")).IsEqualTo("This session has ended");
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.NoTerminal, TerminalSessionState.NotFound, "x")).IsEqualTo("No terminal to send to");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Transitioning, attached)).IsEqualTo("Updating the terminal connection…");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.ReadOnly, TerminalSessionState.Attached("review"))).IsEqualTo("Read-only: review");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Connecting, TerminalSessionState.Connecting)).IsEqualTo("Connecting to the terminal…");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Ended, TerminalSessionState.SessionEnded)).IsEqualTo("This session has ended");
+            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.NoTerminal, TerminalSessionState.NotFound)).IsEqualTo("No terminal to send to");
             await chat.TeardownAsync();
         });
     }
@@ -90,7 +90,7 @@ public class ChatComposerTests {
 
             daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo") with { Status = "Failed" });
             await Assert.That(chat.StatusText).IsEqualTo("Failed");
-            await Assert.That(chat.ModelLabel).IsEqualTo("default");
+            await Assert.That(chat.ModelLabel).IsEqualTo("Default");
             await chat.TeardownAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -48,8 +48,8 @@ public class ChatTabViewSmokeTests {
     /// A synthetic pointer event hit-tests the compositor's last committed scene, which layout alone
     /// does not refresh: a control shown since the last frame is invisible to the click until the
     /// render timer ticks. One tick is enough on macOS/Linux; Windows headless sometimes needs a
-    /// second before a freshly-shown summary button is in the scene (tool groups sit deeper in a
-    /// Border now). Aim at the control's center — a (2,2) corner miss is easy when DPI scales.
+    /// second before a freshly-shown summary button is in the scene (tool groups nest under a Border).
+    /// Aim at the control's center — a (2,2) corner miss is easy when DPI scales.
     static Point PresentAndLocate(Host host, Control target) {
         host.Settle();
         AvaloniaHeadlessPlatform.ForceRenderTimerTick();
@@ -510,20 +510,6 @@ public class ChatTabViewSmokeTests {
             await Assert.That(chip.Text).IsEqualTo("Search");
             await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
             await Assert.That(((ToolCallItem)ToolRows(host.View)[0].DataContext!).Outcome).IsEqualTo(ToolOutcome.Done);
-            await host.CloseAsync();
-        });
-    }
-
-    [Test]
-    [NotInParallel("AvaloniaSession")]
-    public async Task A_lone_task_call_shows_a_task_kind_chip() {
-        await RunOnUiAsync(async () => {
-            var host = new Host();
-            const string taskCall = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t9","name":"Task","input":{"prompt":"Build the CLI project"}}]}}""";
-            const string taskResult = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t9","content":"ok"}]}}""";
-            await host.LoadAsync(Tmp.CreateFile("task.jsonl", [taskCall, taskResult]));
-            await Assert.That(OnlyGroup(host).KindChip).IsEqualTo("Task");
-            await Assert.That(OnlyGroup(host).ShowsKindChip).IsTrue();
             await host.CloseAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -5,7 +5,6 @@ using Avalonia;
 using Avalonia.Controls;
 using Avalonia.Headless;
 using Avalonia.Input;
-using Avalonia.Layout;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -40,9 +39,10 @@ public class ChatTabViewSmokeTests {
     static string CallLine(int n) => ToolCallLine.Replace("\"t1\"", $"\"t{n}\"");
     static string ResultLine(int n) => ToolResultLine.Replace("\"t1\"", $"\"t{n}\"");
 
-    static List<StackPanel> ToolRows(ChatTabView view) => view.GetVisualDescendants().OfType<StackPanel>()
-        .Where(p => p.Orientation == Orientation.Horizontal && p.DataContext is ToolCallItem).ToList();
+    static List<Control> ToolRows(ChatTabView view) => view.GetVisualDescendants().OfType<Control>()
+        .Where(c => c.Name == "ToolCallRow" && c.DataContext is ToolCallItem).ToList();
     static Button Summary(ChatTabView view) => view.GetVisualDescendants().OfType<Button>().Single(b => b.Classes.Contains("toolSummary"));
+    static Button? SummaryOrNull(ChatTabView view) => view.GetVisualDescendants().OfType<Button>().FirstOrDefault(b => b.Classes.Contains("toolSummary"));
     static ToolGroupItem OnlyGroup(Host host) => (ToolGroupItem)host.Chat.Items.Single();
 
     /// A synthetic pointer event hit-tests the compositor's last committed scene, which layout alone
@@ -306,11 +306,11 @@ public class ChatTabViewSmokeTests {
         });
     }
 
-    /// Pins the tool row's outcome colour: the glyph takes the brush ToolOutcomeBrushConverter
+    /// Pins the tool row's outcome colour: the status pill takes the brush ToolOutcomeBrushConverter
     /// maps for the paired result, danger for an error and accent for a success.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task A_paired_tool_row_paints_its_glyph_with_the_outcome_brush() {
+    public async Task A_paired_tool_row_paints_its_status_dot_with_the_outcome_brush() {
         await RunOnUiAsync(async () => {
             var host = new Host();
             await host.LoadAsync(Tmp.CreateFile("tools.jsonl",
@@ -320,12 +320,13 @@ public class ChatTabViewSmokeTests {
 
             await Assert.That(OnlyGroup(host).Calls.Select(i => i.Outcome))
                 .IsEquivalentTo([ToolOutcome.Done, ToolOutcome.Error], CollectionOrdering.Matching);
-            var glyphs = host.View.GetVisualDescendants().OfType<TextBlock>()
-                .Where(t => t.DataContext is ToolCallItem && t.Text is "✓" or "✕").ToList();
+            var pills = ToolRows(host.View)
+                .Select(row => row.GetVisualDescendants().OfType<Border>().Single(b => b.Classes.Contains("toolStatus") && b.IsVisible))
+                .ToList();
 
-            await Assert.That(glyphs.Select(g => g.Text!)).IsEquivalentTo(["✓", "✕"], CollectionOrdering.Matching);
-            await Assert.That(glyphs[0].Foreground).IsSameReferenceAs(Brush(isError: false));
-            await Assert.That(glyphs[1].Foreground).IsSameReferenceAs(Brush(isError: true));
+            await Assert.That(pills).Count().IsEqualTo(2);
+            await Assert.That(pills[0].Background).IsSameReferenceAs(Brush(isError: false));
+            await Assert.That(pills[1].Background).IsSameReferenceAs(Brush(isError: true));
             await host.CloseAsync();
         });
     }
@@ -447,7 +448,7 @@ public class ChatTabViewSmokeTests {
 
             await Assert.That(rows).Count().IsEqualTo(2);
             await Assert.That(Top(rows[1]) - Bottom(rows[0])).IsLessThan(10);
-            await Assert.That(Top(text) - Bottom(rows[1])).IsGreaterThanOrEqualTo(12);
+            await Assert.That(Top(text) - Bottom(rows[1])).IsGreaterThanOrEqualTo(18);
             await host.CloseAsync();
         });
     }
@@ -464,17 +465,55 @@ public class ChatTabViewSmokeTests {
             await Assert.That(host.Chat.Items).Count().IsEqualTo(1);
             var summary = Summary(host.View);
             await Assert.That(summary.IsVisible).IsTrue();
-            await Assert.That(summary.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text)).Contains("Searched files, read a file");
+            await Assert.That(OnlyGroup(host).SummaryLine).IsEqualTo("Searched files, read a file · ls -la");
+            await Assert.That(summary.GetVisualDescendants().OfType<TextBlock>().Select(t => t.Text))
+                .Contains("Searched files, read a file · ls -la");
             await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
             await Assert.That(((ToolCallItem)ToolRows(host.View)[0].DataContext!).Outcome).IsEqualTo(ToolOutcome.Running);
 
             Click(host, summary);
             await Assert.That(OnlyGroup(host).IsExpanded).IsTrue();
+            await Assert.That(OnlyGroup(host).SummaryLine).IsEqualTo("Searched files, read a file");
             await Assert.That(ToolRows(host.View)).Count().IsEqualTo(3);
 
             Click(host, summary);
             await Assert.That(OnlyGroup(host).IsExpanded).IsFalse();
+            await Assert.That(OnlyGroup(host).SummaryLine).IsEqualTo("Searched files, read a file · ls -la");
             await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
+            await host.CloseAsync();
+        });
+    }
+
+    /// A lone settled call is the row itself — no "Ran a command" summary, but a kind chip names it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_single_settled_call_shows_the_row_without_a_summary() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("one.jsonl", [ToolCallLine, ToolResultLine]));
+            await Assert.That(OnlyGroup(host).ShowsSummaryHeader).IsFalse();
+            await Assert.That(OnlyGroup(host).ShowsKindChip).IsTrue();
+            await Assert.That(OnlyGroup(host).KindChip).IsEqualTo("Search");
+            await Assert.That(SummaryOrNull(host.View)?.IsVisible ?? false).IsFalse();
+            var chip = host.View.GetVisualDescendants().OfType<TextBlock>()
+                .Single(t => t.Classes.Contains("toolKindChip") && t.IsEffectivelyVisible);
+            await Assert.That(chip.Text).IsEqualTo("Search");
+            await Assert.That(ToolRows(host.View)).Count().IsEqualTo(1);
+            await Assert.That(((ToolCallItem)ToolRows(host.View)[0].DataContext!).Outcome).IsEqualTo(ToolOutcome.Done);
+            await host.CloseAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_lone_task_call_shows_a_task_kind_chip() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            const string taskCall = """{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t9","name":"Task","input":{"prompt":"Build the CLI project"}}]}}""";
+            const string taskResult = """{"type":"user","message":{"content":[{"type":"tool_result","tool_use_id":"t9","content":"ok"}]}}""";
+            await host.LoadAsync(Tmp.CreateFile("task.jsonl", [taskCall, taskResult]));
+            await Assert.That(OnlyGroup(host).KindChip).IsEqualTo("Task");
+            await Assert.That(OnlyGroup(host).ShowsKindChip).IsTrue();
             await host.CloseAsync();
         });
     }
@@ -486,7 +525,7 @@ public class ChatTabViewSmokeTests {
         await RunOnUiAsync(async () => {
             var host = new Host();
             await host.LoadAsync(Tmp.CreateFile("live.jsonl", [ToolCallLine, ReadCallLine]));
-            await Assert.That(Summary(host.View).IsVisible).IsFalse();
+            await Assert.That(SummaryOrNull(host.View)?.IsVisible ?? false).IsFalse();
             await Assert.That(ToolRows(host.View)).Count().IsEqualTo(2);
             await host.CloseAsync();
         });
@@ -494,13 +533,17 @@ public class ChatTabViewSmokeTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task A_failed_call_inside_a_folded_group_shows_the_danger_cross_on_the_summary() {
+    public async Task A_failed_call_inside_a_multi_call_group_marks_the_summary() {
         await RunOnUiAsync(async () => {
             var host = new Host();
-            await host.LoadAsync(Tmp.CreateFile("fail.jsonl", [ToolCallLine, ToolErrorLine]));
-            var cross = Summary(host.View).GetVisualDescendants().OfType<TextBlock>().Single(t => t.Text == "✕");
-            await Assert.That(cross.IsVisible).IsTrue();
-            await Assert.That(cross.Foreground).IsSameReferenceAs(Avalonia.Application.Current!.FindResource("KcapDangerBrush"));
+            await host.LoadAsync(Tmp.CreateFile("fail.jsonl", [
+                ToolCallLine, ToolErrorLine, ReadCallLine, ReadResultLine,
+            ]));
+            var summary = Summary(host.View);
+            await Assert.That(summary.IsVisible).IsTrue();
+            var failPill = summary.GetVisualDescendants().OfType<Border>()
+                .Single(b => b.Classes.Contains("toolStatus") && b.IsVisible);
+            await Assert.That(failPill.Background).IsSameReferenceAs(Avalonia.Application.Current!.FindResource("KcapDangerBrush"));
             await host.CloseAsync();
         });
     }
@@ -514,8 +557,35 @@ public class ChatTabViewSmokeTests {
             host.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
             await WaitUntilAsync(() => OnlyGroup(host).Calls[0].IsAwaitingPermission, what: "the mark");
             host.Settle();
-            var glyph = host.View.GetVisualDescendants().OfType<TextBlock>().Single(t => t.DataContext is ToolCallItem && t.Text == "?");
+            var call = OnlyGroup(host).Calls[0];
+            await Assert.That(call.IsRunning).IsFalse();
+            await Assert.That(call.ShowRowStatus).IsFalse();
+            var glyph = host.View.GetVisualDescendants().OfType<TextBlock>()
+                .Single(t => t.DataContext is ToolCallItem && t.Text == "?" && t.IsEffectivelyVisible);
             await Assert.That(glyph.Foreground).IsSameReferenceAs(Brush(isError: false));
+            await Assert.That(host.View.GetVisualDescendants().OfType<Border>()
+                .Count(b => b.Classes.Contains("toolRunning") && b.IsEffectivelyVisible)).IsEqualTo(0);
+            await host.CloseAsync();
+        });
+    }
+
+    /// A live row that is not waiting on permission shows the pulsing status pill.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_running_row_shows_the_pulsing_status_dot() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.LoadAsync(Tmp.CreateFile("run.jsonl", [ToolCallLine]));
+            var call = OnlyGroup(host).Calls[0];
+            await Assert.That(call.IsRunning).IsTrue();
+            await Assert.That(call.HasDetail).IsTrue();
+            await Assert.That(call.ShowRowStatus).IsFalse();
+            var pulse = host.View.GetVisualDescendants().OfType<Border>()
+                .Single(b => b.Classes.Contains("toolRunning") && b.IsEffectivelyVisible);
+            await Assert.That(pulse.Background).IsSameReferenceAs(Avalonia.Application.Current!.FindResource("KcapWarningBrush"));
+            var detail = ToolRows(host.View)[0].GetVisualDescendants().OfType<TextBlock>()
+                .Single(t => t.IsEffectivelyVisible && t.Text == "ls -la");
+            await Assert.That(detail.Foreground).IsSameReferenceAs(Avalonia.Application.Current!.FindResource("KcapTextBrush"));
             await host.CloseAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -47,12 +47,22 @@ public class ChatTabViewSmokeTests {
 
     /// A synthetic pointer event hit-tests the compositor's last committed scene, which layout alone
     /// does not refresh: a control shown since the last frame is invisible to the click until the
-    /// render timer ticks once more.
+    /// render timer ticks. One tick is enough on macOS/Linux; Windows headless sometimes needs a
+    /// second before a freshly-shown summary button is in the scene (tool groups sit deeper in a
+    /// Border now). Aim at the control's center — a (2,2) corner miss is easy when DPI scales.
     static Point PresentAndLocate(Host host, Control target) {
         host.Settle();
         AvaloniaHeadlessPlatform.ForceRenderTimerTick();
         Dispatcher.UIThread.RunJobs();
-        return target.TranslatePoint(new Point(2, 2), host.Window)!.Value;
+        AvaloniaHeadlessPlatform.ForceRenderTimerTick();
+        Dispatcher.UIThread.RunJobs();
+        host.Window.UpdateLayout();
+        if (target.Bounds.Width < 1 || target.Bounds.Height < 1)
+            throw new InvalidOperationException(
+                $"Click target '{target.GetType().Name}' has empty bounds after present; cannot hit-test.");
+        var local = new Point(target.Bounds.Width / 2, target.Bounds.Height / 2);
+        return target.TranslatePoint(local, host.Window)
+            ?? throw new InvalidOperationException("Click target is not under the window.");
     }
 
     static void Click(Host host, Control target) {

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -634,6 +634,8 @@ public class DaemonLifecycleControllerTests {
 
         await Assert.That(h.Client.RestartCount).IsEqualTo(1);
         await Assert.That(h.Lane.Requests).IsEmpty();
+        await Assert.That(h.Surface.StatusMessages.Count).IsEqualTo(1);
+        await Assert.That(h.Surface.StatusMessages[0]).Contains("Reconnecting");
     }
 
     [Test]
@@ -649,6 +651,8 @@ public class DaemonLifecycleControllerTests {
         // Task 10: DetachedStart from Start now shares the SAME success handling as every other
         // verb (a strict improvement — it used to be a bare, result-discarding CLI call).
         await Assert.That(h.Client.RestartCount).IsEqualTo(1);
+        await Assert.That(h.Surface.StatusMessages.Count).IsEqualTo(1);
+        await Assert.That(h.Surface.StatusMessages[0]).Contains("Waiting to connect");
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -313,22 +313,42 @@ public class HomeViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task The_scratch_target_is_always_the_last_repository_entry() {
+    public async Task Scratch_appears_only_when_no_real_repositories() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);
             var daemon = new FakeDaemonClientService();
             using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
-            await vm.SelectRepositoryAsync(HomeViewModel.ScratchRepoPath);
-            await vm.ChooseHarnessAsync("pi");
+            var empty = await vm.ListRepositoriesAsync();
+            await Assert.That(empty.Count).IsEqualTo(1);
+            await Assert.That(empty[0].RepoPath).IsEqualTo(HomeViewModel.ScratchRepoPath);
+
             daemon.Agents.AddOrUpdate(Agent("x", "/repo/b"));
+            var withRepo = await vm.ListRepositoriesAsync();
 
+            await Assert.That(withRepo.Any(r => r.RepoPath.Length == 0)).IsFalse();
+            await Assert.That(withRepo.Single(r => r.RepoPath == "/repo/b").Selected).IsTrue();
+            await Assert.That(vm.SelectedRepoPath).IsEqualTo("/repo/b");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Empty_selection_adopts_the_most_recent_known_repository() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            // GetSortedPathsAsync is last-used first — index 0 is the most recent.
+            using var vm = new HomeViewModel(
+                daemon, new AppStateStore(path), new RecordingLaunchClient(),
+                Known("/repo/newer", "/repo/older"));
+
+            await vm.EnsureDefaultRepositoryAsync();
+
+            await Assert.That(vm.SelectedRepoPath).IsEqualTo("/repo/newer");
             var repos = await vm.ListRepositoriesAsync();
-
-            await Assert.That(repos[^1].RepoPath).IsEqualTo(HomeViewModel.ScratchRepoPath);
-            await Assert.That(repos[^1].Vendor).IsEqualTo("pi");
-            await Assert.That(repos[^1].Selected).IsTrue();
-            await Assert.That(repos.Count(r => r.RepoPath.Length == 0)).IsEqualTo(1);
+            await Assert.That(repos.Any(r => r.RepoPath.Length == 0)).IsFalse();
+            await Assert.That(repos.Single(r => r.RepoPath == "/repo/newer").Selected).IsTrue();
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -552,10 +552,22 @@ public class HomeViewModelTests {
             daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "not running", null));
 
             await Assert.That(vm.ConnectionNotice).IsEqualTo(HomeViewModel.DaemonDownNotice);
+            await Assert.That(vm.BannerMessage).IsEqualTo(HomeViewModel.DaemonDownNotice);
             await Assert.That(vm.ConnectionBannerVisible).IsTrue();
             await Assert.That(vm.SignInVisible).IsFalse();
             await Assert.That(await vm.StartCommand.CanExecute.FirstAsync()).IsFalse();
         });
+    }
+
+    [Test]
+    [Arguments(null, null, null)]
+    [Arguments("daemon down", null, "daemon down")]
+    [Arguments("daemon down", "kcap too old", "kcap too old")]
+    [Arguments(null, "kcap too old", "kcap too old")]
+    [Arguments("daemon down", "", "daemon down")]
+    public async Task BannerMessage_prefers_a_start_message_over_the_connection_notice(
+            string? notice, string? startMessage, string? expected) {
+        await Assert.That(HomeViewModel.BannerMessageFor(notice, startMessage)).IsEqualTo(expected);
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -288,6 +288,29 @@ public class HomeViewModelTests {
         });
     }
 
+    /// Trailing separators are spelling, not identity — a remembered path and a known/agent path
+    /// that differ only by `/` must stay one menu row.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_repository_list_dedups_trailing_separators() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(
+                daemon, new AppStateStore(path), new RecordingLaunchClient(),
+                () => Task.FromResult(new[] { "/repo/kcap-cli/" }));
+
+            await vm.SelectRepositoryAsync("/repo/kcap-cli");
+            daemon.Agents.AddOrUpdate(Agent("x", "/repo/kcap-cli/"));
+
+            var repos = (await vm.ListRepositoriesAsync()).Where(r => r.RepoPath.Length > 0).ToList();
+
+            await Assert.That(repos.Count).IsEqualTo(1);
+            await Assert.That(repos[0].RepoPath).IsEqualTo("/repo/kcap-cli");
+            await Assert.That(repos[0].Selected).IsTrue();
+        });
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task The_scratch_target_is_always_the_last_repository_entry() {

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -509,6 +509,7 @@ public class HomeViewModelTests {
             daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "not running", null));
 
             await Assert.That(vm.ConnectionNotice).IsEqualTo(HomeViewModel.DaemonDownNotice);
+            await Assert.That(vm.ConnectionBannerVisible).IsTrue();
             await Assert.That(vm.SignInVisible).IsFalse();
             await Assert.That(await vm.StartCommand.CanExecute.FirstAsync()).IsFalse();
         });

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -548,6 +548,29 @@ public class HomeViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
+    public async Task After_sign_in_a_disconnected_server_shows_finishing_not_sign_in_again() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
+
+            daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "disconnected"));
+            daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
+            await Assert.That(vm.SignInVisible).IsTrue();
+            await Assert.That(vm.ConnectionNotice).IsEqualTo(HomeViewModel.ServerLostNotice);
+
+            vm.NotifySignInCompleted();
+            await Assert.That(vm.SignInVisible).IsFalse();
+            await Assert.That(vm.ConnectionNotice).IsEqualTo(HomeViewModel.FinishingSignInNotice);
+
+            daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "connected"));
+            await Assert.That(vm.SignInVisible).IsFalse();
+            await Assert.That(vm.ConnectionNotice).IsNull();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task A_successful_start_clears_the_goal_and_any_previous_error() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -481,12 +481,15 @@ public class HomeViewModelTests {
             using var vm = new HomeViewModel(daemon, new AppStateStore(path), new RecordingLaunchClient(), Known());
 
             Connect(daemon);
+            await vm.SelectRepositoryAsync("/repo/a");
             await Assert.That(vm.ConnectionNotice).IsNull();
             await Assert.That(vm.SignInVisible).IsFalse();
+            await Assert.That(vm.StartButtonTip).IsEqualTo("Start");
 
             daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "disconnected"));
             await Assert.That(vm.ConnectionNotice).IsEqualTo(HomeViewModel.ServerLostNotice);
             await Assert.That(vm.SignInVisible).IsTrue();
+            await Assert.That(vm.StartButtonTip).IsEqualTo(HomeViewModel.ServerLostNotice);
 
             // Transient by definition — the retry resolves it or lands on "disconnected".
             daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "reconnecting"));

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -354,6 +354,29 @@ public class HomeViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
+    public async Task EnsureDefault_does_not_overwrite_a_pick_made_during_discovery() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            using var tmp = TempDir.WithPathTo("app-state.json", out var path);
+            var daemon = new FakeDaemonClientService();
+            var release = new TaskCompletionSource();
+            using var vm = new HomeViewModel(
+                daemon, new AppStateStore(path), new RecordingLaunchClient(),
+                async () => {
+                    await release.Task;
+                    return ["/repo/default"];
+                });
+
+            var ensure = vm.EnsureDefaultRepositoryAsync();
+            await vm.SelectRepositoryAsync("/repo/user-picked");
+            release.SetResult();
+            await ensure;
+
+            await Assert.That(vm.SelectedRepoPath).IsEqualTo("/repo/user-picked");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task An_agent_without_a_repository_contributes_no_entry() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var tmp = TempDir.WithPathTo("app-state.json", out var path);

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -3,6 +3,8 @@ using System.Collections.Specialized;
 using System.Reactive.Linq;
 using Avalonia.Automation;
 using Avalonia.Controls;
+using Avalonia.Headless;
+using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -26,9 +28,12 @@ public class HomeViewSmokeTests {
 
     sealed class RecordingLaunchClient : ILaunchClient {
         public LaunchOutcome Next = new(true, LaunchedId, null);
+        public int StartCount;
 
-        public Task<LaunchOutcome> StartAsync(LaunchRequest request, CancellationToken ct) =>
-            Task.FromResult(Next);
+        public Task<LaunchOutcome> StartAsync(LaunchRequest request, CancellationToken ct) {
+            StartCount++;
+            return Task.FromResult(Next);
+        }
     }
 
     static (HomeView View, HomeViewModel Vm, FakeDaemonClientService Service, RecordingLaunchClient Launch, TempDir Tmp) Build() {
@@ -226,6 +231,81 @@ public class HomeViewSmokeTests {
 
         await Assert.That(enabledBefore).IsFalse();
         await Assert.That(enabledAfter).IsTrue();
+    }
+
+    /// Enter in the goal box starts the same way as the Start button — tunnel KeyDown, so the
+    /// TextBox cannot swallow the key before Start sees it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Enter_in_the_goal_box_starts_when_Start_can_run() {
+        var (goalAfter, startCount) = await AvaloniaSession.DispatchAsync(async () => {
+            var (_, vm, _, launch, tmp) = Build();
+            using var _tmp = tmp;
+            var window = new Window { Content = new LauncherPaneView { DataContext = vm }, Width = 900, Height = 600 };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            await vm.SelectRepositoryAsync("/repos/kcap-cli");
+            Dispatcher.UIThread.RunJobs();
+
+            var goal = Find<TextBox>(window, "GoalInput")!;
+            goal.Focus();
+            Dispatcher.UIThread.RunJobs();
+            window.KeyTextInput("ship it");
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(goal.Text).IsEqualTo("ship it");
+
+            window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+            for (var i = 0; i < 50 && launch.StartCount == 0; i++) {
+                await Task.Delay(10);
+                Dispatcher.UIThread.RunJobs();
+            }
+
+            var after = vm.Goal;
+            var count = launch.StartCount;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            vm.Dispose();
+            return (after, count);
+        });
+
+        await Assert.That(startCount).IsEqualTo(1);
+        await Assert.That(goalAfter).IsEqualTo("");
+    }
+
+    /// Without a repository, Enter is consumed and starts nothing — same gate as the Start button.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Enter_without_a_repository_does_not_start() {
+        var (goalAfter, startCount) = await AvaloniaSession.DispatchAsync(() => {
+            var (_, vm, _, launch, tmp) = Build();
+            using var _tmp = tmp;
+            var window = new Window { Content = new LauncherPaneView { DataContext = vm }, Width = 900, Height = 600 };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var goal = Find<TextBox>(window, "GoalInput")!;
+            goal.Focus();
+            Dispatcher.UIThread.RunJobs();
+            window.KeyTextInput("ship it");
+            Dispatcher.UIThread.RunJobs();
+
+            window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+
+            var after = goal.Text;
+            var count = launch.StartCount;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            vm.Dispose();
+            return (after, count);
+        });
+
+        await Assert.That(startCount).IsEqualTo(0);
+        await Assert.That(goalAfter).IsEqualTo("ship it");
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -62,7 +62,8 @@ public class HomeViewSmokeTests {
 
             var names = new[] {
                 "GoalInput", "RepositoryChip", "AgentChip", "EffortChip", "PermissionChip", "StartButton",
-                "StartErrorText", "ConnectionNoticeText", "HomeSignInButton",
+                "StartErrorText", "ConnectionNoticeText", "DaemonStartMessageText",
+                "StartDaemonButton", "RetryDaemonButton", "HomeSignInButton",
             };
             var resolved = names.ToDictionary(name => name, name => Find<Control>(window, name) is not null);
 
@@ -80,6 +81,9 @@ public class HomeViewSmokeTests {
         await Assert.That(found["StartButton"]).IsTrue();
         await Assert.That(found["StartErrorText"]).IsTrue();
         await Assert.That(found["ConnectionNoticeText"]).IsTrue();
+        await Assert.That(found["DaemonStartMessageText"]).IsTrue();
+        await Assert.That(found["StartDaemonButton"]).IsTrue();
+        await Assert.That(found["RetryDaemonButton"]).IsTrue();
         await Assert.That(found["HomeSignInButton"]).IsTrue();
     }
 

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -68,7 +68,7 @@ public class HomeViewSmokeTests {
             var names = new[] {
                 "LauncherHeadline", "LauncherRepoSubtitle",
                 "GoalInput", "RepositoryChip", "AgentChip", "EffortChip", "PermissionChip", "StartButton",
-                "StartErrorText", "ConnectionNoticeText", "DaemonStartMessageText",
+                "StartErrorText", "BannerMessageText",
                 "StartDaemonButton", "RetryDaemonButton", "HomeSignInButton",
             };
             var resolved = names.ToDictionary(name => name, name => Find<Control>(window, name) is not null);
@@ -88,8 +88,7 @@ public class HomeViewSmokeTests {
         await Assert.That(found["PermissionChip"]).IsTrue();
         await Assert.That(found["StartButton"]).IsTrue();
         await Assert.That(found["StartErrorText"]).IsTrue();
-        await Assert.That(found["ConnectionNoticeText"]).IsTrue();
-        await Assert.That(found["DaemonStartMessageText"]).IsTrue();
+        await Assert.That(found["BannerMessageText"]).IsTrue();
         await Assert.That(found["StartDaemonButton"]).IsTrue();
         await Assert.That(found["RetryDaemonButton"]).IsTrue();
         await Assert.That(found["HomeSignInButton"]).IsTrue();
@@ -141,7 +140,7 @@ public class HomeViewSmokeTests {
             window.Show();
             Dispatcher.UIThread.RunJobs();
 
-            var notice = Find<TextBlock>(window, "ConnectionNoticeText")!;
+            var notice = Find<TextBlock>(window, "BannerMessageText")!;
             var signIn = Find<Button>(window, "HomeSignInButton")!;
             // The banner Border owns visibility; the text/button stay in the tree.
             var banner = notice.FindAncestorOfType<Border>()!;

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -66,6 +66,7 @@ public class HomeViewSmokeTests {
             Dispatcher.UIThread.RunJobs();
 
             var names = new[] {
+                "LauncherHeadline", "LauncherRepoSubtitle",
                 "GoalInput", "RepositoryChip", "AgentChip", "EffortChip", "PermissionChip", "StartButton",
                 "StartErrorText", "ConnectionNoticeText", "DaemonStartMessageText",
                 "StartDaemonButton", "RetryDaemonButton", "HomeSignInButton",
@@ -78,6 +79,8 @@ public class HomeViewSmokeTests {
             return resolved;
         });
 
+        await Assert.That(found["LauncherHeadline"]).IsTrue();
+        await Assert.That(found["LauncherRepoSubtitle"]).IsTrue();
         await Assert.That(found["GoalInput"]).IsTrue();
         await Assert.That(found["RepositoryChip"]).IsTrue();
         await Assert.That(found["AgentChip"]).IsTrue();
@@ -90,6 +93,42 @@ public class HomeViewSmokeTests {
         await Assert.That(found["StartDaemonButton"]).IsTrue();
         await Assert.That(found["RetryDaemonButton"]).IsTrue();
         await Assert.That(found["HomeSignInButton"]).IsTrue();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Headline_keeps_a_fixed_question_and_a_repo_subtitle() {
+        var (question, subtitleBefore, subtitleVisibleBefore, subtitleAfter, subtitleVisibleAfter) =
+            await AvaloniaSession.DispatchAsync(async () => {
+                var (_, vm, _, _, tmp) = Build();
+                using var _tmp = tmp;
+                var window = new Window { Content = new LauncherPaneView { DataContext = vm }, Width = 900, Height = 600 };
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                var headline = Find<TextBlock>(window, "LauncherHeadline")!;
+                var subtitle = Find<TextBlock>(window, "LauncherRepoSubtitle")!;
+                var beforeText = subtitle.Text;
+                var beforeVisible = subtitle.IsVisible;
+
+                await vm.SelectRepositoryAsync("/repos/Kurrent-Capacitor-New-Machine");
+                Dispatcher.UIThread.RunJobs();
+
+                var afterText = subtitle.Text;
+                var afterVisible = subtitle.IsVisible;
+                var q = headline.Text;
+
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+                vm.Dispose();
+                return (q, beforeText, beforeVisible, afterText, afterVisible);
+            });
+
+        await Assert.That(question).IsEqualTo("What should we build?");
+        await Assert.That(subtitleVisibleBefore).IsFalse();
+        await Assert.That(subtitleBefore ?? "").IsEqualTo("");
+        await Assert.That(subtitleVisibleAfter).IsTrue();
+        await Assert.That(subtitleAfter).IsEqualTo("Kurrent-Capacitor-New-Machine");
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -57,45 +57,6 @@ public class HomeViewSmokeTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task LauncherPane_resolves_its_named_controls() {
-        var found = await AvaloniaSession.DispatchAsync(() => {
-            var (_, vm, _, _, tmp) = Build();
-            using var _tmp = tmp;
-            var window = new Window { Content = new LauncherPaneView { DataContext = vm } };
-            window.Show();
-            Dispatcher.UIThread.RunJobs();
-
-            var names = new[] {
-                "LauncherHeadline", "LauncherRepoSubtitle",
-                "GoalInput", "RepositoryChip", "AgentChip", "EffortChip", "PermissionChip", "StartButton",
-                "StartErrorText", "BannerMessageText",
-                "StartDaemonButton", "RetryDaemonButton", "HomeSignInButton",
-            };
-            var resolved = names.ToDictionary(name => name, name => Find<Control>(window, name) is not null);
-
-            window.Close();
-            Dispatcher.UIThread.RunJobs();
-            vm.Dispose();
-            return resolved;
-        });
-
-        await Assert.That(found["LauncherHeadline"]).IsTrue();
-        await Assert.That(found["LauncherRepoSubtitle"]).IsTrue();
-        await Assert.That(found["GoalInput"]).IsTrue();
-        await Assert.That(found["RepositoryChip"]).IsTrue();
-        await Assert.That(found["AgentChip"]).IsTrue();
-        await Assert.That(found["EffortChip"]).IsTrue();
-        await Assert.That(found["PermissionChip"]).IsTrue();
-        await Assert.That(found["StartButton"]).IsTrue();
-        await Assert.That(found["StartErrorText"]).IsTrue();
-        await Assert.That(found["BannerMessageText"]).IsTrue();
-        await Assert.That(found["StartDaemonButton"]).IsTrue();
-        await Assert.That(found["RetryDaemonButton"]).IsTrue();
-        await Assert.That(found["HomeSignInButton"]).IsTrue();
-    }
-
-    [Test]
-    [NotInParallel("AvaloniaSession")]
     public async Task Headline_keeps_a_fixed_question_and_a_repo_subtitle() {
         var (question, subtitleBefore, subtitleVisibleBefore, subtitleAfter, subtitleVisibleAfter) =
             await AvaloniaSession.DispatchAsync(async () => {
@@ -432,9 +393,8 @@ public class HomeViewSmokeTests {
         await Assert.That(realizedCount).IsEqualTo(1);
     }
 
-    /// The card's click plumbing (spec §3, entry points): the whole card is a Button whose Click
-    /// carries the card's OWN id to the window. Realized-visual-dependent by necessity — the
-    /// handler lives in the item template, so only a rendered card can raise it.
+    /// The card is a Button whose Click carries its own id to the window. Needs a realized visual —
+    /// the handler lives in the item template.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Clicking_a_session_card_asks_to_open_that_session() {

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -95,11 +95,13 @@ public class HomeViewSmokeTests {
 
             var notice = Find<TextBlock>(window, "ConnectionNoticeText")!;
             var signIn = Find<Button>(window, "HomeSignInButton")!;
-            var before = (notice.IsVisible, signIn.IsVisible);
+            // The banner Border owns visibility; the text/button stay in the tree.
+            var banner = notice.FindAncestorOfType<Border>()!;
+            var before = (banner.IsVisible, signIn.IsVisible);
 
             service.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(connection: "disconnected"));
             Dispatcher.UIThread.RunJobs();
-            var after = (notice.IsVisible, notice.Text, signIn.IsVisible);
+            var after = (banner.IsVisible, notice.Text, signIn.IsVisible);
 
             window.Close();
             Dispatcher.UIThread.RunJobs();
@@ -162,6 +164,37 @@ public class HomeViewSmokeTests {
         });
 
         await Assert.That(name).IsEqualTo("Start");
+    }
+
+    /// Disabled Start still exposes why — hover tips are suppressed on disabled controls unless
+    /// ShowOnDisabled is set, and the tip text must name the missing repository gate.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task StartButton_tooltip_explains_disabled_without_repository() {
+        var (tipBefore, tipAfter, showOnDisabled) = await AvaloniaSession.DispatchAsync(async () => {
+            var (_, vm, _, _, tmp) = Build();
+            using var _tmp = tmp;
+            var window = new Window { Content = new LauncherPaneView { DataContext = vm } };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            var startButton = Find<Button>(window, "StartButton")!;
+            var before = ToolTip.GetTip(startButton) as string;
+            var show = ToolTip.GetShowOnDisabled(startButton);
+
+            await vm.SelectRepositoryAsync("/repos/kcap-cli");
+            Dispatcher.UIThread.RunJobs();
+            var after = ToolTip.GetTip(startButton) as string;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            vm.Dispose();
+            return (before, after, show);
+        });
+
+        await Assert.That(showOnDisabled).IsTrue();
+        await Assert.That(tipBefore).IsEqualTo("Select a repository to start");
+        await Assert.That(tipAfter).IsEqualTo("Start");
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/HostedHarnessCatalogTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HostedHarnessCatalogTests.cs
@@ -120,8 +120,21 @@ public class HostedHarnessCatalogTests {
         await Assert.That(HostedHarnessCatalog.ModelLabelFor("claude", "claude-fable-5")).IsEqualTo("Claude Fable 5");
         await Assert.That(HostedHarnessCatalog.ModelLabelFor("claude", "CLAUDE-FABLE-5")).IsEqualTo("Claude Fable 5");
         await Assert.That(HostedHarnessCatalog.ModelLabelFor("claude", "some-future-id")).IsEqualTo("some-future-id");
-        await Assert.That(HostedHarnessCatalog.ModelLabelFor("claude", "")).IsEqualTo("default");
-        await Assert.That(HostedHarnessCatalog.ModelLabelFor("gemini", "  ")).IsEqualTo("default");
+        await Assert.That(HostedHarnessCatalog.ModelLabelFor("claude", "")).IsEqualTo("Default");
+        await Assert.That(HostedHarnessCatalog.ModelLabelFor("gemini", "  ")).IsEqualTo("Default");
+    }
+
+    [Test]
+    public async Task Effort_labels_are_sentence_case_and_default_is_not_auto() {
+        await Assert.That(HostedHarnessCatalog.EffortLabelFor(null)).IsEqualTo("Default");
+        await Assert.That(HostedHarnessCatalog.EffortLabelFor("")).IsEqualTo("Default");
+        await Assert.That(HostedHarnessCatalog.EffortLabelFor("low")).IsEqualTo("Low");
+        await Assert.That(HostedHarnessCatalog.EffortLabelFor("medium")).IsEqualTo("Medium");
+        await Assert.That(HostedHarnessCatalog.EffortLabelFor("high")).IsEqualTo("High");
+        await Assert.That(HostedHarnessCatalog.EffortLabelFor("xhigh")).IsEqualTo("Max");
+        await Assert.That(HostedHarnessCatalog.EffortLabelFor("weird")).IsEqualTo("weird");
+        await Assert.That(HostedHarnessCatalog.EffortLadder)
+            .IsEquivalentTo(["low", "medium", "high", "xhigh"], CollectionOrdering.Matching);
     }
 
     /// The tokens are the Claude CLI's own `--permission-mode` choices, listed from most to least

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -19,6 +19,11 @@ namespace Capacitor.App.Tests.Unit;
 /// that the VM's properties hold the right values (MainWindowViewModelTests already covers
 /// that in isolation).
 public class MainWindowSmokeTests {
+    sealed class NeverLaunchClient : ILaunchClient {
+        public Task<LaunchOutcome> StartAsync(LaunchRequest request, CancellationToken ct) =>
+            Task.FromResult(new LaunchOutcome(false, null, "unexpected launch"));
+    }
+
     // Real AppNotifier (not RecordingNotifier) — the production notifier is fine here; most of
     // these tests don't exercise the toast overlay at all (window.Notifier is left unset), and
     // the one that does (below) needs a real IObservable<string> to subscribe through.
@@ -193,45 +198,50 @@ public class MainWindowSmokeTests {
         await Assert.That(completed).IsTrue();
     }
 
-    /// StartMessageText/ReasonText must not reserve dead space when there is nothing to say
-    /// (spec: "collapse when empty"): both start out empty (Connecting, no failed attempt yet),
-    /// then Reason appears on Unreachable and StartMessage appears once a start attempt fails.
+    /// ConnectionNotice / DaemonStartMessage must not reserve dead space when there is nothing
+    /// to say: both start out empty (Connecting, no failed attempt yet), then the notice appears
+    /// on Unreachable and the start-message appears once a start attempt fails.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task StartMessage_and_reason_text_collapse_when_empty_and_appear_once_set() {
-        var (reasonInitially, startMessageInitially, reasonWhileUnreachable, startMessageAfterFailure) =
+        var (noticeInitially, startMessageInitially, noticeWhileUnreachable, startMessageAfterFailure) =
             await AvaloniaSession.DispatchAsync(async () => {
+                using var tmp = TempDir.WithPathTo("app-state.json", out var path);
                 var service = new FakeDaemonClientService();
-                var (actions, _) = NewActions(service);
-                var vm = new MainWindowViewModel(service, CancellationToken.None, TestActivity.New());
+                var home = new HomeViewModel(
+                    service, new AppStateStore(path), new NeverLaunchClient(),
+                    () => Task.FromResult(Array.Empty<string>()));
+                var vm = new MainWindowViewModel(service, CancellationToken.None, TestActivity.New(), home: home);
                 var window = new MainWindow { DataContext = vm };
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
 
                 TextBlock Find(string name) =>
                     window.GetVisualDescendants().OfType<TextBlock>().First(t => t.Name == name);
+                Border NoticeBanner() => Find("ConnectionNoticeText").FindAncestorOfType<Border>()!;
 
-                var reasonInit = Find("ReasonText").IsVisible;
-                var startMessageInit = Find("StartMessageText").IsVisible;
+                var noticeInit = NoticeBanner().IsVisible;
+                var startMessageInit = Find("DaemonStartMessageText").IsVisible;
 
                 service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
                 Dispatcher.UIThread.RunJobs();
-                var reasonUnreachable = Find("ReasonText").IsVisible;
+                var noticeUnreachable = NoticeBanner().IsVisible;
 
                 service.StartBehavior = _ => Task.FromResult(new StartDaemonResult(false, "boom: could not bind socket"));
                 await vm.StartDaemonCommand.Execute().ToTask();
                 Dispatcher.UIThread.RunJobs();
-                var startMessageAfter = Find("StartMessageText").IsVisible;
+                var startMessageAfter = Find("DaemonStartMessageText").IsVisible;
 
                 window.Close();
                 Dispatcher.UIThread.RunJobs();
+                home.Dispose();
 
-                return (reasonInit, startMessageInit, reasonUnreachable, startMessageAfter);
+                return (noticeInit, startMessageInit, noticeUnreachable, startMessageAfter);
             });
 
-        await Assert.That(reasonInitially).IsFalse();
+        await Assert.That(noticeInitially).IsTrue(); // Connecting… still has a notice
         await Assert.That(startMessageInitially).IsFalse();
-        await Assert.That(reasonWhileUnreachable).IsTrue();
+        await Assert.That(noticeWhileUnreachable).IsTrue();
         await Assert.That(startMessageAfterFailure).IsTrue();
     }
 

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -198,13 +198,12 @@ public class MainWindowSmokeTests {
         await Assert.That(completed).IsTrue();
     }
 
-    /// ConnectionNotice / DaemonStartMessage must not reserve dead space when there is nothing
-    /// to say: both start out empty (Connecting, no failed attempt yet), then the notice appears
-    /// on Unreachable and the start-message appears once a start attempt fails.
+    /// BannerMessage must not reserve dead space when empty: Connecting… shows a notice, then a
+    /// failed start replaces that body with the start message (one line, never stacked).
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task StartMessage_and_reason_text_collapse_when_empty_and_appear_once_set() {
-        var (noticeInitially, startMessageInitially, noticeWhileUnreachable, startMessageAfterFailure) =
+        var (bannerInitially, bannerTextUnreachable, bannerTextAfterFailure) =
             await AvaloniaSession.DispatchAsync(async () => {
                 using var tmp = TempDir.WithPathTo("app-state.json", out var path);
                 var service = new FakeDaemonClientService();
@@ -216,33 +215,31 @@ public class MainWindowSmokeTests {
                 window.Show();
                 Dispatcher.UIThread.RunJobs();
 
-                TextBlock Find(string name) =>
-                    window.GetVisualDescendants().OfType<TextBlock>().First(t => t.Name == name);
-                Border NoticeBanner() => Find("ConnectionNoticeText").FindAncestorOfType<Border>()!;
+                TextBlock Banner() =>
+                    window.GetVisualDescendants().OfType<TextBlock>().First(t => t.Name == "BannerMessageText");
+                Border NoticeBanner() => Banner().FindAncestorOfType<Border>()!;
 
-                var noticeInit = NoticeBanner().IsVisible;
-                var startMessageInit = Find("DaemonStartMessageText").IsVisible;
+                var bannerInit = NoticeBanner().IsVisible;
 
                 service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
                 Dispatcher.UIThread.RunJobs();
-                var noticeUnreachable = NoticeBanner().IsVisible;
+                var textUnreachable = Banner().Text;
 
                 service.StartBehavior = _ => Task.FromResult(new StartDaemonResult(false, "boom: could not bind socket"));
                 await vm.StartDaemonCommand.Execute().ToTask();
                 Dispatcher.UIThread.RunJobs();
-                var startMessageAfter = Find("DaemonStartMessageText").IsVisible;
+                var textAfter = Banner().Text;
 
                 window.Close();
                 Dispatcher.UIThread.RunJobs();
                 home.Dispose();
 
-                return (noticeInit, startMessageInit, noticeUnreachable, startMessageAfter);
+                return (bannerInit, textUnreachable, textAfter);
             });
 
-        await Assert.That(noticeInitially).IsTrue(); // Connecting… still has a notice
-        await Assert.That(startMessageInitially).IsFalse();
-        await Assert.That(noticeWhileUnreachable).IsTrue();
-        await Assert.That(startMessageAfterFailure).IsTrue();
+        await Assert.That(bannerInitially).IsTrue(); // Connecting… still has a notice
+        await Assert.That(bannerTextUnreachable).IsEqualTo(HomeViewModel.DaemonDownNotice);
+        await Assert.That(bannerTextAfterFailure).IsEqualTo("boom: could not bind socket");
     }
 
     // ---- Toast overlay (spec §11: WindowNotificationManager replaces the inline banner) ----

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -95,6 +95,17 @@ public class MainWindowViewModelTests {
     }
 
     [Test]
+    [Arguments(null, "")]
+    [Arguments("", "")]
+    [Arguments("   ", "")]
+    [Arguments("default", "")]
+    [Arguments("Default", "")]
+    [Arguments("kurrent", "kurrent")]
+    public async Task ProfileLabelForRail_hides_the_built_in_default(string? profile, string expected) {
+        await Assert.That(MainWindowViewModel.ProfileLabelForRail(profile)).IsEqualTo(expected);
+    }
+
+    [Test]
     [Arguments(AttachState.Connecting, null, "connected", "#FFB300")]
     [Arguments(AttachState.Unreachable, "daemon_unreachable", "connected", "#9E9E9E")]
     [Arguments(AttachState.Unreachable, "daemon_incompatible", "connected", "#E53935")]

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -16,9 +16,7 @@ namespace Capacitor.App.Tests.Unit;
 /// RxSchedulers.MainThreadScheduler), so every test runs inside
 /// AvaloniaSession.WithImmediateRxScheduler and carries [NotInParallel("AvaloniaSession")].
 public class MainWindowViewModelTests {
-    // Real AppNotifier (not RecordingNotifier) — none of these tests exercise notifications, and
-    // the toast overlay is a View concern MainWindowViewModel no longer touches (spec §11); the
-    // production notifier is fine here, kept only because AgentActionService requires one.
+    // Real AppNotifier — these tests do not exercise toasts; AgentActionService still needs one.
     static (AgentActionService Actions, IAppNotifier Notifier) NewActions(FakeDaemonClientService service) {
         var notifier = new AppNotifier();
         var actions = new AgentActionService(new ScriptedLocalControlOps(), notifier, new RecordingOpener(), service.SnapshotsSubject, CancellationToken.None, NeverConfirm.Confirm);
@@ -265,7 +263,6 @@ public class MainWindowViewModelTests {
             await Assert.That(vm.Reason!).Contains("App and daemon are incompatible");
             await Assert.That(vm.Reason!).Contains("Reconnect");
             await Assert.That(vm.Reason!).DoesNotContain("daemon_incompatible");
-            await Assert.That(vm.RecoveryVisible).IsTrue();
             await Assert.That(vm.StartVisible).IsFalse();
             await Assert.That(vm.RetryVisible).IsTrue();
             await Assert.That(startCanExecute).IsFalse();
@@ -285,16 +282,12 @@ public class MainWindowViewModelTests {
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
             await Assert.That(vm.Reason).IsEqualTo(MainWindowViewModel.UnreachableMessage);
             await Assert.That(vm.Reason!).DoesNotContain("daemon_unreachable");
-            await Assert.That(vm.RecoveryVisible).IsTrue();
 
             service.StartBehavior = _ => Task.FromResult(new StartDaemonResult(false, "boom: could not bind socket"));
             await vm.StartDaemonCommand.Execute().ToTask();
             await Assert.That(vm.StartMessage).IsEqualTo("boom: could not bind socket");
-            await Assert.That(vm.RecoveryVisible).IsTrue();
 
-            // A new attempt replaces the previous failure with StartingMessage SYNCHRONOUSLY,
-            // before the attempt's own async work resolves — proven here while the gated fake
-            // is still pending.
+            // StartingMessage is set before the gated startAction returns.
             var gate = new TaskCompletionSource();
             service.StartBehavior = async _ => {
                 await gate.Task;
@@ -317,7 +310,7 @@ public class MainWindowViewModelTests {
         });
     }
 
-    // spec §6: ILifecycleSurface.Status one-liners ride the same StartMessage lane.
+    // ILifecycleSurface.Status one-liners ride the same StartMessage lane.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Lifecycle_status_sets_and_is_cleared_like_a_start_failure() {
@@ -402,10 +395,7 @@ public class MainWindowViewModelTests {
         });
     }
 
-    // StartDaemonCommand is repointed to the service-aware
-    // DaemonLifecycleController.StartActionAsync when the composition root supplies one — the
-    // plain detached StartDaemonAsync is a fallback for callers with no live controller, not the
-    // production path.
+    // Supplied startAction runs instead of StartDaemonAsync.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task StartDaemonCommand_invokes_the_supplied_startAction_instead_of_StartDaemonAsync() {
@@ -431,9 +421,8 @@ public class MainWindowViewModelTests {
         });
     }
 
-    // ---- Navigation (spec §3). The full surface-swap/teardown matrix lives in
-    // WorkspaceNavigationTests; these two pin what the VM's own nullable-default seams promise. ----
-
+    // Navigation: the full surface-swap/teardown matrix lives in WorkspaceNavigationTests;
+    // these two pin what the VM's own nullable-default seams promise.
     /// Every caller that predates workspaces passes no factory — and must keep landing on the
     /// tabbed shell rather than a half-built workspace or a throw.
     [Test]

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -120,31 +120,32 @@ public class MainWindowViewModelTests {
         await Assert.That(brush.Color).IsEqualTo(Color.Parse(expectedHex));
     }
 
-    // ---- Start/Retry visibility (spec: shows ONLY when the action is meaningful, tracking the
-    // SAME state predicate as canStart/canRetry — but, unlike CanExecute, never hidden just
-    // because a start is in flight) ----
+    // ---- Start/Reconnect visibility (one primary action: Start when unreachable-down;
+    // Reconnect when connecting or skew — never both) ----
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Start_and_retry_visibility_track_the_command_state_matrix() {
+    public async Task Start_and_reconnect_visibility_are_mutually_exclusive() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var (actions, _) = NewActions(service);
             var vm = new MainWindowViewModel(service, CancellationToken.None, TestActivity.New());
 
-            foreach (var reason in new[] { "daemon_unreachable", "daemon_incompatible" }) {
-                service.StatusSubject.OnNext(new AttachStatus(AttachState.Connecting, null, null));
-                await Assert.That(vm.StartVisible).IsFalse();
-                await Assert.That(vm.RetryVisible).IsTrue();
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connecting, null, null));
+            await Assert.That(vm.StartVisible).IsFalse();
+            await Assert.That(vm.RetryVisible).IsTrue();
 
-                service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
-                await Assert.That(vm.StartVisible).IsFalse();
-                await Assert.That(vm.RetryVisible).IsFalse();
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
+            await Assert.That(vm.StartVisible).IsFalse();
+            await Assert.That(vm.RetryVisible).IsFalse();
 
-                service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, reason, null));
-                await Assert.That(vm.StartVisible).IsEqualTo(reason == "daemon_unreachable");
-                await Assert.That(vm.RetryVisible).IsTrue();
-            }
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+            await Assert.That(vm.StartVisible).IsTrue();
+            await Assert.That(vm.RetryVisible).IsFalse();
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_incompatible", null));
+            await Assert.That(vm.StartVisible).IsFalse();
+            await Assert.That(vm.RetryVisible).IsTrue();
         });
     }
 
@@ -220,7 +221,7 @@ public class MainWindowViewModelTests {
 
                 service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, reason, null));
                 await Assert.That(startCanExecute).IsEqualTo(reason == "daemon_unreachable");
-                await Assert.That(retryCanExecute).IsTrue();
+                await Assert.That(retryCanExecute).IsEqualTo(reason != "daemon_unreachable");
             }
 
             // In-flight: an outstanding start disables StartDaemonCommand even though the
@@ -262,7 +263,7 @@ public class MainWindowViewModelTests {
 
             await Assert.That(vm.Reason).IsNotNull();
             await Assert.That(vm.Reason!).Contains("App and daemon are incompatible");
-            await Assert.That(vm.Reason!).Contains("Retry");
+            await Assert.That(vm.Reason!).Contains("Reconnect");
             await Assert.That(vm.Reason!).DoesNotContain("daemon_incompatible");
             await Assert.That(vm.RecoveryVisible).IsTrue();
             await Assert.That(vm.StartVisible).IsFalse();
@@ -339,14 +340,16 @@ public class MainWindowViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Retry_sets_reconnecting_then_settles_if_still_unreachable() {
+    public async Task Reconnect_sets_reconnecting_then_settles_if_still_unreachable() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();
             var vm = new MainWindowViewModel(service, CancellationToken.None, TestActivity.New());
             using var activation = vm.Activator.Activate();
 
-            service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+            // Reconnect is offered while connecting or skewed — not while Start owns the down case.
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connecting, null, null));
             await Assert.That(vm.StartMessage).IsNull();
+            await Assert.That(vm.RetryVisible).IsTrue();
 
             var execute = vm.RetryCommand.Execute().ToTask();
             await Assert.That(vm.StartMessage).IsEqualTo(MainWindowViewModel.ReconnectingMessage);
@@ -375,8 +378,8 @@ public class MainWindowViewModelTests {
                 lifecycleAttention: lifecycleAttention);
             using var activation = vm.Activator.Activate();
 
-            lifecycleAttention.OnNext("A daemon mutation needs attention (verify_viability).");
-            await Assert.That(vm.StartMessage).IsEqualTo("A daemon mutation needs attention (verify_viability).");
+            lifecycleAttention.OnNext("The daemon didn't come up cleanly. Press Start daemon to try again.");
+            await Assert.That(vm.StartMessage).IsEqualTo("The daemon didn't come up cleanly. Press Start daemon to try again.");
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -250,7 +250,12 @@ public class MainWindowViewModelTests {
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_incompatible", null));
 
             await Assert.That(vm.Reason).IsNotNull();
-            await Assert.That(vm.Reason!).Contains("app and daemon are incompatible — make sure both are up to date");
+            await Assert.That(vm.Reason!).Contains("App and daemon are incompatible");
+            await Assert.That(vm.Reason!).Contains("Retry");
+            await Assert.That(vm.Reason!).DoesNotContain("daemon_incompatible");
+            await Assert.That(vm.RecoveryVisible).IsTrue();
+            await Assert.That(vm.StartVisible).IsFalse();
+            await Assert.That(vm.RetryVisible).IsTrue();
             await Assert.That(startCanExecute).IsFalse();
             await Assert.That(retryCanExecute).IsTrue();
         });
@@ -266,23 +271,28 @@ public class MainWindowViewModelTests {
             using var activation = vm.Activator.Activate();
 
             service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+            await Assert.That(vm.Reason).IsEqualTo(MainWindowViewModel.UnreachableMessage);
+            await Assert.That(vm.Reason!).DoesNotContain("daemon_unreachable");
+            await Assert.That(vm.RecoveryVisible).IsTrue();
 
             service.StartBehavior = _ => Task.FromResult(new StartDaemonResult(false, "boom: could not bind socket"));
             await vm.StartDaemonCommand.Execute().ToTask();
             await Assert.That(vm.StartMessage).IsEqualTo("boom: could not bind socket");
+            await Assert.That(vm.RecoveryVisible).IsTrue();
 
-            // A new attempt clears the previous failure message SYNCHRONOUSLY, before the
-            // attempt's own async work resolves — proven here by asserting it's already null
-            // while the gated fake is still pending.
+            // A new attempt replaces the previous failure with StartingMessage SYNCHRONOUSLY,
+            // before the attempt's own async work resolves — proven here while the gated fake
+            // is still pending.
             var gate = new TaskCompletionSource();
             service.StartBehavior = async _ => {
                 await gate.Task;
                 return new StartDaemonResult(true, null);
             };
             var execute = vm.StartDaemonCommand.Execute().ToTask();
-            await Assert.That(vm.StartMessage).IsNull();
+            await Assert.That(vm.StartMessage).IsEqualTo(MainWindowViewModel.StartingMessage);
             gate.SetResult();
             await execute;
+            await Assert.That(vm.StartMessage).IsEqualTo("Daemon start requested. Waiting to connect…");
 
             // A transition to Connected clears it too.
             service.StartBehavior = _ => Task.FromResult(new StartDaemonResult(false, "second failure"));
@@ -316,7 +326,50 @@ public class MainWindowViewModelTests {
         });
     }
 
-    // spec §4.4: StartDaemonCommand is repointed to the service-aware
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Retry_sets_reconnecting_then_settles_if_still_unreachable() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var vm = new MainWindowViewModel(service, CancellationToken.None, TestActivity.New());
+            using var activation = vm.Activator.Activate();
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+            await Assert.That(vm.StartMessage).IsNull();
+
+            var execute = vm.RetryCommand.Execute().ToTask();
+            await Assert.That(vm.StartMessage).IsEqualTo(MainWindowViewModel.ReconnectingMessage);
+            await execute;
+
+            // Still unreachable after the reattach kick: replace the in-flight copy.
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connecting, null, null));
+            await Assert.That(vm.StartMessage).IsEqualTo(MainWindowViewModel.ReconnectingMessage);
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+            await Assert.That(vm.StartMessage).IsEqualTo(MainWindowViewModel.ReconnectFailedMessage);
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
+            await Assert.That(vm.StartMessage).IsNull();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Lifecycle_attention_also_lands_on_the_start_message_lane() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var lifecycleAttention = new Subject<string?>();
+            var vm = new MainWindowViewModel(
+                service, CancellationToken.None, TestActivity.New(),
+                lifecycleAttention: lifecycleAttention);
+            using var activation = vm.Activator.Activate();
+
+            lifecycleAttention.OnNext("A daemon mutation needs attention (verify_viability).");
+            await Assert.That(vm.StartMessage).IsEqualTo("A daemon mutation needs attention (verify_viability).");
+        });
+    }
+
+    // StartDaemonCommand is repointed to the service-aware
     // DaemonLifecycleController.StartActionAsync when the composition root supplies one — the
     // plain detached StartDaemonAsync is a fallback for callers with no live controller, not the
     // production path.

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -369,6 +369,25 @@ public class MainWindowViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
+    public async Task Already_running_reconnect_status_clears_when_attach_stays_unreachable() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var lifecycleStatus = new Subject<string?>();
+            var vm = new MainWindowViewModel(
+                service, CancellationToken.None, TestActivity.New(),
+                lifecycleStatus: lifecycleStatus);
+            using var activation = vm.Activator.Activate();
+
+            lifecycleStatus.OnNext(DaemonLifecycleController.AlreadyRunningReconnectStatus);
+            await Assert.That(vm.StartMessage).IsEqualTo(DaemonLifecycleController.AlreadyRunningReconnectStatus);
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+            await Assert.That(vm.StartMessage).IsEqualTo(MainWindowViewModel.ReconnectFailedMessage);
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Lifecycle_attention_also_lands_on_the_start_message_lane() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var service = new FakeDaemonClientService();

--- a/test/Capacitor.App.Tests.Unit/ReauthCompositionTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ReauthCompositionTests.cs
@@ -101,6 +101,6 @@ public class ReauthCompositionTests {
         });
 
         await Assert.That(buttonFound).IsTrue();
-        await Assert.That(status).IsEqualTo($"Ready to sign in to {ServerUrl}.");
+        await Assert.That(status).IsEqualTo(ServerUrl);
     }
 }

--- a/test/Capacitor.App.Tests.Unit/SessionRailViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SessionRailViewModelTests.cs
@@ -47,6 +47,26 @@ public class SessionRailViewModelTests {
         });
     }
 
+    /// `/repo` and `/repo/` are one repository — without separator normalization the rail would
+    /// show two same-leaf groups for one checkout.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Trailing_separators_do_not_split_a_repository_group() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (service, rail) = Build();
+            using (rail) {
+                service.Agents.AddOrUpdate(Dto("a1", "/dev/alpha"));
+                service.Agents.AddOrUpdate(Dto("a2", "/dev/alpha/"));
+
+                await Assert.That(rail.Repos).Count().IsEqualTo(1);
+                await Assert.That(rail.Repos[0].RootPath).IsEqualTo("/dev/alpha");
+                await Assert.That(rail.Repos[0].Worktrees).Count().IsEqualTo(1);
+                await Assert.That(rail.Repos[0].Worktrees[0].Sessions.Select(s => s.Id))
+                    .IsEquivalentTo(["a1", "a2"]);
+            }
+        });
+    }
+
     /// A reviewer that borrowed a checkout belongs on that checkout's node, beside the session it
     /// reviews — a snapshot reviewer too, which runs elsewhere but names what it borrowed. The
     /// collapse key follows the same rule, so opening the reviewer expands that node.

--- a/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
@@ -126,7 +126,7 @@ public class SignInStepViewModelTests {
         await Assert.That(satisfied).IsTrue();
         await Assert.That(status).IsEqualTo("Signed in as sam");
         await Assert.That(isError).IsFalse();
-        await Assert.That(detail).IsEqualTo("You're signed in. Updating the app…");
+        await Assert.That(detail).IsEqualTo("You're signed in. Refreshing…");
         await Assert.That(showPrimary).IsFalse();
     }
 

--- a/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
@@ -763,7 +763,7 @@ public class SignInStepViewModelTests {
 
         await Assert.That(connectBox).IsNotNull();
         await Assert.That(signInButton).IsNotNull();
-        await Assert.That(signInStatus).IsEqualTo("Ready to find your workspaces with GitHub.");
+        await Assert.That(signInStatus).IsEqualTo("Find your workspaces with GitHub");
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
@@ -111,7 +111,7 @@ public class SignInStepViewModelTests {
     [Arguments(AuthProvider.GitHubApp)]
     [Arguments(AuthProvider.WorkOS)]
     public async Task A_committed_discovery_satisfies_the_step_and_names_the_signed_in_user(string provider) {
-        var (satisfied, status, isError) = await AvaloniaSession.DispatchAsync(async () => {
+        var (satisfied, status, isError, detail, showPrimary) = await AvaloniaSession.DispatchAsync(async () => {
             using var h = new Harness();
             h.Connect.Choice = ConnectChoice.Discover;
             h.Connect.DiscoveryProvider = provider;
@@ -120,12 +120,14 @@ public class SignInStepViewModelTests {
             await h.Vm.OnEnterAsync(CancellationToken.None);
             await h.SignIn();
 
-            return (h.Vm.Satisfied, h.Vm.Status, h.Vm.StatusIsError);
+            return (h.Vm.Satisfied, h.Vm.Status, h.Vm.StatusIsError, h.Vm.StatusDetail, h.Vm.ShowPrimaryAction);
         });
 
         await Assert.That(satisfied).IsTrue();
         await Assert.That(status).IsEqualTo("Signed in as sam");
         await Assert.That(isError).IsFalse();
+        await Assert.That(detail).IsEqualTo("You're signed in. Updating the app…");
+        await Assert.That(showPrimary).IsFalse();
     }
 
     [Test]
@@ -241,8 +243,8 @@ public class SignInStepViewModelTests {
         await Assert.That(status).IsEqualTo("Sign-in failed.");
         await Assert.That(isError).IsTrue();
         await Assert.That(satisfied).IsFalse();
-        await Assert.That(detail).IsEqualTo("Error: the auth service is unreachable.");
-        await Assert.That(log).IsEquivalentTo(["Error: the auth service is unreachable."]);
+        await Assert.That(detail).IsEqualTo("The auth service is unreachable.");
+        await Assert.That(log).IsEmpty();
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/ToolGroupItemTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ToolGroupItemTests.cs
@@ -32,7 +32,50 @@ public class ToolGroupItemTests {
             a.Outcome = ToolOutcome.Error;
             await Assert.That(group.LiveCalls).IsEmpty();
             await Assert.That(group.Summary).IsEqualTo("Ran a command, read a file");
+            await Assert.That(group.SummaryLine).IsEqualTo("Ran a command, read a file · Bash");
             await Assert.That(group.HasFailure).IsTrue();
+            await Assert.That(group.ShowsSummaryHeader).IsTrue();
+
+            group.Toggle();
+            await Assert.That(group.SummaryLine).IsEqualTo("Ran a command, read a file");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_lone_settled_call_stays_visible_without_summary_chrome() {
+        await RunOnUiAsync(async () => {
+            var group = new ToolGroupItem();
+            var call = Call("Bash", ToolCategory.Command);
+            group.Add(call);
+            call.Outcome = ToolOutcome.Done;
+
+            await Assert.That(group.HasSummary).IsTrue();
+            await Assert.That(group.ShowsSummaryHeader).IsFalse();
+            await Assert.That(group.ShowsKindChip).IsTrue();
+            await Assert.That(group.KindChip).IsEqualTo("Command");
+            await Assert.That(group.LoneCall).IsSameReferenceAs(call);
+            await Assert.That(call.ShowRowStatus).IsFalse();
+            await Assert.That(group.VisibleCalls).IsEquivalentTo(new[] { call });
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Folded_summary_peeks_the_first_settled_detail_and_caps_long_ones() {
+        await RunOnUiAsync(async () => {
+            var group = new ToolGroupItem();
+            var longDetail = new string('x', 80);
+            var first = new ToolCallItem("Bash", longDetail, ToolCategory.Command);
+            var second = Call("Read", ToolCategory.Read);
+            group.Add(first);
+            group.Add(second);
+            first.Outcome = ToolOutcome.Done;
+            second.Outcome = ToolOutcome.Done;
+
+            await Assert.That(group.SummaryLine).IsEqualTo($"Ran a command, read a file · {new string('x', 55)}…");
+            group.Toggle();
+            await Assert.That(group.SummaryLine).IsEqualTo("Ran a command, read a file");
         });
     }
 
@@ -67,13 +110,27 @@ public class ToolGroupItemTests {
     public async Task A_call_glyph_shows_the_question_mark_only_while_running_and_awaiting() {
         var call = Call("Bash", ToolCategory.Command);
         await Assert.That(call.OutcomeGlyph).IsEqualTo("");
+        await Assert.That(call.IsRunning).IsTrue();
+        await Assert.That(call.HasDetail).IsFalse();
         call.IsAwaitingPermission = true;
         await Assert.That(call.OutcomeGlyph).IsEqualTo("?");
         await Assert.That(call.IsSettled).IsFalse();
+        await Assert.That(call.IsRunning).IsFalse();
         call.Outcome = ToolOutcome.Done;
         await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
         await Assert.That(call.IsSettled).IsTrue();
+        await Assert.That(call.IsRunning).IsFalse();
         call.IsAwaitingPermission = false;
         await Assert.That(call.OutcomeGlyph).IsEqualTo("✓");
+    }
+
+    [Test]
+    public async Task Line_text_prefers_detail_over_the_raw_tool_name() {
+        var withDetail = new ToolCallItem("Bash", "ls -la", ToolCategory.Command);
+        await Assert.That(withDetail.HasDetail).IsTrue();
+        await Assert.That(withDetail.LineText).IsEqualTo("ls -la");
+        var bare = Call("Bash", ToolCategory.Command);
+        await Assert.That(bare.HasDetail).IsFalse();
+        await Assert.That(bare.LineText).IsEqualTo("Bash");
     }
 }

--- a/test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ToolSummaryTests.cs
@@ -50,6 +50,14 @@ public class ToolSummaryTests {
     }
 
     [Test]
+    public async Task Chip_label_is_a_short_noun_per_category() {
+        await Assert.That(ToolSummary.ChipLabel(ToolCategory.Agent)).IsEqualTo("Task");
+        await Assert.That(ToolSummary.ChipLabel(ToolCategory.Command)).IsEqualTo("Command");
+        await Assert.That(ToolSummary.ChipLabel(ToolCategory.WebSearch)).IsEqualTo("Web");
+        await Assert.That(ToolSummary.ChipLabel(ToolCategory.Other)).IsEqualTo("Tool");
+    }
+
+    [Test]
     [Arguments("Read", """{"file_path":"/repo/.claude/skills/review/SKILL.md"}""", ToolCategory.Skill)]
     [Arguments("Read", """{"file_path":"/repo/SKILL.md.bak"}""", ToolCategory.Read)]
     [Arguments("exec_command", """{"cmd":"sed -n '1,40p' a.cs"}""", ToolCategory.Read)]

--- a/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
@@ -377,10 +377,10 @@ public class WizardStartupTests {
             channel, surface, WizardFixtures.NeverRunMutation, WizardFixtures.FixedTerminalPath("/usr/bin"),
             () => null, cts.Token);
 
-        channel.Enqueue(WizardFixtures.Envelope("wizard_visible_token"));
+        channel.Enqueue(WizardFixtures.Envelope("internal_error"));
         await WizardFixtures.WaitUntilAsync(() => surface.AttentionText is not null, what: "the wizard-surface presentation");
 
-        await Assert.That(surface.AttentionText!).Contains("wizard_visible_token");
+        await Assert.That(surface.AttentionText).IsEqualTo(AppUnderTest.AttentionCopyFor("internal_error")!);
 
         await cts.CancelAsync();
         await consumer.WaitAsync(TimeSpan.FromSeconds(5));
@@ -416,7 +416,7 @@ public class WizardStartupTests {
             channel, wizardSurface, WizardFixtures.NeverRunMutation, WizardFixtures.FixedTerminalPath("/usr/bin"),
             () => null, cts.Token);
 
-        channel.Enqueue(WizardFixtures.Envelope("raced_token"));
+        channel.Enqueue(WizardFixtures.Envelope("internal_error"));
         await WizardFixtures.WaitUntilAsync(() => wizardSurface.Entered == 1, what: "the wizard consumer's presentation");
 
         await AppUnderTest.HandoffAfterWizardAsync(auth: null, () => Task.CompletedTask, Cap, channel);
@@ -451,10 +451,10 @@ public class WizardStartupTests {
             channel, rootSurface, WizardFixtures.NeverRunMutation, WizardFixtures.FixedTerminalPath("/usr/bin"),
             () => null, cts.Token);
 
-        channel.Enqueue(WizardFixtures.Envelope("post_handoff_token"));
+        channel.Enqueue(WizardFixtures.Envelope("internal_error"));
         await WizardFixtures.WaitUntilAsync(() => rootSurface.AttentionMessages.Count == 1, what: "the root presentation");
 
-        await Assert.That(rootSurface.AttentionMessages[0]).Contains("post_handoff_token");
+        await Assert.That(rootSurface.AttentionMessages[0]).IsEqualTo(AppUnderTest.AttentionCopyFor("internal_error")!);
         await Assert.That(wizardSurface.AttentionMessages).IsEmpty();
 
         await cts.CancelAsync();

--- a/test/Capacitor.App.Tests.Unit/WorkContextViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkContextViewModelTests.cs
@@ -188,7 +188,7 @@ public class WorkContextViewModelTests {
             h.Time.Advance(WorkContextViewModel.PollInterval); // the read parks on the gate, so TickAsync's await would never return
             await Assert.That(h.Source.Requested.Count).IsEqualTo(2);
             await Assert.That(h.Vm.IsReading).IsTrue();
-            await Assert.That(await h.Vm.RefreshCommand.CanExecute.FirstAsync()).IsFalse();
+            await Assert.That(await h.Vm.RefreshCommand.CanExecute.FirstAsync()).IsTrue();
 
             h.Time.Advance(WorkContextViewModel.PollInterval);
             await Assert.That(h.Source.Requested.Count).IsEqualTo(2);
@@ -201,6 +201,31 @@ public class WorkContextViewModelTests {
             await h.Vm.RefreshCommand.Execute();
             await h.Vm.PendingReadForTesting!;
             await Assert.That(h.Source.Requested.Count).IsEqualTo(3);
+            await h.Vm.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_refresh_while_a_read_is_in_flight_queues_one_follow_up() {
+        await RunOnUiAsync(async () => {
+            var h = new Harness();
+            h.Source.Enqueue(Ready());
+            await h.PushAsync(Dto());
+            var gate = h.Source.Gate();
+            h.Time.Advance(WorkContextViewModel.PollInterval);
+            await Assert.That(h.Vm.IsReading).IsTrue();
+            await Assert.That(h.Source.Requested.Count).IsEqualTo(2);
+
+            h.Source.Enqueue(Ready());
+            await h.Vm.RefreshCommand.Execute();
+            await Assert.That(h.Source.Requested.Count).IsEqualTo(2);
+
+            gate.SetResult(Ready());
+            await h.Vm.PendingReadForTesting!;
+            await Assert.That(h.Source.Requested.Count).IsEqualTo(3);
+            await h.Vm.PendingReadForTesting!;
+            await Assert.That(h.Vm.IsReading).IsFalse();
             await h.Vm.TeardownAsync();
         });
     }
@@ -240,7 +265,7 @@ public class WorkContextViewModelTests {
             await Task.Yield();
             await Assert.That(h.Vm.Phase).IsEqualTo(WorkContextPhase.Loading);
             await Assert.That(h.Vm.IsReading).IsTrue();
-            await Assert.That(await h.Vm.RefreshCommand.CanExecute.FirstAsync()).IsFalse();
+            await Assert.That(await h.Vm.RefreshCommand.CanExecute.FirstAsync()).IsTrue();
             h.Time.Advance(WorkContextViewModel.PollInterval);
             await Assert.That(h.Source.Requested.Count).IsEqualTo(2);
 

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -26,7 +26,7 @@ namespace Capacitor.App.Tests.Unit;
 public class WorkspaceNavigationTests {
     const string Id1 = "0123456789abcdef0123456789abcdef";
     const string Id2 = "fedcba9876543210fedcba9876543210";
-    const string UnusableId = "Launched, but the session id was unusable — open it from the session list.";
+    const string UnusableId = HomeViewModel.UnusableIdMessage;
 
     /// The tracker as the VM sees it (Action&lt;Func&lt;Task&gt;&gt;): records every registration and
     /// starts it immediately, exactly like WorkspaceTeardownTracker.Track — so a test can count

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -12,7 +12,7 @@ using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
 namespace Capacitor.App.Tests.Unit;
 
-/// WorkspaceViewModel's header projections (Title/RepoLabelText/VendorChip/FamilyDot/
+/// WorkspaceViewModel's header projections (Title/RepoLabelText/IdentitySubtitle/
 /// ShowsTerminalTab/NoTerminalNote), SessionEnded, and Stop routing. WorkspaceViewModel always
 /// builds a real TerminalTabViewModel internally, so pushing a matching AgentStatusDto into the
 /// shared daemon.Agents cache also drives Terminal's OWN resolve gate -- which reaches
@@ -35,7 +35,7 @@ public class WorkspaceViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Title_repo_and_vendor_chip_project_from_the_pushed_dto() {
+    public async Task Title_repo_and_identity_subtitle_project_from_the_pushed_dto() {
         await RunOnUiAsync(async () => {
             var daemon = new FakeDaemonClientService();
             var actions = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
@@ -51,8 +51,7 @@ public class WorkspaceViewModelTests {
 
             await Assert.That(vm.Title).IsEqualTo("myproj");
             await Assert.That(vm.RepoLabelText).IsEqualTo("myproj");
-            await Assert.That(vm.VendorChip).IsEqualTo("claude (sonnet)");
-            await Assert.That(vm.FamilyDot).IsEqualTo("pty");
+            await Assert.That(vm.IdentitySubtitle).IsEqualTo("myproj · pty · claude (sonnet)");
             await Assert.That(vm.ShowsTerminalTab).IsTrue();
             await Assert.That(vm.NoTerminalNote).IsEqualTo("");
         });
@@ -226,6 +225,7 @@ public class WorkspaceViewModelTests {
 
             await Assert.That(vm.Title).IsEqualTo("Review this PR");
             await Assert.That(vm.RepoLabelText).IsEqualTo("myproj / agent-6da2 · borrowed");
+            await Assert.That(vm.IdentitySubtitle).IsEqualTo("myproj / agent-6da2 · borrowed · pty · codex");
             await vm.TeardownAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -49,7 +49,7 @@ public class WorkspaceViewModelTests {
             daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo/myproj", model: "sonnet"));
             await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
 
-            await Assert.That(vm.Title).IsEqualTo("myproj · claude");
+            await Assert.That(vm.Title).IsEqualTo("myproj");
             await Assert.That(vm.RepoLabelText).IsEqualTo("myproj");
             await Assert.That(vm.VendorChip).IsEqualTo("claude (sonnet)");
             await Assert.That(vm.FamilyDot).IsEqualTo("pty");
@@ -106,8 +106,8 @@ public class WorkspaceViewModelTests {
 
             await Assert.That(vm.SessionEnded).IsTrue();
             // The header keeps identifying the session that just ended rather than reverting to
-            // "— · —" -- a frozen last-known snapshot, not a blanked one.
-            await Assert.That(vm.Title).IsEqualTo("myproj · claude");
+            // a blanked placeholder -- a frozen last-known snapshot.
+            await Assert.That(vm.Title).IsEqualTo("myproj");
             await Assert.That(vm.ShowsTerminalTab).IsTrue();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -12,7 +12,7 @@ using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
 namespace Capacitor.App.Tests.Unit;
 
-/// WorkspaceViewModel's header projections (Title/RepoLabelText/IdentitySubtitle/
+/// WorkspaceViewModel's header projections (Title/RepoLabelText/
 /// ShowsTerminalTab/NoTerminalNote), SessionEnded, and Stop routing. WorkspaceViewModel always
 /// builds a real TerminalTabViewModel internally, so pushing a matching AgentStatusDto into the
 /// shared daemon.Agents cache also drives Terminal's OWN resolve gate -- which reaches
@@ -35,7 +35,7 @@ public class WorkspaceViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Title_repo_and_identity_subtitle_project_from_the_pushed_dto() {
+    public async Task Title_and_repo_label_project_from_the_pushed_dto() {
         await RunOnUiAsync(async () => {
             var daemon = new FakeDaemonClientService();
             var actions = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
@@ -51,7 +51,6 @@ public class WorkspaceViewModelTests {
 
             await Assert.That(vm.Title).IsEqualTo("myproj");
             await Assert.That(vm.RepoLabelText).IsEqualTo("myproj");
-            await Assert.That(vm.IdentitySubtitle).IsEqualTo("myproj · pty · claude (sonnet)");
             await Assert.That(vm.ShowsTerminalTab).IsTrue();
             await Assert.That(vm.NoTerminalNote).IsEqualTo("");
         });
@@ -206,8 +205,7 @@ public class WorkspaceViewModelTests {
     }
 
     /// Pins the header for a titled session on a borrowed checkout: the title line is the
-    /// session's own title, and the subtitle names the repository, the borrowed worktree and the
-    /// marker.
+    /// session's own title, and the subtitle names the repository and the borrowed worktree.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task The_header_shows_the_session_title_over_the_borrowed_worktree() {
@@ -225,7 +223,6 @@ public class WorkspaceViewModelTests {
 
             await Assert.That(vm.Title).IsEqualTo("Review this PR");
             await Assert.That(vm.RepoLabelText).IsEqualTo("myproj / agent-6da2 · borrowed");
-            await Assert.That(vm.IdentitySubtitle).IsEqualTo("myproj / agent-6da2 · borrowed · pty · codex");
             await vm.TeardownAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -107,6 +107,29 @@ public class WorkspaceViewModelTests {
             // a blanked placeholder -- a frozen last-known snapshot.
             await Assert.That(vm.Title).IsEqualTo("myproj");
             await Assert.That(vm.ShowsTerminalTab).IsTrue();
+            await Assert.That(await vm.StopCommand.CanExecute.FirstAsync()).IsFalse();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task SessionEnded_and_Stop_disable_when_status_becomes_Completed_or_Failed() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var actions = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
+            var factory = new FakeTerminalAttachClientFactory();
+            var vm = Build(daemon, actions, factory, new FakeTimeProvider(), agentId: "a1");
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo/myproj") with { Status = "Running" });
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(await vm.StopCommand.CanExecute.FirstAsync()).IsTrue();
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo/myproj") with { Status = "Completed" });
+            await Assert.That(vm.SessionEnded).IsTrue();
+            await Assert.That(await vm.StopCommand.CanExecute.FirstAsync()).IsFalse();
+            await Assert.That(vm.Terminal.State.Phase).IsEqualTo(TerminalSessionPhase.SessionEnded);
+            await Assert.That(vm.Terminal.CanAcceptText).IsFalse();
+            await Assert.That(vm.Title).IsEqualTo("myproj");
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -102,7 +102,7 @@ public class WorkspaceViewSmokeTests {
             Dispatcher.UIThread.RunJobs();
 
             var names = new[] {
-                "WorkspaceTitle", "WorkspaceRepo", "WorkspaceVendorChip", "ChatTabButton",
+                "WorkspaceTitle", "WorkspaceSubtitle", "ChatTabButton",
                 "TerminalTabButton", "NoTerminalNote", "TerminalHost", "TerminalBanners",
                 "DetachButton", "ReattachButton", "SessionEndedNote", "ChatHost", "WorkContextHost",
             };


### PR DESCRIPTION
No GitHub issue — no Linear id for this PR.

## What & why

Desktop app UX pass: launcher chips/flyouts and Start tips, daemon recovery in a banner above the launch card, clearer sign-in (copy, browser fallback, Enter to start), long-repo headline layout, chat tool callouts with status greens, and workspace identity as a muted subtitle. Theme tokens split primary CTAs from success green and lift muted/faint contrast on dark canvas.

## Where to look

`LauncherPaneView` / `HomeViewModel` (chips, recovery, Start tips, repo defaults); `ChatTabView` / `ChatItems` (tool groups); `WorkspaceView` `IdentitySubtitle` beside main's work-context column. Easy to miss: `App.axaml.cs` keeps `_launch` so reauth invalidates the same client `ServerClients` wraps.

## Verification

- `dotnet build src/Capacitor.App/Capacitor.App.csproj` — 0 warnings, 0 errors (after rebase onto main including #763)
- `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/HomeViewModelTests/*"` — passed
- `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/SignInStepViewModelTests/*"` — passed
- `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter "/*/*/HostedHarnessCatalogTests/*"` — passed
- Manual: Start tips (no repo / disconnected); repo flyout; sign-in idle + browser-wait; tool callouts; workspace subtitle

## Visuals
<img width="1518" height="872" alt="Screenshot 2026-09-04 at 18 51 31" src="https://github.com/user-attachments/assets/387fe2f5-5846-4ff4-a03c-848880c35d14" />
<img width="1518" height="872" alt="Screenshot 2026-09-04 at 18 51 26" src="https://github.com/user-attachments/assets/be3e2c3a-6601-442d-b11d-7d9eecb52087" />
<img width="1125" height="810" alt="Screenshot 2026-09-04 at 18 51 44" src="https://github.com/user-attachments/assets/6f98f77e-c0c2-4862-94c2-aaf931126f63" />
