### PR TITLE
Re-advertise a vendor CLI version that changes under a running daemon

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -23,9 +23,14 @@ advertised vendor's binary changes on disk, the certification rejection calls it
 republish because the server's copy has just proven wrong. The watcher fingerprints the file that
 actually runs — bare command resolved on PATH, symlink chain followed — plus size and mtime,
 because a vendor update is usually a symlink retargeted at a new version directory whose file may
-match the old one's size and land on a coarse clock. A refresh that finds nothing changed does not
-re-register: every registration bumps the slot's connection generation, which fails a reviewer
-launch pinned to the previous one, so a same-version reinstall must not cost a launch.
+match the old one's size and land on a coarse clock. Its first baseline is the fingerprint taken
+at startup before the version probe, not the file it finds when the service starts: the probes can
+take the better part of a minute under load, and a vendor updating inside that window would
+otherwise become the baseline while the advertisement still named the old build. A refresh that
+finds nothing changed does not re-register: every registration bumps the slot's connection
+generation, which fails a reviewer launch pinned to the previous one, so a same-version reinstall
+must not cost a launch. The rejection's forced republish is a sticky flag the next pass consumes,
+because a request folded into a running pass reruns that pass's delegate, not its own.
 
 **A failed re-probe keeps the advertised version.** The server reads a null version as the vendor
 being gone, so publishing the probe's null would withdraw a reviewer that was advertised a moment

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,34 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## A vendor update under a running daemon is re-advertised
+
+The vendor CLI version a daemon advertises was a startup probe cached for the process lifetime, and
+reconnects re-sent that cache. When Claude auto-updated under a daemon that had been up for days,
+the next review-flow launch failed the certification's swap arm, and the rejection told the
+operator to restart the daemon: the one action that tears down every hosted agent, on a daemon
+whose idle-gated restart can wait days. The rejection already re-advertised on the live connection
+(a same-connection `DaemonConnect` is an idempotent overwrite that keeps live agents), so the
+remedy was wrong twice over: a retry was enough, and only the first launch after the update was
+ever lost.
+
+**One refresh path, single-flighted.** `AgentOrchestrator.RefreshAdvertisedCapabilities` is the
+only writer of the advertisement while the daemon runs: `VendorCliWatcher` calls it when an
+advertised vendor's binary changes on disk, the certification rejection calls it with a forced
+republish because the server's copy has just proven wrong. The watcher fingerprints the file that
+actually runs — bare command resolved on PATH, symlink chain followed — plus size and mtime,
+because a vendor update is usually a symlink retargeted at a new version directory whose file may
+match the old one's size and land on a coarse clock. A refresh that finds nothing changed does not
+re-register: every registration bumps the slot's connection generation, which fails a reviewer
+launch pinned to the previous one, so a same-version reinstall must not cost a launch.
+
+**A failed re-probe keeps the advertised version.** The server reads a null version as the vendor
+being gone, so publishing the probe's null would withdraw a reviewer that was advertised a moment
+ago. `RetainAdvertisedVersions` carries the previous version over a null re-probe; a later launch
+that still disagrees hits the swap arm and forces another refresh. The refresh probes the vendor set
+fixed at startup rather than re-classifying, which is also what `DaemonConnect` sends as the vendor
+list; a vendor withheld at startup for a version floor stays withheld until a restart.
+
 ## The desktop app shows a session waiting for input
 
 The web already marked a session whose turn was over; the desktop app lit its needs-you pip only

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -132,6 +132,10 @@ public class DaemonConfig {
     public string[]? UnattendedVendors { get; set; }
     public IReadOnlyList<UnattendedVendorCapability>? UnattendedVendorCapabilities { get; set; }
 
+    /// <summary>Per-vendor fingerprint of the binary <see cref="UnattendedVendorCapabilities"/> was
+    /// probed from, taken before that probe; the vendor CLI watcher's starting point.</summary>
+    public IReadOnlyDictionary<string, Services.CliBinaryStat?>? UnattendedVendorBaselines { get; set; }
+
     /// <summary>
     /// Vendor tokens this daemon accepts a launch-time ACP permission preset for — the installed
     /// hostable vendors (a subset of <see cref="SupportedVendors"/>) that route permissions through

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -605,6 +605,9 @@ public static partial class DaemonRunner {
         var unattendedStatuses = ClassifyUnattendedVendors(runtimeFactories);
 
         config.UnattendedVendors = AdvertisedUnattendedVendors(unattendedStatuses);
+        // Fingerprinted BEFORE the probe: a vendor that updates between the two then reads as a
+        // change to the watcher, instead of as the baseline the stale advertisement already matches.
+        config.UnattendedVendorBaselines = FingerprintUnattendedVendors(runtimeFactories, config.UnattendedVendors);
         config.UnattendedVendorCapabilities =
             ComputeUnattendedVendorCapabilities(runtimeFactories, config, config.UnattendedVendors);
 
@@ -1427,6 +1430,19 @@ public static partial class DaemonRunner {
                 SupportsLaunchPosture: string.Equals(vendor, "codex", StringComparison.Ordinal)));
         }
         return capabilities;
+    }
+
+    /// <summary>Fingerprints each advertised vendor's binary through the factory that launches it —
+    /// the same path the version probe runs. A vendor with no locatable binary maps to null.</summary>
+    internal static IReadOnlyDictionary<string, CliBinaryStat?> FingerprintUnattendedVendors(
+            IEnumerable<IHostedAgentRuntimeFactory> factories, IEnumerable<string> vendors) {
+        var byVendor = factories.ToDictionary(f => f.Vendor, StringComparer.Ordinal);
+        return vendors.ToDictionary(
+            vendor => vendor,
+            vendor => byVendor.TryGetValue(vendor, out var factory) && !string.IsNullOrEmpty(factory.CliPath)
+                ? VendorCliWatcher.StatCliBinary(factory.CliPath)
+                : null,
+            StringComparer.Ordinal);
     }
 
     /// <summary>Carries a version already advertised over a re-probe that returned none. The server

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -556,6 +556,9 @@ public static partial class DaemonRunner {
         builder.Services.AddSingleton<RestartCoordinator>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<RestartCoordinator>());
 
+        builder.Services.AddSingleton<VendorCliWatcher>();
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<VendorCliWatcher>());
+
         // Local control socket: lets `kcap agent start`/`attach`/`ls`/`stop` drive daemon-hosted
         // agents from the user's own terminal (AI local-attach Phase 1).
         builder.Services.AddSingleton<LocalControlServer>();
@@ -1426,6 +1429,19 @@ public static partial class DaemonRunner {
         return capabilities;
     }
 
+    /// <summary>Carries a version already advertised over a re-probe that returned none. The server
+    /// reads a null version as the vendor being gone, so a transient probe miss must not withdraw
+    /// a reviewer that was advertised a moment ago. Every other field comes from the re-probe.</summary>
+    internal static IReadOnlyList<UnattendedVendorCapability> RetainAdvertisedVersions(
+            IReadOnlyList<UnattendedVendorCapability>? current, IReadOnlyList<UnattendedVendorCapability> fresh) {
+        if (current is null) return fresh;
+        return fresh.Select(capability => {
+            if (!string.IsNullOrEmpty(capability.CliVersion)) return capability;
+            var advertised = current.FirstOrDefault(c => string.Equals(c.Vendor, capability.Vendor, StringComparison.Ordinal));
+            return string.IsNullOrEmpty(advertised?.CliVersion) ? capability : capability with { CliVersion = advertised.CliVersion };
+        }).ToArray();
+    }
+
     /// <summary>Rendered in place of a <c>CliVersion</c> the probe could not determine (spawn
     /// failure, timeout, empty output, unparseable output). It is a reporting placeholder ONLY — an
     /// unidentifiable build is still a trusted build and its capabilities are unaffected.</summary>
@@ -1435,8 +1451,8 @@ public static partial class DaemonRunner {
     /// One Information line per unattended vendor recording the CLI version probed at daemon
     /// startup, so an operator reading the daemon's own log can tell which build was installed when
     /// this daemon came up. Deliberately reports the version and NOTHING else: it does not compare
-    /// the installed build against any validated-build record (that would be exactly the automated
-    /// version-drift detection this design rejects), and no equivalent line is emitted per launch.
+    /// the installed build against any validated-build record, and no equivalent line is emitted
+    /// per launch. A change on disk is logged once, when it is re-advertised.
     /// Pure over the computed capabilities — same reasoning as
     /// <see cref="ShouldWarnCursorUnavailable"/> — so it is testable without booting the DI host.
     /// See docs/superpowers/specs/2026-07-27-ai1528-trust-by-default-borrowed-review-design.md.
@@ -1551,7 +1567,7 @@ public static partial class DaemonRunner {
     [LoggerMessage(Level = LogLevel.Information, Message = "kcap daemon '{Name}' starting, connecting to {ServerUrl}")]
     static partial void LogDaemonStarting(ILogger logger, string name, string serverUrl);
 
-    [LoggerMessage(Level = LogLevel.Information, Message = "Unattended vendor '{Vendor}': CLI version {CliVersion}, as observed by probing the configured binary at daemon startup. That is a startup observation, not the build a later reviewer runs — if the vendor updates while this daemon keeps running, launches pick up the new build and this line stays stale until the daemon restarts.")]
+    [LoggerMessage(Level = LogLevel.Information, Message = "Unattended vendor '{Vendor}': CLI version {CliVersion}, as observed by probing the configured binary at daemon startup. A later change to that binary on disk is re-probed and re-advertised while the daemon runs.")]
     static partial void LogUnattendedVendorIdentity(ILogger logger, string vendor, string cliVersion);
 
     // Information, not Warning: an installed vendor withheld for a reason the operator chose — an

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -1225,8 +1225,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             return (false, $"could not read the installed {vendor} CLI version (the version probe " +
                            "failed or timed out) — this is usually transient under load; retry the flow");
 
-        // Range BEFORE swap: an out-of-range replacement would otherwise be told only to restart,
-        // and restarting re-advertises the same out-of-range version.
+        // Range BEFORE swap: an out-of-range replacement would otherwise be told only to retry,
+        // and the re-advertisement behind that retry carries the same out-of-range version.
         if (!DaemonRunner.CliVersionAllowed(probedVersion, certification.AllowedCliRanges))
             return (false, $"the installed {vendor} CLI '{probedVersion}' is outside the " +
                            $"server's allowed range '{certification.AllowedCliRanges}'");
@@ -1234,14 +1234,45 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // A missing advertised version means the registration probe failed — not evidence of a CLI
         // swap, which is all this arm exists to catch. It falls through to the range check above.
         // Null or empty: declared non-nullable, but populated from a probe returning null over JSON.
+        // The remedy is a retry, never a restart: the rejection re-advertises the installed version
+        // on the live connection, while a restart tears down every hosted agent.
         if (!string.IsNullOrEmpty(certification.ExpectedCliVersion) &&
             !string.Equals(probedVersion, certification.ExpectedCliVersion, StringComparison.Ordinal))
             return (false, $"the installed {vendor} CLI is '{probedVersion}' but this daemon " +
                            $"advertised '{certification.ExpectedCliVersion}' at registration — " +
-                           "restart the daemon so it re-advertises");
+                           "the daemon is re-advertising the installed version; retry the flow");
 
         return (true, "");
     }
+
+    /// <summary>
+    /// Re-probes the vendors advertised at startup and re-registers when the advertisement changed
+    /// — the one path through which a running daemon updates what the server knows about its CLI
+    /// versions. Returns at once; the work is single-flighted off the caller's stack so a burst of
+    /// requests coalesces and the last publication is always the newest probe.
+    /// </summary>
+    /// <param name="republishUnchanged">Re-register even when the local advertisement already
+    /// reads the same, for a caller that knows the server's copy differs.</param>
+    internal void RefreshAdvertisedCapabilities(string reason, bool republishUnchanged = false) {
+        _capabilityRefresh.Trigger(
+            async () => {
+                var current = _config.UnattendedVendorCapabilities;
+                var fresh   = DaemonRunner.RetainAdvertisedVersions(current,
+                    DaemonRunner.ComputeUnattendedVendorCapabilities(_runtimeFactories.Values, _config, _config.UnattendedVendors));
+
+                if (!republishUnchanged && current is not null && current.SequenceEqual(fresh)) return;
+
+                _config.UnattendedVendorCapabilities = fresh;
+                LogReAdvertising(_logger, reason,
+                    string.Join(", ", fresh.Select(c => $"{c.Vendor} {c.CliVersion ?? DaemonRunner.UnknownCliVersion}")));
+                await _server.ReRegisterAsync();
+            },
+            ex => _logger.LogDebug(ex,
+                "Capability refresh ({Reason}) failed; the next registration or launch re-evaluates it.", reason));
+    }
+
+    /// <summary>Test seam: the most recently scheduled capability refresh, for awaiting quiescence.</summary>
+    internal Task CapabilityRefreshForTest => _capabilityRefresh.Current;
 
     internal AgentLiveness ReadLiveness(string agentId) {
         // Order matters: check _agents first (Live/Quarantined-by-status), then _quarantine, then Dead.
@@ -1940,26 +1971,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 await _server.LaunchFailedAsync(cmd.AgentId,
                     $"reviewer_certification_changed: {certificationCheck.Reason}.");
 
-                // The self-heal (recompute + re-advertise) is genuinely useful — a certification
-                // mismatch usually means the advertisement is stale — but nothing waits on it, and
-                // the caller already has its answer.
-                //
-                // SINGLE-FLIGHT, not bare fire-and-forget. Codex review round 3: concurrent rejected
-                // launches each starting an independent refresh reintroduces this PR's own bug — a
-                // slow failing refresh can complete AFTER a fast successful one and overwrite valid
-                // capabilities with a failed-probe null, durably disabling the reviewer again.
-                // Serialising publication is necessary; coalescing keeps a burst of rejections from
-                // queueing a refresh each, and the rerun pass guarantees the LAST write is the
-                // NEWEST computation.
-                _capabilityRefresh.Trigger(
-                    async () => {
-                        _config.UnattendedVendorCapabilities =
-                            DaemonRunner.ComputeUnattendedVendorCapabilities(_runtimeFactories.Values, _config);
-                        await _server.ReRegisterAsync();
-                    },
-                    ex => _logger.LogDebug(ex,
-                        "Capability recompute after a certification rejection failed; the next " +
-                        "registration or launch re-evaluates it."));
+                // The self-heal: a certification mismatch usually means the advertisement is stale.
+                // Nothing waits on it — the caller already has its answer. Republished even when the
+                // local advertisement already reads the same, because the server's copy has just
+                // proven to disagree with the installed binary.
+                RefreshAdvertisedCapabilities("reviewer certification rejected", republishUnchanged: true);
                 return new CommandOutcome(
                     CommandOutcomeKind.LaunchRejected,
                     agentId,
@@ -5126,6 +5142,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // Vendor belongs on the same line as the model: without it, a model that does not belong to the
     // launched vendor is only visible by correlating with a later runtime line, and PTY vendors emit
     // no such line at all.
+    [LoggerMessage(Level = LogLevel.Information, Message = "Re-advertising unattended vendor capabilities ({Reason}): {Versions}")]
+    static partial void LogReAdvertising(ILogger logger, string reason, string versions);
+
     [LoggerMessage(Level = LogLevel.Information, Message = "Launching agent {AgentId} for {Repo} (vendor={Vendor}, effort={Effort}, model={Model})")]
     partial void LogLaunching(string agentId, string repo, string vendor, string effort, string? model);
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -543,6 +543,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <summary>Serialises + coalesces the background capability refresh fired after a certification
     /// rejection. See SingleFlightRefresh for why bare fire-and-forget was unsafe here.</summary>
     readonly SingleFlightRefresh _capabilityRefresh = new();
+    int                          _republishRequested;
 
     // Hosted-agent PTYs are spawned at a fixed size and never resized. The daemon
     // reports these dims to the server right after the agent registers (and on
@@ -1254,13 +1255,18 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <param name="republishUnchanged">Re-register even when the local advertisement already
     /// reads the same, for a caller that knows the server's copy differs.</param>
     internal void RefreshAdvertisedCapabilities(string reason, bool republishUnchanged = false) {
+        // Sticky rather than captured by the delegate: a request folded into a running pass reruns
+        // THAT pass's delegate, which would otherwise carry the earlier caller's answer.
+        if (republishUnchanged) Interlocked.Exchange(ref _republishRequested, 1);
+
         _capabilityRefresh.Trigger(
             async () => {
-                var current = _config.UnattendedVendorCapabilities;
-                var fresh   = DaemonRunner.RetainAdvertisedVersions(current,
+                var republish = Interlocked.Exchange(ref _republishRequested, 0) == 1;
+                var current   = _config.UnattendedVendorCapabilities;
+                var fresh     = DaemonRunner.RetainAdvertisedVersions(current,
                     DaemonRunner.ComputeUnattendedVendorCapabilities(_runtimeFactories.Values, _config, _config.UnattendedVendors));
 
-                if (!republishUnchanged && current is not null && current.SequenceEqual(fresh)) return;
+                if (!republish && current is not null && current.SequenceEqual(fresh)) return;
 
                 _config.UnattendedVendorCapabilities = fresh;
                 LogReAdvertising(_logger, reason,

--- a/src/Capacitor.Cli.Daemon/Services/SingleFlightRefresh.cs
+++ b/src/Capacitor.Cli.Daemon/Services/SingleFlightRefresh.cs
@@ -55,23 +55,31 @@ internal sealed class SingleFlightRefresh {
     internal Task Current => Volatile.Read(ref _current);
 
     async Task RunHoldingGateAsync(Func<Task> refresh, Action<Exception>? onError) {
-        try {
-            do {
-                // Cleared BEFORE the work, so a request arriving during it sets the flag again and
-                // earns another pass. Clearing after would swallow it.
-                Interlocked.Exchange(ref _rerunRequested, 0);
+        while (true) {
+            try {
+                do {
+                    // Cleared BEFORE the work, so a request arriving during it sets the flag again and
+                    // earns another pass. Clearing after would swallow it.
+                    Interlocked.Exchange(ref _rerunRequested, 0);
 
-                try {
-                    await refresh().ConfigureAwait(false);
-                } catch (Exception ex) {
-                    // A refresh is a self-heal; a failure must never become a second, different
-                    // error for whatever triggered it.
-                    onError?.Invoke(ex);
-                }
-            } while (Interlocked.CompareExchange(ref _rerunRequested, 0, 1) == 1);
-        } finally {
-            // Release pairs with Trigger's interlocked acquire.
-            Volatile.Write(ref _passRunning, 0);
+                    try {
+                        await refresh().ConfigureAwait(false);
+                    } catch (Exception ex) {
+                        // A refresh is a self-heal; a failure must never become a second, different
+                        // error for whatever triggered it.
+                        onError?.Invoke(ex);
+                    }
+                } while (Interlocked.CompareExchange(ref _rerunRequested, 0, 1) == 1);
+            } finally {
+                // Release pairs with Trigger's interlocked acquire.
+                Volatile.Write(ref _passRunning, 0);
+            }
+
+            // A request that landed between the loop's last check and the release found the gate
+            // held and set the flag with no pass left to consume it. Take the gate back and serve
+            // it; a Trigger that already won the gate clears the flag itself before its work.
+            if (Volatile.Read(ref _rerunRequested) == 0) return;
+            if (Interlocked.CompareExchange(ref _passRunning, 1, 0) != 0) return;
         }
     }
 }

--- a/src/Capacitor.Cli.Daemon/Services/VendorCliWatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/VendorCliWatcher.cs
@@ -1,0 +1,113 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>Fingerprint of an installed vendor CLI: the file that actually runs once every symlink
+/// is followed, plus its size and last-write time. The path is part of it because a vendor update
+/// commonly retargets a symlink at a new version directory.</summary>
+public readonly record struct CliBinaryStat(string ResolvedPath, long Size, long MtimeTicks);
+
+/// <summary>
+/// Polls the CLI binaries of the vendors this daemon advertised at startup and, when one changes
+/// on disk, asks the orchestrator to re-probe and re-advertise. Without it the advertised version
+/// is a startup snapshot, and the first reviewer launch after a vendor auto-update is rejected
+/// for the mismatch.
+/// </summary>
+internal sealed partial class VendorCliWatcher : BackgroundService {
+    readonly DaemonConfig?                                             _config;
+    readonly IReadOnlyDictionary<string, IHostedAgentRuntimeFactory>? _factories;
+    readonly ILogger                                                   _logger;
+
+    // Seams (assigned from DI in the production ctor; overridden directly in tests).
+    internal Func<string, CliBinaryStat?>            StatBinary = StatCliBinary;
+    internal Action<string>                          Refresh;
+    internal IReadOnlyList<(string Vendor, string CliPath)> Watched;
+
+    readonly Dictionary<string, CliBinaryStat?> _baselines = new(StringComparer.Ordinal);
+
+    static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(15);
+
+    public VendorCliWatcher(
+            DaemonConfig config, AgentOrchestrator orchestrator,
+            IReadOnlyDictionary<string, IHostedAgentRuntimeFactory> factories,
+            ILogger<VendorCliWatcher> logger) {
+        _config    = config;
+        _factories = factories;
+        _logger    = logger;
+        Refresh    = reason => orchestrator.RefreshAdvertisedCapabilities(reason);
+        Watched    = [];
+    }
+
+    VendorCliWatcher(IReadOnlyList<(string Vendor, string CliPath)> watched, Action<string> refresh,
+            Func<string, CliBinaryStat?> stat) {
+        _logger    = NullLogger.Instance;
+        Watched    = watched;
+        Refresh    = refresh;
+        StatBinary = stat;
+    }
+
+    /// <summary>Test factory — bypasses DI; the caller supplies every seam.</summary>
+    internal static VendorCliWatcher ForTest(
+            IReadOnlyList<(string Vendor, string CliPath)> watched, Action<string> refresh,
+            Func<string, CliBinaryStat?> stat) =>
+        new(watched, refresh, stat);
+
+    internal void PrimeBaselines() {
+        foreach (var (vendor, cliPath) in Watched) _baselines[vendor] = StatBinary(cliPath);
+    }
+
+    /// <summary>One poll iteration (timer-driven; also the unit-test entry point). All vendors
+    /// that changed since the last tick share one refresh, since a refresh re-probes them all.</summary>
+    internal void Tick() {
+        List<string>? changed = null;
+        foreach (var (vendor, cliPath) in Watched) {
+            var current = StatBinary(cliPath);
+            if (!Changed(_baselines.GetValueOrDefault(vendor), current)) continue;
+            _baselines[vendor] = current;
+            (changed ??= []).Add(vendor);
+        }
+
+        if (changed is null) return;
+        var reason = $"{string.Join(", ", changed)} CLI binary changed on disk";
+        LogChanged(_logger, reason);
+        Refresh(reason);
+    }
+
+    /// <summary>A null current fingerprint is a transient (the binary is mid-replacement), never a
+    /// change: acting on it would re-probe a file that is not there.</summary>
+    internal static bool Changed(CliBinaryStat? baseline, CliBinaryStat? current) =>
+        current is { } c && baseline != c;
+
+    /// <summary>Resolves a bare command on PATH, follows the symlink chain to the file that runs and
+    /// stats it. Null when the binary cannot be found right now.</summary>
+    internal static CliBinaryStat? StatCliBinary(string cliPath) {
+        try {
+            if (CliResolver.ResolveExecutable(cliPath) is not { } resolved) return null;
+            var info   = new FileInfo(resolved);
+            var target = info.ResolveLinkTarget(returnFinalTarget: true) as FileInfo ?? info;
+            return target.Exists ? new CliBinaryStat(target.FullName, target.Length, target.LastWriteTimeUtc.Ticks) : null;
+        } catch {
+            return null;
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken ct) {
+        if (_config is not null && _factories is not null)
+            Watched = (_config.UnattendedVendors ?? [])
+                .Where(_factories.ContainsKey)
+                .Select(vendor => (vendor, _factories[vendor].CliPath))
+                .Where(pair => !string.IsNullOrEmpty(pair.CliPath))
+                .ToArray();
+        PrimeBaselines();
+
+        using var timer = new PeriodicTimer(PollInterval);
+        try {
+            while (await timer.WaitForNextTickAsync(ct)) Tick();
+        } catch (OperationCanceledException) { /* shutdown */ }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "Re-probing advertised vendor CLI versions: {Reason}")]
+    static partial void LogChanged(ILogger logger, string reason);
+}

--- a/src/Capacitor.Cli.Daemon/Services/VendorCliWatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/VendorCliWatcher.cs
@@ -27,6 +27,11 @@ internal sealed partial class VendorCliWatcher : BackgroundService {
 
     readonly Dictionary<string, CliBinaryStat?> _baselines = new(StringComparer.Ordinal);
 
+    /// <summary>Fingerprints recorded when the advertised versions were probed. The advertisement
+    /// describes the binary as it was then, so a vendor that updates before this service starts
+    /// must read as a change on the first tick rather than become the baseline.</summary>
+    IReadOnlyDictionary<string, CliBinaryStat?>? _recorded;
+
     static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(15);
 
     public VendorCliWatcher(
@@ -41,21 +46,24 @@ internal sealed partial class VendorCliWatcher : BackgroundService {
     }
 
     VendorCliWatcher(IReadOnlyList<(string Vendor, string CliPath)> watched, Action<string> refresh,
-            Func<string, CliBinaryStat?> stat) {
+            Func<string, CliBinaryStat?> stat, IReadOnlyDictionary<string, CliBinaryStat?>? baselines) {
         _logger    = NullLogger.Instance;
+        _recorded  = baselines;
         Watched    = watched;
         Refresh    = refresh;
         StatBinary = stat;
     }
 
-    /// <summary>Test factory — bypasses DI; the caller supplies every seam.</summary>
     internal static VendorCliWatcher ForTest(
             IReadOnlyList<(string Vendor, string CliPath)> watched, Action<string> refresh,
-            Func<string, CliBinaryStat?> stat) =>
-        new(watched, refresh, stat);
+            Func<string, CliBinaryStat?> stat, IReadOnlyDictionary<string, CliBinaryStat?>? baselines = null) =>
+        new(watched, refresh, stat, baselines);
 
     internal void PrimeBaselines() {
-        foreach (var (vendor, cliPath) in Watched) _baselines[vendor] = StatBinary(cliPath);
+        foreach (var (vendor, cliPath) in Watched)
+            _baselines[vendor] = _recorded is { } recorded && recorded.TryGetValue(vendor, out var baseline)
+                ? baseline
+                : StatBinary(cliPath);
     }
 
     /// <summary>One poll iteration (timer-driven; also the unit-test entry point). All vendors
@@ -94,12 +102,14 @@ internal sealed partial class VendorCliWatcher : BackgroundService {
     }
 
     protected override async Task ExecuteAsync(CancellationToken ct) {
-        if (_config is not null && _factories is not null)
-            Watched = (_config.UnattendedVendors ?? [])
+        if (_config is not null && _factories is not null) {
+            _recorded = _config.UnattendedVendorBaselines;
+            Watched   = (_config.UnattendedVendors ?? [])
                 .Where(_factories.ContainsKey)
                 .Select(vendor => (vendor, _factories[vendor].CliPath))
                 .Where(pair => !string.IsNullOrEmpty(pair.CliPath))
                 .ToArray();
+        }
         PrimeBaselines();
 
         using var timer = new PeriodicTimer(PollInterval);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCapabilityRefreshTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCapabilityRefreshTests.cs
@@ -1,0 +1,58 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit;
+
+/// <summary>
+/// <see cref="DaemonRunner.RetainAdvertisedVersions"/>: a re-probe that fails must not replace a
+/// version already advertised. The server reads a null version as the vendor being gone, so
+/// publishing one over a transient probe miss would withdraw the reviewer.
+/// </summary>
+public class DaemonRunnerCapabilityRefreshTests {
+    static UnattendedVendorCapability Cap(string vendor, string? version, bool borrowed = false) =>
+        new(vendor, version, $"{vendor}-unattended-v1", borrowed);
+
+    [Test]
+    public async Task A_failed_reprobe_keeps_the_previously_advertised_version() {
+        var merged = DaemonRunner.RetainAdvertisedVersions([Cap("claude", "2.1.259")], [Cap("claude", null)]);
+
+        await Assert.That(merged.Single().CliVersion).IsEqualTo("2.1.259");
+    }
+
+    [Test]
+    public async Task A_successful_reprobe_replaces_the_advertised_version() {
+        var merged = DaemonRunner.RetainAdvertisedVersions([Cap("claude", "2.1.259")], [Cap("claude", "2.1.263")]);
+
+        await Assert.That(merged.Single().CliVersion).IsEqualTo("2.1.263");
+    }
+
+    [Test]
+    public async Task A_vendor_never_advertised_with_a_version_stays_unversioned() {
+        var merged = DaemonRunner.RetainAdvertisedVersions([Cap("claude", null)], [Cap("claude", null)]);
+
+        await Assert.That(merged.Single().CliVersion).IsNull();
+    }
+
+    [Test]
+    public async Task A_vendor_absent_from_the_reprobe_is_dropped() {
+        var merged = DaemonRunner.RetainAdvertisedVersions(
+            [Cap("claude", "2.1.259"), Cap("codex", "0.153.0")], [Cap("claude", "2.1.263")]);
+
+        await Assert.That(merged.Select(c => c.Vendor)).IsEquivalentTo(["claude"]);
+    }
+
+    [Test]
+    public async Task With_nothing_advertised_yet_the_reprobe_is_returned_unchanged() {
+        var fresh  = new[] { Cap("claude", null), Cap("codex", "0.153.0") };
+        var merged = DaemonRunner.RetainAdvertisedVersions(null, fresh);
+
+        await Assert.That(merged).IsEquivalentTo(fresh);
+    }
+
+    [Test]
+    public async Task Every_field_but_the_version_comes_from_the_reprobe() {
+        var merged = DaemonRunner.RetainAdvertisedVersions(
+            [Cap("codex", "0.153.0", borrowed: false)], [Cap("codex", null, borrowed: true)]);
+
+        await Assert.That(merged.Single()).IsEqualTo(Cap("codex", "0.153.0", borrowed: true));
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCapabilityRefreshTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCapabilityRefreshTests.cs
@@ -1,4 +1,9 @@
+using System.Runtime.Versioning;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+using Capacitor.Cli.Daemon.Tests.Unit.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit;
 
@@ -54,5 +59,27 @@ public class DaemonRunnerCapabilityRefreshTests {
             [Cap("codex", "0.153.0", borrowed: false)], [Cap("codex", null, borrowed: true)]);
 
         await Assert.That(merged.Single()).IsEqualTo(Cap("codex", "0.153.0", borrowed: true));
+    }
+
+    static PtyHostedAgentRuntimeFactory Factory(string vendor, string cliPath) =>
+        new(new SpyHostedAgentLauncher(vendor, cliPath), new SpyPtyProcessFactory(),
+            NullLogger<PtyHostedAgentRuntimeFactory>.Instance);
+
+    // The startup fingerprint is what the watcher compares against, so it must describe the same
+    // file the version probe ran, through the same factory-owned path.
+    [Test]
+    [UnsupportedOSPlatform("windows")]
+    public async Task Startup_fingerprints_describe_each_advertised_vendors_binary() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary is a POSIX shell script.");
+        using var tmp = new TempDir();
+        var claude = tmp.CreateFile("claude", "#!/bin/sh\necho 2.1.263\n");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(claude, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var baselines = DaemonRunner.FingerprintUnattendedVendors(
+            [Factory("claude", claude), Factory("codex", tmp.PathTo("missing-codex"))], ["claude", "codex"]);
+
+        await Assert.That(baselines["claude"]!.Value.ResolvedPath).IsEqualTo(new FileInfo(claude).FullName);
+        await Assert.That(baselines["codex"]).IsNull();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCursorAvailabilityTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerCursorAvailabilityTests.cs
@@ -541,9 +541,9 @@ public class DaemonRunnerCursorAvailabilityTests {
         await Assert.That(capability.BorrowedReviewContainment).IsEqualTo("independent-snapshot");
     }
 
-    /// <summary>The wording must mark the value as a daemon-startup observation, so nobody reads it
-    /// as the build a later reviewer actually ran — an update after startup makes it stale, which is
-    /// precisely the situation that caused this bug.</summary>
+    /// <summary>The wording must mark the value as a daemon-startup observation and say that a later
+    /// change is re-advertised, so nobody reads this line as the build a later reviewer actually ran
+    /// and nobody restarts the daemon to refresh it.</summary>
     [Test]
     public async Task LogUnattendedVendorIdentities_WordsTheVersionAsAStartupObservation_NotALaunchFact() {
         var logger = new CaptureLogger();
@@ -554,7 +554,8 @@ public class DaemonRunnerCursorAvailabilityTests {
 
         var line = logger.Entries.Single().Message;
         await Assert.That(line).Contains("daemon startup");
-        await Assert.That(line).Contains("stale");
+        await Assert.That(line).Contains("re-advertised");
+        await Assert.That(line).DoesNotContain("restart");
     }
 
     /// <summary>NEGATIVE test, and it is load-bearing: the startup line reports the version and

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorCapabilityRefreshTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorCapabilityRefreshTests.cs
@@ -1,0 +1,103 @@
+using System.Runtime.Versioning;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// <see cref="AgentOrchestrator.RefreshAdvertisedCapabilities"/>: the one path through which a
+/// running daemon re-advertises its vendor CLI versions, shared by the binary watcher and the
+/// certification rejection. Re-probes the real stub binary rather than faking the probe, so what is
+/// pinned is the advertisement the server would see.
+/// </summary>
+[ParallelLimiter<SubprocessLimit>]
+public class AgentOrchestratorCapabilityRefreshTests {
+    [TempDir] public required TempDir Tmp { get; init; }
+
+    const string MissingCli = "/definitely/missing/claude";
+
+    string StubClaude(string version) {
+        var path = Tmp.CreateFile("claude", $"#!/bin/sh\necho '{version} (Claude Code)'\n");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(path, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        return path;
+    }
+
+    static UnattendedVendorCapability Advertised(string? version) =>
+        new("claude", version, DaemonRunner.ClaudeLauncherPolicyVersion, false);
+
+    static (AgentOrchestrator Orchestrator, CaptureServerConnection Server, DaemonConfig Config) Build(
+            string cliPath, IReadOnlyList<UnattendedVendorCapability>? advertised) {
+        var server   = new CaptureServerConnection();
+        var launcher = new SpyHostedAgentLauncher("claude", cliPath) { SupportsUnattended = true };
+        DaemonConfig? captured = null;
+        var orch = AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(),
+            new Dictionary<string, IHostedAgentLauncher> { ["claude"] = launcher },
+            configure: config => {
+                config.UnattendedVendors             = ["claude"];
+                config.UnattendedVendorCapabilities  = advertised;
+                captured = config;
+            });
+        return (orch, server, captured!);
+    }
+
+    static string? ClaudeVersion(DaemonConfig config) =>
+        config.UnattendedVendorCapabilities!.Single(c => c.Vendor == "claude").CliVersion;
+
+    [Test]
+    [UnsupportedOSPlatform("windows")]
+    public async Task A_changed_binary_is_re_advertised_with_its_installed_version() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary is a POSIX shell script.");
+        var (orch, server, config) = Build(StubClaude("2.1.263"), [Advertised("2.1.259")]);
+        await using var _ = orch;
+
+        orch.RefreshAdvertisedCapabilities("test");
+        await orch.CapabilityRefreshForTest;
+
+        await Assert.That(ClaudeVersion(config)).IsEqualTo("2.1.263");
+        await Assert.That(server.RegisterDaemonCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    [UnsupportedOSPlatform("windows")]
+    public async Task An_unchanged_advertisement_is_not_re_registered() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary is a POSIX shell script.");
+        var (orch, server, _) = Build(StubClaude("2.1.263"), advertised: null);
+        await using var __ = orch;
+
+        orch.RefreshAdvertisedCapabilities("first");
+        await orch.CapabilityRefreshForTest;
+        orch.RefreshAdvertisedCapabilities("second");
+        await orch.CapabilityRefreshForTest;
+
+        await Assert.That(server.RegisterDaemonCalls).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task A_failed_reprobe_keeps_the_advertised_version() {
+        var (orch, _, config) = Build(MissingCli, [Advertised("2.1.259")]);
+        await using var __ = orch;
+
+        orch.RefreshAdvertisedCapabilities("test");
+        await orch.CapabilityRefreshForTest;
+
+        await Assert.That(ClaudeVersion(config)).IsEqualTo("2.1.259");
+    }
+
+    // A certification rejection means the server's copy disagrees with the installed binary, so
+    // that path republishes even when the local advertisement already reads the same.
+    [Test]
+    public async Task A_republish_request_re_registers_an_unchanged_advertisement() {
+        var (orch, server, _) = Build(MissingCli, advertised: null);
+        await using var __ = orch;
+
+        orch.RefreshAdvertisedCapabilities("first");
+        await orch.CapabilityRefreshForTest;
+        orch.RefreshAdvertisedCapabilities("rejection", republishUnchanged: true);
+        await orch.CapabilityRefreshForTest;
+
+        await Assert.That(server.RegisterDaemonCalls).IsEqualTo(2);
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorCapabilityRefreshTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorCapabilityRefreshTests.cs
@@ -100,4 +100,22 @@ public class AgentOrchestratorCapabilityRefreshTests {
 
         await Assert.That(server.RegisterDaemonCalls).IsEqualTo(2);
     }
+
+    // The refresh is single-flighted, so a rejection's republish request that lands while a
+    // watcher-triggered pass is running is folded into that pass or its rerun. Folding must not
+    // drop the republish, or the retry the rejection promised meets the same stale server copy.
+    [Test]
+    public async Task A_republish_request_folded_into_a_running_pass_still_re_registers() {
+        var (orch, server, _) = Build(MissingCli, advertised: null);
+        await using var __ = orch;
+
+        orch.RefreshAdvertisedCapabilities("first");
+        await orch.CapabilityRefreshForTest;
+
+        orch.RefreshAdvertisedCapabilities("watcher");
+        orch.RefreshAdvertisedCapabilities("rejection", republishUnchanged: true);
+        await orch.CapabilityRefreshForTest;
+
+        await Assert.That(server.RegisterDaemonCalls).IsEqualTo(2);
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorVendorTests.cs
@@ -701,6 +701,10 @@ public class AgentOrchestratorVendorTests {
         await Assert.That(server.LaunchFailedCalls[0].Reason).Contains("reviewer_certification_changed");
         await Assert.That(claudeSpy.PrepareCalls).IsEqualTo(0);
         await Assert.That(ptyFactory.SpawnCalls).IsEqualTo(0);
+
+        // The rejection is also the self-heal: the daemon re-advertises so the next attempt passes.
+        await orch.CapabilityRefreshForTest;
+        await Assert.That(server.RegisterDaemonCalls).IsEqualTo(1);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
@@ -41,6 +41,17 @@ sealed class CaptureServerConnection() : ServerConnection(
     /// <summary>Reasons passed to EndAgentSessionAsync, in call order.</summary>
     public List<string> EndSessionReasons { get; } = [];
 
+    int _registerDaemonCalls;
+
+    /// <summary>Full daemon re-registrations requested (the capability self-heal's
+    /// <c>ReRegisterAsync</c> lands here). No-op'd: there is no hub to register with.</summary>
+    public int RegisterDaemonCalls => Volatile.Read(ref _registerDaemonCalls);
+
+    internal override Task RegisterDaemonAsync() {
+        Interlocked.Increment(ref _registerDaemonCalls);
+        return Task.CompletedTask;
+    }
+
     public override async Task LaunchFailedAsync(string agentId, string reason) {
         LaunchFailedCalls.Add((agentId, reason));
         LaunchFailedEntered?.TrySetResult();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerCertificationArmTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ReviewerCertificationArmTests.cs
@@ -34,14 +34,17 @@ public class ReviewerCertificationArmTests {
 
     // ...but a genuine swap must still be caught, or the relaxation above would gut the arm.
     // In-range on purpose: an out-of-range replacement is the range arm's business (above), so this
-    // pins the swap arm specifically.
-    [Test] public async Task A_genuine_in_range_cli_swap_is_still_rejected() {
+    // pins the swap arm specifically. The remedy is a retry: the rejection itself re-advertises the
+    // installed version, and a restart would tear down every hosted agent for nothing.
+    [Test] public async Task A_genuine_in_range_cli_swap_is_rejected_with_a_retry_remedy() {
         var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
             "claude", "2.9.9", Conn, Cert(expectedCliVersion: "2.1.212"));
 
         await Assert.That(ok).IsFalse();
         await Assert.That(reason).Contains("2.1.212");
-        await Assert.That(reason).Contains("restart the daemon");
+        await Assert.That(reason).Contains("2.9.9");
+        await Assert.That(reason).Contains("retry the flow");
+        await Assert.That(reason).DoesNotContain("restart");
     }
 
     // A null ADVERTISED version must still fall through to the RANGE check -- that is the real gate,
@@ -72,17 +75,17 @@ public class ReviewerCertificationArmTests {
         await Assert.That(reason).DoesNotContain("restart");      // not the swap remedy
     }
 
-    // Codex review P2 #3: a CLI genuinely replaced with an OUT-OF-RANGE version must be told about
-    // the range, not told to restart -- restarting re-advertises the same out-of-range version, so
-    // that remedy can never work.
-    [Test] public async Task An_out_of_range_replacement_reports_the_range_not_a_restart() {
+    // A CLI genuinely replaced with an OUT-OF-RANGE version must be told about the range, not told
+    // to retry -- the re-advertisement carries the same out-of-range version, so that remedy can
+    // never work.
+    [Test] public async Task An_out_of_range_replacement_reports_the_range_not_a_retry() {
         var (ok, reason) = AgentOrchestrator.EvaluateReviewerCertification(
             "claude", "9.9.9", Conn, Cert(expectedCliVersion: "2.1.212"));
 
         await Assert.That(ok).IsFalse();
         await Assert.That(reason).Contains("outside");
         await Assert.That(reason).Contains(">=2.0.0 <3.0.0");
-        await Assert.That(reason).DoesNotContain("restart the daemon");
+        await Assert.That(reason).DoesNotContain("retry the flow");
     }
 
     // Each arm names ITSELF. The old single message reported the certification revision -- which

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/VendorCliWatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/VendorCliWatcherTests.cs
@@ -119,6 +119,22 @@ public class VendorCliWatcherTests {
         await Assert.That(h.Refreshes[0]).DoesNotContain("claude");
     }
 
+    // The advertised versions are probed at daemon startup, before this service starts; a vendor
+    // that updates in between must not be taken as the baseline, or the stale advertisement is
+    // never corrected. A fingerprint recorded before the probe wins over the file seen at start.
+    [Test]
+    public async Task A_baseline_recorded_before_the_startup_probe_wins_over_the_file_at_start() {
+        var refreshes = new List<string>();
+        var watcher = VendorCliWatcher.ForTest(
+            [("claude", "/bin/claude")], refreshes.Add, _ => New,
+            baselines: new Dictionary<string, CliBinaryStat?> { ["claude"] = Old });
+        watcher.PrimeBaselines();
+
+        watcher.Tick();
+
+        await Assert.That(refreshes.Count).IsEqualTo(1);
+    }
+
     // The fingerprint follows every link to the file that actually runs: a bare command name is
     // resolved on PATH, and a symlink chain is walked to its final target.
     [Test]
@@ -128,8 +144,8 @@ public class VendorCliWatcherTests {
         var target = tmp.CreateFile("versions/2.1.263/claude", "#!/bin/sh\necho 2.1.263\n");
         if (!OperatingSystem.IsWindows())
             File.SetUnixFileMode(target, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        tmp.CreateDir("bin");
         var link = tmp.PathTo("bin/claude");
-        Directory.CreateDirectory(Path.GetDirectoryName(link)!);
         File.CreateSymbolicLink(link, target);
 
         var stat = VendorCliWatcher.StatCliBinary(link);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/VendorCliWatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/VendorCliWatcherTests.cs
@@ -1,0 +1,148 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// The watcher that notices an advertised vendor's CLI binary changing under a running daemon and
+/// asks for the advertisement to be refreshed, so a vendor auto-update does not cost the next
+/// reviewer launch.
+/// </summary>
+public class VendorCliWatcherTests {
+    static readonly CliBinaryStat Old = new("/versions/2.1.259/claude", 100, 1);
+    static readonly CliBinaryStat New = new("/versions/2.1.263/claude", 100, 2);
+
+    sealed class Harness {
+        public readonly List<string>                          Refreshes = [];
+        public readonly Dictionary<string, CliBinaryStat?>    Stats     = new(StringComparer.Ordinal);
+        public readonly VendorCliWatcher                      Watcher;
+
+        public Harness(params (string Vendor, string CliPath)[] watched) {
+            Watcher = VendorCliWatcher.ForTest(
+                watched,
+                refresh: Refreshes.Add,
+                stat: path => Stats.GetValueOrDefault(path));
+        }
+    }
+
+    [Test]
+    public async Task An_unchanged_binary_requests_nothing() {
+        var h = new Harness(("claude", "/bin/claude"));
+        h.Stats["/bin/claude"] = Old;
+        h.Watcher.PrimeBaselines();
+
+        h.Watcher.Tick();
+
+        await Assert.That(h.Refreshes).IsEmpty();
+    }
+
+    [Test]
+    public async Task A_changed_binary_requests_one_refresh_naming_the_vendor() {
+        var h = new Harness(("claude", "/bin/claude"));
+        h.Stats["/bin/claude"] = Old;
+        h.Watcher.PrimeBaselines();
+
+        h.Stats["/bin/claude"] = New;
+        h.Watcher.Tick();
+        h.Watcher.Tick();
+
+        await Assert.That(h.Refreshes.Count).IsEqualTo(1);
+        await Assert.That(h.Refreshes[0]).Contains("claude");
+    }
+
+    // A symlink flip to a new version directory is the common shape of a vendor update, and the
+    // new build can have the same size and a newer mtime that a coarse clock still rounds equal.
+    [Test]
+    public async Task A_symlink_retarget_alone_counts_as_a_change() {
+        var h = new Harness(("claude", "/bin/claude"));
+        h.Stats["/bin/claude"] = Old;
+        h.Watcher.PrimeBaselines();
+
+        h.Stats["/bin/claude"] = Old with { ResolvedPath = "/versions/2.1.263/claude" };
+        h.Watcher.Tick();
+
+        await Assert.That(h.Refreshes.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task A_transient_stat_failure_neither_refreshes_nor_moves_the_baseline() {
+        var h = new Harness(("claude", "/bin/claude"));
+        h.Stats["/bin/claude"] = Old;
+        h.Watcher.PrimeBaselines();
+
+        h.Stats["/bin/claude"] = null;   // mid-install: the binary is briefly gone
+        h.Watcher.Tick();
+        h.Stats["/bin/claude"] = Old;    // ...and back, unchanged
+        h.Watcher.Tick();
+
+        await Assert.That(h.Refreshes).IsEmpty();
+    }
+
+    [Test]
+    public async Task A_binary_that_was_missing_at_startup_is_noticed_when_it_appears() {
+        var h = new Harness(("claude", "/bin/claude"));
+        h.Watcher.PrimeBaselines();      // stat returns null: nothing to fingerprint yet
+
+        h.Stats["/bin/claude"] = New;
+        h.Watcher.Tick();
+
+        await Assert.That(h.Refreshes.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Several_vendors_changing_in_one_tick_share_one_refresh() {
+        var h = new Harness(("claude", "/bin/claude"), ("codex", "/bin/codex"));
+        h.Stats["/bin/claude"] = Old;
+        h.Stats["/bin/codex"]  = new("/lib/codex.js", 500, 1);
+        h.Watcher.PrimeBaselines();
+
+        h.Stats["/bin/claude"] = New;
+        h.Stats["/bin/codex"]  = new("/lib/codex.js", 520, 2);
+        h.Watcher.Tick();
+
+        await Assert.That(h.Refreshes.Count).IsEqualTo(1);
+        await Assert.That(h.Refreshes[0]).Contains("claude");
+        await Assert.That(h.Refreshes[0]).Contains("codex");
+    }
+
+    [Test]
+    public async Task Only_the_changed_vendor_is_named() {
+        var h = new Harness(("claude", "/bin/claude"), ("codex", "/bin/codex"));
+        h.Stats["/bin/claude"] = Old;
+        h.Stats["/bin/codex"]  = new("/lib/codex.js", 500, 1);
+        h.Watcher.PrimeBaselines();
+
+        h.Stats["/bin/codex"] = new("/lib/codex.js", 520, 2);
+        h.Watcher.Tick();
+
+        await Assert.That(h.Refreshes.Count).IsEqualTo(1);
+        await Assert.That(h.Refreshes[0]).Contains("codex");
+        await Assert.That(h.Refreshes[0]).DoesNotContain("claude");
+    }
+
+    // The fingerprint follows every link to the file that actually runs: a bare command name is
+    // resolved on PATH, and a symlink chain is walked to its final target.
+    [Test]
+    public async Task The_real_fingerprint_follows_symlinks_to_the_installed_file() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "Symlink creation needs no privilege only on Unix.");
+        using var tmp = new TempDir();
+        var target = tmp.CreateFile("versions/2.1.263/claude", "#!/bin/sh\necho 2.1.263\n");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(target, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        var link = tmp.PathTo("bin/claude");
+        Directory.CreateDirectory(Path.GetDirectoryName(link)!);
+        File.CreateSymbolicLink(link, target);
+
+        var stat = VendorCliWatcher.StatCliBinary(link);
+
+        await Assert.That(stat).IsNotNull();
+        await Assert.That(stat!.Value.ResolvedPath).IsEqualTo(new FileInfo(target).FullName);
+        await Assert.That(stat.Value.Size).IsEqualTo(new FileInfo(target).Length);
+    }
+
+    [Test]
+    public async Task A_missing_binary_has_no_fingerprint() {
+        using var tmp = new TempDir();
+
+        await Assert.That(VendorCliWatcher.StatCliBinary(tmp.PathTo("nope"))).IsNull();
+    }
+}


### PR DESCRIPTION
Closes #802 — AI-2547

## What & why

The vendor CLI version a daemon advertises is a startup probe cached for the process lifetime, so a Claude auto-update under a long-running daemon costs the next review-flow launch, and the rejection tells the operator to restart the daemon: the one action that tears down every hosted agent. The rejection already re-advertised on the live connection, so the remedy now says retry. A `VendorCliWatcher` fingerprints each advertised vendor's binary (PATH-resolved, symlink chain followed, size, mtime) every 15 s and, on a change, re-probes and re-registers through the orchestrator's single-flight refresh, which the rejection path now shares.

## Where to look

`DaemonRunner.RetainAdvertisedVersions`: a re-probe that returns null keeps the previously advertised version, because the server reads null as the vendor being gone. An unchanged refresh skips the re-register, since every registration bumps the slot's connection generation and fails a reviewer launch pinned to the previous one; the rejection path forces a republish because the server's copy has just proven wrong, and that request is a sticky flag because a request folded into a running pass reruns the first caller's delegate. The watcher's first baseline is the fingerprint taken at startup before the version probe, so a vendor updating inside the probe window still reads as a change. `SingleFlightRefresh` re-takes its gate when a request lands between the last rerun check and the release, so a watcher request cannot be lost. The refresh probes the startup vendor set rather than re-classifying, so a vendor withheld at startup for a version floor stays withheld until a restart.

## Verification

Live: Claude flipped 2.1.259 → 2.1.263 on Sep 6 under a daemon started Sep 3; one spec-review launch was rejected at 08:31 on Sep 7 and `GET /api/daemons` then showed `cli_version: 2.1.263` with the daemon never restarted, which is the self-heal this PR builds on.

```
Capacitor.Cli.Daemon.Tests.Unit (full suite)   total 3067, failed 1 (Installed_codex_schema_matches_the_vendored_pin, local codex newer than the pin), skipped 38
dotnet publish src/Capacitor.Cli.Daemon -c Release   no IL2026/IL3050 warnings
```
