### PR TITLE
Render the desktop app through OpenGL on macOS

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -985,3 +985,12 @@ a run of them.
 **Stopping does not wait for a beat in flight**, and does not cancel it either. Nothing is owed to it:
 the relinquish that follows states the ending, and the browser reads a stated ending ahead of an inferred
 one.
+
+## The desktop app renders through OpenGL on macOS
+
+Avalonia puts Metal first in its macOS renderer order. On macOS 26 that path presents alternate frames
+with different colour matching, so any steady repaint flickers the whole window between two shades — the
+composer caret blinking while the window is focused is enough, and the flicker stops the moment focus
+leaves. Nothing in the app drives it: every surface is a static brush, and the shift covers the rail, the
+panes and the text alike. The renderer order leaves Metal out, OpenGL first with the software renderer
+behind it, and the flicker is gone.

--- a/src/Capacitor.App/Program.cs
+++ b/src/Capacitor.App/Program.cs
@@ -9,9 +9,14 @@ internal static class Program
     public static void Main(string[] args) => BuildAvaloniaApp()
         .StartWithClassicDesktopLifetime(args);
 
+    // Metal stays out of the macOS renderer order: on macOS 26 it presents alternate frames with
+    // different colour matching, so a focused window flickers at the caret blink rate.
     public static AppBuilder BuildAvaloniaApp() =>
         AppBuilder.Configure<App>()
             .UsePlatformDetect()
+            .With(new AvaloniaNativePlatformOptions {
+                RenderingMode = [AvaloniaNativeRenderingMode.OpenGl, AvaloniaNativeRenderingMode.Software],
+            })
             .UseReactiveUI(_ => { })
             .LogToTrace();
 }


### PR DESCRIPTION
No tracker issue exists for this: the bug is reported and fixed in this PR, so both halves of the reference line are dropped.

## What & why

Avalonia 12 puts Metal first in its macOS renderer order, and on macOS 26 that path presents alternate frames with different colour matching. The whole window shifts between two shades on every repaint, so a focused window with a blinking caret flickers once a second and stops the moment focus leaves. No app colour is involved: every surface is a static brush, and the shift covers the rail, the panes and the header text alike. The renderer order now leaves Metal out, OpenGL first with the software renderer behind it.

## Where to look

Only `Program.cs` changes behaviour. `AvaloniaNativePlatformOptions` is read by the macOS backend alone, so Windows and Linux keep their defaults, and the headless test session builds its own `AppBuilder`.

## Verification

Pixel samples from two consecutive frames of identical content under Metal, macOS 26.6.2, M2 Ultra:

| Surface | Design token | Frame with caret | Frame without caret |
|---|---|---|---|
| Canvas | 11,13,18 | 10,13,19 | 8,10,18 |
| Surface | 18,21,29 | 17,21,30 | 15,21,33 |
| Header text | | 196,199,203 | 200,203,206 |

With this change the app was run from the branch build on the same machine with the composer focused: no flicker.

`dotnet build src/Capacitor.App/Capacitor.App.csproj --no-incremental`: 0 warnings, 0 errors.
