### PR TITLE
Step through desktop question cards and retire them on a terminal answer

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -494,6 +494,14 @@ what bounds the outgoing resolve frame by arithmetic. An unparseable or oversize
 back to the permission card (Allow = let the TUI ask) with "Allow always" hidden for the
 question tool.
 
+**A series is walked one question at a time**, the way Claude Code's own TUI does it: a step chip
+per question plus a closing Review step, a single-select pick advances, Enter on an answered
+question advances, and only the Review step — every answer listed, each row a way back to its
+question — submits. A lone question keeps its Submit inline and the fast path (one single-select
+question with options) still submits on the pick. Option chrome lives in class styles only: a
+local `Background`/`BorderBrush` on the button outranks the `selected` style and leaves it inert,
+which is what made a pick look like nothing had happened.
+
 ## Compact tool calls in the Chat tab
 
 **AI-2418** (spec: `docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md`) folds a

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -509,9 +509,10 @@ the transcript, and a `tool_result` for a pending request's `tool_use_id` is the
 the prompt was answered elsewhere — so the tab sends the resolve frame with decision `withdraw`,
 which the daemon settles as `withdrawn`/`tool_settled` and answers the hook with a deny (an allow
 could only apply to some later call). An older daemon rejects the decision and the app concludes
-the entry locally on that ack, so the card still goes. Sent once per request; a transport failure
-reopens it for the next reconcile, and the resubscribe that follows a daemon reconnect is what
-brings that reconcile.
+the entry locally on that ack, so the card still goes. Sent once per request. A failed send
+reopens it and retries on a bounded doubling backoff of its own, because the resolve rides a
+one-shot socket that can fail while the subscription stays healthy, and an empty transcript poll
+never reconciles; past the cap, the next resubscribe or permission/transcript change tries again.
 
 ## Compact tool calls in the Chat tab
 

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -502,6 +502,17 @@ question with options) still submits on the pick. Option chrome lives in class s
 local `Background`/`BorderBrush` on the button outranks the `selected` style and leaves it inert,
 which is what made a pick look like nothing had happened.
 
+**A terminal answer retires the card.** The daemon never sees a TUI answer: the `PermissionRequest`
+hook stays parked and no hook reports the tool's completion (the plugin registers no
+`PostToolUse`), so the broker holds the request until the agent exits. The Chat tab already tails
+the transcript, and a `tool_result` for a pending request's `tool_use_id` is the one signal that
+the prompt was answered elsewhere — so the tab sends the resolve frame with decision `withdraw`,
+which the daemon settles as `withdrawn`/`tool_settled` and answers the hook with a deny (an allow
+could only apply to some later call). An older daemon rejects the decision and the app concludes
+the entry locally on that ack, so the card still goes. Sent once per request; a transport failure
+reopens it for the next reconcile, and the resubscribe that follows a daemon reconnect is what
+brings that reconcile.
+
 ## Compact tool calls in the Chat tab
 
 **AI-2418** (spec: `docs/superpowers/specs/2026-09-02-ai2418-compact-tool-calls-design.md`) folds a

--- a/src/Capacitor.App/Services/IPermissionService.cs
+++ b/src/Capacitor.App/Services/IPermissionService.cs
@@ -57,4 +57,8 @@ public interface IPermissionService : IDisposable {
     /// Answers a classified AskUserQuestion entry (Questions non-null; ArgumentException otherwise,
     /// as for an invalid answer set — both thrown before anything reaches the wire).
     Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target, IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct);
+    /// Retires a request whose tool already has a result in the transcript: it was answered where
+    /// the daemon cannot see (the vendor's own terminal prompt), so the app is the party that knows.
+    /// Concluded here on any ack, a rejected decision from an older daemon included.
+    Task<PermissionResolveOutcome> WithdrawAsync(PendingPermissionRequest target, CancellationToken ct);
 }

--- a/src/Capacitor.App/Services/PermissionService.cs
+++ b/src/Capacitor.App/Services/PermissionService.cs
@@ -46,7 +46,7 @@ public sealed class PermissionService : IPermissionService {
             .StartWith(PendingSummary.From(_cache.Items));
 
     public async Task<PermissionResolveOutcome> ResolveAsync(PendingPermissionRequest target, PermissionAnswer answer, CancellationToken ct) {
-        var decision = answer == PermissionAnswer.Deny ? "deny" : "allow";
+        var decision = answer == PermissionAnswer.Deny ? PermissionResolveDecisions.Deny : PermissionResolveDecisions.Allow;
         var apply = answer == PermissionAnswer.AllowAlways ? ClaudePermissions.AlwaysAllow(target.ToolName) : (System.Text.Json.JsonElement?)null;
         return await SendResolveAsync(new PermissionResolveDto(target.RequestId, decision, apply, null), ct).ConfigureAwait(false);
     }
@@ -54,8 +54,11 @@ public sealed class PermissionService : IPermissionService {
     public async Task<PermissionResolveOutcome> AnswerAsync(PendingPermissionRequest target, IReadOnlyList<ElicitationAnswer> answers, CancellationToken ct) {
         if (target.Questions is null) throw new ArgumentException("not an elicitation entry", nameof(target));
         var updated = ClaudeElicitation.ComposeAnswers(target.Questions, answers);
-        return await SendResolveAsync(new PermissionResolveDto(target.RequestId, "allow", null, updated), ct).ConfigureAwait(false);
+        return await SendResolveAsync(new PermissionResolveDto(target.RequestId, PermissionResolveDecisions.Allow, null, updated), ct).ConfigureAwait(false);
     }
+
+    public async Task<PermissionResolveOutcome> WithdrawAsync(PendingPermissionRequest target, CancellationToken ct) =>
+        await SendResolveAsync(new PermissionResolveDto(target.RequestId, PermissionResolveDecisions.Withdraw, null, null), ct).ConfigureAwait(false);
 
     async Task<PermissionResolveOutcome> SendResolveAsync(PermissionResolveDto dto, CancellationToken ct) {
         PermissionAckDto ack;

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -27,6 +27,9 @@ public enum ChatTabPhase { Waiting, Reading, Missing, Unavailable }
 /// completes under a stale generation and is discarded.
 public sealed class ChatTabViewModel : ReactiveObject {
     internal static readonly TimeSpan PollInterval = TimeSpan.FromMilliseconds(500);
+    /// First retry gap after a failed withdraw; each further one doubles it.
+    internal static readonly TimeSpan WithdrawRetryDelay = TimeSpan.FromSeconds(2);
+    internal const int MaxWithdrawRetries = 3;
 
     readonly string _agentId;
     readonly TerminalTabViewModel _terminal;
@@ -36,12 +39,16 @@ public sealed class ChatTabViewModel : ReactiveObject {
     readonly IPermissionService _permissions;
     readonly CompositeDisposable _disposables = new();
     readonly CancellationTokenSource _lifetime = new();
+    // Read once: the source is disposed at teardown, and a retry waking after that still needs a
+    // token it can ask without an ObjectDisposedException.
+    readonly CancellationToken _lifetimeToken;
     readonly AvaloniaList<ChatItemViewModel> _items = new();
     readonly Dictionary<string, ToolCallItem> _pendingTools = new(StringComparer.Ordinal);
     // Every tool id with a result, not only the running ones: a replayed request can arrive after
     // the transcript's initial load, and then only this set can tell that its tool is done.
     readonly HashSet<string> _settledTools = new(StringComparer.Ordinal);
     readonly HashSet<string> _withdrawing = new(StringComparer.Ordinal);
+    readonly Dictionary<string, int> _withdrawFailures = new(StringComparer.Ordinal);
     readonly ConcurrentDictionary<string, byte> _loggedFailures = new(StringComparer.Ordinal);
     readonly Dictionary<string, PendingPermissionRequest> _requests = new(StringComparer.Ordinal);
     readonly HashSet<ToolCallItem> _marked = new(ReferenceEqualityComparer.Instance);
@@ -172,6 +179,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
         _opener = opener;
         _time = time;
         _permissions = permissions;
+        _lifetimeToken = _lifetime.Token;
         _phase = projection is null ? ChatTabPhase.Unavailable : ChatTabPhase.Waiting;
 
         // ObserveOn BEFORE the binding operator: the cache is mutated on the service's
@@ -211,7 +219,11 @@ public sealed class ChatTabViewModel : ReactiveObject {
                 foreach (var change in changes) {
                     switch (change.Reason) {
                         case ChangeReason.Add or ChangeReason.Update: _requests[change.Key] = change.Current; break;
-                        case ChangeReason.Remove: _requests.Remove(change.Key); break;
+                        case ChangeReason.Remove:
+                            _requests.Remove(change.Key);
+                            _withdrawing.Remove(change.Key);
+                            _withdrawFailures.Remove(change.Key);
+                            break;
                     }
                 }
                 Reconcile();
@@ -415,8 +427,9 @@ public sealed class ChatTabViewModel : ReactiveObject {
 
     /// A pending request whose tool already has a result was answered where the daemon cannot see
     /// (the vendor's own terminal prompt), so this tab is the one party that can retire it. Sent
-    /// once per request; a transport failure reopens it for the next reconcile.
+    /// once per request; a failed send reopens it and retries on a bounded backoff.
     void WithdrawSettled() {
+        if (_lifetimeToken.IsCancellationRequested) return;
         foreach (var request in _requests.Values) {
             if (request.ToolUseId is not { } id || !_settledTools.Contains(id) || !_withdrawing.Add(request.RequestId)) continue;
             _ = WithdrawAsync(request);
@@ -424,14 +437,26 @@ public sealed class ChatTabViewModel : ReactiveObject {
     }
 
     async Task WithdrawAsync(PendingPermissionRequest request) {
+        var id = request.RequestId;
         try {
-            var outcome = await _permissions.WithdrawAsync(request, _lifetime.Token);
-            if (outcome.Kind == PermissionResolveKind.TransportFailure) _withdrawing.Remove(request.RequestId);
-        } catch (OperationCanceledException) when (_lifetime.IsCancellationRequested) {
+            var outcome = await _permissions.WithdrawAsync(request, _lifetimeToken);
+            if (outcome.Kind != PermissionResolveKind.TransportFailure) { _withdrawFailures.Remove(id); return; }
+        } catch (OperationCanceledException) when (_lifetimeToken.IsCancellationRequested) {
+            return;
         } catch (Exception ex) {
-            _withdrawing.Remove(request.RequestId);
             LogOnce($"withdraw: {ex.Message}");
         }
+
+        // The resolve rides a one-shot socket that can fail while the subscription stays healthy,
+        // and an empty poll never reconciles, so the retry has to be this method's own. Past the
+        // cap, the next resubscribe or permission/transcript change is what tries again.
+        _withdrawing.Remove(id);
+        var failures = _withdrawFailures.GetValueOrDefault(id) + 1;
+        _withdrawFailures[id] = failures;
+        if (failures > MaxWithdrawRetries) return;
+        try { await Task.Delay(WithdrawRetryDelay * (1 << (failures - 1)), _time, _lifetimeToken); }
+        catch (OperationCanceledException) { return; }
+        WithdrawSettled();
     }
 
     void LogOnce(string reason) {

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -33,9 +33,15 @@ public sealed class ChatTabViewModel : ReactiveObject {
     readonly ITranscriptProjection? _projection;
     readonly IUrlOpener _opener;
     readonly TimeProvider _time;
+    readonly IPermissionService _permissions;
     readonly CompositeDisposable _disposables = new();
+    readonly CancellationTokenSource _lifetime = new();
     readonly AvaloniaList<ChatItemViewModel> _items = new();
     readonly Dictionary<string, ToolCallItem> _pendingTools = new(StringComparer.Ordinal);
+    // Every tool id with a result, not only the running ones: a replayed request can arrive after
+    // the transcript's initial load, and then only this set can tell that its tool is done.
+    readonly HashSet<string> _settledTools = new(StringComparer.Ordinal);
+    readonly HashSet<string> _withdrawing = new(StringComparer.Ordinal);
     readonly ConcurrentDictionary<string, byte> _loggedFailures = new(StringComparer.Ordinal);
     readonly Dictionary<string, PendingPermissionRequest> _requests = new(StringComparer.Ordinal);
     readonly HashSet<ToolCallItem> _marked = new(ReferenceEqualityComparer.Instance);
@@ -154,6 +160,9 @@ public sealed class ChatTabViewModel : ReactiveObject {
     /// await that, advance one tick, then await again to see the new path's first rows.
     internal Task? PendingReadForTesting => _pendingRead;
 
+    /// Test-only seam: withdraws sent and not yet acknowledged, or failed.
+    internal int WithdrawsInFlightForTesting => _withdrawing.Count;
+
     public ChatTabViewModel(
             string agentId, IDaemonClientService daemon, TerminalTabViewModel terminal,
             ITranscriptProjection? projection, IUrlOpener opener, TimeProvider time, IPermissionService permissions) {
@@ -162,6 +171,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
         _projection = projection;
         _opener = opener;
         _time = time;
+        _permissions = permissions;
         _phase = projection is null ? ChatTabPhase.Unavailable : ChatTabPhase.Waiting;
 
         // ObserveOn BEFORE the binding operator: the cache is mutated on the service's
@@ -283,6 +293,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
     void SwitchPath(string path) {
         _items.Clear();
         _pendingTools.Clear();
+        _settledTools.Clear();
         _openGroup = null;
         _marked.Clear();
         _path = path;
@@ -334,6 +345,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
             case TailStatus.Reset:
                 _items.Clear();
                 _pendingTools.Clear();
+                _settledTools.Clear();
                 _openGroup = null;
                 _marked.Clear();
                 break;
@@ -369,7 +381,9 @@ public sealed class ChatTabViewModel : ReactiveObject {
                     break;
                 }
                 case AcpEventKind.ToolResult:
-                    if (e.ToolCallId is { } resultId && _pendingTools.Remove(resultId, out var call))
+                    if (e.ToolCallId is not { } resultId) break;
+                    _settledTools.Add(resultId);
+                    if (_pendingTools.Remove(resultId, out var call))
                         call.Outcome = e.ToolIsError ? ToolOutcome.Error : ToolOutcome.Done;
                     break;
             }
@@ -396,6 +410,28 @@ public sealed class ChatTabViewModel : ReactiveObject {
         foreach (var call in targets) call.IsAwaitingPermission = true;
         _marked.Clear();
         _marked.UnionWith(targets);
+        WithdrawSettled();
+    }
+
+    /// A pending request whose tool already has a result was answered where the daemon cannot see
+    /// (the vendor's own terminal prompt), so this tab is the one party that can retire it. Sent
+    /// once per request; a transport failure reopens it for the next reconcile.
+    void WithdrawSettled() {
+        foreach (var request in _requests.Values) {
+            if (request.ToolUseId is not { } id || !_settledTools.Contains(id) || !_withdrawing.Add(request.RequestId)) continue;
+            _ = WithdrawAsync(request);
+        }
+    }
+
+    async Task WithdrawAsync(PendingPermissionRequest request) {
+        try {
+            var outcome = await _permissions.WithdrawAsync(request, _lifetime.Token);
+            if (outcome.Kind == PermissionResolveKind.TransportFailure) _withdrawing.Remove(request.RequestId);
+        } catch (OperationCanceledException) when (_lifetime.IsCancellationRequested) {
+        } catch (Exception ex) {
+            _withdrawing.Remove(request.RequestId);
+            LogOnce($"withdraw: {ex.Message}");
+        }
     }
 
     void LogOnce(string reason) {
@@ -409,6 +445,8 @@ public sealed class ChatTabViewModel : ReactiveObject {
         _timer = null;
         _disposables.Dispose();
         _rootSubject.Dispose();
+        try { _lifetime.Cancel(); } catch (ObjectDisposedException) { }
+        _lifetime.Dispose();
         return Task.CompletedTask;
     }
 }

--- a/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
+++ b/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
@@ -43,17 +43,27 @@ public sealed class QuestionGroupViewModel : ReactiveObject {
     readonly BehaviorSubject<bool> _answered = new(false);
     string _otherText = "";
     bool _inFastPath;
+    bool _showsHeader;
 
+    public int Index { get; }
     public string? Header { get; }
     public string Text { get; }
     public bool MultiSelect { get; }
     public IReadOnlyList<QuestionOptionViewModel> Options { get; }
     public int MaxOtherLength => ClaudeElicitation.MaxOtherTextChars;
     public ReactiveCommand<Unit, Unit> EnterCommand { get; }
+    /// Returns the card to this question from the review step.
+    public ReactiveCommand<Unit, Unit> EditCommand { get; }
     internal IObservable<bool> Answered => _answered;
     internal bool InFastPath {
         get => _inFastPath;
         set => this.RaiseAndSetIfChanged(ref _inFastPath, value);
+    }
+
+    /// The header rides the step chip once there is a series; alone, it sits above the question.
+    public bool ShowsHeader {
+        get => _showsHeader;
+        internal set => this.RaiseAndSetIfChanged(ref _showsHeader, value);
     }
 
     public string OtherText {
@@ -70,13 +80,24 @@ public sealed class QuestionGroupViewModel : ReactiveObject {
     public bool IsAnswered => Options.Any(o => o.IsSelected) || !string.IsNullOrWhiteSpace(OtherText);
     public bool ShowsOtherAnswer => InFastPath && !string.IsNullOrWhiteSpace(OtherText);
 
-    internal QuestionGroupViewModel(ElicitationQuestion question, Func<QuestionOptionViewModel, QuestionGroupViewModel, Task> pick,
-            Func<QuestionGroupViewModel, Task> enter, IObservable<bool> idle) {
+    /// The review line: picked labels in option order, then any Other text; empty when unanswered.
+    public string AnswerSummary {
+        get {
+            var parts = Options.Where(o => o.IsSelected).Select(o => o.Label).ToList();
+            if (!string.IsNullOrWhiteSpace(OtherText)) parts.Add(OtherText.Trim());
+            return string.Join(", ", parts);
+        }
+    }
+
+    internal QuestionGroupViewModel(int index, ElicitationQuestion question, Func<QuestionOptionViewModel, QuestionGroupViewModel, Task> pick,
+            Func<QuestionGroupViewModel, Task> enter, Action<QuestionGroupViewModel> edit, IObservable<bool> idle) {
+        Index = index;
         Header = question.Header;
         Text = question.Question;
         MultiSelect = question.MultiSelect;
         Options = question.Options.Select(o => new QuestionOptionViewModel(o, question.MultiSelect, opt => pick(opt, this), idle, Refresh)).ToList();
         EnterCommand = ReactiveCommand.CreateFromTask(() => enter(this), idle);
+        EditCommand = ReactiveCommand.Create(() => edit(this), idle);
     }
 
     internal void SelectExclusively(QuestionOptionViewModel picked) {
@@ -94,20 +115,84 @@ public sealed class QuestionGroupViewModel : ReactiveObject {
         _answered.OnNext(IsAnswered);
         this.RaisePropertyChanged(nameof(IsAnswered));
         this.RaisePropertyChanged(nameof(ShowsOtherAnswer));
+        this.RaisePropertyChanged(nameof(AnswerSummary));
     }
 }
 
-/// The NEEDS YOU question card: renders every question of an AskUserQuestion payload and answers
-/// them all in one resolve. No Deny and no Allow always by design.
+/// One chip in the card's step row: a question, or the closing Review step.
+public sealed class QuestionStepViewModel : ReactiveObject {
+    bool _isCurrent;
+    bool _isAnswered;
+
+    public int Index { get; }
+    public string Title { get; }
+    public bool IsReview { get; }
+    public ReactiveCommand<Unit, Unit> GoCommand { get; }
+
+    public bool IsCurrent {
+        get => _isCurrent;
+        internal set => this.RaiseAndSetIfChanged(ref _isCurrent, value);
+    }
+
+    public bool IsAnswered {
+        get => _isAnswered;
+        internal set => this.RaiseAndSetIfChanged(ref _isAnswered, value);
+    }
+
+    internal QuestionStepViewModel(int index, string title, bool isReview, Action<int> go, IObservable<bool> idle) {
+        Index = index;
+        Title = title;
+        IsReview = isReview;
+        GoCommand = ReactiveCommand.Create(() => go(index), idle);
+    }
+}
+
+/// The NEEDS YOU question card. A series is walked one question at a time — a single-select pick
+/// advances, the last question leads to a Review step listing every answer, and only that step
+/// submits — while a lone question keeps its Submit inline. A lone single-select question with
+/// options is the fast path: the pick itself submits. No Deny and no Allow always by design.
 public sealed class QuestionCardViewModel : PendingCardViewModel {
     readonly PendingPermissionRequest _entry;
     readonly IPermissionService _permissions;
     readonly CancellationTokenSource _lifetime = new();
+    readonly BehaviorSubject<bool> _canBack = new(false);
+    readonly BehaviorSubject<bool> _canNext = new(false);
+    readonly BehaviorSubject<bool> _onSubmitStep;
+    int _currentIndex;
 
     public IReadOnlyList<QuestionGroupViewModel> Questions { get; }
+    /// Every question plus, for a series, the Review step; a lone question has no step row.
+    public IReadOnlyList<QuestionStepViewModel> Steps { get; }
     public bool IsFastPath { get; }
-    public bool ShowsSubmit => !IsFastPath;
+    public bool HasReview => Questions.Count > 1;
+    public bool ShowsSteps => HasReview;
+    public ReactiveCommand<Unit, Unit> BackCommand { get; }
+    public ReactiveCommand<Unit, Unit> NextCommand { get; }
     public ReactiveCommand<Unit, Unit> SubmitCommand { get; }
+
+    public int CurrentIndex {
+        get => _currentIndex;
+        private set {
+            if (_currentIndex == value) return;
+            _currentIndex = value;
+            foreach (var step in Steps) step.IsCurrent = step.Index == value;
+            this.RaisePropertyChanged();
+            this.RaisePropertyChanged(nameof(CurrentQuestion));
+            this.RaisePropertyChanged(nameof(IsOnReview));
+            this.RaisePropertyChanged(nameof(ShowsSubmit));
+            this.RaisePropertyChanged(nameof(ShowsNext));
+            this.RaisePropertyChanged(nameof(NextLabel));
+            this.RaisePropertyChanged(nameof(StepLabel));
+            UpdateNavigation();
+        }
+    }
+
+    public QuestionGroupViewModel? CurrentQuestion => _currentIndex < Questions.Count ? Questions[_currentIndex] : null;
+    public bool IsOnReview => HasReview && _currentIndex == Questions.Count;
+    public bool ShowsSubmit => !IsFastPath && (!HasReview || IsOnReview);
+    public bool ShowsNext => HasReview && !IsOnReview;
+    public string NextLabel => _currentIndex == Questions.Count - 1 ? "Review" : "Next";
+    public string StepLabel => !HasReview ? "" : IsOnReview ? "Review your answers" : $"Question {_currentIndex + 1} of {Questions.Count}";
 
     public QuestionCardViewModel(PendingPermissionRequest entry, IPermissionService permissions) : base(entry) {
         _entry = entry;
@@ -115,29 +200,76 @@ public sealed class QuestionCardViewModel : PendingCardViewModel {
         var parsed = entry.Questions ?? throw new ArgumentException("not an elicitation entry", nameof(entry));
 
         var idle = Busy.Select(b => !b);
-        Questions = parsed.Questions.Select(q => new QuestionGroupViewModel(q, PickAsync, EnterAsync, idle)).ToList();
+        Questions = parsed.Questions.Select((q, i) => new QuestionGroupViewModel(i, q, PickAsync, EnterAsync, g => GoTo(g.Index), idle)).ToList();
         IsFastPath = Questions.Count == 1 && !Questions[0].MultiSelect && Questions[0].Options.Count > 0;
-        foreach (var q in Questions) q.InFastPath = IsFastPath;
+        foreach (var q in Questions) {
+            q.InFastPath = IsFastPath;
+            q.ShowsHeader = !HasReview && q.Header is not null;
+        }
 
+        var steps = new List<QuestionStepViewModel>();
+        if (HasReview) {
+            steps.AddRange(Questions.Select(q => new QuestionStepViewModel(q.Index, q.Header ?? $"Question {q.Index + 1}", false, GoTo, idle)));
+            steps.Add(new QuestionStepViewModel(Questions.Count, "Review", true, GoTo, idle));
+            steps[0].IsCurrent = true;
+        }
+        Steps = steps;
+
+        _onSubmitStep = new BehaviorSubject<bool>(!HasReview);
         var allAnswered = Questions.Select(q => q.Answered).CombineLatest(states => states.All(x => x));
-        SubmitCommand = ReactiveCommand.CreateFromTask(SubmitAsync, allAnswered.CombineLatest(idle, (a, i) => a && i));
+        SubmitCommand = ReactiveCommand.CreateFromTask(SubmitAsync,
+            allAnswered.CombineLatest(idle, _onSubmitStep, (a, i, s) => a && i && s));
+        BackCommand = ReactiveCommand.Create(() => GoTo(_currentIndex - 1), _canBack.CombineLatest(idle, (b, i) => b && i));
+        NextCommand = ReactiveCommand.Create(() => GoTo(_currentIndex + 1), _canNext.CombineLatest(idle, (n, i) => n && i));
+
+        foreach (var q in Questions) {
+            var step = HasReview ? Steps[q.Index] : null;
+            Disposables.Add(q.Answered.Subscribe(answered => {
+                if (step is not null) step.IsAnswered = answered;
+                if (q.Index == _currentIndex) UpdateNavigation();
+            }));
+        }
 
         Disposables.Add(SubmitCommand);
+        Disposables.Add(BackCommand);
+        Disposables.Add(NextCommand);
+        Disposables.Add(_canBack);
+        Disposables.Add(_canNext);
+        Disposables.Add(_onSubmitStep);
         // Dispose() runs Disposables in order: cancel _lifetime BEFORE disposing it, so the
         // token passed to AnswerAsync observes cancellation rather than firing on a disposed CTS.
         Disposables.Add(Disposable.Create(() => { try { _lifetime.Cancel(); } catch (ObjectDisposedException) { } }));
         Disposables.Add(_lifetime);
     }
 
+    void GoTo(int index) {
+        if (IsDisposed) return;
+        var last = HasReview ? Questions.Count : Questions.Count - 1;
+        CurrentIndex = Math.Clamp(index, 0, last);
+    }
+
+    void UpdateNavigation() {
+        _canBack.OnNext(_currentIndex > 0);
+        _canNext.OnNext(ShowsNext && CurrentQuestion is { IsAnswered: true });
+        _onSubmitStep.OnNext(!HasReview || IsOnReview);
+    }
+
     Task PickAsync(QuestionOptionViewModel option, QuestionGroupViewModel group) {
         if (group.MultiSelect) { option.IsSelected = !option.IsSelected; return Task.CompletedTask; }
         group.SelectExclusively(option);
-        return IsFastPath ? SubmitAsync() : Task.CompletedTask;
+        if (IsFastPath) return SubmitAsync();
+        if (HasReview && group.Index == _currentIndex) GoTo(_currentIndex + 1);
+        return Task.CompletedTask;
     }
 
     Task EnterAsync(QuestionGroupViewModel group) {
         if (IsFastPath) return group.ShowsOtherAnswer ? SubmitAsync() : Task.CompletedTask;
-        return Questions.All(q => q.IsAnswered) ? SubmitAsync() : Task.CompletedTask;
+        if (!group.IsAnswered) return Task.CompletedTask;
+        if (HasReview) {
+            if (group.Index == _currentIndex) GoTo(_currentIndex + 1);
+            return Task.CompletedTask;
+        }
+        return SubmitAsync();
     }
 
     async Task SubmitAsync() {

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -134,7 +134,7 @@
         <Border x:Name="NeedsYouRow" Grid.Row="1" Margin="22,0,22,4" IsVisible="{Binding HasPendingCards}">
             <StackPanel Spacing="6">
                 <TextBlock Text="NEEDS YOU" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}" />
-                <ScrollViewer MaxHeight="260" VerticalScrollBarVisibility="Auto">
+                <ScrollViewer MaxHeight="420" VerticalScrollBarVisibility="Auto">
                     <ItemsControl ItemsSource="{Binding PendingCards}">
                         <ItemsControl.DataTemplates>
                             <DataTemplate x:DataType="vm:PermissionCardViewModel">
@@ -158,59 +158,143 @@
                             </DataTemplate>
                             <DataTemplate x:DataType="vm:QuestionCardViewModel">
                                 <Border Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapSuccessBrush}"
-                                        BorderThickness="1" CornerRadius="10" Padding="13,10" Margin="0,0,0,6">
+                                        BorderThickness="1" CornerRadius="10" Padding="14,12" Margin="0,0,0,6">
                                     <Border.Styles>
-                                        <Style Selector="Button.selected">
+                                        <!-- Option chrome lives in class styles only: a local Background/BorderBrush on
+                                             the Button would outrank the selected style and leave it inert, and the
+                                             theme's hover fill on PART_ContentPresenter is overridden for the same reason. -->
+                                        <Style Selector="Button.option">
+                                            <Setter Property="Background" Value="{StaticResource KcapSurfaceBrush}" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapBorderBrush}" />
+                                            <Setter Property="BorderThickness" Value="1" />
+                                            <Setter Property="CornerRadius" Value="8" />
+                                            <Setter Property="Padding" Value="12,9" />
+                                            <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                            <Setter Property="Cursor" Value="Hand" />
+                                        </Style>
+                                        <Style Selector="Button.option:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                                            <Setter Property="Background" Value="{StaticResource KcapSurfaceRaisedBrush}" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapMutedBrush}" />
+                                        </Style>
+                                        <Style Selector="Button.option.selected">
+                                            <Setter Property="Background" Value="{StaticResource KcapSuccessDimBrush}" />
                                             <Setter Property="BorderBrush" Value="{StaticResource KcapSuccessBrush}" />
                                         </Style>
+                                        <Style Selector="Button.option.selected /template/ ContentPresenter#PART_ContentPresenter">
+                                            <Setter Property="Background" Value="{StaticResource KcapSuccessDimBrush}" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapSuccessBrush}" />
+                                        </Style>
+                                        <Style Selector="Border.indicator">
+                                            <Setter Property="Width" Value="16" />
+                                            <Setter Property="Height" Value="16" />
+                                            <Setter Property="BorderThickness" Value="1.5" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapMutedBrush}" />
+                                            <Setter Property="Background" Value="Transparent" />
+                                            <Setter Property="VerticalAlignment" Value="Top" />
+                                            <Setter Property="Margin" Value="0,2,11,0" />
+                                        </Style>
+                                        <Style Selector="Button.option.selected Border.indicator">
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapSuccessBrush}" />
+                                            <Setter Property="Background" Value="{StaticResource KcapSuccessBrush}" />
+                                        </Style>
+                                        <Style Selector="Button.step">
+                                            <Setter Property="Background" Value="Transparent" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapBorderBrush}" />
+                                            <Setter Property="BorderThickness" Value="1" />
+                                            <Setter Property="CornerRadius" Value="999" />
+                                            <Setter Property="Padding" Value="10,3" />
+                                            <Setter Property="FontSize" Value="11.5" />
+                                            <Setter Property="Foreground" Value="{StaticResource KcapMutedBrush}" />
+                                            <Setter Property="Cursor" Value="Hand" />
+                                        </Style>
+                                        <Style Selector="Button.step.answered">
+                                            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+                                        </Style>
+                                        <Style Selector="Button.step.current">
+                                            <Setter Property="Background" Value="{StaticResource KcapSuccessDimBrush}" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapSuccessBrush}" />
+                                            <Setter Property="Foreground" Value="{StaticResource KcapTextBrush}" />
+                                            <Setter Property="FontWeight" Value="SemiBold" />
+                                        </Style>
+                                        <Style Selector="Button.step.current /template/ ContentPresenter#PART_ContentPresenter, Button.step:pointerover /template/ ContentPresenter#PART_ContentPresenter">
+                                            <Setter Property="Background" Value="{StaticResource KcapSuccessDimBrush}" />
+                                        </Style>
+                                        <Style Selector="Button.reviewRow">
+                                            <Setter Property="Background" Value="{StaticResource KcapSurfaceBrush}" />
+                                            <Setter Property="BorderBrush" Value="{StaticResource KcapBorderBrush}" />
+                                            <Setter Property="BorderThickness" Value="1" />
+                                            <Setter Property="CornerRadius" Value="8" />
+                                            <Setter Property="Padding" Value="12,8" />
+                                            <Setter Property="HorizontalAlignment" Value="Stretch" />
+                                            <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                                            <Setter Property="Cursor" Value="Hand" />
+                                        </Style>
                                     </Border.Styles>
-                                    <StackPanel Spacing="8" IsEnabled="{Binding !IsBusy}">
-                                        <ItemsControl ItemsSource="{Binding Questions}">
+                                    <StackPanel Spacing="10" IsEnabled="{Binding !IsBusy}">
+                                        <ItemsControl ItemsSource="{Binding Steps}" IsVisible="{Binding ShowsSteps}">
+                                            <ItemsControl.ItemsPanel>
+                                                <ItemsPanelTemplate>
+                                                    <WrapPanel Orientation="Horizontal" />
+                                                </ItemsPanelTemplate>
+                                            </ItemsControl.ItemsPanel>
                                             <ItemsControl.ItemTemplate>
+                                                <DataTemplate x:DataType="vm:QuestionStepViewModel">
+                                                    <Button Classes="step" Classes.current="{Binding IsCurrent}" Classes.answered="{Binding IsAnswered}"
+                                                            Command="{Binding GoCommand}" Margin="0,0,6,4">
+                                                        <StackPanel Orientation="Horizontal" Spacing="5">
+                                                            <TextBlock Text="✓" FontSize="10.5" Foreground="{StaticResource KcapSuccessBrush}"
+                                                                       IsVisible="{Binding IsAnswered}" VerticalAlignment="Center" />
+                                                            <TextBlock Text="{Binding Title}" VerticalAlignment="Center" TextTrimming="CharacterEllipsis" MaxWidth="180" />
+                                                        </StackPanel>
+                                                    </Button>
+                                                </DataTemplate>
+                                            </ItemsControl.ItemTemplate>
+                                        </ItemsControl>
+                                        <ContentControl Content="{Binding CurrentQuestion}" IsVisible="{Binding !IsOnReview}">
+                                            <ContentControl.ContentTemplate>
                                                 <DataTemplate x:DataType="vm:QuestionGroupViewModel">
-                                                    <StackPanel Spacing="5" Margin="0,0,0,4">
-                                                        <Border Background="{StaticResource KcapSurfaceBrush}" CornerRadius="4" Padding="5,1" HorizontalAlignment="Left"
-                                                                IsVisible="{Binding Header, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
-                                                            <TextBlock Text="{Binding Header}" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}"
+                                                    <StackPanel Spacing="8">
+                                                        <Border Background="{StaticResource KcapSurfaceBrush}" CornerRadius="4" Padding="6,2" HorizontalAlignment="Left"
+                                                                IsVisible="{Binding ShowsHeader}">
+                                                            <TextBlock Text="{Binding Header}" FontSize="11" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}"
                                                                        TextTrimming="CharacterEllipsis" MaxLines="1" />
                                                         </Border>
-                                                        <TextBlock Text="{Binding Text}" FontWeight="SemiBold" FontSize="13" TextWrapping="Wrap"
+                                                        <TextBlock Text="{Binding Text}" FontWeight="SemiBold" FontSize="15" LineHeight="21" TextWrapping="Wrap"
                                                                    Foreground="{StaticResource KcapTextBrush}" />
                                                         <ItemsControl ItemsSource="{Binding Options}">
+                                                            <ItemsControl.ItemsPanel>
+                                                                <ItemsPanelTemplate>
+                                                                    <StackPanel Spacing="6" />
+                                                                </ItemsPanelTemplate>
+                                                            </ItemsControl.ItemsPanel>
                                                             <ItemsControl.ItemTemplate>
                                                                 <DataTemplate x:DataType="vm:QuestionOptionViewModel">
-                                                                    <StackPanel Margin="0,0,0,2">
-                                                                        <Button IsVisible="{Binding !IsMulti}" Command="{Binding PickCommand}"
-                                                                                Classes.selected="{Binding IsSelected}"
-                                                                                HorizontalAlignment="Stretch" HorizontalContentAlignment="Left"
-                                                                                Padding="10,5" FontSize="12" CornerRadius="7"
-                                                                                Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1">
-                                                                            <StackPanel>
-                                                                                <TextBlock Text="{Binding Label}" Foreground="{StaticResource KcapTextBrush}" />
-                                                                                <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
-                                                                                           TextWrapping="Wrap" MaxLines="3" TextTrimming="CharacterEllipsis"
+                                                                    <Button Classes="option" Classes.selected="{Binding IsSelected}" Command="{Binding PickCommand}">
+                                                                        <DockPanel>
+                                                                            <Panel DockPanel.Dock="Left" VerticalAlignment="Top">
+                                                                                <Border Classes="indicator" CornerRadius="8" IsVisible="{Binding !IsMulti}" />
+                                                                                <Border Classes="indicator" CornerRadius="3" IsVisible="{Binding IsMulti}" />
+                                                                            </Panel>
+                                                                            <StackPanel Spacing="3">
+                                                                                <TextBlock Text="{Binding Label}" FontSize="14" FontWeight="Medium" TextWrapping="Wrap"
+                                                                                           Foreground="{StaticResource KcapTextBrush}" />
+                                                                                <TextBlock Text="{Binding Description}" FontSize="12.5" LineHeight="18" TextWrapping="Wrap"
+                                                                                           Foreground="{StaticResource KcapMutedBrush}"
                                                                                            IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                                                                             </StackPanel>
-                                                                        </Button>
-                                                                        <CheckBox IsVisible="{Binding IsMulti}" IsChecked="{Binding IsSelected}" FontSize="12">
-                                                                            <StackPanel>
-                                                                                <TextBlock Text="{Binding Label}" Foreground="{StaticResource KcapTextBrush}" />
-                                                                                <TextBlock Text="{Binding Description}" FontSize="11" Foreground="{StaticResource KcapMutedBrush}"
-                                                                                           TextWrapping="Wrap" MaxLines="3" TextTrimming="CharacterEllipsis"
-                                                                                           IsVisible="{Binding Description, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                                                                            </StackPanel>
-                                                                        </CheckBox>
-                                                                    </StackPanel>
+                                                                        </DockPanel>
+                                                                    </Button>
                                                                 </DataTemplate>
                                                             </ItemsControl.ItemTemplate>
                                                         </ItemsControl>
                                                         <DockPanel>
                                                             <Button DockPanel.Dock="Right" Content="Answer" Command="{Binding EnterCommand}"
                                                                     IsVisible="{Binding ShowsOtherAnswer}" Margin="6,0,0,0"
-                                                                    Padding="10,4" FontSize="12" CornerRadius="7"
-                                                                    Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" />
+                                                                    Padding="12,5" FontSize="13" CornerRadius="7"
+                                                                    Classes="kcapPrimary" Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" />
                                                             <TextBox Text="{Binding OtherText}" PlaceholderText="Other…" MaxLength="{Binding MaxOtherLength}"
-                                                                     AcceptsReturn="False" FontSize="12" MinHeight="30">
+                                                                     AcceptsReturn="False" FontSize="13" MinHeight="34">
                                                                 <TextBox.KeyBindings>
                                                                     <KeyBinding Gesture="Enter" Command="{Binding EnterCommand}" />
                                                                 </TextBox.KeyBindings>
@@ -218,13 +302,47 @@
                                                         </DockPanel>
                                                     </StackPanel>
                                                 </DataTemplate>
-                                            </ItemsControl.ItemTemplate>
-                                        </ItemsControl>
-                                        <TextBlock Text="{Binding ErrorText}" FontSize="11" Foreground="{StaticResource KcapDangerBrush}"
+                                            </ContentControl.ContentTemplate>
+                                        </ContentControl>
+                                        <StackPanel Spacing="8" IsVisible="{Binding IsOnReview}">
+                                            <TextBlock Text="Review your answers" FontWeight="SemiBold" FontSize="15" Foreground="{StaticResource KcapTextBrush}" />
+                                            <ItemsControl ItemsSource="{Binding Questions}">
+                                                <ItemsControl.ItemsPanel>
+                                                    <ItemsPanelTemplate>
+                                                        <StackPanel Spacing="6" />
+                                                    </ItemsPanelTemplate>
+                                                </ItemsControl.ItemsPanel>
+                                                <ItemsControl.ItemTemplate>
+                                                    <DataTemplate x:DataType="vm:QuestionGroupViewModel">
+                                                        <Button Classes="reviewRow" Command="{Binding EditCommand}">
+                                                            <StackPanel Spacing="3">
+                                                                <TextBlock Text="{Binding Text}" FontSize="12.5" TextWrapping="Wrap" Foreground="{StaticResource KcapMutedBrush}" />
+                                                                <TextBlock Text="{Binding AnswerSummary}" FontSize="14" FontWeight="Medium" TextWrapping="Wrap"
+                                                                           Foreground="{StaticResource KcapTextBrush}" IsVisible="{Binding IsAnswered}" />
+                                                                <TextBlock Text="Not answered" FontSize="14" Foreground="{StaticResource KcapWarningBrush}"
+                                                                           IsVisible="{Binding !IsAnswered}" />
+                                                            </StackPanel>
+                                                        </Button>
+                                                    </DataTemplate>
+                                                </ItemsControl.ItemTemplate>
+                                            </ItemsControl>
+                                        </StackPanel>
+                                        <TextBlock Text="{Binding ErrorText}" FontSize="12" Foreground="{StaticResource KcapDangerBrush}"
                                                    IsVisible="{Binding ErrorText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                                        <Button Content="Submit" Command="{Binding SubmitCommand}" IsVisible="{Binding ShowsSubmit}"
-                                                HorizontalAlignment="Right" Padding="12,4" FontSize="12" FontWeight="SemiBold" CornerRadius="7"
-                                                Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" />
+                                        <DockPanel IsVisible="{Binding !IsFastPath}">
+                                            <StackPanel DockPanel.Dock="Right" Orientation="Horizontal" Spacing="6">
+                                                <Button Content="Back" Classes="kcapGhost" Command="{Binding BackCommand}" IsVisible="{Binding ShowsSteps}"
+                                                        Background="Transparent" BorderBrush="Transparent" Foreground="{StaticResource KcapMutedBrush}"
+                                                        Padding="12,5" FontSize="13" CornerRadius="7" />
+                                                <Button Content="{Binding NextLabel}" Command="{Binding NextCommand}" IsVisible="{Binding ShowsNext}"
+                                                        Padding="14,5" FontSize="13" FontWeight="SemiBold" CornerRadius="7"
+                                                        Classes="kcapPrimary" Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" />
+                                                <Button Content="Submit" Command="{Binding SubmitCommand}" IsVisible="{Binding ShowsSubmit}"
+                                                        Padding="14,5" FontSize="13" FontWeight="SemiBold" CornerRadius="7"
+                                                        Classes="kcapPrimary" Background="{StaticResource KcapPrimaryBrush}" Foreground="{StaticResource KcapOnPrimaryBrush}" />
+                                            </StackPanel>
+                                            <TextBlock Text="{Binding StepLabel}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" />
+                                        </DockPanel>
                                     </StackPanel>
                                 </Border>
                             </DataTemplate>

--- a/src/Capacitor.Cli.Core/LocalIpc/PermissionDecisionLog.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/PermissionDecisionLog.cs
@@ -3,7 +3,7 @@ using System.Text.Json.Serialization;
 namespace Capacitor.Cli.Core.LocalIpc;
 
 /// One line of permission-decisions.jsonl. Outcome: allow|deny|withdrawn.
-/// Source: app|server|agent_gone|no_ui|policy.
+/// Source: app|server|policy|agent_gone|no_ui|daemon_shutdown|tool_settled.
 public sealed record PermissionDecisionRecord(
     string DecidedAt, string AgentId, string SessionId, string Vendor,
     string ToolName, string Outcome, string Source);

--- a/src/Capacitor.Cli.Core/LocalIpc/PermissionIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/PermissionIpc.cs
@@ -10,10 +10,16 @@ public sealed record PermissionPendingDto(
     JsonElement? ToolInput, JsonElement? Suggestions, bool ToolInputOmitted, bool SuggestionsOmitted,
     string RequestedAt, string? ToolUseId = null);
 
+/// Decision: allow|deny|withdraw. A withdraw carries no answer: the app saw the tool's result in
+/// the transcript, so whoever prompted has already been answered elsewhere and the request is moot.
 public sealed record PermissionResolveDto(
     string RequestId, string Decision, JsonElement? ApplyPermissions, JsonElement? UpdatedInput);
 
-/// Outcome: allow|deny|withdrawn. Source: app|server|agent_gone|no_ui|daemon_shutdown.
+public static class PermissionResolveDecisions {
+    public const string Allow = "allow", Deny = "deny", Withdraw = "withdraw";
+}
+
+/// Outcome: allow|deny|withdrawn. Source: app|server|policy|agent_gone|no_ui|daemon_shutdown|tool_settled.
 public sealed record PermissionResolvedDto(string RequestId, string Outcome, string Source);
 
 public sealed record PermissionAckDto(bool Ok, string? Error);

--- a/src/Capacitor.Cli.Daemon/Services/PermissionIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PermissionIpc.cs
@@ -46,11 +46,15 @@ internal sealed class PermissionIpc(PermissionPromptBroker broker, ILogger<Permi
         PermissionAckDto ack;
         try {
             var dto = JsonSerializer.Deserialize(payload, PermissionIpcJsonContext.Default.PermissionResolveDto);
-            if (dto is null || string.IsNullOrEmpty(dto.RequestId) || dto.Decision is not ("allow" or "deny")) {
-                ack = new PermissionAckDto(false, "invalid resolve payload (decision must be allow|deny)");
+            if (dto is null || string.IsNullOrEmpty(dto.RequestId)
+                || dto.Decision is not (PermissionResolveDecisions.Allow or PermissionResolveDecisions.Deny or PermissionResolveDecisions.Withdraw)) {
+                ack = new PermissionAckDto(false, "invalid resolve payload (decision must be allow|deny|withdraw)");
             } else {
-                var decision = new PermissionDecision(dto.Decision, dto.ApplyPermissions, dto.UpdatedInput);
-                var settled  = broker.TrySettle(dto.RequestId, decision, dto.Decision, PermissionSettlements.SourceApp);
+                // A withdrawn request still answers its hook, and that answer must be a deny: the
+                // tool has already run, so an allow could only ever apply to some later call.
+                var settled = dto.Decision == PermissionResolveDecisions.Withdraw
+                    ? broker.TrySettle(dto.RequestId, PermissionSettlements.DenyDecision, PermissionSettlements.Withdrawn, PermissionSettlements.SourceToolSettled)
+                    : broker.TrySettle(dto.RequestId, new PermissionDecision(dto.Decision, dto.ApplyPermissions, dto.UpdatedInput), dto.Decision, PermissionSettlements.SourceApp);
                 ack = settled
                     ? new PermissionAckDto(true, null)
                     : new PermissionAckDto(false, "no pending permission request with that id");

--- a/src/Capacitor.Cli.Daemon/Services/PermissionPromptBroker.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PermissionPromptBroker.cs
@@ -16,7 +16,7 @@ internal static class PermissionSettlements {
     public const string Allow = "allow", Deny = "deny", Withdrawn = "withdrawn";
     public const string SourceApp = "app", SourceServer = "server", SourceAgentGone = "agent_gone",
                         SourceNoUi = "no_ui", SourceDaemonShutdown = "daemon_shutdown",
-                        SourcePolicy = "policy";
+                        SourcePolicy = "policy", SourceToolSettled = "tool_settled";
     public static readonly PermissionDecision DenyDecision = new("deny", null, null);
 }
 

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -525,11 +525,11 @@ public class ChatTabViewModelTests {
         });
     }
 
-    /// A withdraw the daemon could not be reached for is not final: the next reconcile retries it,
-    /// and a withdraw in flight is never sent twice.
+    /// A withdraw the daemon could not be reached for is not final: it retries on its own after a
+    /// backoff, with no other event needed, and a withdraw in flight is never sent twice.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task A_failed_withdraw_is_retried_on_the_next_reconcile_and_never_doubled() {
+    public async Task A_failed_withdraw_retries_on_its_own_after_a_backoff_and_is_never_doubled() {
         await RunOnUiAsync(async () => {
             var h = Claude();
             var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ToolResultLine]);
@@ -545,9 +545,43 @@ public class ChatTabViewModelTests {
             gate.SetResult(new PermissionResolveOutcome(PermissionResolveKind.TransportFailure, "daemon_unreachable"));
             await WaitUntilAsync(() => h.Chat.WithdrawsInFlightForTesting == 0, what: "the failure reopened it");
             h.Permissions.Queue(PermissionResolveKind.Applied);
-            h.Permissions.Remove("r2");
-            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 0, what: "the retry withdrew it");
+            h.Time.Advance(ChatTabViewModel.WithdrawRetryDelay);
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "the retry withdrew it");
             await Assert.That(h.Permissions.Withdrawn).IsEquivalentTo(["r1", "r1"]);
+            await h.TeardownAsync();
+        });
+    }
+
+    /// The backoff doubles and stops at the cap; after that only a fresh reconcile retries.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Withdraw_retries_are_capped_and_a_later_reconcile_tries_again() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ToolResultLine]);
+            await h.PushAsync(Dto(path));
+
+            h.Permissions.Queue(PermissionResolveKind.TransportFailure, "daemon_unreachable");
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            await WaitUntilAsync(() => h.Chat.WithdrawsInFlightForTesting == 0, what: "the first failure");
+            for (var retry = 1; retry <= ChatTabViewModel.MaxWithdrawRetries; retry++) {
+                h.Permissions.Queue(PermissionResolveKind.TransportFailure, "daemon_unreachable");
+                h.Time.Advance(ChatTabViewModel.WithdrawRetryDelay * (1 << (retry - 1)) - TimeSpan.FromMilliseconds(1));
+                await Task.Delay(20);
+                await Assert.That(h.Permissions.Withdrawn.Count).IsEqualTo(retry);
+                h.Time.Advance(TimeSpan.FromMilliseconds(1));
+                await WaitUntilAsync(() => h.Permissions.Withdrawn.Count == retry + 1, what: $"retry {retry}");
+                await WaitUntilAsync(() => h.Chat.WithdrawsInFlightForTesting == 0, what: $"retry {retry} failed");
+            }
+
+            h.Time.Advance(TimeSpan.FromMinutes(5));
+            await Task.Delay(20);
+            await Assert.That(h.Permissions.Withdrawn.Count).IsEqualTo(ChatTabViewModel.MaxWithdrawRetries + 1);
+
+            h.Permissions.Queue(PermissionResolveKind.Applied);
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", toolUseId: "t9"));
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "the reconcile's retry withdrew it");
+            await Assert.That(h.Permissions.Withdrawn.Count).IsEqualTo(ChatTabViewModel.MaxWithdrawRetries + 2);
             await h.TeardownAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Linq;
 using Avalonia.Threading;
+using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
@@ -466,7 +467,7 @@ public class ChatTabViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Two_requests_on_one_row_keep_the_mark_until_both_go_and_a_settled_row_is_cleared() {
+    public async Task Two_requests_on_one_row_keep_the_mark_until_both_go_and_a_settled_row_withdraws_the_survivor() {
         await RunOnUiAsync(async () => {
             var h = Claude();
             var path = Tmp.CreateFile("t.jsonl", [ToolCallLine]);
@@ -480,11 +481,73 @@ public class ChatTabViewModelTests {
             await WaitUntilAsync(() => h.Chat.PendingCards.Count == 1, what: "one card left");
             await Assert.That(bash.IsAwaitingPermission).IsTrue();
 
+            h.Permissions.Queue(PermissionResolveKind.Applied);
             File.AppendAllText(path, ToolResultLine + "\n");
             await h.TickAsync();
             await Assert.That(bash.Outcome).IsEqualTo(ToolOutcome.Done);
             await Assert.That(bash.IsAwaitingPermission).IsFalse();
-            await Assert.That(h.Chat.PendingCards).Count().IsEqualTo(1);
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 0, what: "the survivor withdrawn");
+            await Assert.That(h.Permissions.Withdrawn).IsEquivalentTo(["r2"]);
+            await h.TeardownAsync();
+        });
+    }
+
+    /// The daemon never sees a terminal answer, so a result for a pending request's tool is the
+    /// app's cue to retire it — whichever of the two arrives first, since a replayed request can
+    /// land after the transcript's initial load. A request for another tool, or without an id,
+    /// is left alone.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_result_for_a_pending_requests_tool_withdraws_it_in_either_order() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ReadCallLine]);
+            await h.PushAsync(Dto(path));
+
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", toolUseId: "t2"));
+            h.Permissions.Add(PermissionEntries.Entry("r3", "a1", vendor: "codex"));
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 3, what: "three cards");
+
+            h.Permissions.Queue(PermissionResolveKind.Applied);
+            File.AppendAllText(path, ToolResultLine + "\n");
+            await h.TickAsync();
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 2, what: "the result's request withdrawn");
+            await Assert.That(h.Permissions.Withdrawn).IsEquivalentTo(["r1"]);
+
+            // Result already on file when the request arrives: withdrawn on arrival.
+            h.Permissions.Queue(PermissionResolveKind.Applied);
+            h.Permissions.Add(PermissionEntries.Entry("r4", "a1", toolUseId: "t1"));
+            await WaitUntilAsync(() => h.Permissions.Withdrawn.Count == 2, what: "the late request withdrawn");
+            await Assert.That(h.Permissions.Withdrawn[1]).IsEqualTo("r4");
+            await Assert.That(h.Chat.PendingCards.Count).IsEqualTo(2);
+            await h.TeardownAsync();
+        });
+    }
+
+    /// A withdraw the daemon could not be reached for is not final: the next reconcile retries it,
+    /// and a withdraw in flight is never sent twice.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_failed_withdraw_is_retried_on_the_next_reconcile_and_never_doubled() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [ToolCallLine, ToolResultLine]);
+            await h.PushAsync(Dto(path));
+
+            var gate = h.Permissions.Arm();
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1", toolUseId: "t1"));
+            await WaitUntilAsync(() => h.Permissions.Withdrawn.Count == 1, what: "the first withdraw");
+            h.Permissions.Add(PermissionEntries.Entry("r2", "a1", toolUseId: "t9"));
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 2, what: "a reconcile while in flight");
+            await Assert.That(h.Permissions.Withdrawn.Count).IsEqualTo(1);
+
+            gate.SetResult(new PermissionResolveOutcome(PermissionResolveKind.TransportFailure, "daemon_unreachable"));
+            await WaitUntilAsync(() => h.Chat.WithdrawsInFlightForTesting == 0, what: "the failure reopened it");
+            h.Permissions.Queue(PermissionResolveKind.Applied);
+            h.Permissions.Remove("r2");
+            await WaitUntilAsync(() => h.Chat.PendingCards.Count == 0, what: "the retry withdrew it");
+            await Assert.That(h.Permissions.Withdrawn).IsEquivalentTo(["r1", "r1"]);
             await h.TeardownAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -796,4 +796,76 @@ public class ChatTabViewSmokeTests {
             await Assert.That(host.View.GetVisualDescendants().OfType<TextBlock>().Any(t => t.Text == "Pick")).IsTrue();
         });
     }
+    static Button Option(Host host, string label) => host.View.GetVisualDescendants().OfType<Button>()
+        .Single(b => b.Classes.Contains("option") && b.DataContext is QuestionOptionViewModel { Label: var l } && l == label);
+    static List<Button> Steps(Host host) => host.View.GetVisualDescendants().OfType<Button>().Where(b => b.Classes.Contains("step")).ToList();
+    static bool Shows(Host host, string text) => host.View.GetVisualDescendants().OfType<TextBlock>().Any(t => t.Text == text && t.IsEffectivelyVisible);
+
+    /// The picked option must read as picked: its border and fill come from the selected class
+    /// style, which a local brush on the button would silently outrank. A multi-select question
+    /// is used so the click toggles in place rather than advancing or submitting.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_picked_option_paints_the_accent_border_and_a_second_click_clears_it() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            host.Permissions.Add(PermissionEntries.Question("q1",
+                toolInputJson: """{"questions":[{"question":"Tags","multiSelect":true,"options":[{"label":"X"},{"label":"Y"}]}]}"""));
+            host.Settle();
+            var accent = (IBrush)Application.Current!.FindResource("KcapSuccessBrush")!;
+            var option = Option(host, "X");
+            await Assert.That(option.BorderBrush).IsNotSameReferenceAs(accent);
+
+            Click(host, option);
+            await WaitUntilAsync(() => option.Classes.Contains("selected"), what: "the selected class");
+            host.Settle();
+            await Assert.That(option.BorderBrush).IsSameReferenceAs(accent);
+            await Assert.That(option.Background).IsSameReferenceAs((IBrush)Application.Current!.FindResource("KcapSuccessDimBrush")!);
+            await Assert.That(Option(host, "Y").BorderBrush).IsNotSameReferenceAs(accent);
+
+            Click(host, option);
+            await WaitUntilAsync(() => !option.Classes.Contains("selected"), what: "cleared");
+            host.Settle();
+            await Assert.That(option.BorderBrush).IsNotSameReferenceAs(accent);
+            await host.CloseAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_series_renders_one_question_with_step_chips_and_ends_on_a_review() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            host.Permissions.Add(PermissionEntries.Question("q1",
+                toolInputJson: """{"questions":[{"question":"Pick","header":"Choice","options":[{"label":"A"},{"label":"B"}]},{"question":"Tags","multiSelect":true,"options":[{"label":"X"},{"label":"Y"}]}]}"""));
+            host.Settle();
+            var card = (QuestionCardViewModel)host.Chat.PendingCards.Single();
+            await Assert.That(Shows(host, "Pick")).IsTrue();
+            await Assert.That(Shows(host, "Tags")).IsFalse();
+            var chips = Steps(host);
+            await Assert.That(chips.Select(c => ((QuestionStepViewModel)c.DataContext!).Title)).IsEquivalentTo(["Choice", "Question 2", "Review"], CollectionOrdering.Matching);
+            await Assert.That(chips[0].Classes.Contains("current")).IsTrue();
+            await Assert.That(host.View.GetVisualDescendants().OfType<Button>().Any(b => b.Content as string == "Submit" && b.IsEffectivelyVisible)).IsFalse();
+
+            Click(host, Option(host, "A"));
+            await WaitUntilAsync(() => card.CurrentIndex == 1, what: "advanced to the second question");
+            host.Settle();
+            await Assert.That(Shows(host, "Tags")).IsTrue();
+            await Assert.That(Shows(host, "Pick")).IsFalse();
+            chips = Steps(host);
+            await Assert.That(chips[0].Classes.Contains("answered")).IsTrue();
+            await Assert.That(chips[1].Classes.Contains("current")).IsTrue();
+
+            Click(host, chips[2]);
+            await WaitUntilAsync(() => card.IsOnReview, what: "the review step");
+            host.Settle();
+            await Assert.That(Shows(host, "Review your answers")).IsTrue();
+            await Assert.That(Shows(host, "A")).IsTrue();
+            await Assert.That(Shows(host, "Not answered")).IsTrue();
+            var submit = host.View.GetVisualDescendants().OfType<Button>().Single(b => b.Content as string == "Submit");
+            await Assert.That(submit.IsEffectivelyVisible).IsTrue();
+            await Assert.That(submit.IsEffectivelyEnabled).IsFalse();
+            await host.CloseAsync();
+        });
+    }
 }

--- a/test/Capacitor.App.Tests.Unit/FakePermissionService.cs
+++ b/test/Capacitor.App.Tests.Unit/FakePermissionService.cs
@@ -31,6 +31,7 @@ sealed class FakePermissionService : IPermissionService {
     readonly Queue<TaskCompletionSource<PermissionResolveOutcome>> _outcomes = new();
     public readonly List<(string RequestId, PermissionAnswer Answer)> Resolved = [];
     public readonly List<(string RequestId, IReadOnlyList<ElicitationAnswer> Answers)> Answered = [];
+    public readonly List<string> Withdrawn = [];
 
     public IObservable<IChangeSet<PendingPermissionRequest, string>> Pending => Cache.Connect();
     public IObservable<int> PendingCount => Cache.CountChanged;
@@ -64,6 +65,14 @@ sealed class FakePermissionService : IPermissionService {
         if (target.Questions is null) throw new ArgumentException("not an elicitation entry", nameof(target));
         Answered.Add((target.RequestId, answers));
         if (_outcomes.Count == 0) throw new InvalidOperationException("FakePermissionService: unscripted answer call");
+        var outcome = await _outcomes.Dequeue().Task;
+        if (outcome.Kind != PermissionResolveKind.TransportFailure) Cache.Remove(target.RequestId);
+        return outcome;
+    }
+
+    public async Task<PermissionResolveOutcome> WithdrawAsync(PendingPermissionRequest target, CancellationToken ct) {
+        Withdrawn.Add(target.RequestId);
+        if (_outcomes.Count == 0) throw new InvalidOperationException("FakePermissionService: unscripted withdraw call");
         var outcome = await _outcomes.Dequeue().Task;
         if (outcome.Kind != PermissionResolveKind.TransportFailure) Cache.Remove(target.RequestId);
         return outcome;

--- a/test/Capacitor.App.Tests.Unit/PermissionServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PermissionServiceTests.cs
@@ -201,6 +201,36 @@ public class PermissionServiceTests {
         await WaitUntilAsync(() => h.View.Count == 0, what: "push cleared the survivor");
     }
 
+    /// A withdraw carries no answer, and an older daemon that rejects the decision still gets the
+    /// entry concluded here: the tool already ran, so the card is stale whatever the ack says.
+    [Test]
+    public async Task Withdraw_sends_withdraw_with_no_payload_and_concludes_on_either_ack() {
+        using var h = new Harness();
+        await h.StartAsync();
+        var entry = await h.EmitAsync(Dto("r1"));
+
+        h.Ops.QueuePermissionResolve(true);
+        var applied = await h.Service.WithdrawAsync(entry, CancellationToken.None);
+        await Assert.That(applied.Kind).IsEqualTo(PermissionResolveKind.Applied);
+        var payload = h.Ops.PermissionResolvePayloads[0];
+        await Assert.That(payload.Decision).IsEqualTo("withdraw");
+        await Assert.That(payload.ApplyPermissions).IsNull();
+        await Assert.That(payload.UpdatedInput).IsNull();
+        await Assert.That(h.View.Count).IsEqualTo(0);
+
+        var second = await h.EmitAsync(Dto("r2"));
+        h.Ops.QueuePermissionResolve(false, "invalid resolve payload (decision must be allow|deny)");
+        var rejected = await h.Service.WithdrawAsync(second, CancellationToken.None);
+        await Assert.That(rejected.Kind).IsEqualTo(PermissionResolveKind.AlreadyDecided);
+        await Assert.That(h.View.Count).IsEqualTo(0);
+
+        var third = await h.EmitAsync(Dto("r3"));
+        h.Ops.QueuePermissionResolveFailure("daemon_unreachable");
+        var failed = await h.Service.WithdrawAsync(third, CancellationToken.None);
+        await Assert.That(failed.Kind).IsEqualTo(PermissionResolveKind.TransportFailure);
+        await Assert.That(h.View.Count).IsEqualTo(1);
+    }
+
     [Test]
     public async Task Answer_rejects_an_unclassified_target_and_a_bad_answer_set_without_sending() {
         using var h = new Harness();

--- a/test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/QuestionCardViewModelTests.cs
@@ -2,6 +2,7 @@ using System.Reactive.Linq;
 using System.Reactive.Threading.Tasks;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
+using TUnit.Assertions.Enums;
 using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
 namespace Capacitor.App.Tests.Unit;
@@ -9,7 +10,8 @@ namespace Capacitor.App.Tests.Unit;
 public class QuestionCardViewModelTests {
     const string SingleSelect = """{"questions":[{"question":"Pick","header":"Choice","options":[{"label":"A","description":"first"},{"label":"B"}]}]}""";
     const string FreeTextOnly = """{"questions":[{"question":"Say"}]}""";
-    const string MultiAndSingle = """{"questions":[{"question":"Pick","options":[{"label":"A"},{"label":"B"}]},{"question":"Tags","multiSelect":true,"options":[{"label":"X"},{"label":"Y"}]}]}""";
+    const string MultiAndSingle = """{"questions":[{"question":"Pick","header":"Choice","options":[{"label":"A"},{"label":"B"}]},{"question":"Tags","multiSelect":true,"options":[{"label":"X"},{"label":"Y"}]}]}""";
+    const string TwoFreeText = """{"questions":[{"question":"Say"},{"question":"More"}]}""";
 
     static (FakePermissionService Svc, QuestionCardViewModel Card) Make(string input, string requestId = "q1") {
         var svc = new FakePermissionService();
@@ -26,6 +28,8 @@ public class QuestionCardViewModelTests {
             using (svc) using (card) {
                 await Assert.That(card.IsFastPath).IsTrue();
                 await Assert.That(card.ShowsSubmit).IsFalse();
+                await Assert.That(card.ShowsSteps).IsFalse();
+                await Assert.That(card.Questions[0].ShowsHeader).IsTrue();
                 svc.Queue(PermissionResolveKind.Applied);
                 await card.Questions[0].Options[1].PickCommand.Execute().ToTask();
                 await Assert.That(svc.Answered[0].Answers[0].SelectedLabels).IsEquivalentTo(["B"]);
@@ -60,6 +64,7 @@ public class QuestionCardViewModelTests {
             using (svc) using (card) {
                 await Assert.That(card.IsFastPath).IsFalse();
                 await Assert.That(card.ShowsSubmit).IsTrue();
+                await Assert.That(card.ShowsSteps).IsFalse();
                 card.Questions[0].OtherText = "   ";
                 await Assert.That(card.Questions[0].IsAnswered).IsFalse();
                 await Assert.That(card.Questions[0].ShowsOtherAnswer).IsFalse();
@@ -70,24 +75,145 @@ public class QuestionCardViewModelTests {
         });
     }
 
+    /// A lone question that is not the fast path keeps its Submit inline: Enter on an answered
+    /// question submits, and there is no review step to walk to.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Submit_gates_on_every_question_and_sends_all_answers() {
+    public async Task A_lone_free_text_question_submits_on_enter() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(FreeTextOnly);
+            using (svc) using (card) {
+                await card.Questions[0].EnterCommand.Execute().ToTask();
+                await Assert.That(svc.Answered).IsEmpty();
+                card.Questions[0].OtherText = "hello";
+                svc.Queue(PermissionResolveKind.Applied);
+                await card.Questions[0].EnterCommand.Execute().ToTask();
+                await Assert.That(svc.Answered[0].Answers[0].OtherText).IsEqualTo("hello");
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_series_shows_one_question_at_a_time_and_a_single_select_pick_advances() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var (svc, card) = Make(MultiAndSingle);
             using (svc) using (card) {
-                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsFalse();
+                await Assert.That(card.ShowsSteps).IsTrue();
+                await Assert.That(card.Steps.Select(s => s.Title)).IsEquivalentTo(["Choice", "Question 2", "Review"], CollectionOrdering.Matching);
+                await Assert.That(card.Steps[2].IsReview).IsTrue();
+                await Assert.That(card.CurrentIndex).IsEqualTo(0);
+                await Assert.That(card.CurrentQuestion).IsSameReferenceAs(card.Questions[0]);
+                await Assert.That(card.Questions[0].ShowsHeader).IsFalse();
+                await Assert.That(card.Steps[0].IsCurrent).IsTrue();
+                await Assert.That(card.StepLabel).IsEqualTo("Question 1 of 2");
+                await Assert.That(card.NextLabel).IsEqualTo("Next");
+                await Assert.That(card.ShowsSubmit).IsFalse();
+                await Assert.That(await card.BackCommand.CanExecute.FirstAsync()).IsFalse();
+                await Assert.That(await card.NextCommand.CanExecute.FirstAsync()).IsFalse();
+
+                await card.Questions[0].Options[0].PickCommand.Execute().ToTask();
+                await Assert.That(card.CurrentIndex).IsEqualTo(1);
+                await Assert.That(card.CurrentQuestion).IsSameReferenceAs(card.Questions[1]);
+                await Assert.That(card.Steps[0].IsAnswered).IsTrue();
+                await Assert.That(card.Steps[0].IsCurrent).IsFalse();
+                await Assert.That(card.Steps[1].IsCurrent).IsTrue();
+                await Assert.That(card.StepLabel).IsEqualTo("Question 2 of 2");
+                await Assert.That(card.NextLabel).IsEqualTo("Review");
+                await Assert.That(await card.BackCommand.CanExecute.FirstAsync()).IsTrue();
+                await Assert.That(await card.NextCommand.CanExecute.FirstAsync()).IsFalse();
+
+                // A multi-select pick only toggles; Next opens up once it is answered.
+                await card.Questions[1].Options[0].PickCommand.Execute().ToTask();
+                await Assert.That(card.CurrentIndex).IsEqualTo(1);
+                await Assert.That(await card.NextCommand.CanExecute.FirstAsync()).IsTrue();
+                await card.Questions[1].Options[0].PickCommand.Execute().ToTask();
+                await Assert.That(card.Questions[1].IsAnswered).IsFalse();
+                await Assert.That(await card.NextCommand.CanExecute.FirstAsync()).IsFalse();
+
+                await card.BackCommand.Execute().ToTask();
+                await Assert.That(card.CurrentIndex).IsEqualTo(0);
+                await Assert.That(svc.Answered).IsEmpty();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_review_step_lists_every_answer_and_only_it_submits() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(MultiAndSingle);
+            using (svc) using (card) {
                 card.Questions[0].Options[0].IsSelected = true;
-                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsFalse();
                 card.Questions[1].Options[0].IsSelected = true;
                 card.Questions[1].Options[1].IsSelected = true;
+                card.Questions[1].OtherText = "and mine";
+                // Everything is answered, but the card is still on a question.
+                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsFalse();
+
+                await card.Steps[2].GoCommand.Execute().ToTask();
+                await Assert.That(card.IsOnReview).IsTrue();
+                await Assert.That(card.CurrentQuestion).IsNull();
+                await Assert.That(card.ShowsSubmit).IsTrue();
+                await Assert.That(card.ShowsNext).IsFalse();
+                await Assert.That(card.StepLabel).IsEqualTo("Review your answers");
+                await Assert.That(card.Questions[0].AnswerSummary).IsEqualTo("A");
+                await Assert.That(card.Questions[1].AnswerSummary).IsEqualTo("X, Y, and mine");
                 await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsTrue();
+
+                // Editing from the review returns to that question; Submit closes again.
+                await card.Questions[1].EditCommand.Execute().ToTask();
+                await Assert.That(card.CurrentIndex).IsEqualTo(1);
+                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsFalse();
+                await card.NextCommand.Execute().ToTask();
+                await Assert.That(card.IsOnReview).IsTrue();
 
                 svc.Queue(PermissionResolveKind.Applied);
                 await card.SubmitCommand.Execute().ToTask();
                 var answers = svc.Answered[0].Answers;
                 await Assert.That(answers[0].SelectedLabels).IsEquivalentTo(["A"]);
                 await Assert.That(answers[1].SelectedLabels).IsEquivalentTo(["X", "Y"]);
+                await Assert.That(answers[1].OtherText).IsEqualTo("and mine");
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task An_unanswered_question_leaves_the_review_unsubmittable_and_its_summary_empty() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(MultiAndSingle);
+            using (svc) using (card) {
+                card.Questions[0].Options[1].IsSelected = true;
+                await card.Steps[2].GoCommand.Execute().ToTask();
+                await Assert.That(card.IsOnReview).IsTrue();
+                await Assert.That(card.Questions[1].IsAnswered).IsFalse();
+                await Assert.That(card.Questions[1].AnswerSummary).IsEqualTo("");
+                await Assert.That(card.Steps[1].IsAnswered).IsFalse();
+                await Assert.That(await card.SubmitCommand.CanExecute.FirstAsync()).IsFalse();
+            }
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Enter_on_an_answered_question_advances_and_the_last_leads_to_the_review() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (svc, card) = Make(TwoFreeText);
+            using (svc) using (card) {
+                await card.Questions[0].EnterCommand.Execute().ToTask();
+                await Assert.That(card.CurrentIndex).IsEqualTo(0);
+                card.Questions[0].OtherText = "hi";
+                await card.Questions[0].EnterCommand.Execute().ToTask();
+                await Assert.That(card.CurrentIndex).IsEqualTo(1);
+                card.Questions[1].OtherText = "yo";
+                await card.Questions[1].EnterCommand.Execute().ToTask();
+                await Assert.That(card.IsOnReview).IsTrue();
+                await Assert.That(svc.Answered).IsEmpty();
+
+                svc.Queue(PermissionResolveKind.Applied);
+                await card.SubmitCommand.Execute().ToTask();
+                await Assert.That(svc.Answered[0].Answers.Select(a => a.OtherText ?? "")).IsEquivalentTo(["hi", "yo"], CollectionOrdering.Matching);
             }
         });
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/PermissionIpcTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/PermissionIpcTests.cs
@@ -83,8 +83,8 @@ public class PermissionIpcTests {
     [Test]
     [Arguments("""{"request_id":"r1","decision":"allow","apply_permissions":null,"updated_input":null}""", true, null)]
     [Arguments("""{"request_id":"nope","decision":"allow","apply_permissions":null,"updated_input":null}""", false, "no pending permission request with that id")]
-    [Arguments("""{"request_id":"r1","decision":"maybe","apply_permissions":null,"updated_input":null}""", false, "invalid resolve payload (decision must be allow|deny)")]
-    [Arguments("""{"decision":"allow"}""", false, "invalid resolve payload (decision must be allow|deny)")]
+    [Arguments("""{"request_id":"r1","decision":"maybe","apply_permissions":null,"updated_input":null}""", false, "invalid resolve payload (decision must be allow|deny|withdraw)")]
+    [Arguments("""{"decision":"allow"}""", false, "invalid resolve payload (decision must be allow|deny|withdraw)")]
     [Arguments("""{ not json""", false, "malformed resolve payload")]
     public async Task Resolve_acks(string payload, bool ok, string? error) {
         var broker = new PermissionPromptBroker();
@@ -103,6 +103,32 @@ public class PermissionIpcTests {
             await Assert.That(s.Source).IsEqualTo("app");
             await Assert.That(s.Decision.Behavior).IsEqualTo("allow");
         }
+    }
+
+    /// A withdraw is the app reporting the tool already ran (its result is in the transcript), so
+    /// the settlement is withdrawn under the tool_settled source and the hook is answered deny —
+    /// a decision nothing reads any more, never an allow that could apply to a later call.
+    [Test]
+    public async Task Resolve_withdraw_settles_as_withdrawn_by_tool_settled_and_pushes_resolved() {
+        var broker = new PermissionPromptBroker();
+        var settlement = broker.Register(Dto("r1"));
+        var (_, reader) = broker.Subscribe();
+        _ = await reader.ReadAsync(new CancellationTokenSource(5000).Token); // Pending
+        var ipc = new PermissionIpc(broker, NullLogger<PermissionIpc>.Instance);
+        var (server, client) = Duplex();
+
+        await ipc.HandleResolveAsync("""{"request_id":"r1","decision":"withdraw","apply_permissions":null,"updated_input":null}""", server, CancellationToken.None);
+        var reply = await FrameCodec.ReadAsync(client, CancellationToken.None);
+        var ack = JsonSerializer.Deserialize(reply!.Text, PermissionIpcJsonContext.Default.PermissionAckDto)!;
+        await Assert.That(ack.Ok).IsTrue();
+
+        var s = await settlement;
+        await Assert.That(s.Outcome).IsEqualTo("withdrawn");
+        await Assert.That(s.Source).IsEqualTo("tool_settled");
+        await Assert.That(s.Decision.Behavior).IsEqualTo("deny");
+        var resolved = ((PermissionStreamItem.Resolved)await reader.ReadAsync(new CancellationTokenSource(5000).Token)).Dto;
+        await Assert.That(resolved.Outcome).IsEqualTo("withdrawn");
+        await Assert.That(resolved.Source).IsEqualTo("tool_settled");
     }
 
     [Test]


### PR DESCRIPTION
Closes #769 — AI-2497

## What & why

The NEEDS YOU question card listed every question of a series at once, a pick showed no selected state, the text was small and dim, and a question answered in the terminal tab stayed on screen until the agent exited. The card walks a series one question at a time with step chips and a Review step that submits, option chrome lives in class styles so the selected state paints, and the Chat tab withdraws a pending request through a `withdraw` decision on the existing resolve frame once the transcript carries the tool's result — the only completion signal there is, since the plugin registers no `PostToolUse` hook.

## Where to look

The daemon answers a withdrawn hook with a deny, never an allow: the tool already ran, so an allow could only apply to a later call. An older daemon rejects `withdraw`, and the app concludes the entry locally on that ack, so the card still goes.

## Verification

- `Capacitor.App.Tests.Unit` full suite: 1337 passed, 0 failed.
- Daemon `Permission*` and `LocalPermissionBridge*` classes: 104 passed; Core `Permission*` classes: 17 passed.
- `dotnet build src/Capacitor.App --no-incremental`: 0 warnings. `dotnet publish src/Capacitor.Cli -c Release`: no IL2026/IL3050.
- Headless smoke tests click an option and assert its border is the accent resource, and walk a two-question series through to a disabled Submit on the Review step.
