### PR TITLE
Send all seven RespondToPermission arguments from the daemon relay

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1069,10 +1069,13 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
 
     /// The hub method the web UI answers through, invoked as the owner so the web card clears
     /// after a local settlement. Never throws; runs on the daemon-lifetime token.
+    /// SignalR binds a positional invocation by argument count, so all seven of the server
+    /// method's parameters are sent; the last two name an ACP option, which a hook decision
+    /// never carries.
     public virtual async Task<RespondOutcome> RespondToPermissionAsync(string sessionId, string serverRequestId, PermissionDecision decision) {
         try {
             await _hub.InvokeAsync("RespondToPermission", sessionId, serverRequestId, decision.Behavior,
-                decision.ApplyPermissions, decision.UpdatedInput, _ct);
+                decision.ApplyPermissions, decision.UpdatedInput, null, null, _ct);
             return new RespondOutcome(RespondOutcomeKind.Applied, null);
         } catch (Exception ex) {
             return ClassifyRespondFailure(ex);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj
@@ -17,6 +17,11 @@
         <PackageReference Include="Microsoft.Extensions.TimeProvider.Testing" />
     </ItemGroup>
     <ItemGroup>
+        <!-- Hosts a real SignalR hub for the wire tests: positional hub arity is checked by the
+             protocol layer, which a seam-overriding ServerConnection double never reaches. -->
+        <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    </ItemGroup>
+    <ItemGroup>
         <Using Include="Capacitor.Tests.Helpers" />
     </ItemGroup>
 </Project>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionRespondToPermissionWireTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionRespondToPermissionWireTests.cs
@@ -1,0 +1,86 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// Pins the daemon's local-decision relay against the server's positional
+/// <c>RespondToPermission</c> hub method over a real SignalR hub. The protocol layer matches a
+/// positional invocation by argument count before the hub body runs, so a
+/// <see cref="ServerConnection"/> double that overrides the invoke seam can never observe a
+/// mismatch — only a hub declaring the server's parameter list can.
+/// </summary>
+public class ServerConnectionRespondToPermissionWireTests {
+    static readonly TimeSpan HangGuard = TimeSpan.FromSeconds(15);
+
+    [TempConfigRoot] public required TempConfigRoot Config { get; init; }
+
+    sealed class Received {
+        public TaskCompletionSource<(string SessionId, string RequestId, string Behavior)> Call { get; } =
+            new(TaskCreationOptions.RunContinuationsAsynchronously);
+    }
+
+    /// <summary>
+    /// <c>CapacitorHub.RespondToPermission</c>'s parameter list, verbatim. The trailing defaults
+    /// exist for in-process C# callers only: over the wire all seven arguments must be sent.
+    /// </summary>
+    sealed class SessionsHub(Received received) : Hub {
+        public Task RespondToPermission(
+                string  sessionId,
+                string  requestId,
+                string  behavior,
+                object? applyPermissions    = null,
+                object? updatedInput        = null,
+                string? selectedOptionId    = null,
+                string? selectedOptionLabel = null
+            ) {
+            received.Call.TrySetResult((sessionId, requestId, behavior));
+
+            return Task.CompletedTask;
+        }
+    }
+
+    sealed class TestServerConnection(DaemonConfig config)
+        : ServerConnection(config, NullLoggerFactory.Instance, NullLogger<ServerConnection>.Instance);
+
+    [Test]
+    public async Task Relay_lands_on_a_hub_declaring_the_servers_parameter_list() {
+        var received = new Received();
+        var builder  = WebApplication.CreateSlimBuilder();
+        builder.Logging.ClearProviders();
+        builder.WebHost.UseUrls("http://127.0.0.1:0");
+        builder.Services.AddSingleton(received);
+        builder.Services.AddSignalR(o => o.EnableDetailedErrors = true);
+
+        await using var app = builder.Build();
+        app.MapHub<SessionsHub>("/hubs/sessions");
+        await app.StartAsync();
+
+        var config = new DaemonConfig {
+            Name       = "test",
+            ServerUrl  = app.Urls.Single(),
+            ConfigRoot = Config.Root,
+            Profiles   = Resolutions.None(Config.Root),
+        };
+        await using var conn = new TestServerConnection(config);
+        using var cts = new CancellationTokenSource(HangGuard);
+        await conn.StartHubAsync(cts.Token);
+
+        var outcome = await conn
+            .RespondToPermissionAsync("sess-1", "req-1", new PermissionDecision("allow", null, null))
+            .WaitAsync(HangGuard);
+
+        await Assert.That(outcome.Reason).IsNull();
+        await Assert.That(outcome.Kind).IsEqualTo(ServerConnection.RespondOutcomeKind.Applied);
+        var call = await received.Call.Task.WaitAsync(HangGuard);
+        await Assert.That(call).IsEqualTo(("sess-1", "req-1", "allow"));
+
+        await app.StopAsync(cts.Token);
+    }
+}


### PR DESCRIPTION
Closes #771 — AI-2498

## What & why

The daemon relays a permission decided in the desktop app to the server through the `RespondToPermission` hub method, which has seven positional parameters. The relay sent five, so SignalR rejected every call before the hub body ran: the agent proceeded on the local answer while the web UI kept the permission card and "needs attention". The daemon now sends all seven, with nulls for the ACP option pair a hook decision never carries. The server-side half, a record-based method plus a wire test pinning the positional arity, is AI-2496.

## Where to look

The new test hosts a real Kestrel SignalR hub declaring the server's parameter list. A `ServerConnection` double that overrides the invoke seam can never observe an argument-count mismatch, which is why the existing tests passed with the bug in place and why the daemon test project gains a `Microsoft.AspNetCore.App` framework reference.

## Verification

- Without the fix the new test fails with `InvalidDataException: Invocation provides 5 argument(s) but target expects 7.`, the rejection behind the production daemon log line `Relaying the local decision … failed: Failed to invoke 'RespondToPermission' due to an error on the server.`; with it, passes.
- Daemon unit suite, run twice: 2995 tests. `Installed_codex_schema_matches_the_vendored_pin` fails on a machine with Codex 0.153.0 against the 0.147.0 pin; `Local_socket_stopv2_with_force…` failed once under load and passes in isolation and on the re-run.
- `scripts/check-linear-ids.sh` exits 0; release AOT publish of the daemon reports zero IL2026/IL3050 warnings.
