### PR TITLE
Surface Codex searches and classify imported tool calls

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -909,3 +909,28 @@ shell call did run something.
 completed item carries both halves, the same rule `fileChange` follows — an orphan tool call renders
 as running forever, since a result is what settles one. It is `fetch`, the kind a web tool gets
 wherever it appears, so the hosted lane and a later import of the same session cannot disagree.
+
+## Codex web and tool searches reach the transcript
+
+**#794** projects two `response_item` payloads the Codex rollout projection dropped, so a Codex web
+search no longer disappears: `web_search_call` and the `tool_search_call` / `tool_search_output` pair.
+Until now `fetch` was unreachable for Codex while Claude's `WebSearch` mapped straight to it, so the
+vocabulary was populated asymmetrically across vendors.
+
+**A web search projects as a synthesized pair.** It is written already settled, carries no id of its
+own — its payload is exactly `action` / `status` / `type` — and keeps its results in the `event_msg`
+lane this projection does not read. So the record supplies the call id for both halves, and the two
+events take the record id and its `result` sibling. A call with no result never settles for a consumer
+that pairs by id; the status is the only outcome available. A tool-registry lookup needs none of that:
+it has a `call_id` and its own output record.
+
+**`tool_search` is `other`, not `search`.** The ACP kind means searching for content, and counting a
+tool-registry lookup as one would skew every consumer measuring how much the agent searched the
+workspace.
+
+**The kind for an imported transcript is stamped by the vendor's chat rules**, which already rewrite
+envelopes and already live per vendor. That gives an import the same kinds the hosted lane carries
+without waiting on the canonical schema, which has no field for it — a projected tool call is a
+`Kurrent.Agent.Schema` `ToolCallInfo`, so the persisted event stays kind-less until the package gains
+one. The shell-command rule is shared with the daemon rather than written twice: a hosted session and
+an import of it must not answer differently for the same call.

--- a/src/Capacitor.App/ViewModels/ToolSummary.cs
+++ b/src/Capacitor.App/ViewModels/ToolSummary.cs
@@ -1,5 +1,6 @@
 using System.Text;
 using System.Text.Json;
+using Capacitor.Cli.Core;
 using Capacitor.Models.Transcripts.Harness.Codex;
 
 namespace Capacitor.App.ViewModels;
@@ -52,7 +53,7 @@ public static class ToolSummary {
             if (!root.IsObject) return category;
             if (category == ToolCategory.Read)
                 return IsSkillFile(root.Str("file_path")) ? ToolCategory.Skill : category;
-            var hint = CodexCommandClassifier.Classify(CommandText(root));
+            var hint = CodexCommandClassifier.Classify(ToolCommandText.From(root));
             return hint?.Type switch {
                 "read"                   => IsSkillFile(hint.Name) ? ToolCategory.Skill : ToolCategory.Read,
                 "search" or "list_files" => ToolCategory.Search,
@@ -98,16 +99,4 @@ public static class ToolSummary {
 
     static bool IsSkillFile(string? path) =>
         path is not null && (path == "SKILL.md" || path.EndsWith("/SKILL.md", StringComparison.Ordinal));
-
-    /// `cmd` (unified exec), then `command` as a string, then `command` as an argv array — a
-    /// `bash -lc &lt;script&gt;` array hands its script through, since the classifier only peels the
-    /// wrapper when the script is one quoted token.
-    static string? CommandText(JsonElement root) {
-        if (root.Str("cmd") is { } cmd) return cmd;
-        if (root.Str("command") is { } command) return command;
-        if (root.Arr("command") is not { } argv) return null;
-        var parts = argv.EnumerateArray().Where(p => p.ValueKind == JsonValueKind.String).Select(p => p.GetString()!).ToList();
-        if (parts.Count == 3 && parts[1] is "-lc" or "-c" && parts[0].EndsWith("sh", StringComparison.Ordinal)) return parts[2];
-        return string.Join(' ', parts);
-    }
 }

--- a/src/Capacitor.Cli.Core/Harness/Claude/ClaudeChatRules.cs
+++ b/src/Capacitor.Cli.Core/Harness/Claude/ClaudeChatRules.cs
@@ -22,6 +22,8 @@ public sealed partial class ClaudeChatRules : IChatDisplayRules {
                 var text = StripWrappers(envelope.Text ?? "");
                 return text.Length == 0 ? null : envelope with { Text = text };
             }
+            case AcpEventKind.ToolCall:
+                return envelope with { ToolKind = ClaudeToolKinds.Of(envelope.ToolName) };
             case AcpEventKind.ToolResult:
                 return envelope with { ToolIsError = SchemaExtensions.Flag(slug, ClaudeCodeExtension.IsError) };
             default:

--- a/src/Capacitor.Cli.Core/Harness/Claude/ClaudeToolKinds.cs
+++ b/src/Capacitor.Cli.Core/Harness/Claude/ClaudeToolKinds.cs
@@ -1,0 +1,18 @@
+namespace Capacitor.Cli.Core.Harness.Claude;
+
+/// What a Claude tool call did, in the vendor-neutral vocabulary.
+public static class ClaudeToolKinds {
+    /// Claude's built-in tools carry their kind in their name, so the table is the whole mapping —
+    /// no input inspection. A `Bash` call stays `execute` however its command reads: Claude has real
+    /// `Read` and `Grep` tools, so classifying the command would misreport the tool the model chose.
+    /// Everything unlisted (subagents, skills, todos, `mcp__*`) is `other`: none of the above, which
+    /// is not the same as the null a lane that classifies nothing leaves behind.
+    public static string Of(string? toolName) => toolName switch {
+        "Read" or "NotebookRead"                           => AcpToolKind.Read,
+        "Edit" or "MultiEdit" or "Write" or "NotebookEdit" => AcpToolKind.Edit,
+        "Bash" or "BashOutput" or "KillShell"              => AcpToolKind.Execute,
+        "Grep" or "Glob" or "LS"                           => AcpToolKind.Search,
+        "WebFetch" or "WebSearch"                          => AcpToolKind.Fetch,
+        _                                                  => AcpToolKind.Other,
+    };
+}

--- a/src/Capacitor.Cli.Core/Harness/Codex/CodexChatRules.cs
+++ b/src/Capacitor.Cli.Core/Harness/Codex/CodexChatRules.cs
@@ -1,6 +1,7 @@
 namespace Capacitor.Cli.Core.Harness.Codex;
 
-/// Codex writes its injected preludes as user messages; the chat shows none of them.
+/// Codex writes its injected preludes as user messages; the chat shows none of them. A tool call
+/// gains the vendor-neutral kind its raw name alone does not carry.
 public sealed class CodexChatRules : IChatDisplayRules {
     public static readonly CodexChatRules Instance = new();
 
@@ -10,8 +11,11 @@ public sealed class CodexChatRules : IChatDisplayRules {
 
     CodexChatRules() { }
 
-    public AcpEventEnvelope? Filter(CanonicalEvent evt, AcpEventEnvelope envelope) =>
-        envelope.Kind == AcpEventKind.UserMessage && IsInjectedPrelude(envelope.Text ?? "") ? null : envelope;
+    public AcpEventEnvelope? Filter(CanonicalEvent evt, AcpEventEnvelope envelope) => envelope.Kind switch {
+        AcpEventKind.UserMessage when IsInjectedPrelude(envelope.Text ?? "") => null,
+        AcpEventKind.ToolCall => envelope with { ToolKind = CodexToolKinds.Of(envelope.ToolName, envelope.ToolInputJson) },
+        _                     => envelope,
+    };
 
     static bool IsInjectedPrelude(string text) {
         var trimmed = text.TrimStart();

--- a/src/Capacitor.Cli.Core/Harness/Codex/CodexToolKinds.cs
+++ b/src/Capacitor.Cli.Core/Harness/Codex/CodexToolKinds.cs
@@ -1,0 +1,30 @@
+using Capacitor.Models.Transcripts.Harness.Codex;
+
+namespace Capacitor.Cli.Core.Harness.Codex;
+
+/// What a codex tool call did, in the vendor-neutral vocabulary. The one place that rule lives: the
+/// daemon's hosted lane and an imported rollout must not answer differently for the same call.
+public static class CodexToolKinds {
+    /// Codex's shell tools have no name of their own for a read or a search — `sed -n`, `cat` and
+    /// `rg` all arrive as the same tool — so the command itself decides. `exec` is Codex's
+    /// JavaScript sandbox rather than a shell, so it is never handed to the classifier. MCP tools
+    /// arrive under their bare server-side name, indistinguishable from any other unrecognised
+    /// tool, so both land on `other` — as does `tool_search`, deliberately: `search` means
+    /// searching for content, and counting a tool-registry lookup as one would skew every consumer
+    /// measuring how much the agent searched the workspace.
+    public static string Of(string? toolName, string? inputJson) => toolName switch {
+        "apply_patch"                              => AcpToolKind.Edit,
+        "shell" or "exec_command" or "local_shell" => Shell(ToolCommandText.From(inputJson)),
+        "write_stdin" or "exec"                    => AcpToolKind.Execute,
+        "web_search"                               => AcpToolKind.Fetch,
+        _                                          => AcpToolKind.Other,
+    };
+
+    /// The kind of a shell call from its command alone. An unclassifiable command is `execute`: a
+    /// shell call did run something.
+    public static string Shell(string? command) => CodexCommandClassifier.Classify(command)?.Type switch {
+        "read"                   => AcpToolKind.Read,
+        "search" or "list_files" => AcpToolKind.Search,
+        _                        => AcpToolKind.Execute,
+    };
+}

--- a/src/Capacitor.Cli.Core/ToolCommandText.cs
+++ b/src/Capacitor.Cli.Core/ToolCommandText.cs
@@ -1,0 +1,33 @@
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core;
+
+/// The command a shell tool call was given, dug out of the tool input each vendor shapes
+/// differently: Codex writes `cmd`, Claude writes `command` as a string, and the argv form is a
+/// `bash -lc &lt;script&gt;` triple.
+public static class ToolCommandText {
+    /// Null when the input carries no command. An argv triple hands its script through, since
+    /// <see cref="Harness.Codex.CodexToolKinds"/>'s classifier only peels the wrapper when the
+    /// script is one quoted token.
+    public static string? From(JsonElement root) {
+        if (!root.IsObject) return null;
+        if (root.Str("cmd") is { } cmd) return cmd;
+        if (root.Str("command") is { } command) return command;
+        if (root.Arr("command") is not { } argv) return null;
+        var parts = argv.EnumerateArray().Where(p => p.IsString).Select(p => p.GetString()!).ToList();
+        if (parts.Count == 3 && parts[1] is "-lc" or "-c" && parts[0].EndsWith("sh", StringComparison.Ordinal)) return parts[2];
+        return string.Join(' ', parts);
+    }
+
+    /// The same read from an unparsed input string; null when it is absent, not JSON, or not an
+    /// object.
+    public static string? From(string? inputJson) {
+        if (string.IsNullOrEmpty(inputJson)) return null;
+        try {
+            using var doc = JsonDocument.Parse(inputJson);
+            return From(doc.RootElement);
+        } catch (JsonException) {
+            return null;
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexNotificationMapper.cs
@@ -2,7 +2,7 @@ using System.Globalization;
 using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core;
-using Capacitor.Models.Transcripts.Harness.Codex;
+using Capacitor.Cli.Core.Harness.Codex;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Harness.Codex;
@@ -172,7 +172,7 @@ internal sealed partial class CodexNotificationMapper {
             case "commandExecution":
                 return One(new AcpEventEnvelope(
                     Kind: AcpEventKind.ToolCall, ToolCallId: id, ToolName: "shell",
-                    ToolInputJson: RenderCommandOpen(item), ToolKind: ShellKind(item.Str("command")),
+                    ToolInputJson: RenderCommandOpen(item), ToolKind: CodexToolKinds.Shell(item.Str("command")),
                     ItemId: id, TimestampIso: ts));
 
             case "mcpToolCall":
@@ -255,15 +255,6 @@ internal sealed partial class CodexNotificationMapper {
             ToolInputJson: item.GetRawText(), ToolKind: AcpToolKind.Other,
             ItemId: id, TimestampIso: ts));
     }
-
-    /// A codex shell call has no name of its own for a read or a search — `sed -n`, `cat` and `rg` all
-    /// arrive as the same tool — so the command itself decides. An unclassifiable command is
-    /// `execute`: a shell call did run something.
-    static string ShellKind(string? command) => CodexCommandClassifier.Classify(command)?.Type switch {
-        "read"                   => AcpToolKind.Read,
-        "search" or "list_files" => AcpToolKind.Search,
-        _                        => AcpToolKind.Execute,
-    };
 
     // ── Rendering helpers (pure) ──────────────────────────────────────────────────────────────────
     static IReadOnlyList<AcpEventEnvelope> One(AcpEventEnvelope e) => [e];

--- a/src/Capacitor.Models.Transcripts/Harness/Codex/CodexRolloutEvents.cs
+++ b/src/Capacitor.Models.Transcripts/Harness/Codex/CodexRolloutEvents.cs
@@ -28,7 +28,11 @@ public sealed class CodexRolloutEvents : ITranscriptProjection {
             if (root.Str("type") != "response_item" || root.Obj("payload") is not { } payload) return ProjectionResult.Empty;
 
             var (at, recordTimestamp) = TranscriptTime.Resolve(root.Str("timestamp"), receivedAt);
-            var ts = Timestamp.FromDateTimeOffset(at);
+            var ts       = Timestamp.FromDateTimeOffset(at);
+            var recordId = TranscriptIds.CodexRecord(line);
+
+            if (payload.Str("type") == "web_search_call")
+                return ProjectionResult.Of(WebSearch(payload, recordId, at, recordTimestamp, ts));
 
             IMessage? evt = payload.Str("type") switch {
                 "message"          => Message(payload, ts),
@@ -36,11 +40,14 @@ public sealed class CodexRolloutEvents : ITranscriptProjection {
                 "custom_tool_call" => ToolCall(payload, Wrap("input", payload.Str("input") ?? ""), ts),
                 "function_call_output" or "custom_tool_call_output"
                                    => new ToolResultReceived { CallId = payload.Str("call_id") ?? "", Result = OutputText(payload), Timestamp = ts },
+                "tool_search_call" => ToolSearchCall(payload, ts),
+                "tool_search_output"
+                                   => new ToolResultReceived { CallId = payload.Str("call_id") ?? "", Result = ToolsText(payload), Timestamp = ts },
                 "reasoning"        => Reasoning(payload, ts),
                 _                  => null,
             };
             if (evt is null) return ProjectionResult.Empty;
-            return ProjectionResult.Of([new CanonicalEvent(CanonicalEventTypes.Of(evt), evt, TranscriptIds.CodexRecord(line), at, recordTimestamp)]);
+            return ProjectionResult.Of([new CanonicalEvent(CanonicalEventTypes.Of(evt), evt, recordId, at, recordTimestamp)]);
         }
     }
 
@@ -59,6 +66,43 @@ public sealed class CodexRolloutEvents : ITranscriptProjection {
                 return null;
         }
     }
+
+    /// A web search is written already settled, carries no id of its own, and keeps its results in
+    /// the `event_msg` lane this projection does not read. So it projects as a PAIR whose call id is
+    /// the record's — a consumer pairs a result to its call by that id, and a call that never gets
+    /// one reads as still running. The result carries the status, the only outcome available here.
+    static IReadOnlyList<CanonicalEvent> WebSearch(
+            JsonElement payload, Guid recordId, DateTimeOffset at, string? recordTimestamp, Timestamp ts) {
+        var callId = recordId.ToString();
+
+        var call = new AssistantToolCallsGenerated { Timestamp = ts };
+        call.ToolCalls.Add(new ToolCallInfo {
+            CallId    = callId,
+            ToolName  = "web_search",
+            Arguments = payload.Obj("action") is { } action ? StructOf(action) : new Struct(),
+        });
+
+        var result = new ToolResultReceived { CallId = callId, Result = payload.Str("status") ?? "", Timestamp = ts };
+
+        return [
+            new CanonicalEvent(CanonicalEventTypes.Of(call), call, recordId, at, recordTimestamp),
+            new CanonicalEvent(CanonicalEventTypes.Of(result), result, TranscriptIds.Sibling(recordId, "result"), at, recordTimestamp),
+        ];
+    }
+
+    /// A tool-registry lookup. It has a call_id and its own `tool_search_output`, so it pairs like
+    /// any other call; only the tool name is ours to supply, the payload carrying none.
+    static AssistantToolCallsGenerated ToolSearchCall(JsonElement payload, Timestamp ts) {
+        var call = new AssistantToolCallsGenerated { Timestamp = ts };
+        call.ToolCalls.Add(new ToolCallInfo {
+            CallId    = payload.Str("call_id") ?? "",
+            ToolName  = "tool_search",
+            Arguments = payload.Obj("arguments") is { } args ? StructOf(args) : new Struct(),
+        });
+        return call;
+    }
+
+    static string ToolsText(JsonElement payload) => payload.Arr("tools")?.GetRawText() ?? "";
 
     static AssistantToolCallsGenerated ToolCall(JsonElement payload, Struct arguments, Timestamp ts) {
         var call = new AssistantToolCallsGenerated { Timestamp = ts };

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudeChatRulesTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Claude/ClaudeChatRulesTests.cs
@@ -111,4 +111,31 @@ public class ClaudeChatRulesTests {
         var human = P("""{"type":"user","origin":{"kind":"human"},"promptSource":"typed","message":{"content":"hello"}}""");
         await Assert.That(human[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
     }
+
+    /// Pins the vendor-neutral kind beside the raw name. Every tool gets one — an unlisted tool is
+    /// `other`, never null, so a null kind can only mean a lane that classifies nothing.
+    [Test]
+    public async Task Every_tool_call_carries_a_kind_and_an_unlisted_tool_is_other() {
+        foreach (var (name, kind) in new[] {
+            ("Read", AcpToolKind.Read), ("NotebookRead", AcpToolKind.Read),
+            ("Edit", AcpToolKind.Edit), ("MultiEdit", AcpToolKind.Edit), ("Write", AcpToolKind.Edit), ("NotebookEdit", AcpToolKind.Edit),
+            ("Bash", AcpToolKind.Execute), ("BashOutput", AcpToolKind.Execute), ("KillShell", AcpToolKind.Execute),
+            ("Grep", AcpToolKind.Search), ("Glob", AcpToolKind.Search), ("LS", AcpToolKind.Search),
+            ("WebFetch", AcpToolKind.Fetch), ("WebSearch", AcpToolKind.Fetch),
+            ("Task", AcpToolKind.Other), ("Skill", AcpToolKind.Other), ("TodoWrite", AcpToolKind.Other),
+            ("mcp__linear__get_issue", AcpToolKind.Other), ("SomeFutureTool", AcpToolKind.Other),
+        }) {
+            var e = P($$$"""{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t","name":"{{{name}}}","input":{}}]}}""");
+            await Assert.That(e[0].ToolName).IsEqualTo(name);
+            await Assert.That(e[0].ToolKind).IsEqualTo(kind).Because(name);
+        }
+    }
+
+    /// A shell call keeps `execute` whatever the command reads like: Claude has real Read and Grep
+    /// tools, so classifying the command would misreport the tool the model actually chose.
+    [Test]
+    public async Task A_bash_call_that_reads_a_file_is_still_execute() {
+        var e = P("""{"type":"assistant","message":{"content":[{"type":"tool_use","id":"t","name":"Bash","input":{"command":"sed -n '1,20p' src/Program.cs"}}]}}""");
+        await Assert.That(e[0].ToolKind).IsEqualTo(AcpToolKind.Execute);
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexChatRulesTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Harness/Codex/CodexChatRulesTests.cs
@@ -85,6 +85,44 @@ public class CodexChatRulesTests {
         await Assert.That(P(Item("""{"type":"message","role":"user","content":"not-an-array"}"""))).IsEmpty();
     }
 
+    /// Pins the vendor-neutral kind beside the raw name. Codex's shell tools have no name of their
+    /// own for a read or a search, so the command decides; `exec` is its JavaScript sandbox and never
+    /// reaches the shell classifier; MCP tools arrive under a bare name and land on `other` with
+    /// every other unrecognised tool.
+    [Test]
+    public async Task Tool_calls_carry_a_vendor_neutral_kind() {
+        foreach (var (payload, kind) in new[] {
+            ("""{"type":"custom_tool_call","name":"apply_patch","call_id":"c","input":"*** Begin Patch"}""",                     AcpToolKind.Edit),
+            ("""{"type":"function_call","name":"exec_command","call_id":"c","arguments":"{\"cmd\":\"cargo build\"}"}""",          AcpToolKind.Execute),
+            ("""{"type":"function_call","name":"exec_command","call_id":"c","arguments":"{\"cmd\":\"sed -n '1,40p' a.rs\"}"}""",  AcpToolKind.Read),
+            ("""{"type":"function_call","name":"exec_command","call_id":"c","arguments":"{\"cmd\":\"rg needle src\"}"}""",        AcpToolKind.Search),
+            ("""{"type":"function_call","name":"exec_command","call_id":"c","arguments":"{\"cmd\":\"ls src\"}"}""",               AcpToolKind.Search),
+            ("""{"type":"function_call","name":"shell","call_id":"c","arguments":"{\"command\":[\"bash\",\"-lc\",\"cat a.rs\"]}"}""", AcpToolKind.Read),
+            ("""{"type":"function_call","name":"write_stdin","call_id":"c","arguments":"{\"chars\":\"y\\n\"}"}""",                AcpToolKind.Execute),
+            ("""{"type":"custom_tool_call","name":"exec","call_id":"c","input":"await tool.read('cat a.rs')"}""",                 AcpToolKind.Execute),
+            ("""{"type":"function_call","name":"get_issue","call_id":"c","arguments":"{\"id\":\"1\"}"}""",                        AcpToolKind.Other),
+            ("""{"type":"tool_search_call","call_id":"c","arguments":{"query":"x"}}""",                                           AcpToolKind.Other),
+        }) {
+            var e = P(Item(payload));
+            await Assert.That(e[0].ToolKind).IsEqualTo(kind).Because(payload);
+        }
+    }
+
+    /// A web search reaches the chat as a settled pair — an unpaired call would read as still
+    /// running — and is `fetch`, the kind a web tool gets in every lane.
+    [Test]
+    public async Task A_web_search_reaches_the_chat_as_a_settled_fetch_pair() {
+        var e = P(Item("""{"type":"web_search_call","status":"completed","action":{"type":"search","query":"acp"}}"""));
+
+        await Assert.That(e).Count().IsEqualTo(2);
+        await Assert.That(e[0].Kind).IsEqualTo(AcpEventKind.ToolCall);
+        await Assert.That(e[0].ToolName).IsEqualTo("web_search");
+        await Assert.That(e[0].ToolKind).IsEqualTo(AcpToolKind.Fetch);
+        await Assert.That(e[1].Kind).IsEqualTo(AcpEventKind.ToolResult);
+        await Assert.That(e[1].ToolCallId).IsEqualTo(e[0].ToolCallId);
+        await Assert.That(e[0].ToolCallId).IsNotNull();
+    }
+
     [Test]
     public async Task An_unknown_vendor_has_no_chat_projection() {
         await Assert.That(TranscriptChat.For("cursor")).IsNull();

--- a/test/Capacitor.Models.Transcripts.Tests.Unit/Harness/Codex/CodexRolloutEventsTests.cs
+++ b/test/Capacitor.Models.Transcripts.Tests.Unit/Harness/Codex/CodexRolloutEventsTests.cs
@@ -28,6 +28,53 @@ public class CodexRolloutEventsTests {
         await Assert.That(((AssistantTextGenerated)assistant[0].Payload).Content).IsEqualTo("Hi");
     }
 
+    /// A web search is written already settled and carries no id of its own, so the record has to
+    /// supply one — and it must reach BOTH halves, or nothing pairs the result to its call. The two
+    /// events are distinct records, so their EventIds differ even though their call id is shared.
+    [Test]
+    public async Task A_web_search_projects_as_a_pair_sharing_a_call_id_derived_from_the_record() {
+        var line = Item("""{"type":"web_search_call","status":"completed","action":{"type":"search","query":"acp tool kinds"}}""");
+        var e    = E(line);
+
+        await Assert.That(e).Count().IsEqualTo(2);
+
+        var call = (AssistantToolCallsGenerated)e[0].Payload;
+        await Assert.That(call.ToolCalls[0].ToolName).IsEqualTo("web_search");
+        await Assert.That(call.ToolCalls[0].Arguments.Fields["query"].StringValue).IsEqualTo("acp tool kinds");
+        await Assert.That(e[0].EventId).IsEqualTo(TranscriptIds.CodexRecord(line));
+
+        var result = (ToolResultReceived)e[1].Payload;
+        await Assert.That(result.CallId).IsEqualTo(call.ToolCalls[0].CallId);
+        await Assert.That(result.Result).IsEqualTo("completed");
+        await Assert.That(e[1].EventId).IsEqualTo(TranscriptIds.Sibling(TranscriptIds.CodexRecord(line), "result"));
+        await Assert.That(e[1].EventId).IsNotEqualTo(e[0].EventId);
+
+        // Two searches differing only in their action are distinct calls, not one.
+        var other = E(Item("""{"type":"web_search_call","status":"completed","action":{"type":"openPage","url":"https://x/y"}}"""));
+        await Assert.That(((AssistantToolCallsGenerated)other[0].Payload).ToolCalls[0].CallId)
+            .IsNotEqualTo(call.ToolCalls[0].CallId);
+
+        // An action-less record still pairs rather than emitting a call with no arguments object.
+        var bare = E(Item("""{"type":"web_search_call","status":"completed"}"""));
+        await Assert.That(bare).Count().IsEqualTo(2);
+        await Assert.That(((AssistantToolCallsGenerated)bare[0].Payload).ToolCalls[0].Arguments.Fields).IsEmpty();
+    }
+
+    [Test]
+    public async Task A_tool_search_pairs_on_its_own_call_id() {
+        var call = E(Item("""{"type":"tool_search_call","call_id":"call_1","status":"completed","arguments":{"query":"linear issue","limit":8}}"""));
+        await Assert.That(call).Count().IsEqualTo(1);
+        var info = ((AssistantToolCallsGenerated)call[0].Payload).ToolCalls[0];
+        await Assert.That(info.CallId).IsEqualTo("call_1");
+        await Assert.That(info.ToolName).IsEqualTo("tool_search");
+        await Assert.That(info.Arguments.Fields["query"].StringValue).IsEqualTo("linear issue");
+
+        var output = E(Item("""{"type":"tool_search_output","call_id":"call_1","status":"completed","tools":[{"type":"function","name":"get_issue"}]}"""));
+        var result = (ToolResultReceived)output[0].Payload;
+        await Assert.That(result.CallId).IsEqualTo("call_1");
+        await Assert.That(result.Result).IsEqualTo("""[{"type":"function","name":"get_issue"}]""");
+    }
+
     [Test]
     public async Task Injected_preludes_are_kept_here_and_developer_and_system_roles_are_skipped() {
         var prelude = E(Item("""{"type":"message","role":"user","content":[{"type":"input_text","text":"<environment_context>\nstuff"}]}"""));


### PR DESCRIPTION
Part of #794 — AI-2538

## What & why

Two `response_item` payloads the Codex rollout projection dropped now project, so a Codex web search
stops disappearing from the transcript: `web_search_call`, and the `tool_search_call` /
`tool_search_output` pair. Until now `fetch` was unreachable for Codex while Claude's `WebSearch`
mapped straight to it, so #746's vocabulary was populated asymmetrically across vendors.

An imported tool call also gains its `ToolKind`, stamped by the vendor's chat rules — which already
rewrite envelopes and already live per vendor. That was the half #794 recorded as blocked; only the
*persisted canonical* event still is, since a projected tool call is a `Kurrent.Agent.Schema`
`ToolCallInfo` with no field for it (still 0.4.1, checked).

## Where to look

`CodexRolloutEvents.WebSearch`. A web search is written already settled and its payload is exactly
`action` / `status` / `type` — no id — with its results in the `event_msg` lane this projection does
not read. So the record supplies the call id for both halves and the two events take the record id and
its `result` sibling: a call whose result never arrives reads as still running to a consumer pairing
by id, and the status is the only outcome available here.

`tool_search` maps to `other`, not `search`: the ACP kind means searching for *content*, and counting
a tool-registry lookup as one would skew the consumers this field exists to serve.

The shell-command rule moved to `CodexToolKinds`, shared with the daemon's mapper rather than written
twice — a hosted session and an import of it must not answer differently for the same call.

## Verification

`dotnet run` per suite: Models.Transcripts 137, App 1442, Core 2943 (2932 passed, 9 skipped, 2
contention flakes in `AgentAttachClientTests` that pass in isolation), daemon
`CodexNotificationMapperTests` 18 — 0 failed. `dotnet publish -c Release` greps 0 IL2026/IL3050.

Grounded on the rollouts on this machine: `web_search_call` 593 records / 593 distinct timestamps;
`tool_search` call↔output pairing verified per session file, 207 files / 337 calls / 0 mismatches.
