### PR TITLE
Keep the chat at the bottom when a NEEDS YOU card arrives or retires

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -523,7 +523,8 @@ text, system note) closes the run. **The fold is uniform** — a lone settled ca
 command" — and **folding never hides an error**: a failed call inside a folded group puts the danger
 `✕` on the summary line. The group binds ONE inner list whose source swaps on toggle, because a
 hidden `ItemsControl` keeps its containers; expanding a group realizes every row and folding releases
-them. Expanding holds follow-tail once, so the clicked summary stays in view. Summary wording keys on
+them. Expanding is the reader's own gesture, so follow-tail leaves the clicked summary in view until
+the reader returns to the bottom. Summary wording keys on
 the transcript's tool name (Codex's rollout says `shell`, its hook says `Bash`), with Codex shell
 commands classified by `CodexCommandClassifier`, ported verbatim from the server into Core so the
 server can delete its copy on the next submodule bump. A row waiting on a permission shows an accent

--- a/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
+++ b/docs/superpowers/specs/2026-08-26-ai2196-chat-for-pty-harnesses-design.md
@@ -317,18 +317,22 @@ the shape Avalonia virtualizes; an `ItemsControl` dropped inside an external
 `ScrollViewer` is measured at infinite height and realizes every item. Item
 templates are per item type (`DataTemplates` keyed on the three shapes).
 
-Follow-tail is a view concern that sticks to the bottom: on every
-`ScrollViewer.ScrollChanged` whose extent or viewport moved, the view decides
-*was at the bottom before this change* from the event's deltas and, if so,
-scrolls to the new end. It is not a once-per-append scroll because the
-virtualizing panel reports the extent as an estimate that a tall row corrects
-only once it is realized — a single scroll to the estimated end lands short,
-and the next append then reads "not at the bottom" and stops following;
-re-evaluating on each change converges instead. A reader scrolling up moves
-the offset down, in the same change or an earlier one, and a change whose
-offset delta is negative is never followed — only the panel's own anchoring
-moves the offset up while the extent grows — so a user who has scrolled up
-keeps their offset untouched until they return to the bottom. The hook is
+Follow-tail is a view concern that sticks to the bottom until the reader
+leaves it: on every `ScrollViewer.ScrollChanged` that lands above the bottom,
+the view scrolls to the new end unless a gesture of the reader's own — a
+pointer press or release, wheel, scroll gesture, key or scrollbar drag inside
+the list — landed in the same layout pass; a change that lands on the bottom
+re-arms following. It is not a once-per-append scroll because the virtualizing
+panel reports the extent as an estimate that a tall row corrects only once it
+is realized — a single scroll to the estimated end lands short; re-evaluating
+on each change converges instead. The decision cannot be read from the
+change's deltas: a realized row changing height (a tool row marked as awaiting
+permission, a group folding) makes the panel drop its anchor and re-place
+every row from the average realized size, after which the presenter clamps or
+anchor-shifts the offset by arbitrary amounts that look exactly like a reader
+scrolling up. Only input tells the two apart, so a reader who scrolled up
+keeps their offset untouched until they return to the bottom, and a layout
+that moves a following reader off the bottom is always corrected. The hook is
 attached when the list's template is applied, which for a surface built
 before its first layout is later than its first rows, so the initial load
 lands at the bottom through the same rule.

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Input;
 using Avalonia.Controls;
+using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
 using Avalonia.Threading;
@@ -8,26 +9,37 @@ using Capacitor.App.ViewModels;
 
 namespace Capacitor.App.Views;
 
-/// Follow-tail sticks to the bottom: on every extent or viewport change, a reader who was at the
-/// bottom before the change lands at the new bottom. The virtualizing panel reports the extent
-/// as an estimate that a tall row corrects only once it is realized, so following re-evaluates
-/// on each change rather than scrolling once per append. A reader scrolling up moves the offset
-/// down in the same change or an earlier one — either way the change is not followed, and only
-/// the panel's own adjustments move the offset up while growing the extent.
+/// Follow-tail sticks to the bottom until the reader leaves it: a scroll change that lands above
+/// the bottom is followed unless a gesture of the reader's own — pointer, wheel, key or scrollbar
+/// inside the list — landed in the same layout pass, and any change that lands on the bottom
+/// re-arms it.
+/// The decision cannot be read from the change's deltas: the virtualizing panel reports the extent
+/// as an estimate, and a realized row changing height makes it drop its anchor and re-place every
+/// row from the average size, after which the presenter clamps or anchor-shifts the offset by
+/// arbitrary amounts that look exactly like a reader scrolling up.
 public partial class ChatTabView : UserControl {
     const double BottomTolerance = 2;
 
     ScrollViewer? _scroll;
-    /// Armed by a click on a group's summary line and released once the dispatcher queue drains past layout, so neither the
-    /// expansion's own extent change nor an append already queued behind the click scrolls the clicked line out of view.
-    bool _holdTail;
+    bool _followTail = true;
+    /// Armed by a gesture inside the list and released once the dispatcher queue drains past
+    /// layout, so it covers exactly the scroll changes that gesture produced — an expansion click
+    /// or a wheel notch — and not the appends that land later.
+    bool _readerGesture;
 
     public ChatTabView() {
         InitializeComponent();
         // Tunnel, not bubble: TextBox's own class handler runs first on the bubbling route, where
         // it inserts the newline and marks Enter handled before any instance handler sees it.
         ComposerInput.AddHandler(KeyDownEvent, OnComposerKeyDown, RoutingStrategies.Tunnel);
-        ChatItems.AddHandler(Button.ClickEvent, OnItemButtonClick);
+        // Press and release both: a click's command runs on the release, in a later dispatcher turn
+        // than the press, by which time a flag armed on the press alone has been released.
+        ChatItems.AddHandler(PointerPressedEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
+        ChatItems.AddHandler(PointerReleasedEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
+        ChatItems.AddHandler(PointerWheelChangedEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
+        ChatItems.AddHandler(ScrollGestureEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
+        ChatItems.AddHandler(KeyDownEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
+        ChatItems.AddHandler(Thumb.DragDeltaEvent, OnReaderGesture, RoutingStrategies.Bubble, handledEventsToo: true);
         // The ScrollViewer is the list template's; it exists only once the list is first measured,
         // which for a surface built before its first layout is later than the first rows.
         ChatItems.TemplateApplied += (_, _) => {
@@ -37,21 +49,17 @@ public partial class ChatTabView : UserControl {
         };
     }
 
-    void OnItemButtonClick(object? sender, RoutedEventArgs e) {
-        if (e.Source is not Button button || !button.Classes.Contains("toolSummary")) return;
-        var wasHeld = _holdTail;
-        _holdTail = true;
-        if (!wasHeld) Dispatcher.UIThread.Post(() => _holdTail = false, DispatcherPriority.Background);
+    void OnReaderGesture(object? sender, RoutedEventArgs e) {
+        if (_readerGesture) return;
+        _readerGesture = true;
+        Dispatcher.UIThread.Post(() => _readerGesture = false, DispatcherPriority.Background);
     }
 
     void OnScrollChanged(object? sender, ScrollChangedEventArgs e) {
-        if (sender is not ScrollViewer scroll || (e.ExtentDelta.Y == 0 && e.ViewportDelta.Y == 0)) return;
-        if (_holdTail) return;
-        var offsetBefore   = scroll.Offset.Y - e.OffsetDelta.Y;
-        var viewportBefore = scroll.Viewport.Height - e.ViewportDelta.Y;
-        var extentBefore   = scroll.Extent.Height - e.ExtentDelta.Y;
-        var stayed = e.OffsetDelta.Y >= 0;
-        if (stayed && offsetBefore + viewportBefore >= extentBefore - BottomTolerance) scroll.ScrollToEnd();
+        if (sender is not ScrollViewer scroll) return;
+        var atBottom = scroll.Offset.Y + scroll.Viewport.Height >= scroll.Extent.Height - BottomTolerance;
+        _followTail = _readerGesture ? atBottom : _followTail || atBottom;
+        if (_followTail && !atBottom) scroll.ScrollToEnd();
     }
 
     /// A bare Enter is always consumed — it sends when the composer can send, and otherwise does

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -37,8 +37,9 @@ public partial class ChatTabView : UserControl {
         ChatItems.AddHandler(PointerPressedEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
         ChatItems.AddHandler(PointerReleasedEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
         ChatItems.AddHandler(PointerWheelChangedEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
-        ChatItems.AddHandler(ScrollGestureEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
         ChatItems.AddHandler(KeyDownEvent, OnReaderGesture, RoutingStrategies.Tunnel, handledEventsToo: true);
+        // Bubble-only events: a tunnel registration for these never fires.
+        ChatItems.AddHandler(ScrollGestureEvent, OnReaderGesture, RoutingStrategies.Bubble, handledEventsToo: true);
         ChatItems.AddHandler(Thumb.DragDeltaEvent, OnReaderGesture, RoutingStrategies.Bubble, handledEventsToo: true);
         // The ScrollViewer is the list template's; it exists only once the list is first measured,
         // which for a surface built before its first layout is later than the first rows.

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -882,6 +882,31 @@ public class ChatTabViewSmokeTests {
         });
     }
 
+    /// A touch pan reaches the list as a scroll gesture, which routes on the bubbling strategy only;
+    /// it must count as the reader's gesture like a wheel notch does, or every pan up is undone.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_scroll_gesture_up_leaves_the_reader_where_they_panned() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var path = Tmp.CreateFile("pan.jsonl", Enumerable.Repeat(UserLine, 60).ToArray());
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            var items = host.View.FindControl<ItemsControl>("ChatItems")!;
+            var row = items.GetRealizedContainers().First();
+            row.RaiseEvent(new ScrollGestureEventArgs(ScrollGestureEventArgs.GetNextFreeId(), new Vector(0, -300)) { RoutedEvent = InputElement.ScrollGestureEvent });
+            host.Settle();
+            var panned = host.Scroll.Offset.Y;
+            await Assert.That(host.AtBottom()).IsFalse();
+
+            await host.AppendAndTickAsync(path, 20);
+            host.Settle();
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(panned);
+            await host.CloseAsync();
+        });
+    }
+
     /// Pins the reader at the bottom across a question card's life. Marking the awaiting row
     /// changes its height, which makes the virtualizing panel drop its anchor and re-place every
     /// row from the average realized size; with tall prose above short rows that estimate is far

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -72,6 +72,15 @@ public class ChatTabViewSmokeTests {
         host.Settle();
     }
 
+    /// A wheel gesture over the list, big enough to reach the top. The reader's own scrolling has to
+    /// arrive as input: follow-tail tells the reader apart from layout by the gesture, so a bare
+    /// Offset assignment reads as the panel's doing and is followed.
+    static void WheelUp(Host host) {
+        var list = host.View.FindControl<ItemsControl>("ChatItems")!;
+        var center = list.TranslatePoint(new Point(list.Bounds.Width / 2, list.Bounds.Height / 2), host.Window)!.Value;
+        host.Window.MouseWheel(center, new Vector(0, 100_000));
+    }
+
     sealed class Host {
         bool _shown;
 
@@ -189,8 +198,9 @@ public class ChatTabViewSmokeTests {
         });
     }
 
-    /// Pins follow-tail's whole contract: it tracks the bottom, leaves a scrolled-up reader where
-    /// they are, and abandons a scroll it had already decided on if the reader moves first.
+    /// Pins follow-tail's whole contract: it tracks the bottom, leaves a reader who scrolled up
+    /// where they are, and does not follow an append that lands in the same layout pass as the
+    /// reader's scroll.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Follow_tail_tracks_the_bottom_and_leaves_a_scrolled_up_reader_alone() {
@@ -206,21 +216,21 @@ public class ChatTabViewSmokeTests {
             Dispatcher.UIThread.RunJobs();
             await Assert.That(host.AtBottom()).IsTrue();
 
-            host.Scroll.Offset = new Vector(0, 0);
-            host.Window.UpdateLayout();
+            WheelUp(host);
+            host.Settle();
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
             await host.AppendAndTickAsync(path, 20);
             Dispatcher.UIThread.RunJobs();
             host.Window.UpdateLayout();
             Dispatcher.UIThread.RunJobs();
             await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
 
-            // At the bottom, append, then scroll up before the layout pass completes. The view
-            // subscribes first, so this handler runs after it has decided to follow and captured
-            // the offset — the one ordering that reaches the abandon path.
+            // At the bottom, append, then wheel up before the layout pass runs: the one change
+            // carries both, and the reader's gesture wins.
             host.Scroll.ScrollToEnd();
             host.Window.UpdateLayout();
             await Assert.That(host.AtBottom()).IsTrue();
-            void ScrollUp(object? sender, NotifyCollectionChangedEventArgs e) => host.Scroll.Offset = new Vector(0, 0);
+            void ScrollUp(object? sender, NotifyCollectionChangedEventArgs e) => WheelUp(host);
             ((INotifyCollectionChanged)host.Chat.Items).CollectionChanged += ScrollUp;
             await host.AppendAndTickAsync(path, 20);
             ((INotifyCollectionChanged)host.Chat.Items).CollectionChanged -= ScrollUp;
@@ -604,19 +614,21 @@ public class ChatTabViewSmokeTests {
             await host.AppendLinesAndTickAsync(path, ResultLine(1));
             await Assert.That(host.AtBottom()).IsTrue();
 
-            host.Scroll.Offset = new Vector(0, 0);
-            host.Window.UpdateLayout();
+            WheelUp(host);
+            host.Settle();
+            await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
             await host.AppendLinesAndTickAsync(path, CallLine(4), ResultLine(2));
             await Assert.That(host.Scroll.Offset.Y).IsEqualTo(0);
             await host.CloseAsync();
         });
     }
 
-    /// Expanding keeps the viewport: the hold is one-shot, so a reader who returns to the bottom is
-    /// followed again on the next append.
+    /// Expanding keeps the viewport: the click is the reader's gesture and it lands above the
+    /// bottom, so following stops until the reader returns to the bottom, when the next append
+    /// follows again.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Expanding_the_trailing_group_keeps_the_offset_and_the_hold_is_one_shot() {
+    public async Task Expanding_the_trailing_group_keeps_the_offset_and_returning_to_the_bottom_resumes_following() {
         await RunOnUiAsync(async () => {
             var host = new Host();
             var lines = new List<string>(Enumerable.Repeat(UserLine, 60));
@@ -644,11 +656,12 @@ public class ChatTabViewSmokeTests {
         });
     }
 
-    /// An append that lands in the same dispatcher turn as the click is held with the expansion:
-    /// the reader stays put, and only a later append, after they return to the bottom, follows.
+    /// An append that lands in the same dispatcher turn as the click shares its layout pass, so it
+    /// is the reader's change too: the reader stays put, and only a later append, after they return
+    /// to the bottom, follows.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task An_append_queued_behind_the_expansion_click_does_not_steal_the_hold() {
+    public async Task An_append_queued_behind_the_expansion_click_does_not_move_the_reader() {
         await RunOnUiAsync(async () => {
             var host = new Host();
             var lines = new List<string>(Enumerable.Repeat(UserLine, 60));
@@ -865,6 +878,45 @@ public class ChatTabViewSmokeTests {
             var submit = host.View.GetVisualDescendants().OfType<Button>().Single(b => b.Content as string == "Submit");
             await Assert.That(submit.IsEffectivelyVisible).IsTrue();
             await Assert.That(submit.IsEffectivelyEnabled).IsFalse();
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins the reader at the bottom across a question card's life. Marking the awaiting row
+    /// changes its height, which makes the virtualizing panel drop its anchor and re-place every
+    /// row from the average realized size; with tall prose above short rows that estimate is far
+    /// off, so the extent collapses and the presenter clamps and anchor-shifts the offset. Neither
+    /// move is the reader's, so the view must keep following through both the card's arrival and
+    /// its retirement. The prose rows genuinely have to be tall — with uniform rows the estimate is
+    /// exact and this test proves nothing.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_question_card_arriving_and_retiring_keeps_the_reader_at_the_bottom() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            var prose = string.Join("\\n\\n", Enumerable.Range(1, 60).Select(i => $"Paragraph {i} of a long reply that wraps across the column."));
+            var tall = "{\"type\":\"assistant\",\"message\":{\"content\":[{\"type\":\"text\",\"text\":\"" + prose + "\"}]}}";
+            const string question = """{"questions":[{"question":"Pick","options":[{"label":"A"},{"label":"B"}]}]}""";
+            var ask = $$$"""{"type":"assistant","message":{"content":[{"type":"tool_use","id":"q-tool","name":"AskUserQuestion","input":{{{question}}}}]}}""";
+            var path = Tmp.CreateFile("card.jsonl", [tall, tall, tall, .. Enumerable.Repeat(UserLine, 20), ask]);
+            await host.LoadAsync(path);
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            host.Permissions.Add(PermissionEntries.Entry("q1", "a1", "claude", ClaudeElicitation.ToolName, question, toolUseId: "q-tool"));
+            await WaitUntilAsync(() => host.Chat.PendingCards.Count == 1, what: "the card");
+            host.Settle();
+            await Assert.That(host.AtBottom()).IsTrue();
+
+            host.Permissions.Queue(PermissionResolveKind.Applied);
+            var option = host.View.GetVisualDescendants().OfType<Button>().First(b => b.Classes.Contains("option"));
+            // Headless pointer events do not focus, so the focus a real click gives the button is applied by hand.
+            option.Focus(NavigationMethod.Pointer);
+            Click(host, option);
+            await WaitUntilAsync(() => host.Chat.PendingCards.Count == 0, what: "the card retired");
+            host.Settle();
+            host.Settle();
+
+            await Assert.That(host.AtBottom()).IsTrue();
             await host.CloseAsync();
         });
     }


### PR DESCRIPTION
Closes #788 — AI-2532

## What & why

Answering a card in the desktop app scrolled the chat to its beginning. Marking the awaiting tool row changes its height, which makes Avalonia's virtualizing panel drop its anchor and re-place every row from the average realized height; with tall prose above short rows the estimate is far off, the extent collapses, and retiring the card grows the viewport and clamps the offset down by the same amount. Follow-tail read that offset drop as the reader scrolling up and stopped correcting. It now keys on the reader's input: a change landing above the bottom is followed unless a pointer, wheel, key or scrollbar gesture inside the list landed in the same layout pass, and a change landing on the bottom re-arms it. The expansion hold is a case of the same rule. The same re-anchoring still moves a reader who has scrolled up; that is #789 (AI-2533).

## Where to look

A click's command runs on the pointer release, a dispatcher turn after the press, so both events arm the gesture flag; arming on the press alone let the expansion click scroll the summary away.

## Verification

Headless repro against a real 13-row session cut after its AskUserQuestion call: on the old code the list landed on rows 0..3 at offset 390 with extent 3801 once the card retired, and stayed there; with the fix it converges on the last rows (offset 1871, extent 2651) and the appended transcript keeps it there. The new test fails on the old code at the card's arrival and passes now; ChatTabViewSmokeTests 29/29, Capacitor.App.Tests.Unit 1415/1415.

🤖 Generated with [Claude Code](https://claude.com/claude-code)