### PR TITLE
Carry a vendor-neutral tool kind on daemon tool-call envelopes

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -847,3 +847,25 @@ narrower than before: several text blocks in one Claude user record are one bubb
 tool results is not shown; the envelope carries no model; a user record opening with an
 available-deferred-tools injection is dropped, as the server drops it; and a meta record's tool
 results settle their tool rows instead of vanishing with the record.
+
+## A vendor-neutral tool kind on canonical tool-call events
+
+**#746** puts an `AcpToolKind` beside `ToolName` on `AcpEventEnvelope`, so a consumer that wants to
+know what a tool call *did* reads one closed vocabulary — the ten ACP `ToolKind` tokens — instead of
+keeping a per-vendor name table. `ToolName` stays raw vendor fidelity: the server's Codex handling
+pairs `exec_command` with `write_stdin` and reaches into `apply_patch` results by that name, so the
+name is not ours to normalise. The field is nullable and additive; `ContractVersion` stays 1.
+
+**A null kind means no lane classified the call, never "none of the above."** `AcpToolKind.Normalize`
+is what keeps the set closed — an agent-supplied token outside the vocabulary becomes `other` rather
+than reaching a consumer that switches on it — while an absent one stays absent. That leaves null free
+to say something else: the lanes that carry no kind yet.
+
+**A codex shell call is classified by its command, because it has no name of its own for a read or a
+search** — `sed -n`, `cat` and `rg` all arrive as one tool. An unclassifiable command is `execute`: a
+shell call did run something.
+
+**A hosted web search surfaces as a paired call and result.** It has no `item/started` row, so the
+completed item carries both halves, the same rule `fileChange` follows — an orphan tool call renders
+as running forever, since a result is what settles one. It is `fetch`, the kind a web tool gets
+wherever it appears, so the hosted lane and a later import of the same session cannot disagree.

--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -1322,6 +1322,33 @@ public static class AcpEventKind {
 }
 
 /// <summary>
+/// The vendor-neutral vocabulary for <see cref="AcpEventEnvelope.ToolKind"/> — the ACP
+/// <c>ToolKind</c> tokens, which ACP vendors already put on the wire and the other vendors' lanes map
+/// their raw tool names onto. Closed set: a consumer may switch on these ten and need no per-vendor
+/// name table.
+/// </summary>
+public static class AcpToolKind {
+    public const string Read       = "read";
+    public const string Edit       = "edit";
+    public const string Delete     = "delete";
+    public const string Move       = "move";
+    public const string Search     = "search";
+    public const string Execute    = "execute";
+    public const string Think      = "think";
+    public const string Fetch      = "fetch";
+    public const string SwitchMode = "switch_mode";
+    public const string Other      = "other";
+
+    /// <summary>Maps an agent-supplied kind onto the closed set: a recognised token passes through,
+    /// anything else present becomes <see cref="Other"/>, and an absent one stays null. Null is what
+    /// tells a consumer no lane classified this call — never that the call was none-of-the-above.</summary>
+    public static string? Normalize(string? kind) =>
+        string.IsNullOrWhiteSpace(kind)                                                                        ? null
+        : kind is Read or Edit or Delete or Move or Search or Execute or Think or Fetch or SwitchMode or Other ? kind
+        : Other;
+}
+
+/// <summary>
 /// One canonical-equivalent event the daemon sends over the server's <c>AcpSessionEvents</c> hub
 /// method. Daemon-local, field-for-field mirror of the server-side
 /// <c>Capacitor.Server.Core.Acp.AcpEventEnvelope</c> record (same property names/types/defaults,
@@ -1353,6 +1380,12 @@ public readonly record struct AcpEventEnvelope(
         string? ToolCallId        = null,
         string? ToolName          = null,
         string? ToolInputJson     = null, // JSON object string
+
+        // The vendor-neutral counterpart of ToolName: one of AcpToolKind's tokens, or null when the
+        // producing lane classifies nothing. ToolName stays raw vendor fidelity — a consumer that
+        // needs to know what a call DID reads this instead of keeping its own name table. Additive
+        // and nullable, so ContractVersion stays 1.
+        string? ToolKind          = null,
 
         // tool_result
         string? ToolResult        = null,

--- a/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpEventTranslator.cs
@@ -38,7 +38,10 @@ internal static partial class AcpEventTranslator {
     /// (as <see cref="AcpEventEnvelope.ToolName"/> — ACP's <c>tool_call</c> has no separate machine
     /// "name" field, only <c>title</c>/<c>kind</c>; <c>title</c> is the closest analogue and is what
     /// the server's <c>AssistantToolCallsGenerated.ToolCallInfo.ToolName</c> expects to
-    /// display)/<see cref="AcpSessionUpdate.ToolInputJson"/>.</description></item>
+    /// display)/<see cref="AcpSessionUpdate.ToolInputJson"/>, plus the update's own <c>kind</c>
+    /// normalized onto <see cref="AcpToolKind"/>'s closed set — the agent supplies it, so an
+    /// unrecognised token becomes <c>other</c> rather than reaching a consumer that switches on
+    /// the vocabulary.</description></item>
     /// <item><description><see cref="AcpUpdateKind.ToolCallUpdate"/> → <see cref="AcpEventKind.ToolResult"/>
     /// ONLY when the status is terminal (<see cref="IsTerminalToolStatus"/>) AND
     /// <see cref="AcpSessionUpdate.ToolResultText"/> is non-null — a status-only update (non-terminal,
@@ -90,6 +93,7 @@ internal static partial class AcpEventTranslator {
                     ToolCallId: update.ToolCallId,
                     ToolName: update.ToolTitle,
                     ToolInputJson: update.ToolInputJson,
+                    ToolKind: AcpToolKind.Normalize(update.ToolKind),
                     TimestampIso: timestampIso);
 
             case AcpUpdateKind.ToolCallUpdate:

--- a/src/Capacitor.Cli.Daemon/Acp/AcpPermissionPresets.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpPermissionPresets.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.Daemon.Acp;
 
@@ -19,10 +20,13 @@ internal static class AcpPermissionPresets {
     internal const string Edit    = "edit";
 
     static readonly AcpLaunchPermissionPreset ExplorePreset = new(
-        Explore, new HashSet<string>(StringComparer.Ordinal) { "read", "search" });
+        Explore, new HashSet<string>(StringComparer.Ordinal) { AcpToolKind.Read, AcpToolKind.Search });
 
     static readonly AcpLaunchPermissionPreset EditPreset = new(
-        Edit, new HashSet<string>(StringComparer.Ordinal) { "read", "search", "edit", "move", "delete" });
+        Edit,
+        new HashSet<string>(StringComparer.Ordinal) {
+            AcpToolKind.Read, AcpToolKind.Search, AcpToolKind.Edit, AcpToolKind.Move, AcpToolKind.Delete
+        });
 
     /// <summary>Resolves a wire token to its preset; false (and null out) for null/blank/unknown.</summary>
     internal static bool TryResolve(string? token, [NotNullWhen(true)] out AcpLaunchPermissionPreset? preset) {

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core;
+using Capacitor.Models.Transcripts.Harness.Codex;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Harness.Codex;
@@ -131,10 +132,23 @@ internal sealed partial class CodexNotificationMapper {
                 return Two(
                     new AcpEventEnvelope(
                         Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: "apply_patch",
-                        ToolInputJson: RenderChanges(item.Arr("changes")), ItemId: id, TimestampIso: ts),
+                        ToolInputJson: RenderChanges(item.Arr("changes")), ToolKind: AcpToolKind.Edit,
+                        ItemId: id, TimestampIso: ts),
                     new AcpEventEnvelope(
                         Kind: AcpEventKind.ToolResult, ToolCallId: id, ToolResult: item.Str("status") ?? "",
                         ToolIsError: item.Str("status") is "failed" or "declined", ItemId: id, TimestampIso: ts));
+
+            case "webSearch":
+                // Like fileChange, no item/started row — so the completed item carries both halves and a
+                // consumer never sees an orphan call. Every action of the one web tool is a fetch.
+                return Two(
+                    new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: "web_search",
+                        ToolInputJson: RenderWebSearchOpen(item), ToolKind: AcpToolKind.Fetch,
+                        ItemId: id, TimestampIso: ts),
+                    new AcpEventEnvelope(
+                        Kind: AcpEventKind.ToolResult, ToolCallId: id, ToolResult: Content(item, "results") ?? "",
+                        ItemId: id, TimestampIso: ts));
 
             case "mcpToolCall":
                 return One(new AcpEventEnvelope(
@@ -158,12 +172,14 @@ internal sealed partial class CodexNotificationMapper {
             case "commandExecution":
                 return One(new AcpEventEnvelope(
                     Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: "shell",
-                    ToolInputJson: RenderCommandOpen(item), ItemId: id, TimestampIso: ts));
+                    ToolInputJson: RenderCommandOpen(item), ToolKind: ShellKind(item.Str("command")),
+                    ItemId: id, TimestampIso: ts));
 
             case "mcpToolCall":
                 return One(new AcpEventEnvelope(
                     Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: McpToolName(item),
-                    ToolInputJson: McpArguments(item), ItemId: id, TimestampIso: ts));
+                    ToolInputJson: McpArguments(item), ToolKind: AcpToolKind.Other,
+                    ItemId: id, TimestampIso: ts));
 
             // Text/reasoning/plan/userMessage/fileChange have no separate "open" row — their content
             // arrives via deltas + the completed snapshot. An unknown type is counted once at completion,
@@ -223,7 +239,8 @@ internal sealed partial class CodexNotificationMapper {
         // the completed item's canonical envelopes are authoritative either way).
         return One(new AcpEventEnvelope(
             Kind: AcpEventKind.ToolCall, ToolCallId: itemId, ToolName: "apply_patch",
-            ToolInputJson: RenderChanges(changes), Ephemeral: true, ItemId: itemId));
+            ToolInputJson: RenderChanges(changes), ToolKind: AcpToolKind.Edit,
+            Ephemeral: true, ItemId: itemId));
     }
 
     IReadOnlyList<AcpEventEnvelope> Unmapped(string? type, string? id, JsonElement item, string? ts) {
@@ -235,8 +252,18 @@ internal sealed partial class CodexNotificationMapper {
         // item is a JSON object, so it rides as the tool's arguments for a viewer to inspect.
         return One(new AcpEventEnvelope(
             Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: type ?? "unknown",
-            ToolInputJson: item.GetRawText(), ItemId: id, TimestampIso: ts));
+            ToolInputJson: item.GetRawText(), ToolKind: AcpToolKind.Other,
+            ItemId: id, TimestampIso: ts));
     }
+
+    /// A codex shell call has no name of its own for a read or a search — `sed -n`, `cat` and `rg` all
+    /// arrive as the same tool — so the command itself decides. An unclassifiable command is
+    /// `execute`: a shell call did run something.
+    static string ShellKind(string? command) => CodexCommandClassifier.Classify(command)?.Type switch {
+        "read"                   => AcpToolKind.Read,
+        "search" or "list_files" => AcpToolKind.Search,
+        _                        => AcpToolKind.Execute,
+    };
 
     // ── Rendering helpers (pure) ──────────────────────────────────────────────────────────────────
     static IReadOnlyList<AcpEventEnvelope> One(AcpEventEnvelope e) => [e];
@@ -314,6 +341,22 @@ internal sealed partial class CodexNotificationMapper {
             w.WriteStartObject();
             WriteNullable(w, "command", item.Str("command"));
             WriteNullable(w, "cwd", item.Str("cwd"));
+            w.WriteEndObject();
+        }
+        return Encoding.UTF8.GetString(buffer.ToArray());
+    }
+
+    // The query is the item's own required field; the action (search / openPage / find-in-page) rides
+    // along verbatim, since its variants carry the url or pattern the query alone does not show.
+    static string RenderWebSearchOpen(JsonElement item) {
+        using var buffer = new MemoryStream();
+        using (var w = new Utf8JsonWriter(buffer)) {
+            w.WriteStartObject();
+            WriteNullable(w, "query", item.Str("query"));
+            if (item.Obj("action") is { } action) {
+                w.WritePropertyName("action");
+                action.WriteTo(w);
+            }
             w.WriteEndObject();
         }
         return Encoding.UTF8.GetString(buffer.ToArray());

--- a/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/AcpEventEnvelopeWireCompatTests.cs
@@ -29,6 +29,7 @@ public class AcpEventEnvelopeWireCompatTests {
             ToolCallId:        "call-1",
             ToolName:          "bash",
             ToolInputJson:     """{"command":"ls"}""",
+            ToolKind:          AcpToolKind.Execute,
             ToolResult:        "ok",
             ToolIsError:       true,
             Model:             "claude-opus-4-8",
@@ -54,6 +55,7 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(json).Contains(@"""tool_call_id"":""call-1""");
         await Assert.That(json).Contains(@"""tool_name"":""bash""");
         await Assert.That(json).Contains(@"""tool_input_json""");
+        await Assert.That(json).Contains(@"""tool_kind"":""execute""");
         await Assert.That(json).Contains(@"""tool_result"":""ok""");
         await Assert.That(json).Contains(@"""tool_is_error"":true");
         await Assert.That(json).Contains(@"""model"":""claude-opus-4-8""");
@@ -76,6 +78,35 @@ public class AcpEventEnvelopeWireCompatTests {
         await Assert.That(back.ContextWindowTokens).IsEqualTo(200_000L);
         await Assert.That(back.Ephemeral).IsTrue();
         await Assert.That(back.ItemId).IsEqualTo("item-42");
+        await Assert.That(back.ToolKind).IsEqualTo(AcpToolKind.Execute);
+    }
+
+    [Test]
+    public async Task AcpToolKind_constants_match_the_ACP_tool_kind_vocabulary() {
+        await Assert.That(AcpToolKind.Read).IsEqualTo("read");
+        await Assert.That(AcpToolKind.Edit).IsEqualTo("edit");
+        await Assert.That(AcpToolKind.Delete).IsEqualTo("delete");
+        await Assert.That(AcpToolKind.Move).IsEqualTo("move");
+        await Assert.That(AcpToolKind.Search).IsEqualTo("search");
+        await Assert.That(AcpToolKind.Execute).IsEqualTo("execute");
+        await Assert.That(AcpToolKind.Think).IsEqualTo("think");
+        await Assert.That(AcpToolKind.Fetch).IsEqualTo("fetch");
+        await Assert.That(AcpToolKind.SwitchMode).IsEqualTo("switch_mode");
+        await Assert.That(AcpToolKind.Other).IsEqualTo("other");
+    }
+
+    /// The closed set is what lets a consumer switch on ten tokens. An absent kind stays absent —
+    /// "no lane classified this" is a different answer from "none of the above".
+    [Test]
+    public async Task Normalize_keeps_the_vocabulary_closed_and_absence_distinguishable() {
+        foreach (var known in new[] { "read", "edit", "delete", "move", "search", "execute", "think", "fetch", "switch_mode", "other" })
+            await Assert.That(AcpToolKind.Normalize(known)).IsEqualTo(known).Because(known);
+
+        await Assert.That(AcpToolKind.Normalize("Read")).IsEqualTo(AcpToolKind.Other);
+        await Assert.That(AcpToolKind.Normalize("summarise")).IsEqualTo(AcpToolKind.Other);
+        await Assert.That(AcpToolKind.Normalize(null)).IsNull();
+        await Assert.That(AcpToolKind.Normalize("")).IsNull();
+        await Assert.That(AcpToolKind.Normalize("  ")).IsNull();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpEventTranslatorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpEventTranslatorTests.cs
@@ -80,6 +80,19 @@ public class AcpEventTranslatorTests {
         await Assert.That(env.Value.ToolCallId).IsEqualTo("call-1");
         await Assert.That(env.Value.ToolName).IsEqualTo("Run shell command");
         await Assert.That(env.Value.ToolInputJson).IsEqualTo("""{"command":"echo hi"}""");
+        await Assert.That(env.Value.ToolKind).IsEqualTo(AcpToolKind.Execute);
+    }
+
+    /// The kind is agent-supplied, so it is normalized onto the closed vocabulary before it reaches
+    /// a consumer that switches on it — and a kind-less tool_call stays kind-less rather than
+    /// claiming to have been classified.
+    [Test]
+    public async Task ToolCall_normalizes_an_agent_supplied_kind_and_leaves_an_absent_one_null() {
+        var unknown = new AcpSessionUpdate(AcpUpdateKind.ToolCall, ToolCallId: "c", ToolKind: "summarise");
+        await Assert.That(AcpEventTranslator.Translate(unknown, 1, TimestampIso)!.Value.ToolKind).IsEqualTo(AcpToolKind.Other);
+
+        var none = new AcpSessionUpdate(AcpUpdateKind.ToolCall, ToolCallId: "c");
+        await Assert.That(AcpEventTranslator.Translate(none, 2, TimestampIso)!.Value.ToolKind).IsNull();
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexNotificationMapperTests.cs
@@ -64,6 +64,61 @@ public class CodexNotificationMapperTests {
         await Assert.That(e.ToolInputJson!).Contains("/repo");
     }
 
+    /// Pins the vendor-neutral kind on every tool call the hosted lane opens. A shell call has no
+    /// name of its own for a read or a search, so its command decides.
+    [Test]
+    public async Task Tool_calls_carry_a_vendor_neutral_kind() {
+        foreach (var (command, kind) in new[] {
+            ("ls -la", AcpToolKind.Search), ("cat a.rs", AcpToolKind.Read),
+            ("rg needle src", AcpToolKind.Search), ("cargo build", AcpToolKind.Execute),
+        }) {
+            var e = Single(Run(NewMapper(), "item/started",
+                $$$"""{"item":{"type":"commandExecution","id":"c1","command":"{{{command}}}","cwd":"/repo","status":"inProgress"}}"""));
+            await Assert.That(e.ToolKind).IsEqualTo(kind).Because(command);
+        }
+
+        var mcp = Single(Run(NewMapper(), "item/started",
+            """{"item":{"type":"mcpToolCall","id":"m1","server":"srv","tool":"do","status":"inProgress"}}"""));
+        await Assert.That(mcp.ToolKind).IsEqualTo(AcpToolKind.Other);
+
+        var patch = Run(NewMapper(), "item/completed",
+            """{"item":{"type":"fileChange","id":"f1","status":"completed","changes":[{"path":"a.txt","kind":"update","diff":"@@"}]}}""")[0];
+        await Assert.That(patch.ToolKind).IsEqualTo(AcpToolKind.Edit);
+
+        var unknown = Single(Run(NewMapper(), "item/completed", """{"item":{"type":"someFutureThing","id":"z1"}}"""));
+        await Assert.That(unknown.ToolKind).IsEqualTo(AcpToolKind.Other);
+    }
+
+    /// A hosted web search has no item/started row, so the completed item carries the pair — an
+    /// orphan call would render as running forever. It is `fetch`, matching the kind every other
+    /// lane gives a web tool.
+    [Test]
+    public async Task WebSearch_completed_maps_to_a_paired_fetch_call_and_result() {
+        var r = Run(NewMapper(), "item/completed",
+            """{"item":{"type":"webSearch","id":"w1","query":"acp tool kinds","action":{"type":"search","query":"acp tool kinds"},"results":[{"url":"https://x/y"}]}}""");
+        await Assert.That(r.Count).IsEqualTo(2);
+
+        await Assert.That(r[0].Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(r[0].ToolName).IsEqualTo("web_search");
+        await Assert.That(r[0].ToolKind).IsEqualTo(AcpToolKind.Fetch);
+        await Assert.That(r[0].ToolCallId).IsEqualTo("w1");
+        await Assert.That(r[0].ToolInputJson!).Contains("acp tool kinds");
+        using var doc = JsonDocument.Parse(r[0].ToolInputJson!);
+        await Assert.That(doc.RootElement.ValueKind).IsEqualTo(JsonValueKind.Object);
+
+        await Assert.That(r[1].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(r[1].ToolCallId).IsEqualTo("w1");
+        await Assert.That(r[1].ToolResult!).Contains("https://x/y");
+
+        // An openPage action and an absent results array still pair, and still read as a fetch.
+        var page = Run(NewMapper(), "item/completed",
+            """{"item":{"type":"webSearch","id":"w2","query":"q","action":{"type":"openPage","url":"https://x/z"}}}""");
+        await Assert.That(page.Count).IsEqualTo(2);
+        await Assert.That(page[0].ToolKind).IsEqualTo(AcpToolKind.Fetch);
+        await Assert.That(page[0].ToolInputJson!).Contains("https://x/z");
+        await Assert.That(page[1].ToolResult).IsEqualTo("");
+    }
+
     [Test]
     public async Task CommandExecution_completed_is_the_authoritative_result_with_error_from_exit_code() {
         var ok = Single(Run(NewMapper(), "item/completed",


### PR DESCRIPTION
Closes #746 — AI-2426

## What & why

Every consumer that wants to say what a tool call *did* keys on the vendor's raw tool name, and the
names disagree per vendor. `AcpEventEnvelope` gains a nullable `ToolKind` carrying the ACP tool-kind
vocabulary, populated by the ACP translator and the daemon's Codex app-server lane. `ToolName` keeps
raw vendor fidelity, since the server pairs `exec_command` with `write_stdin` by it. Null means no
lane classified the call; `other` means none of the above.

**This is the daemon half only.** #773 replaced the transcript-projection contract: a projected tool
call is now a `Kurrent.Agent.Schema` `ToolCallInfo`, which has no kind field, so the Claude/Codex
projections cannot carry one until that package gains it. Tracked as #794 — see the follow-up
issue for the shape it needs.

## Where to look

`CodexNotificationMapper` gains a `webSearch` case. Without it a hosted web search fell through to
`Unmapped` and reported `other`, which would have contradicted every other lane's `fetch`. Like
`fileChange` it has no `item/started` row, so the completed item emits the pair — an orphan tool call
renders as running forever, because only a result settles one.

The Codex kind table is not the one in the issue body; [the comment on #746](https://github.com/kurrent-io/kcap-cli/issues/746#issuecomment-5558997523)
records what the rollouts actually contain.

## Verification

`dotnet run` per suite: Core 2936 (2926 passed, 9 skipped, 1 contention flake that passes in
isolation — `ProcessRunnerTests.KillTree_cancelled_ct_kills_the_child_then_throws`), plus the touched
daemon classes — `AcpEventTranslatorTests` 20, `CodexNotificationMapperTests` 18,
`AcpEventEnvelopeWireCompatTests` 11 — 0 failed. `dotnet publish -c Release` greps 0 IL2026/IL3050.
