### PR TITLE
Heal the Codex MCP registration on every refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -1232,7 +1232,7 @@ kcap plugin install --codex                          # user scope (~/.codex/hook
 kcap plugin install --codex --project                # project scope (<repo>/.codex/hooks.json), skills still user-wide
 kcap plugin install --skills                         # skills only (~/.agents/skills/), no Codex hooks
 kcap plugin install --skills --if-installed          # refresh only if skills were previously installed (used by npm postinstall, harmless to call by hand)
-kcap plugin install --codex --if-installed           # refresh Codex hooks only if previously installed (used by npm postinstall)
+kcap plugin install --codex --if-installed           # refresh Codex hooks and add missing MCP servers, only if previously installed (used by npm postinstall)
 kcap plugin install --if-installed                   # refresh Claude plugin registration only if previously installed (used by npm postinstall)
 ```
 
@@ -1264,7 +1264,7 @@ The first five (`kcap-recap`, `kcap-errors`, `kcap-hide`, `kcap-disable`, `kcap-
 > domains = { "**.kcap.ai" = "allow" }
 > ```
 >
-> The `**.kcap.ai` wildcard covers every SaaS tenant — current and future — plus `auth.kcap.ai`, so switching profiles and adding tenants just work with no per-tenant edits. **Self-hosted** servers are added as exact-host entries, derived from every configured profile's `server_url` and refreshed on each `kcap setup`. Existing config is respected: if you already run a `network_proxy` policy, kcap's hosts are merged into your `domains` (yours preserved); if you've already opened the network (`network_access = true` with no proxy), nothing changes. Opt out with `--skip-codex-network-access` on either command (and the npm-postinstall `--if-installed` refresh never touches `config.toml`). A localhost dev server additionally needs `allow_local_binding = true`, which kcap does not set. Uninstall leaves these keys in place — they're your security posture, not kcap state.
+> The `**.kcap.ai` wildcard covers every SaaS tenant — current and future — plus `auth.kcap.ai`, so switching profiles and adding tenants just work with no per-tenant edits. **Self-hosted** servers are added as exact-host entries, derived from every configured profile's `server_url` and refreshed on each `kcap setup`. Existing config is respected: if you already run a `network_proxy` policy, kcap's hosts are merged into your `domains` (yours preserved); if you've already opened the network (`network_access = true` with no proxy), nothing changes. Opt out with `--skip-codex-network-access` on either command (the npm-postinstall `--if-installed` refresh never touches these keys; its only `config.toml` write is adding missing kcap MCP servers). A localhost dev server additionally needs `allow_local_binding = true`, which kcap does not set. Uninstall leaves these keys in place — they're your security posture, not kcap state.
 
 **Sandbox and approval posture.** By default the daemon starts Codex with `--sandbox workspace-write` and `--ask-for-approval on-request`. This lets Codex edit files in the agent's worktree but escalates sensitive operations (e.g. network calls, shell commands outside the worktree) through the daemon's permission bridge to the dashboard.
 

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -60,6 +60,15 @@ ago. `RetainAdvertisedVersions` carries the previous version over a null re-prob
 that still disagrees hits the swap arm and forces another refresh. The refresh probes the vendor set
 fixed at startup rather than re-classifying, which is also what `DaemonConnect` sends as the vendor
 list; a vendor withheld at startup for a version floor stays withheld until a restart.
+## A Codex refresh heals the MCP registration
+
+**#807** registers the kcap MCP servers on every Codex refresh, the `plugin install --codex
+--if-installed` that `kcap update` and the npm postinstall run. The hooks version marker gates only
+the hooks write: it says nothing about `~/.codex/config.toml`, so a server that joined the Codex set
+after the last full install stayed unregistered however current the hooks were, and Codex loaded a
+session with the session and review tools but no flow tools. The registration is idempotent and
+leaves every unclaimed or user entry alone, so repeating it is safe; the opt-in gate stays ahead of
+it, so a user who never installed the Codex integration still gets no entries.
 
 ## The desktop app shows a session waiting for input
 

--- a/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
+++ b/src/Capacitor.Cli/Commands/CodingAgentsStep.cs
@@ -1073,7 +1073,7 @@ internal static class CodingAgentsStep {
     /// CLI picks them up with no manual TOML edit. Gated on Codex hooks installing — the
     /// same "full Codex integration" trigger as skills. No prompt: registration is
     /// non-destructive (only adds missing kcap servers) and mirrors how the Claude plugin
-    /// auto-registers its MCP servers. <c>kcap-flows</c> stays Claude-only.
+    /// auto-registers its MCP servers.
     /// </summary>
     static bool HandleCodexMcp(
             Paths          paths,

--- a/src/Capacitor.Cli/Commands/PluginCommand.cs
+++ b/src/Capacitor.Cli/Commands/PluginCommand.cs
@@ -329,24 +329,29 @@ public sealed class PluginCommand(PluginEnvironment env) {
             ? Path.Combine(Environment.CurrentDirectory, ".codex", "hooks.json")
             : env.Paths.Codex.UserHooksJson;
 
-        // --if-installed: refresh-only mode used by the npm postinstall hook.
-        // Skip when the user never opted in; short-circuit when the marker
-        // already matches the current CLI version. Skills are NOT touched
+        // --if-installed: refresh-only mode used by the npm postinstall hook and
+        // `kcap update`. Skip when the user never opted in. Skills are NOT touched
         // here — `--skills --if-installed` is its own postinstall call.
         var refreshOnly = args.Contains("--if-installed");
 
-        switch (refreshOnly) {
-            case true when !CodexHooksInstaller.IsInstalled(hooksPath):
-            case true when CodexHooksInstaller.ReadMarker(hooksPath) == CapacitorVersion.Current():
-            // Hooks-only refresh: rewrite the kcap entries in hooks.json,
-            // stamp the marker, exit. No skills, no plugin folder needed.
-            // Never fail the npm install path.
-            case true when !InstallCodexHooks(hooksPath):
-                return 0;
-            case true:
-                await env.Stdout.WriteLineAsync($"Codex hooks refreshed ({scope}: {hooksPath})");
+        if (refreshOnly) {
+            if (!CodexHooksInstaller.IsInstalled(hooksPath)) return 0;
 
-                return 0;
+            // The marker gates only the hooks write. The MCP registration is healed on every
+            // refresh: the marker says nothing about config.toml, and a server that joined the
+            // Codex set after the last full install is otherwise never registered.
+            // Never fail the npm install path.
+            if (CodexHooksInstaller.ReadMarker(hooksPath) != CapacitorVersion.Current()) {
+                if (InstallCodexHooks(hooksPath))
+                    await env.Stdout.WriteLineAsync($"Codex hooks refreshed ({scope}: {hooksPath})");
+                else
+                    await env.Stderr.WriteLineAsync(
+                        $"Warning: could not refresh Codex hooks ({hooksPath}); continuing with MCP registration.");
+            }
+
+            await RegisterCodexMcpServersAsync();
+
+            return 0;
         }
 
         // `--codex` is an atomic hooks AND skills contract. Resolve the
@@ -427,9 +432,7 @@ public sealed class PluginCommand(PluginEnvironment env) {
 
         // Register the kcap MCP servers in ~/.codex/config.toml so Codex CLI picks them up
         // with no manual TOML edit (the plugin descriptor path alone isn't enough — many
-        // users never run `codex plugin add`). Non-destructive + idempotent. `kcap-flows`
-        // stays Claude-only. The --if-installed refresh returns earlier, so npm
-        // postinstall never touches config.toml here.
+        // users never run `codex plugin add`). Non-destructive + idempotent.
         await RegisterCodexMcpServersAsync();
 
         if (scope == "project") {

--- a/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandCodexTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/PluginCommandCodexTests.cs
@@ -582,6 +582,74 @@ public class PluginCommandCodexInstallIntegrationTests {
         await Assert.That(toml).Contains("[mcp_servers.kcap-memory]");
     }
 
+    /// <summary>A refresh with current hooks still adds the kcap servers the last full install
+    /// predates, and touches nothing else: the legacy entries stay unclaimed and hooks.json is
+    /// not rewritten.</summary>
+    [Test]
+    public async Task InstallCodex_if_installed_registers_missing_mcp_servers_when_hooks_are_current() {
+        using var fakeHome = new TempDir();
+        var configPath = SeedCodexConfigWithKcapServers(fakeHome.GetResolvedPath());
+        var codexDir   = fakeHome.CreateDir(".codex");
+        var hooksPath  = codexDir.CreateFile("hooks.json", """{"sentinel": "must-survive"}""");
+        codexDir.CreateFile(CodexHooksInstaller.MarkerFileName, CapacitorVersion.Current());
+
+        var exit = await new PluginCommand(TestEnv(fakeHome.GetResolvedPath())).HandleAsync(
+            ["plugin", "install", "--codex", "--if-installed"]);
+        await Assert.That(exit).IsEqualTo(0);
+
+        var toml = await File.ReadAllTextAsync(configPath);
+        await Assert.That(toml).Contains("[mcp_servers.kcap-flows]");
+        await Assert.That(toml).Contains("[mcp_servers.kcap-workitems]");
+        await Assert.That(toml).Contains("[mcp_servers.kcap-analytics]");
+        await Assert.That(toml).Contains("[mcp_servers.my-tool]");
+        // Both sides normalized: a Windows checkout gives the literal CRLF, the TOML writer emits LF.
+        await Assert.That(toml.ReplaceLineEndings("\n")).Contains("""
+            [mcp_servers.kcap-review]
+            command = "kcap"
+            """.ReplaceLineEndings("\n"));
+
+        var hooks = JsonNode.Parse(await File.ReadAllTextAsync(hooksPath))!.AsObject();
+        await Assert.That(hooks["sentinel"]!.GetValue<string>()).IsEqualTo("must-survive");
+    }
+
+    [Test]
+    public async Task InstallCodex_if_installed_registers_missing_mcp_servers_after_refreshing_stale_hooks() {
+        using var fakeHome = new TempDir();
+        var configPath = SeedCodexConfigWithKcapServers(fakeHome.GetResolvedPath());
+        var hooksPath  = fakeHome.PathTo(".codex", "hooks.json");
+        PluginCommand.InstallCodexHooks(hooksPath);
+        CodexHooksInstaller.DeleteMarker(hooksPath);
+
+        var exit = await new PluginCommand(TestEnv(fakeHome.GetResolvedPath())).HandleAsync(
+            ["plugin", "install", "--codex", "--if-installed"]);
+        await Assert.That(exit).IsEqualTo(0);
+
+        await Assert.That(CodexHooksInstaller.ReadMarker(hooksPath)).IsEqualTo(CapacitorVersion.Current());
+        var toml = await File.ReadAllTextAsync(configPath);
+        await Assert.That(toml).Contains("[mcp_servers.kcap-flows]");
+    }
+
+    /// <summary>The opt-in gate stays ahead of the healing: a user who never installed the Codex
+    /// integration gets no MCP entries from a refresh.</summary>
+    [Test]
+    public async Task InstallCodex_if_installed_leaves_config_toml_alone_when_never_installed() {
+        using var fakeHome = new TempDir();
+        var codexDir   = fakeHome.CreateDir(".codex");
+        var configPath = codexDir.CreateFile("config.toml", """
+            [mcp_servers.my-tool]
+            command = "my-tool"
+            args = ["serve"]
+            """);
+
+        var exit = await new PluginCommand(TestEnv(fakeHome.GetResolvedPath())).HandleAsync(
+            ["plugin", "install", "--codex", "--if-installed"]);
+        await Assert.That(exit).IsEqualTo(0);
+
+        var toml = await File.ReadAllTextAsync(configPath);
+        await Assert.That(toml).DoesNotContain("kcap-flows");
+        await Assert.That(File.Exists(codexDir.PathTo("hooks.json"))).IsFalse();
+    }
+
     [Test]
     public async Task RemoveCodex_user_scope_preserves_unowned_manual_mcp_servers() {
         using var fakeHome = new TempDir();


### PR DESCRIPTION
Closes #807 — AI-2555

## What & why

`kcap update` and the npm postinstall refresh Codex through `plugin install --codex --if-installed`, which rewrote `hooks.json` and returned before the MCP registration. A machine set up before `kcap-flows`, `kcap-workitems` and `kcap-analytics` joined the Codex set kept only the original three servers through every update, and a Codex session then had session and review tools but no flow tools. The refresh now registers the kcap servers on every run, whether or not the hooks needed rewriting, as the Copilot refresh already does.

## Where to look

The opt-in gate is unchanged: a home with no Codex hooks still gets no entries. A hooks write failure on refresh warns and continues to the registration instead of returning silently.

## Verification

Reproduced on a machine whose last `kcap setup` was 2026-07-06 with only `kcap update` since: hooks and skills carried the update's timestamp, `config.toml` was untouched and had no `kcap-flows`. The new tests seed that state (three legacy entries, bare `kcap` command, no ledger) and failed on `[mcp_servers.kcap-flows]` before the fix.

| Check | Result |
|---|---|
| `dotnet run --project test/Capacitor.Cli.Tests.Unit` | 3980 passed, 19 skipped, 0 failed |
| `dotnet publish src/Capacitor.Cli -c Release` | fresh AOT binary, 0 IL2026/IL3050 warnings |
