### PR TITLE
Match the server's rules for declared structure and reviewer hosting

### DIFF
--- a/README.md
+++ b/README.md
@@ -657,9 +657,9 @@ It provides seven tools:
 
 - **`declare_work_item`** — attach the current session (and its continuation chain) to a work item. Pass exactly one of `issue_key` (e.g. `"AI-1234"`), `pr_number`, `work_item_id`, or `new_title` (creates a brand-new work item).
 - **`get_session_work_items`** — list the work items the current session is attached to.
-- **`declare_work_breakdown`** — declare that a work item is broken into parts (`parent_id` + `part_ids`). Idempotent; a part has at most one parent, and all items must live in the same repository.
+- **`declare_work_breakdown`** — declare that a work item is broken into parts (`parent_id` + `part_ids`). Idempotent; a part has at most one parent, and every item must be visible to the caller — a part may live in a different repository than its parent.
 - **`retract_work_breakdown`** — detach the named parts from the parent.
-- **`declare_work_relation`** — declare a dependency between two items (`from_id`, `to_id`, `relation_kind` `"blocks"` or `"blocked_by"`). Same repository, no self-relation.
+- **`declare_work_relation`** — declare a dependency between two items (`from_id`, `to_id`, `relation_kind` `"blocks"` or `"blocked_by"`). Both ends must be visible to the caller and may live in different repositories; no self-relation.
 - **`retract_work_relation`** — retract a previously declared dependency.
 - **`get_work_item_topology`** — read a work item's parent, parts, and dependencies (scoped to what the caller can see).
 

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,29 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## The reviewer lookup places a session running in a linked worktree
+
+`RepoPathStore` collapses a linked worktree to its main repository before storing it, and
+`GitRepository.FindRoot` stops at the worktree's own `.git` file — so comparing the session's root
+against the advertised paths answers `no_repo_hosting_daemon` for a repository the daemon does host,
+from every session inside `<repo>/.claude/worktrees/<slug>`. That the same session can
+`start_review_flow` is not a contradiction: the server matches daemons by repository identity, not by
+path.
+
+**Both shapes of advertised path match, because a daemon's `RepoPaths` carries two origins.** The
+store collapses what it persists; a configured `AllowedRepoPaths` entry is advertised as written, so
+an operator who allowlists a worktree root by hand has that root on the wire. The session's own root
+and its main repository are both compared, and either matching is enough — collapsing one side alone
+would trade the bug for its mirror image.
+
+**The collapse lives in the aggregation, which costs it its purity.** Resolving at the call site
+would leave the next caller free to compare a raw root again, and hashing the way the server does
+would put the server's identity algorithm on the client. It touches the filesystem, but a path that
+names nothing comes back unchanged, so a synthetic root still compares as itself.
+
+A submodule keeps its own identity through this: its `.git` points into `.git/modules`, which the
+resolver leaves alone, so a submodule checkout does not match a daemon hosting the superproject.
+
 ## The work-context pane reads the work item from one endpoint
 
 **AI-2521** fills the sidebar's SOON slots — the item's state, its overview, per-part completion,

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,15 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## Declared work structure is bounded by visibility, not by repository
+
+The server takes a breakdown or a relation whose other end lives in another repository — it bounds
+both by what the caller can see, and repository is display only. The `declare_work_breakdown` and
+`declare_work_relation` descriptions, the `kcap-workitems` preamble, the skill and the README state
+that boundary, because an agent reads them before it calls: a repository rule in that text costs
+declarations the server would have accepted, and the loss is silent — the structure is simply never
+declared.
+
 ## The reviewer lookup places a session running in a linked worktree
 
 `RepoPathStore` collapses a linked worktree to its main repository before storing it, and

--- a/kcap/skills/work-items/SKILL.md
+++ b/kcap/skills/work-items/SKILL.md
@@ -52,8 +52,9 @@ no breakdown.
 
 ## Rules the server enforces
 
-- **Same repository.** A parent and its parts, and both ends of a relation, must
-  live in the same repository. Cross-repo structure is rejected.
+- **Visibility, not repository.** Every item you name must be visible to you.
+  Repository is display only: a part may live in a different repository than its
+  parent, and a relation may cross repositories.
 - **One parent per part.** A part can belong to at most one parent breakdown.
 - **No self-relation.** An item cannot block or be blocked by itself.
 - **Idempotent declares.** Re-declaring an existing part or relation is fine.

--- a/src/Capacitor.Cli.Core/Resources/help-mcp.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-mcp.txt
@@ -117,11 +117,12 @@ mcp workitems:
                                 attached to.
       declare_work_breakdown   Declare that a work item is broken into parts
                                 (parent_id + part_ids); idempotent, one parent
-                                per part, all items in the same repository.
+                                per part, every item visible to the caller.
       retract_work_breakdown   Detach the named parts from the parent.
       declare_work_relation    Declare a dependency between two items (from_id,
                                 to_id, relation_kind 'blocks' or 'blocked_by');
-                                same repository, no self-relation.
+                                both ends visible to the caller, no
+                                self-relation.
       retract_work_relation    Retract a previously declared dependency.
       get_work_item_topology   Read a work item's parent, parts, and
                                 dependencies (scoped to what the caller sees).

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -140,8 +140,8 @@ sealed class McpWorkItemsServer(ConfigRoot config, ProfileContext profiles) {
         "(declare_work_breakdown); when one item must land before another, declare the dependency " +
         "(declare_work_relation — 'blocks'/'blocked_by'). Breakdown and relations are DECLARED, never " +
         "inferred: if you don't declare them the work item's topology stays empty. Declare only real " +
-        "structure you're confident of, keep every item in the same repository, and use the retract_* " +
-        "tools when it changes.";
+        "structure you're confident of — every item must be visible to you, but parts and dependencies " +
+        "may cross repositories — and use the retract_* tools when it changes.";
 
     static string BuildInitializeResponse(JsonNode id, JsonObject request) =>
         ToResponse<McpInitResult>(
@@ -492,7 +492,8 @@ sealed class McpWorkItemsServer(ConfigRoot config, ProfileContext profiles) {
         new("declare_work_breakdown",
             "Declare that a work item is broken down into parts (sub-items). Idempotent: re-declaring an "
           + "existing part is accepted and reported as existing rather than created. A part can have at "
-          + "most one parent, and all items must live in the same repository.",
+          + "most one parent, and every item must be visible to you — a part may live in a different "
+          + "repository than its parent, where repository is display only.",
             new("object", new() {
                 ["parent_id"] = new("string", "The work item being broken down."),
                 ["part_ids"]  = new("array", "Work item ids that are parts of the parent.", new("string", "A work item id."))
@@ -507,8 +508,8 @@ sealed class McpWorkItemsServer(ConfigRoot config, ProfileContext profiles) {
 
         new("declare_work_relation",
             "Declare a dependency between two work items: 'blocks' means from_id blocks to_id, "
-          + "'blocked_by' means from_id is blocked by to_id. Both items must live in the same repository, "
-          + "and an item cannot relate to itself.",
+          + "'blocked_by' means from_id is blocked by to_id. Both items must be visible to you and may "
+          + "live in different repositories; an item cannot relate to itself.",
             new("object", new() {
                 ["from_id"]       = new("string", "The work item the relation starts from."),
                 ["to_id"]         = new("string", "The work item on the other end of the relation."),

--- a/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
+++ b/src/Capacitor.Cli/Commands/ReviewerVendorLookup.cs
@@ -1,5 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
+using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.Commands;
 
@@ -36,7 +37,7 @@ public sealed record ReviewerVendorDiagnostics(
     [property: JsonPropertyName("supported_but_not_unattended")] string[] SupportedButNotUnattended,
     [property: JsonPropertyName("reason")]                       string? Reason);
 
-/// <summary>Pure repo-aware aggregation behind the <c>list_reviewer_vendors</c> MCP tool: given the
+/// <summary>Repo-aware aggregation behind the <c>list_reviewer_vendors</c> MCP tool: given the
 /// daemons the server reports and the current session's repo, returns the reviewer vendors that can
 /// ACTUALLY run an unattended review flow for this repo right now. All the failure modes are
 /// disambiguated by a single <c>reason</c> so an empty result never reads as one specific cause it is
@@ -55,6 +56,11 @@ public static class ReviewerVendorLookup {
 
     /// <param name="daemons">Parsed daemon records, or null when the lookup itself failed
     /// (transport/auth/API) — distinct from an empty list, which is "connected zero daemons".</param>
+    /// <param name="repoRoot">The session's local repo root. Matched both as given and collapsed to
+    /// its main repository, because a daemon's <c>RepoPaths</c> carries either shape: what
+    /// <see cref="Core.Config.RepoPathStore"/> persists is collapsed, while a configured
+    /// <c>AllowedRepoPaths</c> entry is advertised as written. Collapsing one side alone loses a
+    /// session in a linked worktree, or an operator who allowlisted that worktree by hand.</param>
     /// <param name="repoIdentity">A non-sensitive, stable id for the repo (e.g. owner/repo), surfaced
     /// as <c>repo.identity</c>. Never the local path.</param>
     /// <param name="schemaSkew">Set when the server response could not be parsed at all (client too
@@ -79,8 +85,10 @@ public static class ReviewerVendorLookup {
         if (daemons is null)
             return Empty(repo, driverVendor, 0, 0, skippedRecords, Reason.LookupFailed);
 
+        var mainRoot = GitRepository.ResolveMainRepoRoot(repoRoot!);
+
         var hosting = daemons
-            .Where(d => d.RepoPaths.Any(p => RepoPathMatches(p, repoRoot!)) &&
+            .Where(d => d.RepoPaths.Any(p => RepoPathMatches(p, repoRoot!) || RepoPathMatches(p, mainRoot)) &&
                         (requesterMachineId is null || d.MachineId == requesterMachineId))
             .ToList();
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpWorkItemsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpWorkItemsServerTests.cs
@@ -231,6 +231,22 @@ public class McpWorkItemsServerTests {
     }
 
     [Test]
+    public async Task Declared_structure_is_bounded_by_visibility_not_by_repository() {
+        // The server accepts a part or a relation whose other end lives in another repository; only
+        // visibility to the caller bounds it. Text claiming otherwise makes agents skip declarations
+        // the server would take, so the preamble and both declare tools must not restate a repository
+        // rule.
+        var byName = McpWorkItemsServer.BuildToolsList().ToDictionary(t => t.Name);
+
+        foreach (var name in (string[])["declare_work_breakdown", "declare_work_relation"]) {
+            await Assert.That(byName[name].Description).Contains("visible");
+            await Assert.That(byName[name].Description).DoesNotContain("same repository");
+        }
+
+        await Assert.That(McpWorkItemsServer.ServerInstructions).DoesNotContain("same repository");
+    }
+
+    [Test]
     public async Task Every_breakdown_tool_declares_its_ids_required() {
         // Unlike session_id, these ids have no ambient fallback — a schema that marked them optional
         // would invite a call with no id at all.

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorLookupTests.cs
@@ -143,6 +143,55 @@ public class ReviewerVendorLookupTests {
         await Assert.That(r.Diagnostics.Reason).IsNull();
     }
 
+    /// A daemon advertises the MAIN repository root (RepoPathStore collapses a linked worktree before
+    /// storing it), so a session running inside a linked worktree must collapse the same way or it
+    /// reads as no_repo_hosting_daemon for a repository the daemon does host.
+    [Test]
+    public async Task Linked_worktree_root_matches_a_daemon_advertising_the_main_repository() {
+        using var tmp = new TempDir();
+        var main = tmp.CreateDir("main");
+        tmp.CreateDir("main", ".git", "worktrees", "wt1");
+        var worktree = tmp.PathTo("main", ".capacitor", "worktrees", "agent-1");
+        tmp.CreateFile(["main", ".capacitor", "worktrees", "agent-1", ".git"], "gitdir: ../../../.git/worktrees/wt1\n");
+
+        var r = ReviewerVendorLookup.Aggregate([Daemon([main], "m1", ["codex"])], worktree, "m1", null);
+
+        await Assert.That(r.Diagnostics.RepoHostingDaemons).IsEqualTo(1);
+        await Assert.That(r.Diagnostics.Reason).IsNull();
+        await Assert.That(r.Reviewers.Single().Vendor).IsEqualTo("codex");
+    }
+
+    /// The other origin of a daemon's RepoPaths: an AllowedRepoPaths entry is advertised as the
+    /// operator wrote it, so an allowlisted worktree root reaches the wire uncollapsed and must still
+    /// match the session standing in it.
+    [Test]
+    public async Task Linked_worktree_root_matches_a_daemon_advertising_that_worktree_path() {
+        using var tmp = new TempDir();
+        tmp.CreateDir("main", ".git", "worktrees", "wt1");
+        var worktree = tmp.PathTo("main", ".capacitor", "worktrees", "agent-1");
+        tmp.CreateFile(["main", ".capacitor", "worktrees", "agent-1", ".git"], "gitdir: ../../../.git/worktrees/wt1\n");
+
+        var r = ReviewerVendorLookup.Aggregate([Daemon([worktree], "m1", ["codex"])], worktree, "m1", null);
+
+        await Assert.That(r.Diagnostics.RepoHostingDaemons).IsEqualTo(1);
+        await Assert.That(r.Diagnostics.Reason).IsNull();
+    }
+
+    /// The collapse must not merge two genuinely distinct repositories: a submodule's .git file points
+    /// into .git/modules, and a submodule is a repository of its own.
+    [Test]
+    public async Task Submodule_checkout_does_not_match_the_superproject_daemon_path() {
+        using var tmp = new TempDir();
+        var super = tmp.CreateDir("super");
+        tmp.CreateDir("super", ".git", "modules", "sub");
+        var sub = tmp.PathTo("super", "sub");
+        tmp.CreateFile(["super", "sub", ".git"], "gitdir: ../.git/modules/sub\n");
+
+        var r = ReviewerVendorLookup.Aggregate([Daemon([super], "m1", ["codex"])], sub, "m1", null);
+
+        await Assert.That(r.Diagnostics.Reason).IsEqualTo("no_repo_hosting_daemon");
+    }
+
     // --- ParseDaemons ---
 
     [Test]


### PR DESCRIPTION
Closes #764 — AI-2485

## What & why

Two places where the CLI states or assumes a rule the server does not have.

The `kcap-workitems` tool descriptions, its `instructions` preamble, the skill, the README and `kcap mcp --help` all claimed a parent and its parts — and both ends of a relation — must share a repository. The server bounds them by caller visibility; repository is display only. Agents read the description before they call, so the claim costs declarations the server would accept, silently.

`list_reviewer_vendors` compared the session's `GitRepository.FindRoot` result against the daemon's advertised `RepoPaths` as an exact string. `RepoPathStore` collapses a linked worktree to its main repository before persisting it, so from `<repo>/.claude/worktrees/<slug>` the two never match and the tool answers `reviewers: []` with `no_repo_hosting_daemon` for a repository the daemon does host.

## Where to look

`RepoPaths` carries two shapes, so the match takes both: the store collapses what it persists, while a configured `AllowedRepoPaths` entry is advertised as the operator wrote it (`MergeRepoPathsAsync` only trims separators and wildcards). Comparing the session's own root *and* its main repository keeps an allowlisted worktree matching while fixing the collapsed case — collapsing one side alone trades the bug for its mirror image. A submodule keeps its own identity: its `.git` points into `.git/modules`, which the resolver leaves alone.

The resolution sits inside `ReviewerVendorLookup.Aggregate` rather than at the `McpFlowsServer` call site, which costs the aggregation its purity. `repoRoot` is untouched everywhere else in `McpFlowsServer`, so `start_flow` / `start_review_flow` still send the worktree path the server matches by identity.

## Verification

`Linked_worktree_root_matches_a_daemon_advertising_the_main_repository` reproduces the bug before the fix (`RepoHostingDaemons` 0, expected 1); `..._advertising_that_worktree_path` guards the allowlist shape. `Capacitor.Cli.Tests.Unit`: `ReviewerVendorLookupTests` 25/25, `McpWorkItemsServerTests` 40/40. `dotnet build Capacitor.slnx` — 14 projects, 0 warnings; `dotnet publish -c Release` — no IL2026/IL3050.
