### PR TITLE
Read linked pull requests in the desktop workspace

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,6 @@ src/Capacitor.Cli.Core/Resources/*.txt text eol=lf
 # `diff` attribute forces text: giving it a value (diff=csharp) selects a driver
 # instead and the file goes binary again.
 *.cs diff
+
+# The shared wire fixture is hashed as literal bytes on every platform.
+test/fixtures/pull-request-reads-v1.json text eol=lf

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,26 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## Read a linked pull request inside the workspace
+
+The work-context pane now has a compact PR card and a wide native reader beside
+Chat and Terminal. Description, checks, requested reviewers, published reviews,
+inline threads and conversation are readable without leaving a session. Chat
+drafts, terminal size and the existing hosts survive tab switches; PR context is
+also available on ended sessions and sessions without a terminal.
+
+The tenant server owns GitHub reads and current user/repository admission. The
+desktop negotiates a versioned contract, subtracts network time from short access
+leases and masks protected content when the workspace loses foreground. A transient
+failure can retain the already visible view temporarily; a denial clears it.
+Frozen pages keep stable ordering, expose incomplete coverage and bound retained
+content. Markdown uses native controls with explicit safe links and no remote images.
+
+The compatible server is required for native reading. Older servers retain safe
+external PR links after an independently authorized summary read. See the
+[design](superpowers/specs/2026-09-07-desktop-pr-context-design.md) and
+[credential design](superpowers/specs/2026-09-07-github-app-pr-credentials-design.md).
+
 ## Desktop shell: remote daemons
 
 The rail now merges the local daemon's agents with the server's registry of every daemon the

--- a/docs/github-app-token-lifecycle-research.md
+++ b/docs/github-app-token-lifecycle-research.md
@@ -1,0 +1,142 @@
+# GitHub App installation token lifecycle for a shared broker
+
+Research date: 2026-09-07. Scope: GitHub.com primary documentation and GitHub's
+public OpenAPI description. No credentials or live installations were inspected.
+Broker recommendations below are design inferences, not GitHub guarantees.
+
+## Issuance, expiry, and scope
+
+The app signs an `RS256` JWT with its private key. GitHub recommends the client ID
+as `iss`, an `iat` 60 seconds behind the current time, and an `exp` no more than
+10 minutes ahead. The JWT authenticates app-level operations; its expiry is
+separate from the installation token's expiry. Source:
+[Generating a JWT](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-json-web-token-jwt-for-a-github-app).
+
+`POST /app/installations/{installation_id}/access_tokens`, authenticated with the
+app JWT, creates an installation token. Tokens expire after one hour. An expired
+token returns 401; renewal means creating another token through the same endpoint,
+not using an OAuth refresh token. Source:
+[Create an installation access token](https://docs.github.com/en/rest/apps/apps#create-an-installation-access-token-for-an-app).
+
+The issuance request can restrict `repository_ids` or `repositories` to at most
+500 repositories and supply an explicit `permissions` map. Restrictions cannot
+exceed the installation's repository access or the app's granted permissions.
+Omitting repository restrictions grants access to every repository available to
+the installation; omitting permissions grants the app's granted permissions.
+The response includes `expires_at`, permissions, and repository information when
+applicable. GitHub is rolling out longer installation tokens; a fixed 40-character
+assumption is invalid. Source:
+[Generating installation tokens](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-an-installation-access-token-for-a-github-app).
+
+**Broker inference:** keep the private key and app JWT at the proxy. Issue only
+explicit repository IDs and a broker-owned permission profile. Reject an empty
+repository selection before contacting GitHub. Treat tokens as opaque bearer
+secrets and return their actual expiry. Cache and renew by tenant binding,
+installation, repository set, permission profile, and binding generation; a
+single installation-only cache could cross tenant or purpose boundaries. Renew
+before expiry with a small clock margin and coalesce concurrent requests. GitHub
+does not document a caller-selected shorter expiry in the issuance contract.
+
+## Installation selection and authority
+
+GitHub warns that an `installation_id` in a setup URL is spoofable. It directs
+apps to obtain a user access token and check that the installation is associated
+with that user. A valid OAuth state binds the browser transaction but is not, by
+itself, proof that the submitted installation belongs to the user. Source:
+[About the setup URL](https://docs.github.com/en/apps/creating-github-apps/registering-a-github-app/about-the-setup-url).
+
+`GET /user/installations` lists installations accessible to the authenticated
+GitHub App user token through read, write, or admin access. It is not an
+installation-owner list. `GET /user/installations/{installation_id}/repositories`
+lists repositories that user can access within the installation and includes the
+user's repository permissions. Both lists are paginated. These endpoints support
+GitHub App user access tokens; an identity-only OAuth credential is not an
+interchangeable credential type. Source:
+[Installation and repository discovery](https://docs.github.com/en/rest/apps/installations#list-app-installations-accessible-to-the-user-access-token).
+
+A user access token is restricted to the intersection of the app's and user's
+permissions and resources. Installation tokens instead act independently of the
+installing user; an organization installation can continue working after that
+person leaves. Sources:
+[User token access](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/generating-a-user-access-token-for-a-github-app),
+[GitHub App independence](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps).
+
+**Broker inference:** distinguish three decisions: the caller administers this
+Capacitor tenant; the GitHub installation belongs to the registered App and is
+accessible to the verified GitHub identity; the identity may delegate the chosen
+repositories to that tenant. A positive installation-list result establishes only
+the second decision. Bind numeric account, installation, and repository IDs, plus
+the explicit repository grant, in proxy-owned state. Do not accept a tenant's
+asserted installation ID as the authorization record.
+
+If product policy requires organization-owner approval, GitHub provides membership
+state and role through `GET /user/memberships/orgs/{org}`. This endpoint supports
+App user tokens with organization `Members: read`; a pending membership is not
+active membership. GitHub's membership documentation defines `admin` as the
+organization-owner role. Sources:
+[Authenticated-user organization membership](https://docs.github.com/en/rest/orgs/members#get-an-organization-membership-for-the-authenticated-user),
+[Organization membership roles](https://docs.github.com/en/rest/orgs/members#set-organization-membership-for-a-user).
+Requiring that permission and owner role, or permitting repository administrators
+to delegate individual repositories, is a product policy choice that must be
+decided explicitly. Neither GitHub discovery nor a Capacitor tenant-admin role
+automatically establishes the other authority.
+
+## Revocation and changing grants
+
+| Change | GitHub behavior | Broker consequence (inference) |
+| --- | --- | --- |
+| Individual token revocation | `DELETE /installation/token` invalidates the token used to authenticate that request. It needs an installation token, not the app JWT. [Revoke a token](https://docs.github.com/en/rest/apps/installations#revoke-an-installation-access-token) | Keep enough protected state to revoke each outstanding tenant lease on disconnect. Revoking one lease must not break another tenant's shared token. |
+| App uninstalled | Associated installation tokens are deactivated. [Credential revocation reference](https://docs.github.com/en/organizations/managing-programmatic-access-to-your-organization/github-credential-types) | Disable the binding and discard all its cached tokens. |
+| Installation suspended | API and webhook access to that account is blocked. [Suspend an installation](https://docs.github.com/en/rest/apps/apps#suspend-an-app-installation) | Deny issuance until current GitHub state confirms the suspension was removed. |
+| Repository removed | Existing installation tokens lose access to the removed resource. [App/OAuth comparison](https://docs.github.com/en/apps/oauth-apps/building-oauth-apps/differences-between-github-apps-and-oauth-apps) | Reconcile repository grants and invalidate affected leases. |
+| App permissions reduced | Removed permissions take effect immediately. [Modify App permissions](https://docs.github.com/en/apps/maintaining-github-apps/modifying-a-github-app-registration#changing-the-permissions-of-a-github-app) | Recheck the required permission profile; do not interpret a cached issuance response as current authority. |
+| App permissions increased | Each installation must approve additional repository/organization permissions; the existing grant remains until acceptance. [Approve permissions](https://docs.github.com/en/apps/using-github-apps/approving-updated-permissions-for-a-github-app) | Expose missing-permission state and mint again after approval; do not assume registration changes updated every installation. |
+
+If a tenant binding is removed only within Capacitor, GitHub has not itself revoked
+the bearer credential. **Inference:** stopping future issuance and deleting local
+cache entries cannot recall a token already delivered to the tenant. Successful
+per-token revocation, upstream installation changes, or expiry ends its GitHub
+access. A shorter broker lease only controls cooperating callers; it does not
+shorten GitHub's token lifetime.
+
+## Lifecycle notifications and reconciliation
+
+GitHub's public OpenAPI schemas define these actions:
+
+- `installation`: `created`, `deleted`, `new_permissions_accepted`, `suspend`,
+  `unsuspend`.
+- `installation_repositories`: `added`, `removed`.
+- `installation_target`: `renamed`.
+
+Source: [GitHub's OpenAPI description](https://github.com/github/rest-api-description/blob/main/descriptions/api.github.com/api.github.com.json),
+the `webhook-installation-*` schemas. GitHub Apps receive installation and
+installation-repository events by default. `repositories_removed` can be empty
+when repository selection changes from `all` to `selected`; applying only the
+listed removals is therefore incomplete. User authorization revocation is a
+separate `github_app_authorization` event and does not uninstall the app. Source:
+[Webhook events and payloads](https://docs.github.com/en/webhooks/webhook-events-and-payloads#installation).
+
+GitHub does not automatically redeliver failed deliveries. Source:
+[Handling failed deliveries](https://docs.github.com/en/webhooks/using-webhooks/handling-failed-webhook-deliveries).
+**Broker inference:** authenticate webhook bodies, deduplicate delivery IDs,
+invalidate affected leases, and reconcile current installation/repository state.
+Webhooks accelerate reconciliation; issuance and periodic reconciliation must
+also cover missing deliveries. Unknown authorization state must not extend an
+existing positive grant. A rename should update display labels, not transfer a
+binding to another numeric account.
+
+## Limits to carry into the implementation design
+
+- GitHub supplies no tenant concept. Delegation approval, binding exclusivity or
+  sharing, tenant authentication, and disconnect semantics belong to the broker.
+- Installation access does not implement per-user access checks for desktop PR
+  reads. Preserve the separate linked-identity repository gate described in
+  [linked GitHub access research](github-linked-pr-access-research.md).
+- The cited docs do not give an end-to-end propagation SLA for permission changes,
+  guarantee webhook order, or promise atomic authorization and content reads.
+  Define bounded cache lifetimes and fail-closed revalidation behavior explicitly.
+- The lifecycle schema has an acceptance notification for increased permissions;
+  it does not justify assuming a corresponding permission-reduction notification.
+- GitHub.com findings do not establish support across GitHub Enterprise Server
+  versions. No live token issuance, approval, revocation, or cross-tenant isolation
+  test was performed in this research.

--- a/docs/github-linked-pr-access-research.md
+++ b/docs/github-linked-pr-access-research.md
@@ -48,7 +48,7 @@ GitHub documents:
    tokens, and fine-grained PATs, with **Metadata: read** for fine-grained tokens.
    Source: the endpoint's fine-grained token section at the same official URL.
 
-Proposed private-PR admission sequence:
+Private-PR admission sequence:
 
 - Authenticate the Capacitor caller and retain the existing Full-session,
   repository visibility, and linked-PR identity gates.
@@ -74,7 +74,7 @@ still needs sufficient access to read the underlying PR/check/comment content.
 An independent feature switch could disable interactive reads without disabling
 tracker enrichment.
 
-### Limits and checks before adopting it
+### Limits and deployment validation
 
 - This is a server-enforced **repository-role check**, not a GitHub request made
   with the caller's token. Do not describe it as full per-user GitHub session/SSO/IP
@@ -86,11 +86,12 @@ tracker enrichment.
   before using publication as evidence; do not derive it from a session label.
 - A renamed username must not transfer access to a different numeric account. A
   permission response with a missing or mismatched target user cannot authorize.
-- The deployed integration token's ability to call the permission endpoint has not
-  been tested here. No server token was retrieved. Before implementation planning,
-  the operator/driver must verify it in its protected deployment environment with
-  a public repository and an authorized private test repository,
-  including team/base-role access and a denied user. Use only read operations.
+- The [deployment preflight](github-pr-context-preflight.md) verified numeric-ID
+  lookup and the permission endpoint for the current operator on both approved
+  repositories, using the existing fine-grained PAT inside the server container.
+  No credential left that environment. Team-only and denied-user controls remain
+  untested. Private check-suite/status/commit endpoints returned scope-related
+  403s; the full preflight is blocked pending compatible read permissions.
 - This introduces permission-query traffic; it belongs in the interactive request
   budget and must not starve background enrichment.
 
@@ -115,6 +116,7 @@ The approved read-only v1 approach is linked GitHub identity plus a fail-closed
 repository-role gate. The design specifies the public-repository case, proof
 lifetime and cache/page admission. Server fetches remain fail-closed; the draft gives
 already visible client content a bounded, labelled transient-outage display grace,
-never a grant to fetch or reveal more content. Deployed-token compatibility remains
-unverified and blocks implementation planning.
+never a grant to fetch or reveal more content. Deployment validation is partial:
+the tested user's permission gate works, but missing private CI/commit-read
+capabilities and remaining identity controls still block implementation planning.
 Use delegated user tokens if exact user-to-server authorization is required.

--- a/docs/github-linked-pr-access-research.md
+++ b/docs/github-linked-pr-access-research.md
@@ -89,9 +89,45 @@ tracker enrichment.
 - The [deployment preflight](github-pr-context-preflight.md) verified numeric-ID
   lookup and the permission endpoint for the current operator on both approved
   repositories, using the existing fine-grained PAT inside the server container.
-  No credential left that environment. Team-only and denied-user controls remain
-  untested. Private check-suite/status/commit endpoints returned scope-related
-  403s; the full preflight is blocked pending compatible read permissions.
+  No credential left that environment. That PAT run tested only the operator;
+  later App controls below cover a non-admin reader and denied user. Private
+  check-suite/status/commit endpoints returned scope-related
+  403s. GitHub also explicitly lists Checks API access as a fine-grained PAT
+  limitation, not a missing toggle; see the preflight report's primary-source
+  links. The role gate works for the tested user, but full checks need a compatible
+  credential path or an approved scope change, not Actions/Code quality permissions.
+- The operator selected the existing `kurrent-capacitor` GitHub App. Protected
+  metadata reads confirm the App and its `kurrent-io` installation now have all six
+  required read-only grants. That does not upgrade the server's PAT. The App key
+  and token exchange live in `Capacitor.AuthProxy/GitHubApiClient.cs`, with a
+  50-minute authentication-use cache in `TenantMatching.cs`; the tracker provider
+  only reads its configured token. There is no tenant-scoped PR-read/token-broker
+  bridge to reuse as-is. WorkOS discovery deliberately does not use GitHub-auth
+  tenant registration, so adding such a row is not a valid credential workaround.
+  No installation token was issued or exported by that metadata-only probe.
+- The operator then authorized one temporary, repo-restricted App token. It was
+  issued and used inside the proxy, proved to have exactly the six read-only grants
+  and two approved repositories, and revoked with HTTP 204 afterward. Numeric-ID
+  lookup and permission checks returned 200/admin for the operator on both repos;
+  complete private overview, commit metadata, suite-scoped checks and status reads
+  succeeded. Populated discussion cursor samples succeeded, including a public
+  nested thread. REST/GraphQL reported 12,500 limits and every sampled GraphQL query
+  cost 1. No token or body was exported. That operator-only run supplied capability
+  evidence, not non-admin or denied-user coverage.
+- A further protected control used a token restricted to Metadata read and the
+  private fixture. The designated account's username and numeric-ID lookups and
+  permission response succeeded, with matching IDs, but GitHub reported `admin`
+  rather than the operator-described team `write` grant. That does not isolate the
+  team's grant or validate a non-admin control. No private content was fetched;
+  the token was revoked with HTTP 204. Grant provenance was not independently audited.
+- A subsequent operator-designated pair passed the private permission controls:
+  the non-admin team-member fixture returned `write`, and the external fixture
+  returned `none`. Username/numeric lookups and both permission responses matched
+  the intended numeric IDs. A metadata-only, single-repository App token sufficed;
+  no content was fetched and the token was revoked with HTTP 204. Team membership
+  and grant provenance were operator-supplied, not independently audited; the
+  positive role is Write, not least-privileged Read. These are GitHub API controls,
+  not end-to-end Capacitor session/link admission tests.
 - This introduces permission-query traffic; it belongs in the interactive request
   budget and must not starve background enrichment.
 
@@ -117,6 +153,12 @@ repository-role gate. The design specifies the public-repository case, proof
 lifetime and cache/page admission. Server fetches remain fail-closed; the draft gives
 already visible client content a bounded, labelled transient-outage display grace,
 never a grant to fetch or reveal more content. Deployment validation is partial:
-the tested user's permission gate works, but missing private CI/commit-read
-capabilities and remaining identity controls still block implementation planning.
+the App's required grants and operator read-capability probes now pass, including
+private checks and populated pagination samples. The operator-designated non-admin
+Write and denied-user controls now pass with matching identities. The
+[credential addition](superpowers/specs/2026-09-07-github-app-pr-credentials-design.md)
+consolidates the qualifications and proposes a tenant-scoped broker with managed
+renewal. It awaits approval before implementation planning. The existing tracker
+provider accepts an opaque configured token but does not obtain or renew App
+tokens; it is not inherently PAT-only.
 Use delegated user tokens if exact user-to-server authorization is required.

--- a/docs/github-linked-pr-access-research.md
+++ b/docs/github-linked-pr-access-research.md
@@ -87,8 +87,9 @@ tracker enrichment.
 - A renamed username must not transfer access to a different numeric account. A
   permission response with a missing or mismatched target user cannot authorize.
 - The deployed integration token's ability to call the permission endpoint has not
-  been tested here. No server token was retrieved. Before implementation sign-off,
-  verify it with a public repository and an authorized private test repository,
+  been tested here. No server token was retrieved. Before implementation planning,
+  the operator/driver must verify it in its protected deployment environment with
+  a public repository and an authorized private test repository,
   including team/base-role access and a denied user. Use only read operations.
 - This introduces permission-query traffic; it belongs in the interactive request
   budget and must not starve background enrichment.
@@ -112,5 +113,8 @@ linking alone cannot mint this delegation.
 
 The approved read-only v1 approach is linked GitHub identity plus a fail-closed
 repository-role gate. The design specifies the public-repository case, proof
-lifetime and cache/page admission. Deployed-token compatibility remains unverified.
+lifetime and cache/page admission. Server fetches remain fail-closed; the draft gives
+already visible client content a bounded, labelled transient-outage display grace,
+never a grant to fetch or reveal more content. Deployed-token compatibility remains
+unverified and blocks implementation planning.
 Use delegated user tokens if exact user-to-server authorization is required.

--- a/docs/github-linked-pr-access-research.md
+++ b/docs/github-linked-pr-access-research.md
@@ -1,0 +1,116 @@
+# Using linked GitHub identities for desktop PR reads
+
+Research date: 2026-09-07. The user approved the linked-identity permission-check
+approach; its current policy is in the [PR context design](superpowers/specs/2026-09-07-desktop-pr-context-design.md).
+This note records the evidence and limitations, not implementation sign-off. No
+production code or credentials were changed.
+
+## What account linking supplies
+
+The server can identify the caller's verified GitHub account, but the existing
+linking flow does not supply a reusable per-user repository credential:
+
+- The explicit proxy linking flow requests `read:user` and proves identity.
+  Source: `kcap-server/src/Capacitor.AuthProxy/LinkGitHubHandler.cs`.
+- The proxy exchanges the OAuth code and reads `/user`, then sends the tenant a
+  signed `LinkCompletionPayload` containing purpose, numeric GitHub ID, login,
+  avatar, tenant origin, nonce, and expiry. It contains no GitHub access or refresh
+  token. The link branch does not use the native sign-in token cache.
+  Source: `kcap-server/src/Capacitor.AuthProxy/CallbackHandler.cs`.
+- The tenant validates that payload and calls `LinkAsync` with identity/profile
+  fields. `GitHubLinkService.GetStateAsync` reads holder/link/merge state rather
+  than token material.
+  Sources: `kcap-server/src/Capacitor.Server/Auth/GitHubLink/GitHubLinkEndpoints.cs`
+  and `GitHubLinkService.cs` in that directory.
+- Automatic WorkOS linking can supply only the numeric GitHub ID: username/avatar
+  can be absent. Username text is therefore not a reliable identity key.
+  Source: `kcap-server/docs/AUTHENTICATION.md`, GitHub account linking section.
+
+The link is useful as proof of **who**, not proof of access to **which repository**.
+
+## Feasible option: identity plus a repository-permission check
+
+Keep the existing server integration token for fetching data, but make a GitHub
+permission decision for the linked user a prerequisite for serving it.
+
+GitHub documents:
+
+1. [`GET /user/{account_id}`](https://docs.github.com/en/rest/users/users#get-a-user-using-their-id)
+   resolves a durable numeric account ID to its current public profile/login. The
+   documentation explicitly distinguishes the durable ID from a changeable login.
+   Enterprise Managed User visibility can cause a 404 for an unauthorized token.
+2. [`GET /repos/{owner}/{repo}/collaborators/{username}/permission`](https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user)
+   returns the user's calculated base repository permission and role, considering
+   repository, team, organization, and enterprise grants. Legacy permission values
+   are `admin`, `write`, `read`, and `none`; maintain maps to write and triage to
+   read. The response includes the target user, including numeric ID when present.
+3. The permission endpoint supports GitHub App installation tokens, App user
+   tokens, and fine-grained PATs, with **Metadata: read** for fine-grained tokens.
+   Source: the endpoint's fine-grained token section at the same official URL.
+
+Proposed private-PR admission sequence:
+
+- Authenticate the Capacitor caller and retain the existing Full-session,
+  repository visibility, and linked-PR identity gates.
+- Resolve the caller's current verified GitHub identity. Use the current holder
+  state, not a stale login claim or a pending identity-merge marker. GitHub-native
+  users already have an identity; WorkOS users use the existing linking flow.
+- Resolve the current login from the numeric ID; do not infer it from the server's
+  generic display-name/username field.
+- Ask GitHub for that user's permission on the PR's base repository, using the
+  existing integration credential. Require a matching returned user ID and an
+  explicit read-capable permission. Unknown, absent, malformed, denied, or failed
+  evidence does not authorize the read.
+- Apply the authorization gate before any detail response, including cached
+  content and continuation pages. Positive evidence may only be reused within a
+  short, explicitly bounded validity window; never reuse stale permission on an
+  upstream failure. Unlink/account changes invalidate evidence and client bodies.
+- No link produces a **Link GitHub to read PR details** action using the existing
+  browser flow. Linking by itself still does not grant repository access.
+
+This avoids manual per-repository user allowlists and avoids adding per-user token
+storage or broadening the existing identity-only OAuth flow for v1. The integration
+still needs sufficient access to read the underlying PR/check/comment content.
+An independent feature switch could disable interactive reads without disabling
+tracker enrichment.
+
+### Limits and checks before adopting it
+
+- This is a server-enforced **repository-role check**, not a GitHub request made
+  with the caller's token. Do not describe it as full per-user GitHub session/SSO/IP
+  policy parity or native GitHub audit attribution to the user.
+- The permission query and content read are not atomic. State a bounded evidence
+  lifetime and revalidation behavior, including revocation during a long fetch.
+- Public-repository access needs its own explicit rule: lack of collaborator status
+  does not mean a public PR is unreadable. Verify repository visibility from GitHub
+  before using publication as evidence; do not derive it from a session label.
+- A renamed username must not transfer access to a different numeric account. A
+  permission response with a missing or mismatched target user cannot authorize.
+- The deployed integration token's ability to call the permission endpoint has not
+  been tested here. No server token was retrieved. Before implementation sign-off,
+  verify it with a public repository and an authorized private test repository,
+  including team/base-role access and a denied user. Use only read operations.
+- This introduces permission-query traffic; it belongs in the interactive request
+  budget and must not starve background enrichment.
+
+## Stronger alternative: delegated GitHub user tokens
+
+GitHub App user access tokens enforce the intersection of the user's repository
+access and the app's installed access/permissions. GitHub explicitly documents that
+an app cannot access a repository on a user's behalf if the user cannot access it,
+even when the app itself is installed there.
+
+Source: [Authenticating with a GitHub App on behalf of a user](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-with-a-github-app-on-behalf-of-a-user).
+
+That is stronger than checking another user's role with an integration token, but
+it is not available merely because an account is linked. It needs an explicit
+authorization flow plus encrypted server-side per-user token storage, refresh,
+revocation, unlink cleanup, and user-partitioned caches. Automatic WorkOS identity
+linking alone cannot mint this delegation.
+
+## Recommendation
+
+The approved read-only v1 approach is linked GitHub identity plus a fail-closed
+repository-role gate. The design specifies the public-repository case, proof
+lifetime and cache/page admission. Deployed-token compatibility remains unverified.
+Use delegated user tokens if exact user-to-server authorization is required.

--- a/docs/github-pr-context-preflight.md
+++ b/docs/github-pr-context-preflight.md
@@ -2,7 +2,18 @@
 
 ## Result
 
-**Partial verification; implementation planning remains blocked.**
+**The requested live credential/API controls pass for the approved App fixtures.**
+
+Allowed non-admin and denied-user permission checks now both pass with matching
+numeric IDs, alongside the successful private-read capability probe. Team grant
+provenance is operator-attested; the allowed fixture has Write, not least-privileged
+Read. This is not a deployed tenant integration or end-to-end session-admission test.
+The [App credential proposal](superpowers/specs/2026-09-07-github-app-pr-credentials-design.md)
+consolidates this evidence and defines the acquisition/renewal path. The user
+accepted it and the stated evidence qualifications, waived independent review,
+and authorized implementation.
+
+## Initial PAT probe
 
 The approved current deployment was probed on 2026-09-07, running Capacitor 0.11.39,
 using the approved `kurrent-io/kcap-cli` public and `kurrent-io/kcap-server` private
@@ -26,36 +37,169 @@ was tested; no other test identities were selected implicitly.
 
 The linked-user permission-check approach is supported by this credential for the
 tested administrator. It is **not yet verified** for a team-only reader or denied
-user. The current token is incompatible with the complete proposed private-PR
-reader: Checks and Commit statuses reads are unavailable, and its GraphQL commit
-connection is forbidden independently of those fields. Contents read is required
+user. The initially tested token was incompatible with the complete proposed
+private-PR reader: Checks and Commit statuses reads were unavailable, and its
+GraphQL commit connection was forbidden independently of those fields. Contents read is required
 by the commit-metadata endpoint and is the permission to verify for that connection.
 A cost of 1 for a partially denied query does not certify the final fully authorized
 query's cost; remeasure it after the permission correction.
 
+## GitHub App permission verification
+
+The operator selected the existing GitHub App and updated both its requested
+permissions and the installation grant. A protected probe at 13:22 UTC on
+2026-09-07 confirmed the deployed auth proxy's configured App is
+`kurrent-capacitor`, installed on `kurrent-io`, not suspended, with repository
+selection `all`. Both App metadata and installation metadata report **read** for
+Metadata, Contents, Pull requests, Issues, Checks and Commit statuses.
+
+This was two successful GETs (`/app`, `/orgs/kurrent-io/installation`) from inside
+`kcap-system/auth-proxy`, using its existing App signing key for authentication.
+No key or JWT was returned to the agent or saved in artifacts; the JWT was used
+only to authenticate to GitHub. No installation token was created. Temporary
+binaries were removed. The proxy image was
+`kurrentplatform/kcap-auth-proxy:0.0.0-main.20260903.7fbf43a6`; tenant server remained
+0.11.39. Neither metadata response supplied primary-rate-limit headers, so these
+reads do not establish the installation token's REST/GraphQL budgets.
+
+**App metadata alone is not a complete preflight.** The token probe below verifies
+actual reads for the operator. Installation-wide `all` selection is not permission
+to widen the diagnostic's targets; the issued token was restricted to the two
+approved repositories and six read-only permissions.
+
+Source inspection shows `GitHubApiClient` already signs App JWTs and exchanges them
+for installation tokens. `TenantMatching` caches authentication-use tokens for
+50 minutes and obtains a new token on a cache miss. This is not a tenant PR-read
+integration: `GitHubCredentialProvider` still reads `Integrations:GitHub:Token`
+(an opaque configured token, not a PAT-only API) without acquisition or renewal,
+and the auth proxy has no tenant-scoped PR-read/token-broker route. App permission
+changes do not convert or replace the server's PAT. No server setting was switched.
+A WorkOS tenant must not be registered as a GitHub-auth tenant merely to obtain App
+access; those registrations affect authentication and tenant discovery.
+
+## Protected App-token read probe
+
+The operator explicitly authorized temporary token issuance and revocation. At
+14:09 UTC on 2026-09-07, the same protected auth-proxy environment created **one**
+installation token, with exactly the six read-only permissions and only `kcap-cli`
+and `kcap-server`. Its returned permissions and `/installation/repositories` were
+validated before any PR read. Reported expiry was 59 minutes. Before issuance, a
+separate guarded read-only tenant transaction refreshed the operator's current
+`users.github_id`; it read no tracker credential or Data Protection key.
+
+| Check | App-token result |
+| --- | --- |
+| Holder ID lookup and repository-role check | HTTP 200; matching numeric IDs and `admin` on both repositories. |
+| Public overview, `kcap-cli#803` | Complete query succeeded without GraphQL errors. |
+| Private overview, `kcap-server#1834` | Complete query succeeded without GraphQL errors, including the commit/check connection denied to the PAT. |
+| Commit metadata and commits-only query | HTTP 200 and no GraphQL errors on both repositories. |
+| Suite-scoped latest runs | All enumerated: 5 runs across 5 public suites; 21 runs across 6 private suites. Run head/suite identities matched; head rechecks were unchanged. |
+| Legacy statuses | HTTP 200 on both: one public status, zero private statuses on the selected heads. Private permission is verified, not a populated private-status case. |
+| Public conversation/reviews/threads | Populated cursor reads succeeded; public reviews and threads remained partial after the three-page sampling cap. |
+| Private discussion, `kcap-server#1831` | Four conversation comments across two pages, five submitted reviews across three pages, three threads across two pages; all reached their connection ends with no duplicate sampled IDs. |
+| Nested thread-comment cursor | Public fixture: three published comments across two pages, parent PR/repository identity matched. No qualifying long private thread was encountered in the bounded sample. |
+| GraphQL cost | 22 successful queries, each cost 1; no GraphQL errors. |
+| Quota snapshots | REST and GraphQL reported 12,500; all observed remaining values were at least 12,478, above 99.8%. These are snapshots, not a sustained background-interference benchmark. |
+| Token cleanup | `DELETE /installation/token` returned HTTP 204; revocation confirmed. Temporary pod files removed. |
+
+The run made **53 GitHub requests**: 51 reads, one token exchange and one revocation.
+No repository data, membership, permissions, deployment or server credential setting
+was changed. Tokens, App keys, PR bodies and diffs were not returned to the agent or
+written to artifacts. The token was used only inside the proxy for GitHub requests.
+Neither a production PR endpoint nor an automatic tenant credential/renewal bridge
+was implemented by this diagnostic.
+
+These results resolve the App credential's tested read-capability blocker. That
+operator-only run did not exercise the further permission controls recorded below,
+complete large manifests, requested-team visibility, or a sustained four-reader workload. The small paging
+samples demonstrate live cursor behavior, not provider snapshot isolation.
+
+## Designated private writer control
+
+At 14:48 UTC on 2026-09-07, the operator-designated team member was checked against
+private `kcap-server`. The operator described a team Write grant. A new temporary
+installation token was restricted to **Metadata: read** and that single repository;
+both scope restrictions were verified. No PR or code-content request was permitted.
+
+Username lookup, numeric-ID lookup, private repository metadata and the permission
+endpoint all returned HTTP 200. The permission response matched the designated
+numeric ID but reported **`admin`**, not the expected `write`. The existing Write
+grant may still be present; this endpoint does not identify which grant supplies
+the effective higher role. No team membership, organization ownership or other
+access source was independently audited.
+
+This confirms a metadata-only token can perform the permission lookup. It does
+**not** validate the intended non-admin/team-only control. The diagnostic stopped
+on its expected-role assertion, not a GitHub authentication or API failure. It also
+was not a Capacitor link/session-admission test for this fixture account.
+
+Nine requests were made: seven reads, one token exchange and one revocation.
+Revocation returned HTTP 204; temporary pod files were removed. No content, credential
+or participant identifier was included in the sanitized report. The fixed named
+fixture is retained only in the ignored local probe source and working notes.
+
+## Paired non-admin and denied-user controls
+
+At 15:13 UTC on 2026-09-07, two newly operator-designated accounts were checked
+against private `kcap-server`, using one temporary token restricted to **Metadata:
+read** and that repository. The operator described the positive fixture as an
+team member, with a team Write grant, and the negative fixture as external
+with no repository access. Named access details remain in ignored local artifacts
+and working notes, not this public report.
+
+| Control | Observed result |
+| --- | --- |
+| Positive fixture | Username and numeric-ID lookups succeeded; permission endpoint returned HTTP 200, matching user ID, `permission=write`. The read-role predicate admits it without administrator privilege. |
+| Denied fixture | Both identity lookups succeeded; permission endpoint returned HTTP 200, matching user ID, `permission=none`. The read-role predicate denies it. No missing-identity or 404 fallback was needed. |
+| Scope and privacy | Private repository identity/visibility and exact single-repo, metadata-only token scope verified. Zero PR/code-content requests, including for the denied fixture. |
+| Cleanup | Token revocation returned HTTP 204; temporary pod files removed. |
+
+Both control assertions passed. This run made **13 requests**: eleven reads, one
+token exchange and one revocation. It validates the expected positive/negative
+GitHub permission API shapes, not the fixture accounts' Capacitor link/session
+admission. Team provenance was supplied by the operator, not independently audited;
+no exclusive-team or least-privileged Read-role claim is made.
+
 ## Operator action and remaining gate
 
-The token owner must enable/approve these **read-only repository permissions** for
-the intended repositories, or provide a compatible scoped integration credential:
+**Checks is not a grantable fine-grained PAT permission.** The operator's token
+editor has no such option, and GitHub explicitly lists calling the Checks API as a
+[fine-grained PAT limitation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens-limitations).
+The response header `checks=read` identifies the endpoint's requirement; it does not
+prove the current token type can be granted that permission. The instruction to add
+Checks to this PAT was incorrect. Actions and Code quality are separate APIs, not
+replacement permissions for arbitrary check runs.
 
-- Checks
-- Commit statuses
-- Contents, for the specified commit/GraphQL overview path
+Contents and Commit statuses **read-only** remain valid permissions to enable/approve
+on the existing PAT and retest. They do not remove the Checks API limitation.
 
-No scope or credential change was made by this session. Any required organization
-approval belongs to the operator. Do not paste the token into an agent session.
+Full check-run support needs a supported credential path, preferably a GitHub App
+installation with [Checks read](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps#repository-permissions-for-checks)
+and managed token renewal. A classic PAT with `repo` scope is documented for private
+check reads, but is materially broader and is not a silent substitute. Reusing an
+existing App was selected by the operator; replacing server credentials or shipping
+without check runs is not implied by that permission update. The App's read
+capabilities and the paired private permission controls now pass their live probes.
+
+The operator updated the App and installation grants; the agent made no permission,
+credential-setting or deployment changes. Do not paste tokens or keys into an agent session.
 Do not weaken the approved per-caller repository gate as a workaround.
 
-After correction, repeat the protected probe and finish the remaining controls:
+The requested allowed/denied API controls are complete using the operator-provided
+fixtures. A literal least-privileged Read role and exclusive team-grant provenance
+were not demonstrated; retain that qualification in consolidated sign-off rather
+than relabelling the observed Write role. Large manifests, churn/isolation behavior,
+requested-team visibility and sustained multi-reader scheduling were not certified
+by these bounded capability probes.
 
-- Designated team-only reader and designated denied user, including numeric-ID
-  matching and expected permission results.
-- Full private overview with no GraphQL errors, suite-scoped latest check runs and
-  legacy statuses, and actual query cost/headroom.
-- Suitable existing populated/paged discussion fixtures to validate connection
-  behavior; a one-row query on the latest PR is not a long-pagination test.
-
-The approved design's preflight gate is **not passed** until these are resolved.
+The [credential addition](superpowers/specs/2026-09-07-github-app-pr-credentials-design.md)
+accepts these capability/role controls for implementation planning,
+with the stated qualifications and final broker/end-to-end/load tests required
+before rollout. The user approved this architecture and qualification. The deployed
+tenant still reads its configured PAT; the auth proxy's existing authentication
+cache is not a tenant PR-read bridge. A one-off installation token is not a production
+configuration or renewal procedure. No extra membership or repository permission
+changes are required merely to collect another fixture.
 
 ## Safety and reproducibility
 
@@ -66,13 +210,14 @@ Every database read followed `SET TRANSACTION READ ONLY` and a successful
 was disabled and the in-memory key repository rejected writes. It did not start the
 server application or invoke startup migrations.
 
-GitHub calls used fixed `api.github.com` origins, redirects disabled, read-only
-GET/HEAD and GraphQL query operations, bounded response sizes/timeouts, pacing,
-and rate-limit stop guards. Output was restricted to status codes, approved fixture
+Data reads used fixed `api.github.com` origins, redirects disabled, read-only
+GET/HEAD and GraphQL queries, bounded response sizes/timeouts, pacing, and rate-limit
+stop guards. Each App-token probe additionally allowed its one authorized token
+exchange and revocation; no repository-write operation was allowed. Output was restricted to status codes, approved fixture
 identity checks, permission categories, whitelisted error paths and rate counters.
 No token, connection string, key material, PR body or diff was returned to the
 agent or local artifacts; the token was used only for in-pod GitHub authentication. Temporary uploaded probe binaries were removed after every invocation.
-No deployment, daemon, application source, server settings or GitHub data changed.
+No deployment, daemon, application source, server settings or GitHub repository data changed.
 
 Two initial attempts stopped at the database read-only guard, before reading the
 credential or making GitHub calls: the connection startup option alone resulted in
@@ -84,7 +229,21 @@ warnings and its local self-test passed, but it is not production implementation
 Sanitized runtime reports and the throwaway probe source are retained locally under
 `.superpowers/preflight/2026-09-07/`, ignored by Git. The reports are first-party
 observations from the deployment/GitHub APIs, not inferred from documentation.
-The initial recorded desktop test baseline is unchanged; no new app tests were run.
+The App-permissions probe source and sanitized report are under the `app-permissions/`
+subdirectory, with a separate SHA-256 manifest. Its local signing/path/permission
+projection self-test passed and it built without warnings. App-token data-probe
+source and reports are in `app-data/`, including the identity-only probe source and
+a separate hash manifest. Both helpers built without warnings and passed local
+self-tests; the token probe's test includes revocation after a rejected grant.
+The metadata-only role probe is archived in `app-role/`; it built warning-free and
+passed local scope, identity and rejected-grant cleanup self-tests. Its live expected
+Write-role assertion did not pass because GitHub returned Admin.
+The successful paired controls are archived separately in `app-role-pair/`, retaining
+the earlier Admin-mismatch probe and its original source unchanged. The paired helper
+built without warnings and passed local identity, scope and revocation self-tests.
+Across all probes, GitHub requests total **106**: 100 reads, three token exchanges and
+three successful revocations. The initial recorded desktop test baseline is unchanged;
+no new production app tests were run.
 
 Related documents:
 

--- a/docs/github-pr-context-preflight.md
+++ b/docs/github-pr-context-preflight.md
@@ -1,0 +1,92 @@
+# Desktop PR context: deployment preflight
+
+## Result
+
+**Partial verification; implementation planning remains blocked.**
+
+The approved current deployment was probed on 2026-09-07, running Capacitor 0.11.39,
+using the approved `kurrent-io/kcap-cli` public and `kurrent-io/kcap-server` private
+repository fixtures. The integration is a **fine-grained PAT** from encrypted server
+settings (`Integrations:GitHub:Token`). Only the operator's current linked identity
+was tested; no other test identities were selected implicitly.
+
+| Check | Observed result |
+| --- | --- |
+| Current verified GitHub holder → numeric-ID lookup | HTTP 200; returned ID matched. |
+| Public/private repository identity and visibility | HTTP 200; both matched the fixtures. |
+| Repository-permission query for current linked user | HTTP 200 on both; matching user ID and `admin` permission. |
+| Public PR overview query | HTTP 200, no GraphQL errors; reported cost 1. |
+| Private PR overview query | HTTP 200 with partial data and one FORBIDDEN error at `repository.pullRequest.commits.nodes`. Not a successful complete overview. |
+| Bounded PR discussion queries | HTTP 200, no GraphQL errors for both fixtures; reported cost 1. This does not establish long-thread pagination or nonempty coverage for every collection. |
+| Private check-suite endpoint | HTTP 403; `X-Accepted-GitHub-Permissions` required `checks=read`. No Retry-After; primary budget remained available. |
+| Private legacy commit-status endpoint | HTTP 403; required `statuses=read`, also without rate-limit evidence. |
+| Private commit metadata HEAD | HTTP 403; required `contents=read`. No commit body was requested. |
+| Private commits-only GraphQL control | FORBIDDEN at the same commits connection without any check/status fields. |
+| Primary limits | REST and GraphQL reported 5,000; remaining budgets stayed above the design's 20% yield threshold. |
+
+The linked-user permission-check approach is supported by this credential for the
+tested administrator. It is **not yet verified** for a team-only reader or denied
+user. The current token is incompatible with the complete proposed private-PR
+reader: Checks and Commit statuses reads are unavailable, and its GraphQL commit
+connection is forbidden independently of those fields. Contents read is required
+by the commit-metadata endpoint and is the permission to verify for that connection.
+A cost of 1 for a partially denied query does not certify the final fully authorized
+query's cost; remeasure it after the permission correction.
+
+## Operator action and remaining gate
+
+The token owner must enable/approve these **read-only repository permissions** for
+the intended repositories, or provide a compatible scoped integration credential:
+
+- Checks
+- Commit statuses
+- Contents, for the specified commit/GraphQL overview path
+
+No scope or credential change was made by this session. Any required organization
+approval belongs to the operator. Do not paste the token into an agent session.
+Do not weaken the approved per-caller repository gate as a workaround.
+
+After correction, repeat the protected probe and finish the remaining controls:
+
+- Designated team-only reader and designated denied user, including numeric-ID
+  matching and expected permission results.
+- Full private overview with no GraphQL errors, suite-scoped latest check runs and
+  legacy statuses, and actual query cost/headroom.
+- Suitable existing populated/paged discussion fixtures to validate connection
+  behavior; a one-row query on the latest PR is not a long-pagination test.
+
+The approved design's preflight gate is **not passed** until these are resolved.
+
+## Safety and reproducibility
+
+The throwaway .NET probe ran inside the existing server container. It read only
+one encrypted setting, the existing key ring and the operator's holder identity.
+Every database read followed `SET TRANSACTION READ ONLY` and a successful
+`SHOW transaction_read_only` guard. The transaction was rolled back. Key generation
+was disabled and the in-memory key repository rejected writes. It did not start the
+server application or invoke startup migrations.
+
+GitHub calls used fixed `api.github.com` origins, redirects disabled, read-only
+GET/HEAD and GraphQL query operations, bounded response sizes/timeouts, pacing,
+and rate-limit stop guards. Output was restricted to status codes, approved fixture
+identity checks, permission categories, whitelisted error paths and rate counters.
+No token, connection string, key material, PR body or diff was returned to the
+agent or local artifacts; the token was used only for in-pod GitHub authentication. Temporary uploaded probe binaries were removed after every invocation.
+No deployment, daemon, application source, server settings or GitHub data changed.
+
+Two initial attempts stopped at the database read-only guard, before reading the
+credential or making GitHub calls: the connection startup option alone resulted in
+`transaction_read_only=off`. Explicit transaction mode fixed the probe without
+removing that guard. Three subsequent invocations made 29 bounded GitHub requests
+in total (11, 8, 10); no write API was called. The diagnostic compiled without
+warnings and its local self-test passed, but it is not production implementation.
+
+Sanitized runtime reports and the throwaway probe source are retained locally under
+`.superpowers/preflight/2026-09-07/`, ignored by Git. The reports are first-party
+observations from the deployment/GitHub APIs, not inferred from documentation.
+The initial recorded desktop test baseline is unchanged; no new app tests were run.
+
+Related documents:
+
+- [Approved design](superpowers/specs/2026-09-07-desktop-pr-context-design.md)
+- [Linked-identity research](github-linked-pr-access-research.md)

--- a/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
+++ b/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
@@ -197,8 +197,9 @@ usable; it does not fabricate a GitHub identity.
 
 Existing linking is identity-only: the proxy requests `read:user`, sends signed
 identity fields, and the tenant records the association, not reusable OAuth tokens.
-Use `IGitHubLinkService.GetStateAsync` for the canonical caller: require `Linked`
-and a positive `GitHubId`, not the pending `LinkedGitHubId` claim marker, a cached
+Read the canonical caller's positive `users.github_id` directly, matching the holder
+state reported by `GitHubLinkService.GetStateAsync` without requiring WorkOS's link
+service registration. Do not use the pending `linked_github_id` claim marker, a cached
 login string, or a generic display name. This includes GitHub-native human accounts;
 do not resurrect a missing holder association by parsing an old `github:` user ID.
 Unlinked WorkOS users see **Link GitHub to read PR details**, opening the configured tenant's

--- a/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
+++ b/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
@@ -304,6 +304,9 @@ remain text in v1; no repository-relative URL inference. Disallowed schemes are 
 
 ## Preflight gate before implementation planning
 
+[Deployment probe results](../../github-pr-context-preflight.md) record partial
+verification and outstanding permission/identity controls; the gate is not passed.
+
 Before planning or building either part, the implementation driver and operator
 must run a read-only probe using the intended deployment's actual integration
 credential **in its existing protected environment**. The agent must not retrieve,
@@ -401,7 +404,8 @@ measured query cost, not one assumed point. Sixty starts/minute leaves section
 capacity at the faster cadence. Excess workloads yield rather than promise freshness.
 
 Documented profiles are fine-grained PAT or App installation with Metadata read
-plus PR/issue/check/status read permissions. An existing classic PAT needs private-
+plus PR/issue/check/status read permissions and Contents read for the specified
+GraphQL commit-connection overview. An existing classic PAT needs private-
 repo `repo` scope and the same live admission probes; enrichment success alone
 never certifies it. Do not add scopes or change credential type automatically. Preflight must
 verify at least 5,000/hour REST and GraphQL primary limits and measured headroom

--- a/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
+++ b/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
@@ -1,151 +1,428 @@
 # Desktop pull-request context
 
-## Outcome and agreed scope
+## Agreed outcome
 
-Find the current PR, understand its state, and read feedback without visiting the
-Capacitor web UI first. GitHub remains the destination for actions and full diff
-browsing.
+Find the PR, understand its state, and read feedback without first visiting the
+Capacitor web UI. GitHub remains the destination for actions and full diff browsing.
 
-The selected layout is **C: sidebar summary plus a wide reader**. Keep the existing
-400px work-context sidebar. Add a compact PR card there and a **Pull request** tab
-beside **Chat** and **Terminal**. Clicking a section in the card selects that PR and
-opens the corresponding reader section directly.
+The user selected **C: sidebar summary plus a wide reader**, read-only v1, and
+server-supplied GitHub data. The user also approved using the caller's **linked
+GitHub identity plus a GitHub repository-permission check**, rather than granting
+all Capacitor members the integration credential's repository access.
 
-The user approved:
+Keep the existing 400px work-context sidebar. Add a compact PR card and a **Pull
+request** tab beside **Chat** and **Terminal**. Clicking Checks, Reviews, or
+Conversation in the card selects the PR and opens that reader section.
 
-- Layout C rather than an expanding sidebar card or dedicated sidebar tab.
-- Read-only v1: no posting, replying, resolving, requesting/submitting reviews,
-  rerunning checks, changing draft state, closing, or merging.
-- Server-supplied GitHub data using the configured integration, rather than a
-  desktop dependency on `gh` or a second desktop sign-in.
-
-This document specifies the remaining interaction and technical details for review.
-Implementation starts only after the written design is approved.
+No posting, replying, resolving, requesting/submitting reviews, rerunning checks,
+changing draft state, closing, or merging. No local `gh` prerequisite, new desktop
+credential store, or new per-user GitHub OAuth grant. The written design and its
+independent review must be approved before implementation planning.
 
 ## Experience
 
-### Sidebar
+### Sidebar and PR selection
 
-Place the PR card after the work-item card and before the linked issue. Keep work
-item, contributors, and session facts in their existing places.
+Place the card after the work-item card, before the linked issue. Preserve the
+existing work item, contributors, and session facts.
 
-The card shows:
+The card shows repository, number, title, source/target branches, lifecycle state,
+checks summary, review decision, section navigation, and last successful fetch.
+Lifecycle is Draft, Open, Closed, Merged, or Unknown. Merged takes precedence over
+closed; draft is an open PR with its draft flag set. Unknown values never imply
+success or closure. Zero checks says **No checks reported**, not Passed. Skipped,
+neutral, cancelled, and unknown results retain their actual labels.
 
-- Repository, PR number, title, and source/target branches.
-- Explicit **Draft**, **Open**, **Closed**, **Merged**, or **Unknown** lifecycle state.
-  Draft is an open PR with its draft flag set; merged takes precedence over closed.
-- Copy-number and copy-URL actions with visible copied feedback; an explicit
-  **Open on GitHub** action. Clicking the title opens the in-app reader.
-- Checks summary: failed, running/pending, passed, and skipped/neutral as distinct
-  categories. Zero checks says **No checks reported**, not **Passed**.
-- GitHub's review decision when available; otherwise an honest review summary,
-  without claiming that the PR meets branch protection or is ready to merge.
-- Navigation rows for **Checks**, **Reviews**, and **Conversation**. Counts appear
-  only with their completeness known. An unresolved-thread count is optional, not
-  a reason to download every comment before showing the card.
-- A last-successful-fetch time and refresh action. Refresh failure marks retained
-  data as stale; it does not change the PR to closed, empty, or passing.
+Clicking the title opens the reader. Provide copy-number, copy-URL, copied feedback,
+and an explicit Open on GitHub action. The card does not claim merge readiness:
+check success and approvals do not prove satisfaction of branch protection.
 
-When a session has multiple PRs, show one expanded summary and a selector labelled
-with repository, number, and title. Keep the user's selection for that workspace.
-For an initial selection, prefer a unique match on the session's primary repository
-and branch. Otherwise use the server's deterministic repository/number ordering;
-never silently guess that the largest PR number is the relevant PR. Subsequent
-polls must not switch away from a PR the user is reading.
+For multiple PRs, show one card plus a repository/number/title selector. Identity is
+provider + host + base repository + number, never head repository or number alone.
+Collapse duplicate links for that identity. Fork PRs retain their base-repo identity.
 
-PRs are identified by their **base repository and number**, not just the number or
-head branch. A fork's head repository must not become the PR's identity. A
-cross-repository session can expose distinct PRs with equal numbers.
+The server orders the list by canonical lower-case owner, lower-case repository,
+then positive numeric PR number ascending. A client initially selects a unique
+match on the session summary's primary repository and its exact head branch. The
+primary repository is its unique `is_primary` repository, else its legacy
+`repo_owner`/`repo_name` pair; ambiguous/missing primary data means no preferred
+match. No match or multiple matches uses the first ordered link. Keep an explicit
+user selection across polls, even if another PR matches better later.
 
-A successful, authoritative empty link list shows **No pull request linked**. An
-unregistered session shows **Waiting for the session to register…**. A failed link
-read cannot manufacture the empty state. Unsupported providers keep their existing
-external links but do not offer GitHub-specific detail controls.
+Successful empty data from the new list route alone means **No pull request linked**.
+Unknown session identity means **Waiting for the session to register…**. Failures,
+legacy empty data, and permission denial never mean no PR. If the selected PR is
+unlinked, clear its detail state and show unavailable without silently selecting
+another PR. Unsupported hosts/providers retain existing safe external links.
 
 ### Reader
 
-The reader uses the center column, not a new window, overlay, embedded browser, or
-second nested sidebar. Its header repeats PR identity/state and the GitHub action.
-The header includes a collapsed, expandable PR description.
+Use the center column, not an overlay, new window, embedded browser, or another
+sidebar. Repeat identity/state and the external action in the header. Include an
+expandable PR description and the provenance line **Via the workspace GitHub
+integration · access checked for @login**.
 
-Three sections provide the following:
-
-| Section | Content and order |
+| Section | Content |
 | --- | --- |
-| Checks | Latest head commit's check runs and commit-status contexts. Failures first, then pending/running, then successful and neutral/skipped results. Show name, provider/app, actual outcome, timing when available, and the check's GitHub/details link. |
-| Reviews | GitHub review decision, current reviewer/request status, submitted review bodies, and inline discussion threads. Group loaded threads unresolved-first; offer Show resolved, and label outdated separately from resolved. Keep the pagination indicator visible so the loaded subset cannot look like the whole discussion. |
-| Conversation | Top-level PR comments, newest first, with author, timestamp, edited indication when supplied, and Markdown body. Identify automated authors and allow their comments to be collapsed; never hide their existence from counts. |
+| Checks | Latest head commit's check runs and legacy status contexts, with actual outcome, provider/app, timing when supplied, and an external details link. |
+| Reviews | GitHub's PR-wide review decision, current reviewer/request state including team requests, published review bodies, and inline threads. Outdated and resolved are separate states. |
+| Conversation | Top-level PR comments, author, created time, edited indication, Markdown body, and comment link. Automated authors are labelled and optionally collapsed, not removed from totals. |
 
-Review threads show the file path, available current/original line information,
-review-provided diff hunk, comment bodies, replies, author/time, and a direct link
-to the thread. Do not reconstruct historical context from the local checkout.
-File-level comments and outdated comments without a current line are valid.
-Published review submissions remain available even when superseded by another
-verdict. Do not expose unpublished pending reviews visible only to the integration
-credential's owner.
+Thread expansion shows the provider's file path, current/original line information,
+diff hunk, published comments/replies and timestamps. Do not reconstruct historical
+code from the local checkout. File-level comments and outdated comments without a
+current line are valid. Superseded published review bodies remain readable.
 
-Checks, reviewer summaries, review submissions, threads, thread replies, and
-conversation comments are paged. **Load more** extends the relevant collection. A failed later page retains
-the loaded portion with a retry action; it never labels the collection complete.
-No full-file diff browser, check-log viewer, PR search, or manual link editor is
-included in v1.
+Each collection has Load more. Later-page failure keeps already loaded rows while
+access remains valid, exposes Retry, and does not mark traversal complete. Surface
+snapshot time and incomplete-coverage labels. A resolved-thread filter is
+server-side and is part of snapshot/cursor identity, not a filter that hides an
+entire loaded page without explanation.
 
-### Navigation and preservation
+No full-file diff browser, check-log viewer, PR search, attachment downloads, or
+manual link editor in v1.
 
-- Opening a PR is always an explicit action; detecting a newly linked PR does not
-  steal focus from Chat or Terminal.
-- Returning to Chat preserves its draft and scroll position. Switching tabs must
-  not detach, restart, or dispose the terminal/agent.
-- Returning to the reader restores its selected PR, section, thread expansion, and
-  scroll state for the workspace's lifetime. No disk persistence is needed.
-- PR availability is independent of PTY support. A workspace with no Chat/Terminal
-  surface can still display the PR reader. Existing terminal absence banners must
-  not overlay it.
-- Ended sessions can still read their linked PRs while their workspace is open.
-- If a selected PR is unlinked or access is revoked, clear its detailed content and
-  explain that it is unavailable. Do not silently replace it with another PR.
-- Keyboard focus, accessible tab selection, text labels alongside status colors,
-  and readable long paths/bodies are part of the design.
+### Navigation and native view state
 
-## Architecture
+Detecting a PR never changes the active tab. A card-row action explicitly selects
+the Pull request tab/section and moves keyboard focus to its heading.
 
-### Existing code and the missing data
+`WorkspaceViewModel` owns one PR view model. It passes that same instance to the
+reader and to a child `PullRequests` property on `WorkContextViewModel`; the latter
+only hosts it and neither fetches nor disposes it. Workspace teardown is its one
+owner. Work-context failures cannot blank PR state; PR failures cannot degrade work
+item state.
 
-`WorkContextView.axaml` currently renders PRs as number/title links.
-`SessionPullRequestDto` in Core's `WorkItems/WorkContextDtos.cs` carries identity,
-URL, title, and head ref, but no checks or discussions. `WorkContextReader` also
-couples its summary result to work-item route outcomes; the new PR read must not
-inherit that coupling.
+Keep the existing Chat and Terminal hosts realized while changing visibility and
+hit testing. Do not replace them through a tab-content factory. This preserves
+chat draft/scroll, terminal buffer/attach, and agent lifetime. The PR host is created
+once on first explicit opening and remains realized until workspace teardown.
+Selection/expansion/scroll metadata lives in workspace state, independently of
+bounded body caches.
 
-The server's `/api/review` surface supplies recorded coding-session context, files,
-and transcript excerpts. It is not a GitHub discussion/checks interface. Existing
-`GitHubEnrichmentSource` reads lifecycle and review aggregates for tracker
-processing; `GitHubReviewRequestClient` handles requested-reviewer observations.
-Neither inspected surface provides the complete reader.
+For a workspace without PTY support, retain its initial no-terminal explanatory
+view and offer a Pull request tab when an admitted link exists. Discovery does not
+auto-select it. Clicking the card selects it. Chat/Terminal buttons remain absent;
+keyboard cycling includes only enabled tabs. With PR as the only available tab,
+cycling stays on it. No-terminal/attach/end banners belong only to the non-PR
+content host and never overlay the reader. Ended sessions continue normal PR
+polling while visible; existing access resolution, not ended status, admits them.
 
-### Server module
+Expose selected-state tab semantics, labelled copy/refresh/external actions, text
+alongside status colors, visible focus, and a polite live region for asynchronous
+section completion/failure. Long paths and bodies must wrap or scroll without
+changing the sidebar width.
 
-Add a dedicated pull-request read module. It owns GitHub reads, normalization,
-pagination, conditional requests, caching, and typed failures. Keep interactive
-reads out of the background work-item enrichment pipeline: opening a panel must
-not append enrichment events or trigger work-item lifecycle transitions.
+## Data ownership and compatibility
 
-Reuse the configured GitHub tracker credential provider and HTTP setup. The
-configured credential needs read access to PRs, issue comments, checks, and commit
-statuses for the relevant repositories. Missing configuration or insufficient
-scope is a supported UI outcome, not a request to discover another credential.
-The daemon and desktop never receive this token.
+The current `SessionPullRequestDto` is identity/link metadata only. The existing
+`/api/review` routes are coding-session/transcript context, not GitHub reviews.
+`WorkContextReader` also gates its summary through work-item outcomes. New PR
+reads must not inherit that work-item coupling or subscription gate.
 
-GitHub REST and GraphQL are implementation details of the server module. Use the
-provider's review decision and resolution/outdated flags rather than inferring
-these from text or comment ordering. Include both check runs and legacy commit
-statuses. A repeated run must not count an obsolete attempt as a current failure.
-Preserve unknown provider statuses as unknown rather than treating them as success.
+Add `pull_request_reads_version: 1` to every provider's existing `/auth/config`
+response. It describes protocol availability only, not token configuration, user
+link state, or repository access. This route is already anonymous; the new field
+contains no user/tenant-private data. Add the nullable field to
+`AuthDiscoveryResponse`; absence on a successfully parsed response means an older
+server. Version 1 is advertised even when interactive reads are disabled.
 
-### HTTP interface
+Discover once per profile activation; cache for five minutes. Recheck on manual
+refresh, reconnect, and profile change. Until a supported version is observed, do
+not call the new routes. An unknown higher version is unsupported until explicitly
+supported by the client. Malformed/non-JSON capability responses are a discovery
+failure, not proof of an old server; retry discovery with 30s, 60s, then five-minute
+backoff. Manual refresh is coalesced and cannot flood discovery.
 
-Use additive, session-scoped routes; do not change the meaning of `/api/review` or
-require a new daemon protocol. The route family is:
+Source precedence is explicit:
+
+1. With supported capability, the new link-list route is authoritative. Do not
+   union its results with legacy links, resurrect missing entries, or override its
+   ordering/titles from legacy data. A 404 clears protected PR state, not capability.
+2. Without capability, retain only legacy links from a successful, independently
+   admitted session-summary read. Read that summary independently of work-item
+   assignments for this fallback. An empty legacy result says details unavailable,
+   not No PR linked. There is no live-details polling.
+3. A malformed response on an advertised new route is an unavailable protocol
+   result, never route-unsupported or an authoritative empty list. Back off as
+   above; do not downgrade authorization by switching to legacy detail data.
+
+Capability discovery is shared by the app's profile-scoped source; old desktop
+clients ignore the additive field. There is no new daemon IPC or SignalR contract.
+
+## Linked-user authorization
+
+### Policy and configuration
+
+`PullRequestReads:Enabled` defaults to true. Effective detail availability still
+requires a configured integration, a verified positive GitHub user ID, Capacitor
+admission, and GitHub access evidence. Setting Enabled false disables interactive
+PR reads without removing the token or disabling enrichment/reviewer polling. It
+invalidates detail caches and access leases. Document the switch in server settings;
+a new settings UI is not required for v1.
+
+There is no admin-only role floor and no new repository allowlist. Any human caller
+who passes **both** Capacitor admission and the following GitHub gate can read.
+Service principals and synthetic/no-auth identities without a real GitHub identity
+cannot receive detail data. AuthStatus.NoAuthRequired still makes the HTTP client
+usable; it does not fabricate a GitHub identity.
+
+Existing linking is identity-only: the proxy requests `read:user`, sends signed
+identity fields, and the tenant records the association, not reusable OAuth tokens.
+Use `IGitHubLinkService.GetStateAsync` for the canonical caller: require `Linked`
+and a positive `GitHubId`, not the pending `LinkedGitHubId` claim marker, a cached
+login string, or a generic display name. This includes GitHub-native human accounts;
+do not resurrect a missing holder association by parsing an old `github:` user ID.
+Unlinked WorkOS
+users see **Link GitHub to read PR details**, opening the configured tenant's
+existing `/auth/github-link/start` browser flow; a sign-in to the website may be
+needed if the browser lacks its cookie. Recheck association on return/manual refresh.
+Do not transfer desktop tokens in a browser URL or mint new linking credentials.
+
+### Gate, on every detail read
+
+1. Resolve the authenticated caller and existing Full session access; also apply
+   `IsRepoVisibleAsync` to the requested base repository. This existing repository
+   gate is session-derived and is **not** evidence of GitHub access.
+2. Resolve the admitted link afresh from this session's data. Validate a positive
+   Int32 PR number and the repository hash; zero/multiple canonical matches fail
+   closed. Hidden sessions may contribute no rows, titles, counts or ordering.
+3. Check Enabled, integration generation, and the caller's current GitHub identity.
+4. Resolve the current GitHub login with `GET /user/{account_id}`. Verify returned
+   numeric ID. Cache this non-authorizing identity lookup for up to one hour;
+   missing or mismatched identities cannot authorize. An ID/login mismatch on the
+   permission call discards this lookup and allows one fresh lookup on next retry.
+5. Fetch canonical base-repository metadata using the integration token. Require a
+   matching repository identity and explicit visibility. Only `visibility=public`
+   supplies public-read evidence; `private`, `internal`, missing, or unknown values
+   do not. The caller still needs a linked identity for this v1 reader.
+6. For non-public repos, call
+   `GET /repos/{owner}/{repo}/collaborators/{login}/permission`. Require a matching
+   returned user ID and explicit `permission` of `read`, `write`, or `admin`.
+   GitHub maps triage/maintain onto those base roles. No role-name substring checks.
+   Missing/null user, unknown permission, denial, malformed data, or failed probe
+   cannot authorize. Public repos do not require collaborator membership.
+7. Admit before accessing a cached body. Re-read current Capacitor admission and
+   holder/configuration state before delivery; renew expired external evidence
+   before releasing a long-running result. Always construct provider URLs from the
+   freshly admitted link. Neither
+   a cursor nor a provider node ID supplies repository/host authority.
+
+Permission/public-visibility evidence has a maximum 30-second positive lifetime.
+Renew any proof with ten seconds or less remaining instead of returning another
+near-expiry lease; concurrent renewals coalesce. It is bound to integration generation, canonical repository ID, and numeric user
+ID (public visibility itself may be shared, but the caller's identity gate is not).
+No stale positive evidence is usable. A failed fresh permission check clears the
+proof; never fall back to a previous successful proof after that failure. Negative
+results can be cached for at most 30 seconds. Every page and cached read still
+rechecks current Capacitor access and current identity/configuration state.
+
+Changing the configured token value or Enabled increments an in-process integration
+generation, invalidating proofs, payload caches, snapshots, and cursors. A process
+restart invalidates opaque handles. Generation is not a logged token hash. A
+GitHub-side permission change without an options change takes effect when observed,
+with positive evidence bounded to 30 seconds; final-response revalidation bounds
+long reads too. This is not instantaneous revocation.
+
+The result contains a remaining access lifetime. The desktop masks protected bodies
+when this lifetime expires and obtains new evidence before revealing them again.
+It also masks bodies immediately when a workspace becomes hidden and before
+revealing retained data on return. A local profile/sign-out change clears all PR
+state. When permission/configuration failure or a session/list 404 is observed,
+clear **all** loaded bodies/cursors in the affected PR/session, not just the polled
+section. Retain only separately admitted link metadata, if still admitted.
+
+This checks repository roles/publication, not all of GitHub's per-user SSO, session,
+IP, or conditional-access policies. Requests are made as the integration, not with
+a delegated user token. The user accepted this read-only v1 trade-off. Exact
+user-to-server authorization would need a separate grant and encrypted per-user
+token lifecycle; that is outside this feature.
+
+### Audit and provider safety
+
+Record structured server access events for detail decisions: caller ID, session ID,
+repository hash/PR number, section, UTC timestamp, admitted/denied/unavailable result,
+and cache-hit flag. Use existing protected operational logging/retention, not a new
+public analytics view, event-store stream, or audit UI. Do not log bodies, tokens,
+raw provider errors, cursor contents, or full query strings. This is an operational
+access trail, not a compliance-grade immutable audit product.
+
+Live details are github.com-only. Resolve fixed provider origins and refuse
+off-origin redirects. Provider identities and thread membership must match the
+admitted PR, even for globally addressable node IDs. Outbound PR/comment/thread
+links must be HTTPS github.com links for that PR. Check details URLs may legitimately
+belong to external CI providers: accept absolute HTTPS without userinfo, show the
+destination host, and open only on an explicit user action. Never fetch those URLs.
+They are not authority for an API request. Do not silently restrict CI to github.com.
+
+Use raw Markdown `body`, never provider `body_html`. Render through native text
+modules, not an HTML browser. Unsupported constructs render as inert text; external
+images/attachments are not fetched. Only explicit absolute HTTP/HTTPS body links
+pass through LinkPolicy. Relative links, mentions and issue-reference shorthand
+remain text in v1; no repository-relative URL inference. Disallowed schemes are inert.
+
+## Server module and request budget
+
+Add a dedicated pull-request read module, separate from enrichment. Reads do not
+append work-item events or change correlation/lifecycle state. Reuse only the
+credential provider and common request/header helpers, not the enrichment HTTP
+client registration: it currently has a ten-second timeout. The integration must
+support the permission endpoint plus repository metadata, PRs/reviews, issue
+comments, checks, and commit-status reads. Insufficient provider permissions are a
+supported unavailable result, never a reason to discover another credential. The
+daemon and desktop never receive the integration token.
+
+Register `GitHubPullRequestReads` with fixed GitHub origins, a 15-second upstream
+headers-and-body deadline, explicit cancellation, no automatic retries and no
+off-origin redirect following. Bound a complete admitted HTTP operation, including
+queue wait and capture, to 30 seconds. Desktop request deadline is 35 seconds.
+Deadline expiry is typed unavailable, never empty or complete. Limit decoded
+upstream bodies to 16 MiB while streaming, before JSON parsing, and client-side
+server response reads to 4 MiB. Neither side may buffer an unbounded response merely
+to discover that its normalized form exceeds the budget.
+
+The lightweight overview uses one bounded GraphQL request for identity/lifecycle,
+head SHA, description, `reviewDecision`, the first 50 current-review/request rows,
+and the first 50 status-rollup contexts plus totals/page information. Request the
+actual GraphQL rate-limit cost/remaining/reset data. Aggregates from incomplete
+connections are lower bounds or unknown, never exact. The overview must not fetch
+thread/comment bodies or traverse those connections to render the card.
+
+A cold private-repo overview therefore costs at most three REST gate calls (user
+lookup, repo metadata, permission) and one GraphQL overview call. A repeated
+30-second poll normally reuses user lookup, with at most two REST gate calls plus
+one GraphQL call; coalesce repo metadata and overview fetches across viewers, and
+permission checks only for the same numeric user/repository/generation. The link
+list and capability reads never contact GitHub.
+
+Add a credential-scoped rate-limit observer used by the interactive client and the
+existing GitHub background HTTP clients. This observer consumes response headers
+and GraphQL cost information; background scheduling semantics stay unchanged.
+Interactive reads yield when REST or GraphQL remaining quota is below 20% of its
+reported limit, during any primary/secondary cooldown, or while the corresponding
+background provider gate is cooling down. No interactive request bypasses this rule
+for an access probe, cache revalidation or manual refresh.
+
+Limit interactive upstream concurrency to two and starts to 30 requests/minute per
+credential. Charge GraphQL by actual reported points, separately from REST calls.
+An unknown primary budget permits one serialized observation request; missing
+budget headers retain conservative local pacing rather than pretending quota is
+unlimited. A cooldown without a supplied reset/retry time defaults to 60 seconds.
+Return `retry_at`/`poll_after_seconds`; server backoff always wins over ordinary
+polling and early access-lease renewal. With no backoff, `poll_after_seconds` is zero.
+Expired access proof remains masked while yielding. The feature may become
+unavailable rather than starving background work.
+
+## Stable pagination and bounded storage
+
+### Collection snapshots
+
+A native GitHub cursor is not assumed to provide a transactional snapshot. For
+client pagination, the server freezes a bounded **metadata manifest** for each PR
+collection before returning its first page. It holds stable provider IDs, sort keys,
+publication/resolution flags and body-fetch references, not nested reply bodies.
+Each thread's comments get their own manifest on expansion.
+
+Capture traverses native GitHub connections into server-owned storage; client
+cursors never encode live provider offsets. GitHub's schema does not offer a
+created-at keyset/order parameter on every collection, so do not invent that API.
+Capture spans an interval, not an atomic historical snapshot. After the manifest
+is frozen, newly created items wait for explicit refresh.
+
+Record provider connection counts/boundaries before and after capture, and compare
+unique enumerated IDs with the unfiltered provider count before applying publication
+or resolved filters. Changed boundaries/counts, missing nodes, or repeated/non-advancing
+provider cursors cannot produce complete coverage. Retry enumeration at most once
+within the same deadline, merging by stable ID; otherwise return a limited manifest
+with a changed-during-capture reason and an explicit Refresh action. An API without
+sufficient enumeration/completeness evidence also yields limited coverage. Complete
+means a verified traversal over that capture interval, not transaction isolation or
+a historical point-in-time view. In-place body/state edits retain that caveat.
+
+Paging the frozen manifest cannot skip/reorder captured IDs when GitHub grows.
+Tests cover growth during capture as a stable retry or visibly limited result, and
+no missed captured rows when growth happens between client pages. Deleted items
+may be tombstones only with positive deletion evidence. Null/missing nodes or 404
+alone are ambiguous and follow the authorization-class failure policy.
+
+Once frozen, a manifest cannot reorder as the user pages. The server sorts the
+whole captured sequence before cutting pages; the client appends without re-sorting:
+
+- Conversation and published reviews: `created_at` descending, provider ID as a
+  stable tiebreak. Editing changes `updated_at`, never the order.
+- Thread comments: `created_at` ascending, then provider ID.
+- Threads: unresolved before resolved, then root-comment `created_at` descending,
+  then thread ID. The default is unresolved-only; `resolved=all` starts a separate
+  manifest. Root-comment metadata is allowed during capture, not its body/replies.
+- Reviewers: actor type, canonical login/team slug, then stable actor ID.
+- Checks: failed, pending/running, unknown, successful, neutral/skipped; then app ID,
+  name and stable run/context ID. Preserve cancelled/timed-out/action-required
+  labels in the failed/non-success group instead of calling them passed.
+
+Check manifests are tied to a head SHA. Use the provider's latest check-run filter;
+retain suite/app/name identity and never collapse distinct suites solely because
+names match. Within the same suite/app/name, retain the most recent attempt by
+`started_at`/`created_at` and ID tiebreak. Legacy statuses use latest `created_at`, ID
+per context. If the provider cannot establish the latest set, mark coverage limited
+and do not publish an exact success aggregate. A fixture must cover two workflows
+with the same job name, as well as reruns; name-only deduplication is forbidden.
+
+Manifest capture is bounded to 5,000 metadata entries, 4 MiB, and the operation
+deadline. If the entry/size ceiling is reached, a limited manifest can still be
+read, with `coverage=limited`, lower-bound counts, and **More on GitHub** after the
+captured rows. Do not call it the whole collection. Timeout/provider failure returns
+unavailable rather than an ostensibly complete manifest; rate advice is preserved. These limits deliberately bound exceptional PRs;
+ordinary large bodies alone do not make an entire collection unreadable.
+
+### Pages and cursors
+
+Pages have a maximum of 50 items and 4 MiB of normalized JSON. Hydrate bodies only
+for that page's IDs. Return fewer items when needed to fit, and point the cursor to
+the next unreturned manifest entry. Never consume/drop an item just because it did
+not fit. For a single oversized body, include an explicit truncated preview,
+`body_truncated=true`, and item URL; bound the preview to 256 KiB. Preserve identity
+and truncation metadata. An unavailable whole section is the last resort, not the
+normal handling of an oversized body.
+
+Use 256-bit random **server-side opaque cursor handles**, not client-authored JSON.
+A handle record binds caller, tenant, session, PR identity, section/filter, thread
+where applicable, integration generation, snapshot ID, next position, and expiry.
+Expire after five minutes; the snapshot lives no longer than its handles. Bind to
+the numeric GitHub identity used for access too. A cursor supplies position only:
+re-resolve the link and thread membership to build each upstream request. Unknown
+or foreign handles never cause a GitHub call. A well-formed handle missing from the
+bounded store returns generic `cursor_unavailable`; a known foreign handle returns
+400. Retained records can identify expiry/eviction/generation changes precisely;
+do not keep unbounded tombstones just to distinguish all forgotten handles.
+
+`has_more=true` iff `next_cursor` is non-null/non-empty. `has_more=false` only means
+end of the captured manifest; `coverage` separately says whether it covers the
+whole provider collection. The client rejects inconsistent combinations and never
+runs a continuation loop automatically. Zero-length pages with a continuation
+are a protocol failure. Stable IDs prevent duplicate appends on retried pages.
+
+Server bodies/manifests/handles share a 64 MiB payload budget and 256 payload-entry
+cap; evict least recently used entries, with ten-minute idle expiry and the shorter
+five-minute manifest/handle lifetime. Coalesced data is keyed by integration
+generation, canonical PR, section/filter, snapshot/page, and check SHA. Mutable overview/body payloads have a 30-second freshness window;
+use conditional requests where supported. Manual refresh can reuse a still-fresh
+payload and must retain its actual timestamp. Frozen manifest metadata remains its
+own snapshot until explicit refresh/expiry; fresh body hydration does not reorder it.
+Authorization is never cached inside shared body entries. Evicted handles/snapshots
+require restart.
+
+Desktop retains data for only the current PR, at most eight pages per section and
+32 MiB total per workspace. Evict least-recently-viewed non-visible pages first;
+show a Reload earlier control rather than claiming evicted rows are still loaded.
+A single manifest page can always be re-requested through its saved page handle
+while valid. First pages carry a page handle too. Expired handles require refresh.
+On PR switch, cancel old fetches and drop bodies/cursors; preserve only selection,
+expanded-ID and scroll metadata in a 20-PR LRU. Restore scroll/expansion after the
+corresponding data is reloaded, not by retaining unbounded content.
+
+## Wire contract
+
+Paths are additive and session-scoped:
 
 ```text
 GET /api/sessions/{sessionId}/pull-requests
@@ -158,213 +435,261 @@ GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}/threads/{threadI
 GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}/conversation
 ```
 
-The list route returns admitted, linked PR identities without a GitHub fan-out.
-It is independent of work-item assignments and work-item subscription gates. The
-un-suffixed PR route returns the compact overview and description. Collection
-routes accept an opaque cursor and return items plus `next_cursor` and
-`has_more`; the server fixes the page size at 50. The normalized response budget is
-4 MiB; a response exceeding it returns an explicit unavailable outcome and GitHub
-link rather than silently truncating comment bodies.
+The list does no GitHub fan-out: it returns Capacitor-admitted session link metadata,
+not hydrated GitHub bodies. Its `data` is `{ "items": [...] }`, with each row's
+identity fields plus nullable `url`, `title`, and `head_ref`. Its successful response
+can be empty. All detail routes
+apply the additional GitHub gate. Resolve `repoHash` against this session's admitted
+canonical links, using the existing hash derivation; do not treat the hash itself as
+authorization. No match, ambiguous identity, unknown repository, or unreadable
+Capacitor repository returns 404, even if the integration token can read it.
 
-Use 401 only for Capacitor authentication failure, 404 for unadmitted subjects,
-400 for invalid cursors/inputs, and 409 for a page sequence that must restart.
-Admitted reads use a typed result with `status` (`ready`, `stale`, `unavailable`),
-nullable `data`, `fetched_at`, `reason`, and optional `retry_at`. Provider credential
-failure is a reason inside that result, never a Capacitor 401. Only transient or
-rate-limit failures may return stale data. Overview sections have their own
-availability fields; partially available overview data does not manufacture zeros.
+Only identity/container fields necessary to address/interpret the result are
+required. Optional content fields tolerate absence/null. Unknown JSON members are
+ignored. Wire discriminators are strings parsed through explicit known-value maps;
+unknown values become Unknown, never exceptions or implicit success. A missing or
+unknown result status cannot expose its data. No `UnmappedMemberHandling.Disallow`.
 
-All responses identify their PR and carry fetch metadata. Check responses also
-identify the head commit they describe. The overview can report partial section
-availability without making unavailable counts zero. A count is exact, a labelled
-lower bound, or unknown; those shapes must be distinct on the wire.
+### Common shapes
 
-Reviewer summaries, published review submissions, and threads are separate paged
-collections. Reviewer summaries distinguish a person's latest published verdict
-from an outstanding review request, including team requests. The authoritative
-PR-wide review decision is not recomputed from whichever reviewers fit on a page.
-Thread list rows carry file/line/outdated/resolved metadata and a comment count;
-opening a thread loads its comment page. No nested comment fan-out is needed to
-list threads. Replies retain their own continuation cursor.
+Field names below are normative; JSON fixtures exercise exact source-generated
+serialization/deserialization in both repositories.
 
-Cursors are versioned, bounded, and validated against the requested PR, section,
-and thread where relevant. They cannot contain arbitrary upstream URLs. A cursor
-for checks is also tied to the head SHA; a changed head returns a typed restart
-outcome rather than appending another commit's checks. Other collections are
-live provider reads, not an atomic historical snapshot: stable provider IDs allow
-deduplication, and explicit refresh restarts pagination.
+```json
+{
+  "status": "ready",
+  "subject": {"provider":"github","host":"github.com","repo_hash":"0123456789abcdef","owner":"example","repo_name":"repo","number":42},
+  "data": {},
+  "fetched_at": "2026-09-07T10:00:00Z",
+  "reason": null,
+  "retry_at": null,
+  "poll_after_seconds": 0,
+  "access_valid_for_seconds": 20
+}
+```
 
-### Admission and privacy
+`status`: ready, stale, unavailable. `data` is nullable and typed per route.
+`subject` is absent on the link-list envelope; its rows carry the same identity.
+`fetched_at` is the successful upstream fetch/validation time of that data, not
+cache insertion or response time; a 304 revalidation advances it. Section/snapshot
+times remain separate. All absolute times are RFC 3339 UTC strings ending in Z;
+`retry_at` is absolute UTC. Durations are nonnegative integers in seconds.
 
-Authorization precedes every response, including cache hits and every continuation
-page. Require the existing session access resolver's **Full** level and the existing
-tenant/team repository visibility gate. Resolve owner/name/provider from the
-server's admitted linked-PR data; the route's repository and number must match it.
-Do not accept a caller-supplied GitHub URL, host, or unrelated PR identity. A thread
-identifier must belong to the admitted PR, even when GitHub can address it globally.
-Missing, hidden, below-Full, and unlinked subjects return indistinguishable 404s.
+`access_valid_for_seconds` is remaining positive proof lifetime at server delivery,
+zero on unavailable or failed authorization. The client measures expiry from its
+request's monotonic **start**, not receipt, so network time cannot extend the lease.
+It caps the duration at 30 seconds and masks on expiry. The link list does not grant
+a detail access lease. Each body response needs valid current authorization too.
 
-The configured integration is tenant-shared tracker access, **not a mirror of each
-caller's personal GitHub permissions**. This interface uses Capacitor's repository
-and session access model, as existing tracker reads do. That policy is part of the
-spec approval; the implementation must not claim GitHub-user ACL parity. The
-credential should be scoped to the repositories the tenant intends to expose.
+Reasons: disabled, not_configured, github_not_linked, github_access_denied,
+github_access_unverifiable, provider_unauthorized, provider_forbidden,
+provider_not_found, rate_limited, budget_exhausted, timeout, provider_unavailable,
+protocol_error, capture_unstable, payload_unavailable. Unknown reasons use a generic
+unavailable label. Only transient content failures/rate limits with a still-valid
+access proof may carry stale data. Unknown authorization status never may.
 
-Use the existing identity/visibility helpers rather than a new approximation based
-on an owner string or session presence alone. Do not let another hidden session
-contribute an additional linked PR, title, count, or ordering to this session's list.
-Revalidate access before delivering an upstream result after a long fetch; cache
-entries never cache a caller's authorization decision.
+Count: `{ "value": 2, "kind": "exact" }`; kinds exact, lower_bound, unknown.
+Unknown requires null value. Unknown kind is interpreted as unknown. Negative
+values are malformed. Never show a lower bound as an exact sidebar count.
 
-Only `github.com` receives live detail support in v1. Other hosts/providers retain
-safe external links. Build provider request URLs from validated identities and
-fixed provider origins; refuse off-origin redirects. This is not a generic proxy.
+Section availability: `{ "status":"ready", "reason":null, "fetched_at":"…" }`.
+Overview includes identity/title/URL, lifecycle, is_draft, head_ref/base_ref/head_sha,
+raw Markdown description, PR updated_at, GitHub review_decision, and:
 
-Do not log credential material, comment bodies, description text, or raw provider
-error payloads. Upstream failures are normalized before returning to the client.
+- `checks`: availability, provider rollup, counts by actual normalized outcome,
+  and `head_sha`. Exact aggregate only when complete latest-set evidence exists.
+- `reviews`: availability, published/approved/changes-requested/outstanding-user/
+  outstanding-team count objects. Bounded GraphQL connections can supply lower
+  bounds; review_decision remains authoritative independently.
+- `conversation`: availability and comment count if available without body reads.
 
-### Desktop module
+Absent optional fields remain unknown. Failed section availability is not a zero
+count. An unchanged `updated_at` is not proof every body/check is unchanged; freshness
+is explicit. The reader's update hint is advisory, not a consistency guarantee.
 
-Core gains a `PullRequests` namespace for wire records, source-generated JSON
-metadata, and the read client. It remains NativeAOT-safe and has no Avalonia or
-GitHub-token dependency. Checked-in literal response fixtures pin the interface
-between the two repositories; the desktop does not reference server assemblies.
+Page `data`:
 
-The app gains a workspace-owned pull-request view model plus an authenticated
-server source. The sidebar card and center reader project the same state, so they
-cannot independently select different PRs or display divergent fetch results.
-`WorkspaceViewModel` owns tab navigation and passes session/workspace visibility to
-this module. `WorkContextViewModel` retains responsibility for work-item content.
-Replace its plain PR link presentation without doing unrelated sidebar refactoring.
+```json
+{
+  "snapshot_id": "opaque",
+  "snapshot_started_at": "2026-09-07T10:00:00Z",
+  "snapshot_completed_at": "2026-09-07T10:00:02Z",
+  "coverage": "complete",
+  "head_sha": null,
+  "total": {"value":2,"kind":"exact"},
+  "items": [{"id":"IC_example","url":"https://github.com/example/repo/pull/42#issuecomment-1","created_at":"2026-09-07T09:00:00Z","updated_at":"2026-09-07T09:00:00Z","author":null,"body":"Example comment","body_truncated":false}],
+  "page_cursor": "opaque-current-page-handle",
+  "has_more": true,
+  "next_cursor": "opaque-next-page-handle"
+}
+```
 
-The server source uses the existing profile-aware authentication setup and respects
-both `Ok` and `NoAuthRequired`. Authentication retry/client retirement and teardown
-must use the established lease discipline; share that implementation at an internal
-seam if needed rather than making a second subtly different credential lifecycle.
-A profile change retires the source and its entire PR cache.
+Coverage is complete or limited; unknown coverage is limited. A limited page also
+carries `coverage_reason`: entry_limit, size_limit, changed_during_capture, or
+provider_limit; unknown reasons retain the limited label. Each collection item carries stable provider ID, its validated
+external URL if available, and the section's typed content. Bodies additionally
+carry `body_truncated`. User/team actors have stable ID, kind, nullable login/name,
+and no automatically downloaded image. Pending review state `PENDING` is dropped
+server-side unconditionally; review comments/threads must also exclude unpublished
+review content, rather than assuming the integration cannot see its owner's drafts.
 
-Every asynchronous result is associated with session, PR, section, and a selection
-generation. Old results cannot update a new selection, including an A→B→A switch.
-Dispose cancels owned requests, awaits them, and prevents late bound-state writes.
-All observable collection/property updates occur on the UI scheduler.
+### HTTP outcomes and reset semantics
 
-Render Markdown and code through the app's existing native text modules. Raw HTML
-is not executed and remote images are not automatically fetched. All explicit
-external-link actions go through `LinkPolicy`; disallowed schemes remain inert.
-Do not fetch attachments or evaluate suggested code.
+401 is Capacitor authentication failure only. Missing/hidden/below-Full/unlinked
+Capacitor subjects are indistinguishable 404s. GitHub denials are typed unavailable
+results for an already admitted Capacitor link, not a Capacitor 401/404. Malformed
+inputs or known-foreign/malformed cursor handles return 400 without upstream work.
 
-## Freshness and failure behavior
+409 uses `{ "error":"restart_required", "reason":"…" }`, where reason is
+head_changed, cursor_expired, cursor_unavailable, snapshot_evicted,
+cursor_version_changed, integration_changed, or identity_changed. The current subject must pass admission
+before returning a detailed restart reason. Otherwise return the ordinary denied
+outcome, not a hint about another user's cursor.
 
-- While the workspace is visible, refresh the linked-PR list and selected PR
-  overview every 30 seconds, as well as on first activation and manual refresh.
-  Hidden/minimized workspaces stop polling and refresh on return if stale.
-- Discovering multiple links does not poll all of them. Fetch full sections only
-  when the user opens them; switching to an unfetched section shows its own loader.
-- An open reader retains its content and reading position. Overview refreshes can
-  show **PR updated — refresh details**; they must not replace pages under the user.
-  Opening a section after returning to the reader refreshes it if older than 30
-  seconds. Manual refresh restarts the selected collection and preserves stable
-  expanded thread identities where they still exist.
-- Every section shows its own last successful fetch time. A freshly read overview
-  does not imply that previously loaded comments are also fresh.
-- Server overview/page caches have a 30-second freshness window, coalesce identical
-  requests, and use conditional requests where GitHub supports them. Manual refresh
-  may reuse data still within that window, and the returned timestamp says so.
-- Respect primary and secondary rate limits and `Retry-After`. Do not retry a
-  failed provider call immediately; recovery uses the next eligible poll or manual
-  refresh under the provider cooldown. Use the existing response time budget and
-  cancellation behavior. Repeated clicks cannot bypass cooldowns.
-- Bound the server cache to 256 entries and 64 MiB of normalized payload, evicting
-  least-recently-used entries and entries idle for ten minutes. These are operational
-  defaults, not a limit on how many pages the user can request. Cache identity
-  includes the tenant/integration generation, PR identity, section and cursor, and
-  check head SHA. Removing/rotating the credential invalidates cached detail data;
-  authorization/configuration failures never serve stale bodies.
+- Head changed: discard checks and their counts/cursors immediately; these cannot
+  remain displayed as the current head's checks. Reload on explicit refresh.
+- Integration/identity changed: clear all protected bodies and proofs; reauthorize.
+- Cursor expired/unavailable/version changed/snapshot evicted: disable Load more, retain visible
+  rows only while their access lease is valid, label them as an old snapshot, and
+  offer Refresh. Do not silently replace pages under the user.
+- Manual Refresh explicitly resets the selected collection to page one and scrolls
+  it to the top. Retain expansion IDs only for rows that reappear. This is an
+  intentional exception to ordinary background-refresh scroll preservation.
 
-| Outcome | Presentation |
+## Desktop lifecycle and freshness
+
+Core owns NativeAOT-safe wire records and a small read client in `PullRequests`.
+The app owns the shared workspace state/source. No server assembly references.
+Extract a shared internal authenticated-client lease helper from the established
+source only as needed; preserve its authentication retry and retired-client lease
+discipline. Borrowing/building is serialized, not HTTP requests. A slow
+comment read cannot serialize work-context reads behind itself.
+
+Limit desktop PR HTTP concurrency to four per profile, with one request per
+workspace/section and overview priority. Collapse refresh clicks to one pending
+follow-up. PR/session changes cancel old operations, not just suppress their
+results. Bind result application to profile, session, PR, section and monotonically
+increasing selection generation, including A→B→A. UI updates use the UI scheduler.
+Disposal cancels, awaits, then releases resources; workspace teardown owns this once.
+
+Polling eligibility means selected workspace in a visible, non-minimized,
+foreground app window. Poll the link list and selected PR overview on a 30-second
+target schedule, subject to server backoff. While protected content is displayed,
+renew via the overview five seconds before the conservative access deadline, with
+at least 15 seconds between attempts; reuse fresh content but renew expiring access
+proofs. Early renewal normally avoids a blank flash at each lease boundary, not a
+guarantee during slow/failed requests. It cannot bypass server pacing/cooldowns.
+Ended sessions follow the same rule. Stop polling and mask bodies when ineligible;
+on return, revalidate before showing retained bodies, even if a previous timer had
+not expired. Load other sections on demand.
+
+Background overview refresh never replaces reader pages. It may show an update
+hint. Sections show their own times; manual refresh restarts them. Valid new access
+evidence can authorize redisplaying an old body snapshot, but the snapshot stays
+labelled with its old fetch time. A fresh overview cannot label those bodies fresh.
+
+| Outcome | UI and retention |
 | --- | --- |
-| First read pending | Section-specific skeleton/loading text; unknown counts. |
-| Confirmed no linked PR | No pull request linked. |
-| Confirmed empty collection | No checks/reviews/comments, specific to that successful read. |
-| Temporary provider/network failure after success | Retain that section with stale time and Retry. |
-| Temporary failure before success | Couldn't load this section; Retry and GitHub link if already known. |
-| Integration not configured | GitHub details aren't configured on this server; retain the known PR link. |
-| Provider credential/permission failure | Details unavailable; clear fetched bodies, retain only independently admitted link metadata. |
-| Response exceeds the size budget | This section is too large to display; provide its GitHub link without calling it empty or complete. |
-| Rate limited | Last successful data where safe, explicit rate-limit notice, retry time when supplied. |
-| Caller signed out | Clear protected data and offer the app's existing sign-in action. |
-| Access removed or PR unlinked | Clear protected detail data; unavailable state, not a cached preview. |
-| Older server without the routes | Retain existing admitted PR links, show details unavailable, leave work context/chat working. |
+| First read pending | Section loading, unknown counts. |
+| New authoritative link list empty | No PR linked. |
+| Successful empty captured collection | No comments/reviews/checks, only if coverage is complete. |
+| Missing GitHub link | Link GitHub action; no bodies. |
+| Disabled/missing integration | Known PR link and explanatory note; no bodies. |
+| Denied/unverifiable user permission | Clear bodies/proofs, link retained only if Capacitor-admitted. |
+| Provider 401, non-rate 403, or 404 | Authorization-class: clear fetched bodies, never stale; do not change link or lifecycle. |
+| Content transport/5xx/timeout | Retain stale bodies only until an existing access lease expires. |
+| Rate/budget limit | Respect retry advice; expired evidence is masked, not extended. |
+| Oversized item | Explicit truncated preview and its external link; paging continues. |
+| Limited manifest | Label loaded subset/lower bound; More on GitHub, never all-loaded. |
+| Caller sign-out/session 404 | Clear affected protected state immediately. |
+| Older server | Legacy admitted links only; no unsupported-route polling. |
 
-A provider-side 404 does not prove that a PR was deleted: private resources can
-return 404 for insufficient permissions. It never clears the server's session link
-or changes lifecycle state. A missing route, inaccessible subject, and failed
-provider fetch must not be collapsed into an authoritative empty PR list.
+## Verification and delivery
 
-## Verification contract
+Server tests exercise admission and normalized responses with stubbed GitHub data:
+Full/hidden/team gates, forged session/PR/thread/cursor identity, missing and changed
+GitHub links, numeric-ID mismatch/login rename, public vs internal/private repos,
+team/base-role read and denied/unverifiable permission, cache-hit authorization,
+proof expiry during fetch, token/flag rotation, GitHub-side revocation, and denial
+on 404. Verify that cached bodies cannot bypass the user's GitHub permission gate.
 
-Server tests exercise the public read interface with provider responses stubbed:
+Pagination tests must cover inserts during capture (stable retry or explicit limited
+coverage) and between pages (no missed manifest rows), deletions/tombstones,
+snapshot-stable ordering, resolved filter,
+body-budget short pages without lost items, one oversized body, repeated cursors,
+limited manifests, eviction and every 409 reason. Include pending/dismissed reviews,
+file-level/outdated threads, deleted actors, cross-repo equal PR numbers, same-name
+workflow jobs and reruns. Test rate-limit yielding and coalescing without changing
+background-job scheduling or emitting enrichment events.
 
-- Access floor, team/repository visibility, hidden-session provenance, unlinked PRs,
-  forged cursors, foreign thread IDs, and unauthorized cache reads.
-- Configuration removal, token rotation, 401/403/404/429, both kinds of rate limit,
-  partial provider responses, repeated cursors, and cancellation.
-- PR state normalization, fork/base-repository identity, equal PR numbers across
-  repositories, rerun checks, legacy statuses, and unknown outcomes.
-- Dismissed/superseded/published reviews, pending review exclusion, resolved versus
-  outdated threads, file-level comments, deleted authors, pagination and replies.
-- Cache coalescing/expiry, complete versus incomplete counts, head changes while
-  paging, and no enrichment/event-store mutations from reads.
+Core/app tests pin tolerant JSON parsing, unknown status/enum handling, exact
+count/page invariants, source precedence, unsupported discovery/backoff, provider
+failure versus Capacitor sign-out, memory eviction, monotonic access expiry,
+visibility return masking, and profile/selection cancellation. Avalonia tests assert
+realized Chat/Terminal preservation, non-PTY and ended layouts, card-row focus,
+selected tab accessibility, live announcements, readable long content, and failures
+in one sidebar module not contaminating the other.
 
-Core/app tests pin literal wire fixtures and source-generated metadata, profile
-isolation, rapid session/PR/tab changes, stale success versus access revocation,
-partial page retries, no duplicate rows, and lifecycle teardown.
+Create one canonical v1 JSON fixture bundle plus SHA-256 manifest. The server's
+contract tests serialize representative public response records and compare with
+that bundle; the CLI's tests deserialize the identical bundle with generated
+metadata and verify semantics. Both repositories pin the same bundle digest in
+versioned contract metadata. A server field rename fails its serialization test
+against the checked-in canonical fixture; tests must not regenerate golden files.
+No new cross-repo CI credentials are assumed. The implementation driver compares
+the bundle digests at the paired candidate commits before merge and before release;
+a contract revision needs both pins updated together. This catches accidental field
+drift in local CI and coordinated revision mismatches in paired integration.
 
-Avalonia tests pin direct navigation from each card row, non-PTY PR availability,
-ended-session reading, retained Chat/Terminal state, accessibility, long Markdown
-and file paths, multiple PRs, and older-server fallback. Exercise all lifecycle and
-failure presentations, not only the successful example shown in the prototype.
+The implementation driver owns a read-only smoke check against the paired server
+candidate before requesting implementation sign-off and again before desktop
+release: public and authorized private PRs, team-only reader, denied user, existing
+linked/unlinked accounts, and a long paged discussion. Use designated test accounts;
+do not retrieve/log the production integration token or mutate PRs. Until executed,
+report this as unverified, not covered by stub tests. Verify the configured token
+can call the permission endpoint and exercise the chosen GitHub connection adapters,
+including completeness evidence; do not claim a transactional/keyset guarantee the
+provider cannot supply.
 
-Rebuild all changed projects without warnings. Run affected suites and the desktop
-suite at normal parallelism. Publish the CLI in Release to verify Core changes
-introduce no IL3050/IL2026 warnings; a normal build is not evidence of AOT safety.
-Run a live read-only smoke check against a public and an authorized private test PR,
-including a long paged thread. No test may post or mutate a real PR.
+Rebuild every changed project without warnings, run affected suites plus the desktop
+suite at normal parallelism, and Release-publish the CLI for IL3050/IL2026 checks.
+No code changed during design; the pre-change desktop baseline passed 1,442 tests.
 
-## Delivery and record
+Two work parts: server read/access module and desktop card/reader. Agree fixtures
+first; desktop can develop against them, but live integration/release is blocked
+on the additive server routes and capability field. Deploy server first.
 
-The work has two parts:
+This spec lives on `feat/desktop-pr-sidebar` in `.worktrees/desktop-pr-sidebar` and
+rides the first desktop implementation PR. No spec-only PR. Record the approved
+cross-repo design in a Linear document linked to both implementation issues; the
+server part references that record, without opening a server spec-only PR. Create
+CLI issues in GitHub (Linear auto-import), server issues in Linear. CLI PR bodies
+reference both IDs; server PRs follow that repository's Linear reference convention.
+No external issue identifier is invented here.
 
-1. **Server PR read interface and provider module** — authorization, normalized
-   overview/pages, cache/failure semantics, tests, and integration documentation.
-2. **Desktop PR card and reader** — Core client, shared workspace state, views,
-   compatibility handling, and tests.
-
-Agree the wire fixtures first. Desktop development can use them in parallel, but
-live desktop integration and release depend on the server part being available.
-Deploy the additive server routes before advertising full desktop PR details.
-Existing desktop builds ignore the new routes; new desktop builds degrade safely
-against older servers.
-
-No production code has been changed for this design. The worktree is
-`.worktrees/desktop-pr-sidebar` on `feat/desktop-pr-sidebar`. The pre-change desktop
-baseline passed all 1,442 tests.
-
-The three-option HTML is a throwaway visual reference, not production source. Its
-local artifact is
+Archive the throwaway three-layout HTML on a non-production branch at sign-off and
+link it from the design record; never merge its switcher into the app. Local source:
 `.superpowers/brainstorm/94464-1788768185/content/pr-sidebar-layouts.html`.
-Archive it on a throwaway branch when design sign-off is complete, and retain a
-reference with the implementation tracking. Do not merge the prototype or its
-switcher into production.
 
-Keep this spec on the feature branch so it rides the first implementation PR;
-do not open a spec-only PR. On sign-off, copy the approved design into the linked
-Linear issue/document per the team's recording convention. No external issue
-number is assigned by this document.
+Capacitor parent `26c1058d5f49597faad21b663ab786a1`; server part
+`b5202e2821b259e9bd7bdd178b388b1e`; desktop part
+`a7d3de097c3454c186fc449bd4659f9d`. The declared server→desktop dependency gates live
+integration/release, not parallel fixture-based development.
 
-Capacitor work-item correlation:
+## Primary-source references
 
-- Parent: `26c1058d5f49597faad21b663ab786a1`.
-- Server part: `b5202e2821b259e9bd7bdd178b388b1e`.
-- Desktop part: `a7d3de097c3454c186fc449bd4659f9d`.
-- Server part blocks desktop live integration/release.
+- [Linked-account feasibility research](../../github-linked-pr-access-research.md):
+  actual server linking flow and the distinction between identity and delegation.
+- [Get a user using their ID](https://docs.github.com/en/rest/users/users#get-a-user-using-their-id).
+- [Get repository permissions for a user](https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user):
+  effective base roles across direct/team/org grants; Metadata read for supported
+  fine-grained token types.
+- [List check runs for a Git reference](https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference):
+  latest filter and the provider's 1,000-suite limit; do not claim complete coverage
+  if a provider ceiling was reached.
+- [GitHub's published GraphQL schema](https://docs.github.com/public/fpt/schema.docs.graphql):
+  PR/review/thread/comment connections expose native cursors; review-thread/review
+  connections lack a created-at order parameter, and IssueCommentOrderField exposes
+  UPDATED_AT only. Frozen client paging must not depend on an invented keyset API.
+- [GitHub App user-to-server authorization](https://docs.github.com/en/apps/creating-github-apps/authenticating-with-a-github-app/authenticating-with-a-github-app-on-behalf-of-a-user):
+  the stronger, separately scoped alternative, not implemented by identity linking.

--- a/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
+++ b/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
@@ -1,0 +1,370 @@
+# Desktop pull-request context
+
+## Outcome and agreed scope
+
+Find the current PR, understand its state, and read feedback without visiting the
+Capacitor web UI first. GitHub remains the destination for actions and full diff
+browsing.
+
+The selected layout is **C: sidebar summary plus a wide reader**. Keep the existing
+400px work-context sidebar. Add a compact PR card there and a **Pull request** tab
+beside **Chat** and **Terminal**. Clicking a section in the card selects that PR and
+opens the corresponding reader section directly.
+
+The user approved:
+
+- Layout C rather than an expanding sidebar card or dedicated sidebar tab.
+- Read-only v1: no posting, replying, resolving, requesting/submitting reviews,
+  rerunning checks, changing draft state, closing, or merging.
+- Server-supplied GitHub data using the configured integration, rather than a
+  desktop dependency on `gh` or a second desktop sign-in.
+
+This document specifies the remaining interaction and technical details for review.
+Implementation starts only after the written design is approved.
+
+## Experience
+
+### Sidebar
+
+Place the PR card after the work-item card and before the linked issue. Keep work
+item, contributors, and session facts in their existing places.
+
+The card shows:
+
+- Repository, PR number, title, and source/target branches.
+- Explicit **Draft**, **Open**, **Closed**, **Merged**, or **Unknown** lifecycle state.
+  Draft is an open PR with its draft flag set; merged takes precedence over closed.
+- Copy-number and copy-URL actions with visible copied feedback; an explicit
+  **Open on GitHub** action. Clicking the title opens the in-app reader.
+- Checks summary: failed, running/pending, passed, and skipped/neutral as distinct
+  categories. Zero checks says **No checks reported**, not **Passed**.
+- GitHub's review decision when available; otherwise an honest review summary,
+  without claiming that the PR meets branch protection or is ready to merge.
+- Navigation rows for **Checks**, **Reviews**, and **Conversation**. Counts appear
+  only with their completeness known. An unresolved-thread count is optional, not
+  a reason to download every comment before showing the card.
+- A last-successful-fetch time and refresh action. Refresh failure marks retained
+  data as stale; it does not change the PR to closed, empty, or passing.
+
+When a session has multiple PRs, show one expanded summary and a selector labelled
+with repository, number, and title. Keep the user's selection for that workspace.
+For an initial selection, prefer a unique match on the session's primary repository
+and branch. Otherwise use the server's deterministic repository/number ordering;
+never silently guess that the largest PR number is the relevant PR. Subsequent
+polls must not switch away from a PR the user is reading.
+
+PRs are identified by their **base repository and number**, not just the number or
+head branch. A fork's head repository must not become the PR's identity. A
+cross-repository session can expose distinct PRs with equal numbers.
+
+A successful, authoritative empty link list shows **No pull request linked**. An
+unregistered session shows **Waiting for the session to register…**. A failed link
+read cannot manufacture the empty state. Unsupported providers keep their existing
+external links but do not offer GitHub-specific detail controls.
+
+### Reader
+
+The reader uses the center column, not a new window, overlay, embedded browser, or
+second nested sidebar. Its header repeats PR identity/state and the GitHub action.
+The header includes a collapsed, expandable PR description.
+
+Three sections provide the following:
+
+| Section | Content and order |
+| --- | --- |
+| Checks | Latest head commit's check runs and commit-status contexts. Failures first, then pending/running, then successful and neutral/skipped results. Show name, provider/app, actual outcome, timing when available, and the check's GitHub/details link. |
+| Reviews | GitHub review decision, current reviewer/request status, submitted review bodies, and inline discussion threads. Group loaded threads unresolved-first; offer Show resolved, and label outdated separately from resolved. Keep the pagination indicator visible so the loaded subset cannot look like the whole discussion. |
+| Conversation | Top-level PR comments, newest first, with author, timestamp, edited indication when supplied, and Markdown body. Identify automated authors and allow their comments to be collapsed; never hide their existence from counts. |
+
+Review threads show the file path, available current/original line information,
+review-provided diff hunk, comment bodies, replies, author/time, and a direct link
+to the thread. Do not reconstruct historical context from the local checkout.
+File-level comments and outdated comments without a current line are valid.
+Published review submissions remain available even when superseded by another
+verdict. Do not expose unpublished pending reviews visible only to the integration
+credential's owner.
+
+Checks, reviewer summaries, review submissions, threads, thread replies, and
+conversation comments are paged. **Load more** extends the relevant collection. A failed later page retains
+the loaded portion with a retry action; it never labels the collection complete.
+No full-file diff browser, check-log viewer, PR search, or manual link editor is
+included in v1.
+
+### Navigation and preservation
+
+- Opening a PR is always an explicit action; detecting a newly linked PR does not
+  steal focus from Chat or Terminal.
+- Returning to Chat preserves its draft and scroll position. Switching tabs must
+  not detach, restart, or dispose the terminal/agent.
+- Returning to the reader restores its selected PR, section, thread expansion, and
+  scroll state for the workspace's lifetime. No disk persistence is needed.
+- PR availability is independent of PTY support. A workspace with no Chat/Terminal
+  surface can still display the PR reader. Existing terminal absence banners must
+  not overlay it.
+- Ended sessions can still read their linked PRs while their workspace is open.
+- If a selected PR is unlinked or access is revoked, clear its detailed content and
+  explain that it is unavailable. Do not silently replace it with another PR.
+- Keyboard focus, accessible tab selection, text labels alongside status colors,
+  and readable long paths/bodies are part of the design.
+
+## Architecture
+
+### Existing code and the missing data
+
+`WorkContextView.axaml` currently renders PRs as number/title links.
+`SessionPullRequestDto` in Core's `WorkItems/WorkContextDtos.cs` carries identity,
+URL, title, and head ref, but no checks or discussions. `WorkContextReader` also
+couples its summary result to work-item route outcomes; the new PR read must not
+inherit that coupling.
+
+The server's `/api/review` surface supplies recorded coding-session context, files,
+and transcript excerpts. It is not a GitHub discussion/checks interface. Existing
+`GitHubEnrichmentSource` reads lifecycle and review aggregates for tracker
+processing; `GitHubReviewRequestClient` handles requested-reviewer observations.
+Neither inspected surface provides the complete reader.
+
+### Server module
+
+Add a dedicated pull-request read module. It owns GitHub reads, normalization,
+pagination, conditional requests, caching, and typed failures. Keep interactive
+reads out of the background work-item enrichment pipeline: opening a panel must
+not append enrichment events or trigger work-item lifecycle transitions.
+
+Reuse the configured GitHub tracker credential provider and HTTP setup. The
+configured credential needs read access to PRs, issue comments, checks, and commit
+statuses for the relevant repositories. Missing configuration or insufficient
+scope is a supported UI outcome, not a request to discover another credential.
+The daemon and desktop never receive this token.
+
+GitHub REST and GraphQL are implementation details of the server module. Use the
+provider's review decision and resolution/outdated flags rather than inferring
+these from text or comment ordering. Include both check runs and legacy commit
+statuses. A repeated run must not count an obsolete attempt as a current failure.
+Preserve unknown provider statuses as unknown rather than treating them as success.
+
+### HTTP interface
+
+Use additive, session-scoped routes; do not change the meaning of `/api/review` or
+require a new daemon protocol. The route family is:
+
+```text
+GET /api/sessions/{sessionId}/pull-requests
+GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}
+GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}/checks
+GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}/reviewers
+GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}/reviews
+GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}/threads
+GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}/threads/{threadId}/comments
+GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}/conversation
+```
+
+The list route returns admitted, linked PR identities without a GitHub fan-out.
+It is independent of work-item assignments and work-item subscription gates. The
+un-suffixed PR route returns the compact overview and description. Collection
+routes accept an opaque cursor and return items plus `next_cursor` and
+`has_more`; the server fixes the page size at 50. The normalized response budget is
+4 MiB; a response exceeding it returns an explicit unavailable outcome and GitHub
+link rather than silently truncating comment bodies.
+
+Use 401 only for Capacitor authentication failure, 404 for unadmitted subjects,
+400 for invalid cursors/inputs, and 409 for a page sequence that must restart.
+Admitted reads use a typed result with `status` (`ready`, `stale`, `unavailable`),
+nullable `data`, `fetched_at`, `reason`, and optional `retry_at`. Provider credential
+failure is a reason inside that result, never a Capacitor 401. Only transient or
+rate-limit failures may return stale data. Overview sections have their own
+availability fields; partially available overview data does not manufacture zeros.
+
+All responses identify their PR and carry fetch metadata. Check responses also
+identify the head commit they describe. The overview can report partial section
+availability without making unavailable counts zero. A count is exact, a labelled
+lower bound, or unknown; those shapes must be distinct on the wire.
+
+Reviewer summaries, published review submissions, and threads are separate paged
+collections. Reviewer summaries distinguish a person's latest published verdict
+from an outstanding review request, including team requests. The authoritative
+PR-wide review decision is not recomputed from whichever reviewers fit on a page.
+Thread list rows carry file/line/outdated/resolved metadata and a comment count;
+opening a thread loads its comment page. No nested comment fan-out is needed to
+list threads. Replies retain their own continuation cursor.
+
+Cursors are versioned, bounded, and validated against the requested PR, section,
+and thread where relevant. They cannot contain arbitrary upstream URLs. A cursor
+for checks is also tied to the head SHA; a changed head returns a typed restart
+outcome rather than appending another commit's checks. Other collections are
+live provider reads, not an atomic historical snapshot: stable provider IDs allow
+deduplication, and explicit refresh restarts pagination.
+
+### Admission and privacy
+
+Authorization precedes every response, including cache hits and every continuation
+page. Require the existing session access resolver's **Full** level and the existing
+tenant/team repository visibility gate. Resolve owner/name/provider from the
+server's admitted linked-PR data; the route's repository and number must match it.
+Do not accept a caller-supplied GitHub URL, host, or unrelated PR identity. A thread
+identifier must belong to the admitted PR, even when GitHub can address it globally.
+Missing, hidden, below-Full, and unlinked subjects return indistinguishable 404s.
+
+The configured integration is tenant-shared tracker access, **not a mirror of each
+caller's personal GitHub permissions**. This interface uses Capacitor's repository
+and session access model, as existing tracker reads do. That policy is part of the
+spec approval; the implementation must not claim GitHub-user ACL parity. The
+credential should be scoped to the repositories the tenant intends to expose.
+
+Use the existing identity/visibility helpers rather than a new approximation based
+on an owner string or session presence alone. Do not let another hidden session
+contribute an additional linked PR, title, count, or ordering to this session's list.
+Revalidate access before delivering an upstream result after a long fetch; cache
+entries never cache a caller's authorization decision.
+
+Only `github.com` receives live detail support in v1. Other hosts/providers retain
+safe external links. Build provider request URLs from validated identities and
+fixed provider origins; refuse off-origin redirects. This is not a generic proxy.
+
+Do not log credential material, comment bodies, description text, or raw provider
+error payloads. Upstream failures are normalized before returning to the client.
+
+### Desktop module
+
+Core gains a `PullRequests` namespace for wire records, source-generated JSON
+metadata, and the read client. It remains NativeAOT-safe and has no Avalonia or
+GitHub-token dependency. Checked-in literal response fixtures pin the interface
+between the two repositories; the desktop does not reference server assemblies.
+
+The app gains a workspace-owned pull-request view model plus an authenticated
+server source. The sidebar card and center reader project the same state, so they
+cannot independently select different PRs or display divergent fetch results.
+`WorkspaceViewModel` owns tab navigation and passes session/workspace visibility to
+this module. `WorkContextViewModel` retains responsibility for work-item content.
+Replace its plain PR link presentation without doing unrelated sidebar refactoring.
+
+The server source uses the existing profile-aware authentication setup and respects
+both `Ok` and `NoAuthRequired`. Authentication retry/client retirement and teardown
+must use the established lease discipline; share that implementation at an internal
+seam if needed rather than making a second subtly different credential lifecycle.
+A profile change retires the source and its entire PR cache.
+
+Every asynchronous result is associated with session, PR, section, and a selection
+generation. Old results cannot update a new selection, including an A→B→A switch.
+Dispose cancels owned requests, awaits them, and prevents late bound-state writes.
+All observable collection/property updates occur on the UI scheduler.
+
+Render Markdown and code through the app's existing native text modules. Raw HTML
+is not executed and remote images are not automatically fetched. All explicit
+external-link actions go through `LinkPolicy`; disallowed schemes remain inert.
+Do not fetch attachments or evaluate suggested code.
+
+## Freshness and failure behavior
+
+- While the workspace is visible, refresh the linked-PR list and selected PR
+  overview every 30 seconds, as well as on first activation and manual refresh.
+  Hidden/minimized workspaces stop polling and refresh on return if stale.
+- Discovering multiple links does not poll all of them. Fetch full sections only
+  when the user opens them; switching to an unfetched section shows its own loader.
+- An open reader retains its content and reading position. Overview refreshes can
+  show **PR updated — refresh details**; they must not replace pages under the user.
+  Opening a section after returning to the reader refreshes it if older than 30
+  seconds. Manual refresh restarts the selected collection and preserves stable
+  expanded thread identities where they still exist.
+- Every section shows its own last successful fetch time. A freshly read overview
+  does not imply that previously loaded comments are also fresh.
+- Server overview/page caches have a 30-second freshness window, coalesce identical
+  requests, and use conditional requests where GitHub supports them. Manual refresh
+  may reuse data still within that window, and the returned timestamp says so.
+- Respect primary and secondary rate limits and `Retry-After`. Do not retry a
+  failed provider call immediately; recovery uses the next eligible poll or manual
+  refresh under the provider cooldown. Use the existing response time budget and
+  cancellation behavior. Repeated clicks cannot bypass cooldowns.
+- Bound the server cache to 256 entries and 64 MiB of normalized payload, evicting
+  least-recently-used entries and entries idle for ten minutes. These are operational
+  defaults, not a limit on how many pages the user can request. Cache identity
+  includes the tenant/integration generation, PR identity, section and cursor, and
+  check head SHA. Removing/rotating the credential invalidates cached detail data;
+  authorization/configuration failures never serve stale bodies.
+
+| Outcome | Presentation |
+| --- | --- |
+| First read pending | Section-specific skeleton/loading text; unknown counts. |
+| Confirmed no linked PR | No pull request linked. |
+| Confirmed empty collection | No checks/reviews/comments, specific to that successful read. |
+| Temporary provider/network failure after success | Retain that section with stale time and Retry. |
+| Temporary failure before success | Couldn't load this section; Retry and GitHub link if already known. |
+| Integration not configured | GitHub details aren't configured on this server; retain the known PR link. |
+| Provider credential/permission failure | Details unavailable; clear fetched bodies, retain only independently admitted link metadata. |
+| Response exceeds the size budget | This section is too large to display; provide its GitHub link without calling it empty or complete. |
+| Rate limited | Last successful data where safe, explicit rate-limit notice, retry time when supplied. |
+| Caller signed out | Clear protected data and offer the app's existing sign-in action. |
+| Access removed or PR unlinked | Clear protected detail data; unavailable state, not a cached preview. |
+| Older server without the routes | Retain existing admitted PR links, show details unavailable, leave work context/chat working. |
+
+A provider-side 404 does not prove that a PR was deleted: private resources can
+return 404 for insufficient permissions. It never clears the server's session link
+or changes lifecycle state. A missing route, inaccessible subject, and failed
+provider fetch must not be collapsed into an authoritative empty PR list.
+
+## Verification contract
+
+Server tests exercise the public read interface with provider responses stubbed:
+
+- Access floor, team/repository visibility, hidden-session provenance, unlinked PRs,
+  forged cursors, foreign thread IDs, and unauthorized cache reads.
+- Configuration removal, token rotation, 401/403/404/429, both kinds of rate limit,
+  partial provider responses, repeated cursors, and cancellation.
+- PR state normalization, fork/base-repository identity, equal PR numbers across
+  repositories, rerun checks, legacy statuses, and unknown outcomes.
+- Dismissed/superseded/published reviews, pending review exclusion, resolved versus
+  outdated threads, file-level comments, deleted authors, pagination and replies.
+- Cache coalescing/expiry, complete versus incomplete counts, head changes while
+  paging, and no enrichment/event-store mutations from reads.
+
+Core/app tests pin literal wire fixtures and source-generated metadata, profile
+isolation, rapid session/PR/tab changes, stale success versus access revocation,
+partial page retries, no duplicate rows, and lifecycle teardown.
+
+Avalonia tests pin direct navigation from each card row, non-PTY PR availability,
+ended-session reading, retained Chat/Terminal state, accessibility, long Markdown
+and file paths, multiple PRs, and older-server fallback. Exercise all lifecycle and
+failure presentations, not only the successful example shown in the prototype.
+
+Rebuild all changed projects without warnings. Run affected suites and the desktop
+suite at normal parallelism. Publish the CLI in Release to verify Core changes
+introduce no IL3050/IL2026 warnings; a normal build is not evidence of AOT safety.
+Run a live read-only smoke check against a public and an authorized private test PR,
+including a long paged thread. No test may post or mutate a real PR.
+
+## Delivery and record
+
+The work has two parts:
+
+1. **Server PR read interface and provider module** — authorization, normalized
+   overview/pages, cache/failure semantics, tests, and integration documentation.
+2. **Desktop PR card and reader** — Core client, shared workspace state, views,
+   compatibility handling, and tests.
+
+Agree the wire fixtures first. Desktop development can use them in parallel, but
+live desktop integration and release depend on the server part being available.
+Deploy the additive server routes before advertising full desktop PR details.
+Existing desktop builds ignore the new routes; new desktop builds degrade safely
+against older servers.
+
+No production code has been changed for this design. The worktree is
+`.worktrees/desktop-pr-sidebar` on `feat/desktop-pr-sidebar`. The pre-change desktop
+baseline passed all 1,442 tests.
+
+The three-option HTML is a throwaway visual reference, not production source. Its
+local artifact is
+`.superpowers/brainstorm/94464-1788768185/content/pr-sidebar-layouts.html`.
+Archive it on a throwaway branch when design sign-off is complete, and retain a
+reference with the implementation tracking. Do not merge the prototype or its
+switcher into production.
+
+Keep this spec on the feature branch so it rides the first implementation PR;
+do not open a spec-only PR. On sign-off, copy the approved design into the linked
+Linear issue/document per the team's recording convention. No external issue
+number is assigned by this document.
+
+Capacitor work-item correlation:
+
+- Parent: `26c1058d5f49597faad21b663ab786a1`.
+- Server part: `b5202e2821b259e9bd7bdd178b388b1e`.
+- Desktop part: `a7d3de097c3454c186fc449bd4659f9d`.
+- Server part blocks desktop live integration/release.

--- a/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
+++ b/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
@@ -120,17 +120,26 @@ The current `SessionPullRequestDto` is identity/link metadata only. The existing
 `WorkContextReader` also gates its summary through work-item outcomes. New PR
 reads must not inherit that work-item coupling or subscription gate.
 
-Add `pull_request_reads_version: 1` to every provider's existing `/auth/config`
-response. It describes protocol availability only, not token configuration, user
-link state, or repository access. This route is already anonymous; the new field
-contains no user/tenant-private data. Add the nullable field to
-`AuthDiscoveryResponse`; absence on a successfully parsed response means an older
-server. Version 1 is advertised even when interactive reads are disabled.
+Add `pull_request_reads_versions: [1]` to every provider's existing tenant-server
+`/auth/config` response. `AuthEndpoints.GetConfigHandler` lives in Capacitor.Server,
+not AuthProxy; it is served by the same deployment as the session routes. Fetch it
+from the active tenant API origin, never AuthKit, AuthProxy or an exchange URL.
+Refuse off-origin redirects; partition discovery by tenant origin/profile identity.
+Reverse-proxy routing must preserve this binding.
+
+This anonymous field exposes supported protocols only, not token configuration,
+link state or repository access. Add the nullable set to `AuthDiscoveryResponse`;
+absence on a valid response means an older server. Advertise v1 even when disabled.
+Clients select a shared version and send `version=1` on all v1 routes. Additive,
+fixture-compatible changes retain v1. Breaking changes get a new version/bundle;
+servers continue serving/advertising v1 alongside newer versions for supported
+desktop releases. Removing v1 is an explicit breaking release, not a field addition.
 
 Discover once per profile activation; cache for five minutes. Recheck on manual
-refresh, reconnect, and profile change. Until a supported version is observed, do
-not call the new routes. An unknown higher version is unsupported until explicitly
-supported by the client. Malformed/non-JSON capability responses are a discovery
+refresh, reconnect, and profile change. Until a shared version is observed, do
+not call the new routes. A set containing v1 and unknown higher versions still
+supports v1. Only unknown versions offers legacy links and an app-update explanation.
+Malformed sets or malformed/non-JSON capability responses are a discovery
 failure, not proof of an old server; retry discovery with 30s, 60s, then five-minute
 backoff. Manual refresh is coalesced and cannot flood discovery.
 
@@ -138,10 +147,18 @@ Source precedence is explicit:
 
 1. With supported capability, the new link-list route is authoritative. Do not
    union its results with legacy links, resurrect missing entries, or override its
-   ordering/titles from legacy data. A 404 clears protected PR state, not capability.
+   ordering/titles from legacy data. A 404 clears protected PR state and triggers
+   rediscovery, not an inference of an old server. Three consecutive list 404s pause
+   automatic PR calls for five minutes and rediscover, with explicit Retry. If v1
+   remains advertised, explain unavailable/misconfigured access rather than silently
+   downgrading admission. Legacy fallback requires fresh confirmation of no shared
+   version, not status-code heuristics.
 2. Without capability, retain only legacy links from a successful, independently
    admitted session-summary read. Read that summary independently of work-item
-   assignments for this fallback. An empty legacy result says details unavailable,
+   assignments for this fallback. Add a direct summary read to the PR source;
+   reuse the transport lease, not WorkContextReader's gated aggregate. Leave that
+   reader's work-item gating intact and regression-test its card.
+   An empty legacy result says details unavailable,
    not No PR linked. There is no live-details polling.
 3. A malformed response on an advertised new route is an unavailable protocol
    result, never route-unsupported or an authoritative empty list. Back off as
@@ -173,8 +190,7 @@ Use `IGitHubLinkService.GetStateAsync` for the canonical caller: require `Linked
 and a positive `GitHubId`, not the pending `LinkedGitHubId` claim marker, a cached
 login string, or a generic display name. This includes GitHub-native human accounts;
 do not resurrect a missing holder association by parsing an old `github:` user ID.
-Unlinked WorkOS
-users see **Link GitHub to read PR details**, opening the configured tenant's
+Unlinked WorkOS users see **Link GitHub to read PR details**, opening the configured tenant's
 existing `/auth/github-link/start` browser flow; a sign-in to the website may be
 needed if the browser lacks its cookie. Recheck association on return/manual refresh.
 Do not transfer desktop tokens in a browser URL or mint new linking credentials.
@@ -195,7 +211,9 @@ Do not transfer desktop tokens in a browser URL or mint new linking credentials.
 5. Fetch canonical base-repository metadata using the integration token. Require a
    matching repository identity and explicit visibility. Only `visibility=public`
    supplies public-read evidence; `private`, `internal`, missing, or unknown values
-   do not. The caller still needs a linked identity for this v1 reader.
+   do not. This reader still requires linked identity for uniform GitHub audit
+   attribution, deliberately stricter than public-web access. External public PR
+   links remain usable without linking.
 6. For non-public repos, call
    `GET /repos/{owner}/{repo}/collaborators/{login}/permission`. Require a matching
    returned user ID and explicit `permission` of `read`, `write`, or `admin`.
@@ -205,13 +223,13 @@ Do not transfer desktop tokens in a browser URL or mint new linking credentials.
 7. Admit before accessing a cached body. Re-read current Capacitor admission and
    holder/configuration state before delivery; renew expired external evidence
    before releasing a long-running result. Always construct provider URLs from the
-   freshly admitted link. Neither
-   a cursor nor a provider node ID supplies repository/host authority.
+   freshly admitted link. A cursor or provider node ID never supplies repository/
+   host authority.
 
 Permission/public-visibility evidence has a maximum 30-second positive lifetime.
 Renew any proof with ten seconds or less remaining instead of returning another
-near-expiry lease; concurrent renewals coalesce. It is bound to integration generation, canonical repository ID, and numeric user
-ID (public visibility itself may be shared, but the caller's identity gate is not).
+near-expiry lease; concurrent renewals coalesce. Bind proof to integration generation,
+canonical repository ID and numeric user ID (public visibility itself may be shared, but the caller's identity gate is not).
 No stale positive evidence is usable. A failed fresh permission check clears the
 proof; never fall back to a previous successful proof after that failure. Negative
 results can be cached for at most 30 seconds. Every page and cached read still
@@ -224,13 +242,21 @@ GitHub-side permission change without an options change takes effect when observ
 with positive evidence bounded to 30 seconds; final-response revalidation bounds
 long reads too. This is not instantaneous revocation.
 
-The result contains a remaining access lifetime. The desktop masks protected bodies
-when this lifetime expires and obtains new evidence before revealing them again.
-It also masks bodies immediately when a workspace becomes hidden and before
-revealing retained data on return. A local profile/sign-out change clears all PR
-state. When permission/configuration failure or a session/list 404 is observed,
-clear **all** loaded bodies/cursors in the affected PR/session, not just the polled
-section. Retain only separately admitted link metadata, if still admitted.
+Expiry blocks new fetch/reveal; no server content, cached or otherwise, is delivered
+without a live proof. Desktop display retention is separate: already displayed
+content may remain **Access could not be rechecked · saved view** during a transient
+transport/rate/budget failure, for at most five minutes from the last successful
+access validation's monotonic request start. This grace never slides on failures
+or authorizes loading/revealing another page, section or PR. Server unavailable
+responses carry no protected data. Negative/invalid permission signals, identity/
+configuration changes, sign-out/profile changes and session/list 404s clear **all**
+affected bodies/cursors immediately. Unknown failure classifications fail closed.
+
+Pause polling on foreground loss. A return within five seconds can reuse still-live
+proof for already displayed content, unless a known lock/suspend, identity/profile
+change or denial occurred. Beyond that short grace, mask before redisplay and
+revalidate; the five-minute transient display allowance cannot restore a hidden or
+evicted view. Only separately admitted link metadata survives denied detail access.
 
 This checks repository roles/publication, not all of GitHub's per-user SSO, session,
 IP, or conditional-access policies. Requests are made as the integration, not with
@@ -240,7 +266,8 @@ token lifecycle; that is outside this feature.
 
 ### Audit and provider safety
 
-Record structured server access events for detail decisions: caller ID, session ID,
+Record structured server access events for detail decisions: caller ID, verified
+numeric GitHub ID/resolved login (nullable when unavailable), session ID,
 repository hash/PR number, section, UTC timestamp, admitted/denied/unavailable result,
 and cache-hit flag. Use existing protected operational logging/retention, not a new
 public analytics view, event-store stream, or audit UI. Do not log bodies, tokens,
@@ -261,6 +288,26 @@ images/attachments are not fetched. Only explicit absolute HTTP/HTTPS body links
 pass through LinkPolicy. Relative links, mentions and issue-reference shorthand
 remain text in v1; no repository-relative URL inference. Disallowed schemes are inert.
 
+## Preflight gate before implementation planning
+
+Before planning or building either part, the implementation driver and operator
+must run a read-only probe using the intended deployment's actual integration
+credential **in its existing protected environment**. The agent must not retrieve,
+copy or log the token, or substitute its local GitHub login. Operator approval and
+designated public/private repositories plus reader/denied identities are required.
+No safe probe environment means planning is blocked.
+
+Verify identity lookup, public metadata, private permission for an allowed user
+(including team-only read) and a denied user, matching IDs, content/check read
+permissions, primary limits and actual bounded GraphQL cost. Record only credential
+type, sanitized outcomes, candidate environment and budget measurements, never
+token/body data. Documentation and stub tests are not a passing deployment probe.
+
+If it fails, stop and ask the operator to configure a compatible scoped credential,
+then repeat. Do not weaken the linked-user gate into an allowlist/shared-token-only
+policy. Credential replacement/renewal is separate operator work, not automatic.
+Design review may finish before the probe; implementation planning cannot.
+
 ## Server module and request budget
 
 Add a dedicated pull-request read module, separate from enrichment. Reads do not
@@ -276,10 +323,18 @@ Register `GitHubPullRequestReads` with fixed GitHub origins, a 15-second upstrea
 headers-and-body deadline, explicit cancellation, no automatic retries and no
 off-origin redirect following. Bound a complete admitted HTTP operation, including
 queue wait and capture, to 30 seconds. Desktop request deadline is 35 seconds.
-Deadline expiry is typed unavailable, never empty or complete. Limit decoded
+Deadline expiry is unavailable or an explicitly limited captured subset, never
+empty/complete by inference. Limit decoded
 upstream bodies to 16 MiB while streaming, before JSON parsing, and client-side
 server response reads to 4 MiB. Neither side may buffer an unbounded response merely
 to discover that its normalized form exceeds the budget.
+
+The Checks section's suite-scoped latest set is canonical. Overview GraphQL rollup
+and counts are labelled **GitHub summary**, advisory rather than proof that the
+section has no failures. Once a complete fresh section for the same head exists,
+use its counts in both card and reader; head changes discard them. On disagreement,
+prefer the section and qualify source/time, not contradictory unlabeled green/red
+aggregates. Test disagreement explicitly.
 
 The lightweight overview uses one bounded GraphQL request for identity/lifecycle,
 head SHA, description, `reviewDecision`, the first 50 current-review/request rows,
@@ -299,19 +354,41 @@ Add a credential-scoped rate-limit observer used by the interactive client and t
 existing GitHub background HTTP clients. This observer consumes response headers
 and GraphQL cost information; background scheduling semantics stay unchanged.
 Interactive reads yield when REST or GraphQL remaining quota is below 20% of its
-reported limit, during any primary/secondary cooldown, or while the corresponding
-background provider gate is cooling down. No interactive request bypasses this rule
-for an access probe, cache revalidation or manual refresh.
+reported limit, during any primary/secondary cooldown, or while an observed
+background GitHub cooldown is active. Enrichment stores its cooldown in metadata;
+reviewer polling keeps a private in-process value. Add a metadata observer adapter
+and a notification seam when the poller arms its cooldown. These are new work, not
+an existing shared gate; tests must preserve background scheduling, classification
+and job order. Access probes/cache revalidation/manual refresh cannot bypass yielding.
 
-Limit interactive upstream concurrency to two and starts to 30 requests/minute per
-credential. Charge GraphQL by actual reported points, separately from REST calls.
+Limit interactive upstream concurrency to two and starts to 60 requests/minute per
+credential. Acquire permits per upstream call, not whole capture; queued overview/
+access work takes priority over body/capture calls. Charge actual GraphQL points,
+separately from REST calls.
 An unknown primary budget permits one serialized observation request; missing
 budget headers retain conservative local pacing rather than pretending quota is
 unlimited. A cooldown without a supplied reset/retry time defaults to 60 seconds.
 Return `retry_at`/`poll_after_seconds`; server backoff always wins over ordinary
 polling and early access-lease renewal. With no backoff, `poll_after_seconds` is zero.
-Expired access proof remains masked while yielding. The feature may become
-unavailable rather than starving background work.
+Expired proof blocks fetches while yielding; only an existing view's bounded display
+grace can remain. The feature may become unavailable rather than starve background work.
+
+Capacity target: four active readers on distinct PRs per credential with ordinary
+collections. At 25-second renewals this costs about 1,152 REST gate requests and
+576 overview GraphQL requests/hour before section reads; at the 15-second retry
+floor, about 1,920 REST and 960 GraphQL requests/hour. Multiply GraphQL requests by
+measured query cost, not one assumed point. Sixty starts/minute leaves section
+capacity at the faster cadence. Excess workloads yield rather than promise freshness.
+
+Documented profiles are fine-grained PAT or App installation with Metadata read
+plus PR/issue/check/status read permissions. An existing classic PAT needs private-
+repo `repo` scope and the same live admission probes; enrichment success alone
+never certifies it. Do not add scopes or change credential type automatically. Preflight must
+verify at least 5,000/hour REST and GraphQL primary limits and measured headroom
+alongside background work. Installation tokens are not automatically 15,000/hour:
+GitHub documents 5,000 minimum, scaling to 12,500, or 15,000 for qualifying Enterprise
+Cloud installations. Credential provisioning/installation-token renewal remains
+operator-owned; the feature neither finds nor persists replacement credentials.
 
 ## Stable pagination and bounded storage
 
@@ -331,8 +408,13 @@ is frozen, newly created items wait for explicit refresh.
 
 Record provider connection counts/boundaries before and after capture, and compare
 unique enumerated IDs with the unfiltered provider count before applying publication
-or resolved filters. Changed boundaries/counts, missing nodes, or repeated/non-advancing
-provider cursors cannot produce complete coverage. Retry enumeration at most once
+or resolved filters. Changed boundaries/counts, unexplained missing nodes, or
+repeated/non-advancing cursors cannot produce complete coverage. Provider-declared
+redacted/unreadable nodes with identity/publication evidence become placeholders
+and still count as enumerated; unexplained gaps do not. Compare the unfiltered
+count before dropping PENDING entries. Never expose a review/thread placeholder
+or count when publication cannot be established; pending drafts contribute no
+existence signal. Retry enumeration at most once
 within the same deadline, merging by stable ID; otherwise return a limited manifest
 with a changed-during-capture reason and an explicit Refresh action. An API without
 sufficient enumeration/completeness evidence also yields limited coverage. Complete
@@ -341,15 +423,18 @@ a historical point-in-time view. In-place body/state edits retain that caveat.
 
 Paging the frozen manifest cannot skip/reorder captured IDs when GitHub grows.
 Tests cover growth during capture as a stable retry or visibly limited result, and
-no missed captured rows when growth happens between client pages. Deleted items
-may be tombstones only with positive deletion evidence. Null/missing nodes or 404
-alone are ambiguous and follow the authorization-class failure policy.
+no missed captured rows when growth happens between client pages. A missing item
+at hydration becomes an unavailable row at that manifest position, with no retained
+body/hunk; call it deleted only with positive evidence. It does not clear unrelated
+rows. Repository/PR/permission/user-probe denials remain resource-level failures.
 
 Once frozen, a manifest cannot reorder as the user pages. The server sorts the
 whole captured sequence before cutting pages; the client appends without re-sorting:
 
-- Conversation and published reviews: `created_at` descending, provider ID as a
-  stable tiebreak. Editing changes `updated_at`, never the order.
+- Conversation: `created_at` descending, then provider ID. Editing changes
+  `updated_at`, never the order.
+- Published reviews: `submitted_at` descending, `created_at` only as fallback,
+  then provider ID.
 - Thread comments: `created_at` ascending, then provider ID.
 - Threads: unresolved before resolved, then root-comment `created_at` descending,
   then thread ID. The default is unresolved-only; `resolved=all` starts a separate
@@ -359,20 +444,29 @@ whole captured sequence before cutting pages; the client appends without re-sort
   name and stable run/context ID. Preserve cancelled/timed-out/action-required
   labels in the failed/non-success group instead of calling them passed.
 
-Check manifests are tied to a head SHA. Use the provider's latest check-run filter;
-retain suite/app/name identity and never collapse distinct suites solely because
-names match. Within the same suite/app/name, retain the most recent attempt by
-`started_at`/`created_at` and ID tiebreak. Legacy statuses use latest `created_at`, ID
-per context. If the provider cannot establish the latest set, mark coverage limited
+Check manifests are tied to a head SHA. Enumerate that commit's check suites and
+query each suite's latest runs, not the commit-wide latest filter with unverified
+cross-suite semantics. Suite-scoped filtering cannot drop another suite's same-name
+job. Retain suite/app/name identity; ambiguous latest-attempt evidence keeps labelled
+attempts and an unknown aggregate rather than a guess. Legacy statuses use latest
+`created_at`, ID per context. If the provider cannot establish the latest set, mark coverage limited
 and do not publish an exact success aggregate. A fixture must cover two workflows
 with the same job name, as well as reruns; name-only deduplication is forbidden.
 
 Manifest capture is bounded to 5,000 metadata entries, 4 MiB, and the operation
 deadline. If the entry/size ceiling is reached, a limited manifest can still be
 read, with `coverage=limited`, lower-bound counts, and **More on GitHub** after the
-captured rows. Do not call it the whole collection. Timeout/provider failure returns
-unavailable rather than an ostensibly complete manifest; rate advice is preserved. These limits deliberately bound exceptional PRs;
-ordinary large bodies alone do not make an entire collection unreadable.
+captured rows. Deadline or transient failure after useful metadata was captured
+can also freeze a limited subset, with deadline/provider_failure reason and rate
+advice. Page it without restarting the scan. No useful rows means unavailable, not
+empty; authorization-class failure never publishes a partial capture.
+
+This is an ordered **subset**, not necessarily the newest/failure-first global
+prefix. Label that before rows and never certify omitted failures/unresolved rows
+or global counts/order. The same rule permits partial checks/threads without an
+invented monotone provider API. Reserve time for final admission/serialization;
+pending hydration can yield unavailable item rows. Refresh explicitly retries a
+new capture. Large bodies alone cannot make the collection unreadable.
 
 ### Pages and cursors
 
@@ -382,13 +476,18 @@ the next unreturned manifest entry. Never consume/drop an item just because it d
 not fit. For a single oversized body, include an explicit truncated preview,
 `body_truncated=true`, and item URL; bound the preview to 256 KiB. Preserve identity
 and truncation metadata. An unavailable whole section is the last resort, not the
-normal handling of an oversized body.
+normal handling of an oversized body. Once a page is first materialized, its handle
+also binds the exact start/end manifest positions. Retrying that page keeps its row
+boundaries; if edited bodies now exceed the budget, return explicitly truncated
+previews rather than moving entries into a different page. Coalesce simultaneous
+first requests for a handle so only one boundary is assigned. Next-page handles
+choose their end once, on first materialization.
 
 Use 256-bit random **server-side opaque cursor handles**, not client-authored JSON.
 A handle record binds caller, tenant, session, PR identity, section/filter, thread
 where applicable, integration generation, snapshot ID, next position, and expiry.
-Expire after five minutes; the snapshot lives no longer than its handles. Bind to
-the numeric GitHub identity used for access too. A cursor supplies position only:
+The manifest and all its handles share a fixed absolute expiry of 30 minutes from
+capture start; paging never extends it. Bind to the numeric GitHub identity too. A cursor supplies position only:
 re-resolve the link and thread membership to build each upstream request. Unknown
 or foreign handles never cause a GitHub call. A well-formed handle missing from the
 bounded store returns generic `cursor_unavailable`; a known foreign handle returns
@@ -401,10 +500,19 @@ whole provider collection. The client rejects inconsistent combinations and neve
 runs a continuation loop automatically. Zero-length pages with a continuation
 are a protocol failure. Stable IDs prevent duplicate appends on retried pages.
 
-Server bodies/manifests/handles share a 64 MiB payload budget and 256 payload-entry
-cap; evict least recently used entries, with ten-minute idle expiry and the shorter
-five-minute manifest/handle lifetime. Coalesced data is keyed by integration
-generation, canonical PR, section/filter, snapshot/page, and check SHA. Mutable overview/body payloads have a 30-second freshness window;
+Separate server budgets: body cache 64 MiB/256 entries; manifest store 128 MiB/256
+manifests; opaque-handle store 8 MiB/16,384 records. These operational defaults target
+four active PR readers with six collections and up to twenty expanded-thread
+manifests each, plus opportunistic idle retention. Body paging cannot evict manifests
+or consume handle capacity. Byte accounting includes stored metadata/handle contents.
+Evict idle PRs first; if admission still cannot fit, return capacity unavailable
+rather than silently evict another active reader's manifest.
+
+Ten-minute idle eviction is separate from the fixed 30-minute absolute expiry.
+An admitted foreground overview touches that caller's selected-PR manifests, so
+quiet reading stays active. Body cache touches follow body access. Coalesced data
+is keyed by integration generation, PR, section/filter, snapshot/page and check SHA.
+Mutable overview/body payloads have a 30-second freshness window;
 use conditional requests where supported. Manual refresh can reuse a still-fresh
 payload and must retain its actual timestamp. Frozen manifest metadata remains its
 own snapshot until explicit refresh/expiry; fresh body hydration does not reorder it.
@@ -438,7 +546,8 @@ GET /api/sessions/{sessionId}/pull-requests/{repoHash}/{number}/conversation
 The list does no GitHub fan-out: it returns Capacitor-admitted session link metadata,
 not hydrated GitHub bodies. Its `data` is `{ "items": [...] }`, with each row's
 identity fields plus nullable `url`, `title`, and `head_ref`. Its successful response
-can be empty. All detail routes
+can be empty. This local-data list returns ready or unavailable, never stale;
+`access_valid_for_seconds` is zero/ignored and `access_failure` is null. Detail routes
 apply the additional GitHub gate. Resolve `repoHash` against this session's admitted
 canonical links, using the existing hash derivation; do not treat the hash itself as
 authorization. No match, ambiguous identity, unknown repository, or unreadable
@@ -464,7 +573,8 @@ serialization/deserialization in both repositories.
   "reason": null,
   "retry_at": null,
   "poll_after_seconds": 0,
-  "access_valid_for_seconds": 20
+  "access_valid_for_seconds": 20,
+  "access_failure": null
 }
 ```
 
@@ -478,13 +588,21 @@ times remain separate. All absolute times are RFC 3339 UTC strings ending in Z;
 `access_valid_for_seconds` is remaining positive proof lifetime at server delivery,
 zero on unavailable or failed authorization. The client measures expiry from its
 request's monotonic **start**, not receipt, so network time cannot extend the lease.
-It caps the duration at 30 seconds and masks on expiry. The link list does not grant
-a detail access lease. Each body response needs valid current authorization too.
+Cap it at 30 seconds. At receipt, fewer than five conservative seconds remaining
+cannot reveal new bodies; renew at the next permitted attempt instead. Expiry
+blocks fetch/reveal; only the five-minute display grace retains an existing view.
+The link list grants no lease. Each body response requires current authorization.
+
+`access_failure` is null on admission, otherwise transient, denied or invalid.
+Transient means only network/timeout/5xx/rate/budget inability to check. Explicit
+401/non-rate 403/404, permission=none, unlink/configuration change, ID mismatch, malformed
+evidence and unknown classifications get no display grace. Resource-level signals
+use this field; item-level hydration outcomes do not change it.
 
 Reasons: disabled, not_configured, github_not_linked, github_access_denied,
 github_access_unverifiable, provider_unauthorized, provider_forbidden,
 provider_not_found, rate_limited, budget_exhausted, timeout, provider_unavailable,
-protocol_error, capture_unstable, payload_unavailable. Unknown reasons use a generic
+protocol_error, capture_unstable, payload_unavailable, capacity_exhausted. Unknown reasons use a generic
 unavailable label. Only transient content failures/rate limits with a still-valid
 access proof may carry stale data. Unknown authorization status never may.
 
@@ -517,7 +635,7 @@ Page `data`:
   "coverage": "complete",
   "head_sha": null,
   "total": {"value":2,"kind":"exact"},
-  "items": [{"id":"IC_example","url":"https://github.com/example/repo/pull/42#issuecomment-1","created_at":"2026-09-07T09:00:00Z","updated_at":"2026-09-07T09:00:00Z","author":null,"body":"Example comment","body_truncated":false}],
+  "items": [{"id":"IC_example","availability":"available","reason":null,"url":"https://github.com/example/repo/pull/42#issuecomment-1","created_at":"2026-09-07T09:00:00Z","updated_at":"2026-09-07T09:00:00Z","author":null,"body":"Example comment","body_truncated":false}],
   "page_cursor": "opaque-current-page-handle",
   "has_more": true,
   "next_cursor": "opaque-next-page-handle"
@@ -525,13 +643,22 @@ Page `data`:
 ```
 
 Coverage is complete or limited; unknown coverage is limited. A limited page also
-carries `coverage_reason`: entry_limit, size_limit, changed_during_capture, or
-provider_limit; unknown reasons retain the limited label. Each collection item carries stable provider ID, its validated
+carries `coverage_reason`: entry_limit, size_limit, changed_during_capture,
+provider_limit, deadline or provider_failure; unknown reasons retain the limited
+label. Each collection item carries stable provider ID, its validated
 external URL if available, and the section's typed content. Bodies additionally
 carry `body_truncated`. User/team actors have stable ID, kind, nullable login/name,
 and no automatically downloaded image. Pending review state `PENDING` is dropped
 server-side unconditionally; review comments/threads must also exclude unpublished
 review content, rather than assuming the integration cannot see its owner's drafts.
+
+Each item has `availability` (available, unavailable, redacted) and nullable `reason`
+(item_missing, item_unreadable, item_redacted, hydration_timeout). Missing/unknown
+availability cannot render a body. An unavailable row retains admitted ID and safe
+URL if known; body, hunk and protected previews are null. It occupies its manifest
+position even when alone on a page, preventing a zero-item continuation. Call it
+deleted only with positive evidence. Page reload may retry hydration; failure
+cache freshness is 30 seconds. Publication rules precede any placeholder.
 
 ### HTTP outcomes and reset semantics
 
@@ -542,19 +669,21 @@ inputs or known-foreign/malformed cursor handles return 400 without upstream wor
 
 409 uses `{ "error":"restart_required", "reason":"…" }`, where reason is
 head_changed, cursor_expired, cursor_unavailable, snapshot_evicted,
-cursor_version_changed, integration_changed, or identity_changed. The current subject must pass admission
-before returning a detailed restart reason. Otherwise return the ordinary denied
+cursor_version_changed, integration_changed, or identity_changed. The current
+subject must pass admission before returning a detailed restart reason. Otherwise return the ordinary denied
 outcome, not a hint about another user's cursor.
 
 - Head changed: discard checks and their counts/cursors immediately; these cannot
   remain displayed as the current head's checks. Reload on explicit refresh.
 - Integration/identity changed: clear all protected bodies and proofs; reauthorize.
 - Cursor expired/unavailable/version changed/snapshot evicted: disable Load more, retain visible
-  rows only while their access lease is valid, label them as an old snapshot, and
+  rows under a live lease or eligible display grace, label the old snapshot, and
   offer Refresh. Do not silently replace pages under the user.
 - Manual Refresh explicitly resets the selected collection to page one and scrolls
   it to the top. Retain expansion IDs only for rows that reappear. This is an
   intentional exception to ordinary background-refresh scroll preservation.
+- Toggling `resolved=all` starts a new capture and resets paging/scroll, with a loader
+  explaining the change; it is not a free filter on already loaded rows.
 
 ## Desktop lifecycle and freshness
 
@@ -579,9 +708,9 @@ renew via the overview five seconds before the conservative access deadline, wit
 at least 15 seconds between attempts; reuse fresh content but renew expiring access
 proofs. Early renewal normally avoids a blank flash at each lease boundary, not a
 guarantee during slow/failed requests. It cannot bypass server pacing/cooldowns.
-Ended sessions follow the same rule. Stop polling and mask bodies when ineligible;
-on return, revalidate before showing retained bodies, even if a previous timer had
-not expired. Load other sections on demand.
+Ended sessions follow the same rule. Stop polling when ineligible; apply the stated
+five-second foreground-return grace, otherwise mask and revalidate before showing
+retained bodies. Load other sections on demand.
 
 Background overview refresh never replaces reader pages. It may show an update
 hint. Sections show their own times; manual refresh restarts them. Valid new access
@@ -595,10 +724,11 @@ labelled with its old fetch time. A fresh overview cannot label those bodies fre
 | Successful empty captured collection | No comments/reviews/checks, only if coverage is complete. |
 | Missing GitHub link | Link GitHub action; no bodies. |
 | Disabled/missing integration | Known PR link and explanatory note; no bodies. |
-| Denied/unverifiable user permission | Clear bodies/proofs, link retained only if Capacitor-admitted. |
-| Provider 401, non-rate 403, or 404 | Authorization-class: clear fetched bodies, never stale; do not change link or lifecycle. |
-| Content transport/5xx/timeout | Retain stale bodies only until an existing access lease expires. |
-| Rate/budget limit | Respect retry advice; expired evidence is masked, not extended. |
+| Denied/invalid permission | Clear bodies/proofs; link retained only if Capacitor-admitted. |
+| Resource-level provider 401, non-rate 403, or 404 | Clear bodies, no grace; preserve admitted link/lifecycle. |
+| Item miss/unreadable | Unavailable placeholder without old body/hunk; paging continues. |
+| Transport/5xx/timeout rechecking | No server data without proof; existing visible data gets labelled display grace. |
+| Rate/budget limit | Follow retry advice; no fetch on expired proof, same bounded display grace. |
 | Oversized item | Explicit truncated preview and its external link; paging continues. |
 | Limited manifest | Label loaded subset/lower bound; More on GitHub, never all-loaded. |
 | Caller sign-out/session 404 | Clear affected protected state immediately. |
@@ -611,13 +741,15 @@ Full/hidden/team gates, forged session/PR/thread/cursor identity, missing and ch
 GitHub links, numeric-ID mismatch/login rename, public vs internal/private repos,
 team/base-role read and denied/unverifiable permission, cache-hit authorization,
 proof expiry during fetch, token/flag rotation, GitHub-side revocation, and denial
-on 404. Verify that cached bodies cannot bypass the user's GitHub permission gate.
+on resource 404 versus item misses. Server caches cannot bypass the GitHub gate;
+display grace cannot enable fetch/new reveal or survive a negative signal.
 
 Pagination tests must cover inserts during capture (stable retry or explicit limited
 coverage) and between pages (no missed manifest rows), deletions/tombstones,
-snapshot-stable ordering, resolved filter,
+snapshot-stable ordering, resolved filter, stable page bounds on edited-body retries,
 body-budget short pages without lost items, one oversized body, repeated cursors,
-limited manifests, eviction and every 409 reason. Include pending/dismissed reviews,
+deadline-limited subsets, one-item hydration failures, redacted placeholders,
+separate budget exhaustion under four readers, thirty-minute expiry and all 409s. Include pending/dismissed reviews,
 file-level/outdated threads, deleted actors, cross-repo equal PR numbers, same-name
 workflow jobs and reruns. Test rate-limit yielding and coalescing without changing
 background-job scheduling or emitting enrichment events.
@@ -625,7 +757,8 @@ background-job scheduling or emitting enrichment events.
 Core/app tests pin tolerant JSON parsing, unknown status/enum handling, exact
 count/page invariants, source precedence, unsupported discovery/backoff, provider
 failure versus Capacitor sign-out, memory eviction, monotonic access expiry,
-visibility return masking, and profile/selection cancellation. Avalonia tests assert
+five-minute display-grace expiry, short foreground return, long-hide masking,
+minimum reveal-lease floor, and profile/selection cancellation. Avalonia tests assert
 realized Chat/Terminal preservation, non-PTY and ended layouts, card-row focus,
 selected tab accessibility, live announcements, readable long content, and failures
 in one sidebar module not contaminating the other.
@@ -638,7 +771,8 @@ versioned contract metadata. A server field rename fails its serialization test
 against the checked-in canonical fixture; tests must not regenerate golden files.
 No new cross-repo CI credentials are assumed. The implementation driver compares
 the bundle digests at the paired candidate commits before merge and before release;
-a contract revision needs both pins updated together. This catches accidental field
+a contract revision needs both pins updated together, and a non-additive change
+requires a new negotiated version rather than silently modifying v1. This catches accidental field
 drift in local CI and coordinated revision mismatches in paired integration.
 
 The implementation driver owns a read-only smoke check against the paired server
@@ -684,9 +818,10 @@ integration/release, not parallel fixture-based development.
 - [Get repository permissions for a user](https://docs.github.com/en/rest/collaborators/collaborators#get-repository-permissions-for-a-user):
   effective base roles across direct/team/org grants; Metadata read for supported
   fine-grained token types.
-- [List check runs for a Git reference](https://docs.github.com/en/rest/checks/runs#list-check-runs-for-a-git-reference):
-  latest filter and the provider's 1,000-suite limit; do not claim complete coverage
-  if a provider ceiling was reached.
+- [List check runs in a check suite](https://docs.github.com/en/rest/checks/runs#list-check-runs-in-a-check-suite):
+  suite-scoped latest avoids guessing commit-wide cross-suite deduplication.
+- [GitHub REST rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api):
+  installation alone does not imply the 15,000/hour Enterprise Cloud limit.
 - [GitHub's published GraphQL schema](https://docs.github.com/public/fpt/schema.docs.graphql):
   PR/review/thread/comment connections expose native cursors; review-thread/review
   connections lack a created-at order parameter, and IssueCommentOrderField exposes

--- a/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
+++ b/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
@@ -16,8 +16,14 @@ Conversation in the card selects the PR and opens that reader section.
 
 No posting, replying, resolving, requesting/submitting reviews, rerunning checks,
 changing draft state, closing, or merging. No local `gh` prerequisite, new desktop
-credential store, or new per-user GitHub OAuth grant. The written design and its
-independent review must be approved before implementation planning.
+credential store, or new per-user GitHub OAuth grant.
+
+The reader design was approved in the preceding session. The subsequent App
+preflight passed the tested capabilities and allowed/denied role controls. The
+[App credential addition](2026-09-07-github-app-pr-credentials-design.md) defines
+tenant-scoped acquisition and renewal. The user accepted that addition and the
+qualified preflight evidence, and explicitly waived its independent review.
+Its credential sourcing, generation and budget identities apply to implementation.
 
 ## Experience
 
@@ -302,17 +308,25 @@ images/attachments are not fetched. Only explicit absolute HTTP/HTTPS body links
 pass through LinkPolicy. Relative links, mentions and issue-reference shorthand
 remain text in v1; no repository-relative URL inference. Disallowed schemes are inert.
 
-## Preflight gate before implementation planning
+## Preflight evidence and remaining rollout checks
 
 [Deployment probe results](../../github-pr-context-preflight.md) record partial
-verification and outstanding permission/identity controls; the gate is not passed.
+verification. Repo-restricted App tokens passed operator identity/permission,
+private overview/check/status and populated paging probes, plus an operator-designated
+non-admin Write/denied-user pair with matching numeric IDs. All tokens were revoked.
+Team grant provenance is operator-attested, not independently audited; least-privileged
+Read was not observed. The
+[credential addition](2026-09-07-github-app-pr-credentials-design.md) consolidates
+the evidence and accepts these API controls for implementation, retaining
+their qualifications and requiring integration/load checks before rollout.
+The user approved proceeding on that basis and waived the addition's independent review.
 
-Before planning or building either part, the implementation driver and operator
-must run a read-only probe using the intended deployment's actual integration
+The completed preflight used a read-only probe in the intended deployment's
+protected environment. Remaining rollout probes must use the actual integration
 credential **in its existing protected environment**. The agent must not retrieve,
 copy or log the token, or substitute its local GitHub login. Operator approval and
 designated public/private repositories plus reader/denied identities are required.
-No safe probe environment means planning is blocked.
+No safe probe environment means live rollout verification remains incomplete.
 
 Verify identity lookup, public metadata, private permission for an allowed user
 (including team-only read) and a denied user, matching IDs, content/check read
@@ -320,10 +334,10 @@ permissions, primary limits and actual bounded GraphQL cost. Record only credent
 type, sanitized outcomes, candidate environment and budget measurements, never
 token/body data. Documentation and stub tests are not a passing deployment probe.
 
-If it fails, stop and ask the operator to configure a compatible scoped credential,
-then repeat. Do not weaken the linked-user gate into an allowlist/shared-token-only
+If a rollout probe fails, correct the integration before rollout and repeat it.
+Do not weaken the linked-user gate into an allowlist/shared-token-only
 policy. Credential replacement/renewal is separate operator work, not automatic.
-Design review may finish before the probe; implementation planning cannot.
+The accepted capability evidence permits implementation; it does not certify rollout.
 Record the initial sanitized outcome and renewal procedure in the shared design
 record. Re-run the protected probe before adopting a rotated credential or changed
 credential type/grants. Routine installation-token renewal may automate it; record
@@ -339,6 +353,16 @@ support the permission endpoint plus repository metadata, PRs/reviews, issue
 comments, checks, and commit-status reads. Insufficient provider permissions are a
 supported unavailable result, never a reason to discover another credential. The
 daemon and desktop never receive the integration token.
+
+The existing tracker credential provider reads an opaque configured token, currently
+a PAT, without App-token acquisition or renewal. The selected App's signing key and
+authentication token exchange live in the shared auth proxy.
+Its authentication cache is not a tenant PR-read bridge. The accepted
+[credential addition](2026-09-07-github-app-pr-credentials-design.md) supplies a
+separate tenant-scoped broker and asynchronous PR credential source; it preserves
+the existing configured credential for background consumers. Do not change a
+WorkOS tenant's auth registration to obtain an
+installation token.
 
 Register `GitHubPullRequestReads` with fixed GitHub origins, a 15-second upstream
 headers-and-body deadline, explicit cancellation, no automatic retries and no
@@ -403,11 +427,15 @@ floor, about 1,920 REST and 960 GraphQL requests/hour. Multiply GraphQL requests
 measured query cost, not one assumed point. Sixty starts/minute leaves section
 capacity at the faster cadence. Excess workloads yield rather than promise freshness.
 
-Documented profiles are fine-grained PAT or App installation with Metadata read
-plus PR/issue/check/status read permissions and Contents read for the specified
-GraphQL commit-connection overview. An existing classic PAT needs private-
-repo `repo` scope and the same live admission probes; enrichment success alone
-never certifies it. Do not add scopes or change credential type automatically. Preflight must
+Full check-run support requires a credential supporting the Checks API, such as a
+GitHub App installation with Metadata/PR/issue/check/status read and Contents read
+for the specified GraphQL commit-connection overview. Fine-grained PATs can serve
+parts of this reader but GitHub lists Checks API access as unsupported; neither
+Actions nor Code quality is a substitute. A classic PAT with `repo` scope supports
+private check reads but has broader permissions and still requires live admission
+probes. Selecting an App/renewal path, changing credentials, or reducing v1 check
+coverage needs an explicit operator/product decision. Do not certify a fine-grained
+PAT for full checks or automatically broaden credentials. Preflight must
 verify at least 5,000/hour REST and GraphQL primary limits and measured headroom
 alongside background work. Installation tokens are not automatically 15,000/hour:
 GitHub documents 5,000 minimum, scaling to 12,500, or 15,000 for qualifying Enterprise
@@ -880,6 +908,10 @@ integration/release, not parallel fixture-based development.
   fine-grained token types.
 - [List check runs in a check suite](https://docs.github.com/en/rest/checks/runs#list-check-runs-in-a-check-suite):
   suite-scoped latest avoids guessing commit-wide cross-suite deduplication.
+- [Fine-grained PAT limitations](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens#fine-grained-personal-access-tokens-limitations):
+  Checks API access is unsupported; an endpoint's `checks=read` requirement is not
+  evidence of a permission the PAT editor can grant.
+- [GitHub App Checks permission](https://docs.github.com/en/rest/authentication/permissions-required-for-github-apps#repository-permissions-for-checks).
 - [GitHub REST rate limits](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api):
   installation alone does not imply the 15,000/hour Enterprise Cloud limit.
 - [GitHub's published GraphQL schema](https://docs.github.com/public/fpt/schema.docs.graphql):

--- a/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
+++ b/docs/superpowers/specs/2026-09-07-desktop-pr-context-design.md
@@ -130,7 +130,8 @@ Reverse-proxy routing must preserve this binding.
 This anonymous field exposes supported protocols only, not token configuration,
 link state or repository access. Add the nullable set to `AuthDiscoveryResponse`;
 absence on a valid response means an older server. Advertise v1 even when disabled.
-Clients select a shared version and send `version=1` on all v1 routes. Additive,
+Clients select a shared version and send the query parameter `?version=1` on all
+v1 routes, alongside cursor/filter parameters. Additive,
 fixture-compatible changes retain v1. Breaking changes get a new version/bundle;
 servers continue serving/advertising v1 alongside newer versions for supported
 desktop releases. Removing v1 is an explicit breaking release, not a field addition.
@@ -148,18 +149,22 @@ Source precedence is explicit:
 1. With supported capability, the new link-list route is authoritative. Do not
    union its results with legacy links, resurrect missing entries, or override its
    ordering/titles from legacy data. A 404 clears protected PR state and triggers
-   rediscovery, not an inference of an old server. Three consecutive list 404s pause
-   automatic PR calls for five minutes and rediscover, with explicit Retry. If v1
-   remains advertised, explain unavailable/misconfigured access rather than silently
-   downgrading admission. Legacy fallback requires fresh confirmation of no shared
-   version, not status-code heuristics.
+   rediscovery, not an inference of an old server. Count consecutive list 404s per
+   (profile identity, session), never across subjects. After three, settle that
+   subject as unavailable and stop automatic retries until explicit Retry or a
+   real authentication/session-identity change. Other sessions continue normally.
+   A successful read resets the counter. Rediscovery respects the profile's
+   five-minute cache/backoff and coalescing; 404 cannot force an extra probe.
+   If v1 remains advertised, do not silently downgrade admission. Legacy fallback
+   requires fresh confirmation of no shared version, not status-code heuristics.
 2. Without capability, retain only legacy links from a successful, independently
    admitted session-summary read. Read that summary independently of work-item
    assignments for this fallback. Add a direct summary read to the PR source;
    reuse the transport lease, not WorkContextReader's gated aggregate. Leave that
    reader's work-item gating intact and regression-test its card.
    An empty legacy result says details unavailable,
-   not No PR linked. There is no live-details polling.
+   not No PR linked. Apply the same canonical repository/number ordering client-side
+   to these links. There is no live-details polling.
 3. A malformed response on an advertised new route is an unavailable protocol
    result, never route-unsupported or an authoritative empty list. Back off as
    above; do not downgrade authorization by switching to legacy detail data.
@@ -257,6 +262,15 @@ proof for already displayed content, unless a known lock/suspend, identity/profi
 change or denial occurred. Beyond that short grace, mask before redisplay and
 revalidate; the five-minute transient display allowance cannot restore a hidden or
 evicted view. Only separately admitted link metadata survives denied detail access.
+Where reliable lock/suspend signals are unavailable, disable the short foreground-
+return optimization: any foreground loss requires revalidation on return. Do not
+claim lock detection on such platforms.
+
+Conservative retained-display exposure is at most 30 seconds of positive evidence
+plus five minutes of transient grace, measured from access evidence reflected by
+GitHub; provider-side permission propagation is outside this bound. Explicit
+negative signals clear immediately. This does not extend the server's 30-second
+fetch-admission bound.
 
 This checks repository roles/publication, not all of GitHub's per-user SSO, session,
 IP, or conditional-access policies. Requests are made as the integration, not with
@@ -307,6 +321,10 @@ If it fails, stop and ask the operator to configure a compatible scoped credenti
 then repeat. Do not weaken the linked-user gate into an allowlist/shared-token-only
 policy. Credential replacement/renewal is separate operator work, not automatic.
 Design review may finish before the probe; implementation planning cannot.
+Record the initial sanitized outcome and renewal procedure in the shared design
+record. Re-run the protected probe before adopting a rotated credential or changed
+credential type/grants. Routine installation-token renewal may automate it; record
+each outcome in protected operational logs referenced by that design record.
 
 ## Server module and request budget
 
@@ -331,10 +349,12 @@ to discover that its normalized form exceeds the budget.
 
 The Checks section's suite-scoped latest set is canonical. Overview GraphQL rollup
 and counts are labelled **GitHub summary**, advisory rather than proof that the
-section has no failures. Once a complete fresh section for the same head exists,
-use its counts in both card and reader; head changes discard them. On disagreement,
-prefer the section and qualify source/time, not contradictory unlabeled green/red
-aggregates. Test disagreement explicitly.
+section has no failures. Section counts take precedence only when complete,
+for the same head, captured no more than 30 seconds ago, and not older than the
+overview's checks `fetched_at`. Age uses the capture's completion time, not a cache
+touch, proof renewal or body hydration. Otherwise the card uses the qualified
+GitHub rollup and the reader retains its dated snapshot with a refresh hint. Head
+changes discard old counts. Never show contradictory unlabeled green/red aggregates. Test disagreement explicitly.
 
 The lightweight overview uses one bounded GraphQL request for identity/lifecycle,
 head SHA, description, `reviewDecision`, the first 50 current-review/request rows,
@@ -390,6 +410,19 @@ GitHub documents 5,000 minimum, scaling to 12,500, or 15,000 for qualifying Ente
 Cloud installations. Credential provisioning/installation-token renewal remains
 operator-owned; the feature neither finds nor persists replacement credentials.
 
+A permission-probe HTTP 200 with matching user and `permission=none` is routine
+per-user denial. Authentication/scope failure of the probe itself is distinct:
+return `integration_capability_unavailable` with `access_failure=invalid` and an
+operator-action message. Rate-limit 403 is transient, not a scope diagnosis. Scope
+403/404 can be repository-specific; do not claim all repositories are broken from
+one such response. Emit a sanitized warning keyed by integration generation and
+repository (or global only for explicit invalid credential), throttled to once per
+five minutes. Repeated non-rate probe failures across distinct admitted subjects
+also emit an integration diagnostic, without claiming their users lack GitHub roles.
+Do not probe extra users/repos to generate that diagnostic. Existing protected
+server warning logs are its operator-visible surface; no new audit UI is required.
+A fresh successful compatible probe clears the diagnostic; this is not an allow grant.
+
 ## Stable pagination and bounded storage
 
 ### Collection snapshots
@@ -414,7 +447,11 @@ redacted/unreadable nodes with identity/publication evidence become placeholders
 and still count as enumerated; unexplained gaps do not. Compare the unfiltered
 count before dropping PENDING entries. Never expose a review/thread placeholder
 or count when publication cannot be established; pending drafts contribute no
-existence signal. Retry enumeration at most once
+existence signal. Page `total` counts published entries matching the requested
+filter (lower bound for limited coverage). `excluded_by_filter` is a separate count
+object for published rows excluded by the resolved filter, never draft counts.
+An empty complete default thread view says **No unresolved threads (N resolved)**
+when that excluded count is exact; otherwise omit N. It never says No reviews. Retry enumeration at most once
 within the same deadline, merging by stable ID; otherwise return a limited manifest
 with a changed-during-capture reason and an explicit Refresh action. An API without
 sufficient enumeration/completeness evidence also yields limited coverage. Complete
@@ -490,8 +527,8 @@ The manifest and all its handles share a fixed absolute expiry of 30 minutes fro
 capture start; paging never extends it. Bind to the numeric GitHub identity too. A cursor supplies position only:
 re-resolve the link and thread membership to build each upstream request. Unknown
 or foreign handles never cause a GitHub call. A well-formed handle missing from the
-bounded store returns generic `cursor_unavailable`; a known foreign handle returns
-400. Retained records can identify expiry/eviction/generation changes precisely;
+bounded store and a known foreign handle both return generic `cursor_unavailable`;
+only malformed handle syntax returns 400. Retained records can identify expiry/eviction/generation changes precisely;
 do not keep unbounded tombstones just to distinguish all forgotten handles.
 
 `has_more=true` iff `next_cursor` is non-null/non-empty. `has_more=false` only means
@@ -503,7 +540,9 @@ are a protocol failure. Stable IDs prevent duplicate appends on retried pages.
 Separate server budgets: body cache 64 MiB/256 entries; manifest store 128 MiB/256
 manifests; opaque-handle store 8 MiB/16,384 records. These operational defaults target
 four active PR readers with six collections and up to twenty expanded-thread
-manifests each, plus opportunistic idle retention. Body paging cannot evict manifests
+manifests each, plus opportunistic idle retention. On large PRs the byte ceiling
+binds before the manifest count; the capacity target is not 104 maximum-sized
+manifests simultaneously. Body paging cannot evict manifests
 or consume handle capacity. Byte accounting includes stored metadata/handle contents.
 Evict idle PRs first; if admission still cannot fit, return capacity unavailable
 rather than silently evict another active reader's manifest.
@@ -530,7 +569,16 @@ corresponding data is reloaded, not by retaining unbounded content.
 
 ## Wire contract
 
-Paths are additive and session-scoped:
+Paths are additive and session-scoped. Each requires one `version` query parameter;
+combine it with `cursor`/`resolved` using ordinary URL query encoding. Missing
+version returns HTTP 400 `{ "error":"protocol_version_required" }`; duplicate,
+non-decimal, non-positive, overflowing Int32 or malformed values return 400
+`protocol_version_invalid`; an unsupported
+positive integer returns 400 `protocol_version_unsupported`. These errors never use
+404/409 and never contact GitHub. Authentication still precedes request handling.
+The shared fixture bundle includes request method/path/query and these exact status/
+error cases, not only response-record examples. Protocol and cursor versions are
+independent.
 
 ```text
 GET /api/sessions/{sessionId}/pull-requests
@@ -596,13 +644,16 @@ The link list grants no lease. Each body response requires current authorization
 `access_failure` is null on admission, otherwise transient, denied or invalid.
 Transient means only network/timeout/5xx/rate/budget inability to check. Explicit
 401/non-rate 403/404, permission=none, unlink/configuration change, ID mismatch, malformed
-evidence and unknown classifications get no display grace. Resource-level signals
-use this field; item-level hydration outcomes do not change it.
+evidence and unknown classifications get no display grace. Client-observed timeout,
+DNS or connection failure with no HTTP envelope is transient. A Capacitor 401 after
+the established auth retry, unexpected origin or malformed protocol is not.
+Resource-level signals use this field; item-level hydration outcomes do not change it.
 
 Reasons: disabled, not_configured, github_not_linked, github_access_denied,
 github_access_unverifiable, provider_unauthorized, provider_forbidden,
 provider_not_found, rate_limited, budget_exhausted, timeout, provider_unavailable,
-protocol_error, capture_unstable, payload_unavailable, capacity_exhausted. Unknown reasons use a generic
+protocol_error, capture_unstable, payload_unavailable, capacity_exhausted,
+integration_capability_unavailable. Unknown reasons use a generic
 unavailable label. Only transient content failures/rate limits with a still-valid
 access proof may carry stale data. Unknown authorization status never may.
 
@@ -635,6 +686,7 @@ Page `data`:
   "coverage": "complete",
   "head_sha": null,
   "total": {"value":2,"kind":"exact"},
+  "excluded_by_filter": {"value":0,"kind":"exact"},
   "items": [{"id":"IC_example","availability":"available","reason":null,"url":"https://github.com/example/repo/pull/42#issuecomment-1","created_at":"2026-09-07T09:00:00Z","updated_at":"2026-09-07T09:00:00Z","author":null,"body":"Example comment","body_truncated":false}],
   "page_cursor": "opaque-current-page-handle",
   "has_more": true,
@@ -665,7 +717,8 @@ cache freshness is 30 seconds. Publication rules precede any placeholder.
 401 is Capacitor authentication failure only. Missing/hidden/below-Full/unlinked
 Capacitor subjects are indistinguishable 404s. GitHub denials are typed unavailable
 results for an already admitted Capacitor link, not a Capacitor 401/404. Malformed
-inputs or known-foreign/malformed cursor handles return 400 without upstream work.
+inputs or malformed cursor syntax return 400 without upstream work. Well-formed
+foreign/unknown handles share the generic restart outcome without upstream work.
 
 409 uses `{ "error":"restart_required", "reason":"…" }`, where reason is
 head_changed, cursor_expired, cursor_unavailable, snapshot_evicted,
@@ -729,6 +782,8 @@ labelled with its old fetch time. A fresh overview cannot label those bodies fre
 | Item miss/unreadable | Unavailable placeholder without old body/hunk; paging continues. |
 | Transport/5xx/timeout rechecking | No server data without proof; existing visible data gets labelled display grace. |
 | Rate/budget limit | Follow retry advice; no fetch on expired proof, same bounded display grace. |
+| Capacity exhausted | Temporary server capacity notice; `retry_at` defaults to 60 seconds ahead, normal bounded display grace. |
+| Integration capability unavailable | Server integration needs operator attention; no bodies/grace. |
 | Oversized item | Explicit truncated preview and its external link; paging continues. |
 | Limited manifest | Label loaded subset/lower bound; More on GitHub, never all-loaded. |
 | Caller sign-out/session 404 | Clear affected protected state immediately. |
@@ -758,7 +813,8 @@ Core/app tests pin tolerant JSON parsing, unknown status/enum handling, exact
 count/page invariants, source precedence, unsupported discovery/backoff, provider
 failure versus Capacitor sign-out, memory eviction, monotonic access expiry,
 five-minute display-grace expiry, short foreground return, long-hide masking,
-minimum reveal-lease floor, and profile/selection cancellation. Avalonia tests assert
+minimum reveal-lease floor, no-envelope transport classification, per-session 404
+settling, version query errors, check-source age precedence, and profile cancellation. Avalonia tests assert
 realized Chat/Terminal preservation, non-PTY and ended layouts, card-row focus,
 selected tab accessibility, live announcements, readable long content, and failures
 in one sidebar module not contaminating the other.

--- a/docs/superpowers/specs/2026-09-07-github-app-pr-credentials-design.md
+++ b/docs/superpowers/specs/2026-09-07-github-app-pr-credentials-design.md
@@ -1,0 +1,294 @@
+# GitHub App credentials for the PR reader
+
+## Proposed decision
+
+Add a tenant-scoped installation-token broker to the shared auth proxy. The proxy
+keeps the App signing key and issues a repository-restricted read token to an
+authenticated tenant server. The server holds the token in memory and performs
+the PR queries and linked-user admission checks already specified in the
+[desktop PR design](2026-09-07-desktop-pr-context-design.md).
+
+The user authorized proceeding with this addition and explicitly waived its
+independent review when the flow integration was unavailable. The earlier review
+covers the reader and its access policy; no independent review of this credential
+boundary has run. Deployment and secret provisioning remain separate from preparing
+and testing the implementation.
+
+The [protected preflight](../../github-pr-context-preflight.md) established that the
+selected App can support the reader. Accept the observed non-admin Write role as
+evidence of a readable private repository, alongside the explicit None denial.
+Team provenance remains operator-attested; least-privileged Read, requested-team
+visibility, sustained load, and end-to-end Capacitor admission remain verification
+items. No further named-user probes are needed to make the architecture decision.
+
+## Options and trade-offs
+
+| Approach | Consequence |
+| --- | --- |
+| **Tenant-scoped token broker — recommended** | Keeps the App key in the proxy and PR query/caching logic in the tenant. Introduces a tenant service credential and sends short-lived GitHub tokens over the authenticated server-to-proxy connection. |
+| Typed PR read gateway in the proxy | Keeps installation tokens in the proxy too, but moves GitHub query execution and shared traffic scheduling into that service. It adds a second PR read contract and carries private response bodies through the shared proxy. |
+| Separate App and signing key per tenant | Avoids a broker and isolates each App's authority. Requires another App installation and protected signing-key lifecycle for every tenant. Copying the shared App key into tenants would instead expose its authority across installations. |
+
+The broker is the smallest addition that preserves the chosen server module and
+the existing protected App key. The tenant server becomes a holder of an
+hour-lived GitHub bearer credential. The desktop and daemon receive neither that
+token nor the broker credential.
+
+## Existing boundaries
+
+Source inspected at `kcap-server` revision
+`5fe40a74ce22a0e7753dfba45047a939aeba79b4`:
+
+- `src/Capacitor.AuthProxy/GitHubApiClient.cs` signs App JWTs and exchanges them for
+  installation tokens. Its current exchange returns only a token string, with no
+  explicit repository/permission narrowing or expiry contract.
+- `src/Capacitor.AuthProxy/TenantMatching.cs` caches authentication-use installation
+  tokens for 50 minutes. That cache is separate from the proposed reader leases.
+- `src/Capacitor.AuthProxy/AdminEndpoints.cs` authenticates its admin group with one
+  configured `X-Admin-Key`. A caller supplies the organization and installation in
+  the admin request. This establishes no individual tenant identity.
+- `src/Capacitor.AuthProxy/WorkOS/M2mApplicationsEndpoint.cs` authenticates a human
+  administrator's WorkOS token to provision a machine application. It is not an
+  existing unattended tenant-server authentication mechanism for this broker.
+- `src/Capacitor.AuthProxy/WorkOS/WorkOSTenantResolver.cs` excludes WorkOS discovery
+  results whose hostname appears in the GitHub-auth `TenantStore`. Broker grants
+  must therefore live outside that store.
+- `src/Capacitor.AuthProxy/WebhookHandler.cs` handles selected installation events.
+  It logs permission acceptance and ignores `installation_repositories`; it does
+  not yet invalidate PR credential leases.
+- `src/Capacitor.Server/WorkItems/Enrichment/TrackerCredentialProviders.cs` reads an
+  opaque configured token synchronously. Its shared `ITrackerCredentialProvider`
+  contract has no repository argument, acquisition, expiry, or renewal operation.
+
+Deployment sources also keep GitHub-auth registration separate from WorkOS:
+`kcap-deployments/charts/kcap-tenant/templates/postsync-register.yaml` runs only for
+GitHubApp authentication. The tenant and auth-proxy deployment templates wire
+their existing shared secrets. They do not provision the proposed broker identity.
+
+## Tenant identity and installation binding
+
+Provision a random 256-bit broker secret unique to a tenant deployment. The tenant
+holds it in its protected deployment secret; the proxy holds a SHA-256 verifier
+and a public key identifier. Compare verifiers in constant time. Authenticate
+only over HTTPS with normal certificate validation, and refuse redirects. Neither
+the shared admin key nor a user session token is accepted by broker endpoints.
+
+The proxy's operator-managed grant contains:
+
+- Public broker key ID, verifier, and immutable tenant deployment ID.
+- Enabled state and a monotonic policy revision.
+- Explicit GitHub App ID, installation ID, account type, and numeric account ID.
+- The fixed `pull-request-read-v1` permission profile.
+
+The binding is an operator-established association between a deployment and an
+installation. A hostname, linked GitHub user, WorkOS organization name, setup URL,
+or caller-supplied installation ID cannot establish it. GitHub's installation
+metadata verifies the configured App/account/installation association; it does
+not establish which Capacitor deployment should receive access.
+
+Store grants in a protected proxy configuration file mounted separately from
+login configuration. Deployment automation supplies it and the tenant's secret.
+No endpoint under the shared-key admin group may create, edit, or reveal broker
+grants. Tenant secrets must be delivered only to their own namespace, without a
+wildcard reflection to other tenants. A malformed replacement configuration fails
+closed for broker reads and emits a sanitized diagnostic.
+
+Support multiple explicit installation bindings for one deployment when needed
+for cross-owner sessions. Each request must resolve to exactly one binding. In v1,
+an installation can be bound to only one deployment; reject overlapping grants
+to keep tenant-local scheduling meaningful. Multiple keys for the same deployment
+are allowed during rotation. Multiple independently scheduled server replicas
+sharing a binding require coordinated admission before being supported.
+
+No new per-user or per-PR allowlist is introduced. The installation's selected
+repository set is the integration's ceiling. A repository outside the configured
+installations retains its admitted external link and has unavailable live details.
+The linked-user repository-role check remains mandatory inside that ceiling.
+
+## Broker contract and issuance
+
+Use a versioned service-only route family outside `/admin`:
+
+```text
+POST /integrations/github/v1/token
+POST /integrations/github/v1/validate
+```
+
+The bearer credential identifies the deployment. Token requests supply only the
+validated GitHub base-repository owner/name and the fixed profile name. They carry
+no tenant selector, arbitrary installation ID, upstream URL, permission set, or
+GitHub query. Bodies are bounded to 8 KiB. Validation accepts a bounded set of
+opaque lease IDs previously issued to that deployment; IDs confer no authority
+without authentication and current grant checks.
+
+For issuance, the proxy:
+
+1. Authenticates the deployment and reads its current enabled grant.
+2. Resolves the repository's installation using App-authenticated GitHub metadata.
+   Verifies the exact configured App, account ID/type, installation ID and absence
+   of suspension. It never searches other installations for a working credential.
+3. Requests a token for exactly that repository and the explicit read-only profile:
+   Metadata, Contents, Pull requests, Issues, Checks and Commit statuses. Even if
+   the App later gains write permissions, issued reader tokens remain read-only.
+4. Verifies the returned permission set and expiry, then uses
+   `/installation/repositories` to verify that the token exposes exactly the
+   requested repository, including its numeric repository and owner IDs. Refuses
+   extra repositories, stronger grants, missing required grants, or identity drift.
+5. Publishes a lease only after validation succeeds. Rejected tokens are revoked
+   with an independently bounded cleanup attempt, including on caller cancellation.
+
+If GitHub accepts an exchange but its response is lost, the proxy may not know the
+token to revoke. Record an unknown issuance outcome, apply acquisition backoff,
+and rely on GitHub expiry for that inaccessible token. Do not claim guaranteed
+cleanup or immediately repeat an exchange after an ambiguous transport failure.
+
+The response includes the token, provider expiry, opaque lease ID, policy revision,
+canonical repository ID/name, and an opaque stable rate-budget identity for the
+installation. Set `Cache-Control: no-store` on all broker responses. Suppress
+request/response body logging, bearer headers, and token-bearing exception data
+throughout this route and its tenant client.
+Validation responses contain evidence and policy/budget metadata, never tokens.
+
+Coalesce token acquisition for the same deployment, binding revision, repository
+and permission profile. Use a separate bounded in-memory cache, capped at 256 token
+leases across the proxy. At capacity, return an explicit retryable unavailable
+result; do not mint a token that cannot be tracked. Reap retired/expired leases.
+The existing authentication token cache is never lent to a reader.
+
+Use 401 for invalid broker authentication, indistinguishable 404s for an unknown
+or ungranted repository/lease, 400 for invalid input/version, and typed 429/503
+results for cooldown or temporary unavailability. The tenant normalizes these as
+integration failures; they cannot become a Capacitor sign-in 401 or a user's
+GitHub repository denial.
+
+## Renewal and revocation
+
+GitHub installation tokens expire after one hour. Renewal is a fresh App-JWT
+exchange, not a refresh-token flow. Use GitHub's returned `expires_at`; never
+assume that receipt starts a fresh hour. Begin demand-driven replacement five
+minutes before expiry, coalescing callers. An inactive reader causes no periodic
+token creation. The proxy's cache uses the same renewal window, so acquisition
+cannot repeatedly return the token the tenant is trying to replace. A token with
+less than the full 30-second operation budget plus
+30 seconds of clock allowance remaining cannot start a request. These are local
+scheduling margins, not a change to GitHub's token lifetime.
+
+On transient replacement failure, an existing unexpired token remains usable only
+while the broker grant and the independent caller/repository proofs are live.
+Once any expires, return unavailable. Respect cooldown; no immediate renewal loop
+and no fallback to the configured PAT. A token rejected by GitHub is retired and
+cannot be reused while waiting for the next eligible acquisition.
+
+The tenant validates the broker grant before serving any detail, including cache
+hits. Positive broker evidence lasts at most 30 seconds and coalesces per binding;
+it never outlives the shortest supporting installation/token evidence. The proxy
+rechecks installation metadata at that bound under demand and reports its actual
+evidence expiry. Validation failure cannot extend evidence. Revalidate before
+delivering a long-running response, alongside the existing caller/link/role checks.
+Broker unavailability therefore blocks new data after the lease expires, even if
+the GitHub token itself still works. Only the main design's already-visible,
+bounded transient display grace remains available.
+
+Keep two identities separate:
+
+- **Policy revision** changes on grant, installation, repository-selection,
+  permission-profile, Enabled, or broker-key revocation changes. It invalidates
+  affected access evidence, bodies, manifests and handles.
+- **Token instance** changes on normal renewal with the same verified scope.
+  Replacement does not reset rate limits or invalidate the reader's pages. Fresh
+  broker and caller proofs remain necessary before delivering cached content.
+
+Signed installation suspension/deletion, accepted-permission changes, and
+repository-selection events invalidate affected broker leases. Reconcile live
+installation/repository metadata as well; webhooks are an early signal, not the
+only revocation mechanism. A replacement installation ID requires a new explicit
+binding. An event cannot silently associate another installation with a tenant.
+An all-to-selected change may carry an empty removal list; reconcile the effective
+scope rather than treating that list as complete. Account renames preserve numeric
+identity. Authenticate and deduplicate webhook deliveries, and do not let delayed
+events override newer live denial evidence.
+
+Retire replaced tokens after bounded in-flight use; track retained instances until
+revoked or expired. Disabling a grant or revoking a broker key stops issuance and
+validation immediately at the proxy and attempts revocation of its outstanding
+reader tokens. Cleanup failures are recorded without credential material. A proxy
+restart loses in-memory leases, so tenants discard unknown leases and reacquire;
+untracked old tokens expire at GitHub. This design does not claim immediate
+revocation of a token stolen from a compromised tenant: expiry is the backstop if
+revocation cannot complete. Shared App-key revocation remains an operator incident
+action with effects beyond this reader.
+
+Rotate a tenant broker key by installing a second verifier for the same deployment,
+updating that tenant's protected secret, then removing the old verifier. The old
+key cannot mutate its binding or provision its successor. Removing it invalidates
+its leases. No secret values belong in the spec, issue, logs, or agent transcript.
+
+## Tenant integration and request budget
+
+Introduce an asynchronous, repository-aware PR credential source returning a
+totalized lease result: availability, policy revision, budget identity, token
+expiry and internal token access. It owns acquisition, validation, renewal and
+retirement. PR read code does not implement token lifecycle itself.
+
+Configure `PullRequestReads:CredentialSource` explicitly as `ConfiguredToken`
+(compatibility default) or `AppBroker`. AppBroker also requires its HTTPS base URL
+and protected service credential. Missing/invalid configuration is unavailable;
+there is no automatic discovery or source fallback. The configured-token adapter
+reads the existing provider and retains its capability validation; a fine-grained
+PAT is still insufficient for full check support.
+
+For v1, the broker supplies the interactive PR reader. Existing enrichment and
+reviewer polling retain their configured credential and synchronous interface.
+Switching those consumers to App tokens is separate work because it requires
+repository-aware asynchronous acquisition across their call sites. This narrows
+the credential change without making a second copy of the existing token store.
+
+Use the main design's concurrency, request pacing, priority and 20% quota reserve.
+Account App-backed activity by stable installation identity across repositories
+and renewals, not by token string or token hash. A configured-token credential has
+its own budget identity. Different PAT/App credentials need not share a quota;
+actual provider headers remain authoritative for each.
+
+Broker validation includes the proxy's observed installation cooldown/budget state,
+including its existing GitHub authentication activity. The tenant reports observed
+cooldown and budget exhaustion through the validation lane; reports may tighten a
+cooldown, never raise the remaining quota or shorten an active cooldown. Proxy
+credential and metadata calls participate in its provider pacing; App-JWT calls
+use a separate resource identity when GitHub accounts them separately. A
+scope-narrowed token provides no independent installation quota. Keep the four-reader target subject to a
+measured whole-installation budget, including broker probes and authentication.
+GitHub documents the installation-level primary quota in its
+[REST rate-limit reference](https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api#primary-rate-limit-for-github-app-installations).
+
+## Delivery and acceptance
+
+This adds auth-proxy and deployment work to the existing server/desktop feature.
+Once approved, sequence the implementation around:
+
+1. Broker authentication, protected grant provisioning, scoped token lifecycle,
+   webhook invalidation, and tenant-isolation tests.
+2. Tenant PR credential source and the admitted server read module, with checked-in
+   literal wire fixtures for the desktop contract.
+3. Sidebar summary and reader sharing workspace state; preserve Chat/Terminal
+   lifetimes and all failure/retention semantics in the approved design.
+4. Protected deployment validation through the finished broker, then the real
+   tenant endpoints and desktop. Keep provider/feature configuration changes
+   separate from preparing and testing the implementation.
+
+Required credential tests cover wrong-tenant key/lease/repository, shared-admin-key
+rejection, WorkOS discovery preservation, changed installation/account, an App
+with extra write permissions, overbroad or incomplete returned scope, cancellation
+after mint, expiry/clock margins, concurrent renewal, cache capacity, broker outage,
+revocation during a read, missing webhooks, key rotation and restart recovery.
+Verify that token replacement preserves policy-bound pages and installation
+cooldowns, while policy changes invalidate them. Tests must also prove that
+neither logs nor desktop contracts expose token material.
+
+The live rollout check repeats capability and access validation using the final
+broker path inside the protected runtime. Verify renewal without manual token
+copying, denied-user/session handling, expiry and failure behavior, requested-team
+data, and four active readers alongside background activity. The earlier probes
+prove API feasibility and do not substitute for these integration checks.
+
+GitHub facts and lifecycle sources are collected in
+[the token research note](../../github-app-token-lifecycle-research.md).

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -363,7 +363,8 @@ public partial class App : Application {
         var serverLane = new ServerConnectionService(profiles, _foreignHttp.GetRequiredService<TokenStore>());
         serverLane.Start();
         var workContext = new ServerWorkContextSource(_config, profiles);
-        var serverClients = new ServerClients(serverLane, workContext);
+        var pullRequests = new ServerPullRequestSource(_config, profiles);
+        var serverClients = new ServerClients(serverLane, workContext, pullRequests);
         _serverLane = serverLane;
 
         var machineId = new MachineId(_config).ReadPersisted();
@@ -400,7 +401,10 @@ public partial class App : Application {
         Action requestSignIn = () => OpenSignInDialog(profiles, notifier);
         WorkspaceViewModel BuildWorkspace(string agentId) => new(
             agentId, service, actions, attachFactory, () => new XtermTerminalSurface(80, 24, PtyDumpPath), TimeProvider.System, opener, permissions,
-            workContext, requestSignIn: requestSignIn, signInCompleted: serverClients.SignInCompleted);
+            workContext, requestSignIn: requestSignIn, signInCompleted: serverClients.SignInCompleted, pullRequests: pullRequests,
+            linkGitHub: () => {
+                if (profiles?.Resolution.ServerUrl is { Length: > 0 } url) LinkPolicy.Open(opener, url.TrimEnd('/') + "/auth/github-link/start");
+            });
 
         _coordinator = new MainWindowCoordinator(
             () => BuildAndShowMainWindow(

--- a/src/Capacitor.App/Services/AuthenticatedServerReads.cs
+++ b/src/Capacitor.App/Services/AuthenticatedServerReads.cs
@@ -1,0 +1,149 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Http;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Capacitor.App.Services;
+
+public sealed class AuthenticatedServerReads<TChannel> : IAsyncDisposable where TChannel : class {
+    public delegate Task<(HttpClient Client, AuthStatus Status)> ClientFactory(ConfigRoot config, ProfileContext profiles, string url, CancellationToken ct);
+    sealed class Lease(HttpClient http, TChannel channel, string url) {
+        internal HttpClient Http { get; } = http;
+        internal TChannel Channel { get; } = channel;
+        internal string Url { get; } = url;
+        internal int Borrowers;
+        internal bool Retired;
+        internal bool Disposed;
+    }
+    readonly ConfigRoot _config;
+    readonly ProfileContext? _profiles;
+    readonly ClientFactory _factory;
+    readonly Func<HttpClient, string, TChannel> _channelFactory;
+    readonly SemaphoreSlim _build = new(1, 1);
+    readonly Lock _lock = new();
+    readonly CancellationTokenSource _dispose = new();
+    readonly List<Task> _active = [];
+    Lease? _lease;
+    ServiceProvider? _lane;
+    readonly bool _allowAutoRedirect;
+    long _generation;
+    bool _disposed;
+
+    public AuthenticatedServerReads(ConfigRoot config, ProfileContext? profiles, Func<HttpClient, string, TChannel> channelFactory,
+        ClientFactory? factory = null, bool allowAutoRedirect = true) {
+        _config = config;
+        _profiles = profiles;
+        _channelFactory = channelFactory;
+        _allowAutoRedirect = allowAutoRedirect;
+        _factory = factory ?? RegisteredLaneAsync;
+    }
+    async Task<(HttpClient Client, AuthStatus Status)> RegisteredLaneAsync(
+        ConfigRoot config, ProfileContext profiles, string url, CancellationToken ct) {
+        _lane ??= new ServiceCollection()
+            .AddSingleton(config)
+            .AddSingleton(profiles)
+            .AddSingleton(new CapacitorServer(url, config, profiles))
+            .AddCapacitorHttp()
+            .BuildValidated();
+        var clients = _lane.GetRequiredService<ICapacitorHttpClient>();
+        var attempt = _allowAutoRedirect
+            ? await clients.ForWaitAsync(ct).ConfigureAwait(false)
+            : await clients.ForProtectedReadAsync(ct).ConfigureAwait(false);
+        return (attempt.Client, attempt.Status);
+    }
+    public Task<T> ReadAsync<T>(Func<TChannel, CancellationToken, Task<T>> read, Func<T, bool> signedOut, T noAuth, T disposed, CancellationToken ct) {
+        Task<T> task;
+        lock (_lock) {
+            if (_disposed) return Task.FromResult(disposed);
+            task = ReadCoreAsync(read, signedOut, noAuth, disposed, ct);
+            _active.Add(task);
+        }
+        _ = task.ContinueWith(completed => { lock (_lock) _active.Remove(completed); }, TaskScheduler.Default);
+        return task;
+    }
+    async Task<T> ReadCoreAsync<T>(Func<TChannel, CancellationToken, Task<T>> read, Func<T, bool> signedOut, T noAuth, T disposed, CancellationToken ct) {
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _dispose.Token);
+        if (_profiles is null || _profiles.Resolution.ServerUrl is not { Length: > 0 } url) return noAuth;
+        Lease? lease = null;
+        try {
+            lease = await BorrowAsync(url, linked.Token).ConfigureAwait(false);
+            if (lease is null) return noAuth;
+            var result = await read(lease.Channel, linked.Token).ConfigureAwait(false);
+            if (signedOut(result)) Retire(lease);
+            return result;
+        } catch (OperationCanceledException) when (_dispose.IsCancellationRequested && !ct.IsCancellationRequested) { return disposed; }
+        finally { if (lease is not null) Release(lease); }
+    }
+    async Task<Lease?> BorrowAsync(string url, CancellationToken ct) {
+        await _build.WaitAsync(ct).ConfigureAwait(false);
+        try {
+            Lease? old;
+            long generation;
+            lock (_lock) {
+                if (_lease is { Retired: false } live && live.Url == url) { live.Borrowers++; return live; }
+                old = _lease;
+                if (old is not null) old.Retired = true;
+                _lease = null;
+                generation = _generation;
+            }
+            if (old is not null) DisposeIfUnused(old);
+            var (http, status) = await _factory(_config, _profiles!, url, ct).ConfigureAwait(false);
+            if (status is not (AuthStatus.Ok or AuthStatus.NoAuthRequired)) { http.Dispose(); return null; }
+            TChannel channel;
+            try { channel = _channelFactory(http, url); }
+            catch { http.Dispose(); throw; }
+            var lease = new Lease(http, channel, url) { Borrowers = 1 };
+            lock (_lock) {
+                if (!_disposed && generation == _generation) { _lease = lease; return lease; }
+                lease.Retired = true;
+                lease.Borrowers = 0;
+            }
+            DisposeIfUnused(lease);
+            return null;
+        } finally { _build.Release(); }
+    }
+    void Retire(Lease lease) {
+        lock (_lock) { lease.Retired = true; if (ReferenceEquals(_lease, lease)) _lease = null; }
+    }
+    public void Invalidate() {
+        Lease? lease;
+        lock (_lock) {
+            _generation++;
+            lease = _lease;
+            _lease = null;
+            if (lease is not null) lease.Retired = true;
+        }
+        if (lease is not null) DisposeIfUnused(lease);
+    }
+    void Release(Lease lease) {
+        lock (_lock) lease.Borrowers--;
+        DisposeIfUnused(lease);
+    }
+    void DisposeIfUnused(Lease lease) {
+        lock (_lock) {
+            if (!lease.Retired || lease.Borrowers != 0 || lease.Disposed) return;
+            lease.Disposed = true;
+        }
+        (lease.Channel as IDisposable)?.Dispose();
+        lease.Http.Dispose();
+    }
+    public async ValueTask DisposeAsync() {
+        Task[] active;
+        Lease? lease;
+        lock (_lock) {
+            if (_disposed) return;
+            _disposed = true;
+            active = _active.ToArray();
+            lease = _lease;
+            _lease = null;
+            if (lease is not null) lease.Retired = true;
+        }
+        _dispose.Cancel();
+        try { await Task.WhenAll(active).ConfigureAwait(false); }
+        catch (Exception) { }
+        if (lease is not null) DisposeIfUnused(lease);
+        if (_lane is not null) await _lane.DisposeAsync().ConfigureAwait(false);
+        _dispose.Dispose();
+        _build.Dispose();
+    }
+}

--- a/src/Capacitor.App/Services/ServerClients.cs
+++ b/src/Capacitor.App/Services/ServerClients.cs
@@ -11,9 +11,15 @@ public sealed class ServerClients : IAsyncDisposable {
     readonly Subject<Unit> _signIn = new();
     readonly Lazy<Task> _cleanup;
     volatile bool _cleanupRequested;
+    readonly Action _invalidateAuthentication;
 
-    public ServerClients(IAsyncDisposable? launch, IAsyncDisposable? workContext) =>
-        _cleanup = new Lazy<Task>(() => CleanupAsync(launch, workContext, _signIn), LazyThreadSafetyMode.ExecutionAndPublication);
+    public ServerClients(IAsyncDisposable? launch, IAsyncDisposable? workContext, IAsyncDisposable? pullRequests = null) {
+        _cleanup = new Lazy<Task>(() => CleanupAsync(launch, workContext, _signIn, pullRequests), LazyThreadSafetyMode.ExecutionAndPublication);
+        _invalidateAuthentication = () => {
+            (workContext as ServerWorkContextSource)?.InvalidateAuthentication();
+            (pullRequests as ServerPullRequestSource)?.InvalidateAuthentication();
+        };
+    }
 
     public IObservable<Unit> SignInCompleted => _signIn;
 
@@ -25,6 +31,7 @@ public sealed class ServerClients : IAsyncDisposable {
     /// subject is completed and disposed in the sequence, and a disposed subject throws on OnNext.
     public void NotifySignInCompleted() {
         if (CleanupStarted) return;
+        _invalidateAuthentication();
         _signIn.OnNext(Unit.Default);
     }
 
@@ -35,9 +42,10 @@ public sealed class ServerClients : IAsyncDisposable {
 
     /// Launch client, then the work-context source, then the subject completed and disposed —
     /// each step guarded so a throwing disposal never skips the next.
-    internal static async Task CleanupAsync(IAsyncDisposable? launch, IAsyncDisposable? workContext, Subject<Unit> signIn) {
+    internal static async Task CleanupAsync(IAsyncDisposable? launch, IAsyncDisposable? workContext, Subject<Unit> signIn, IAsyncDisposable? pullRequests = null) {
         await DisposeGuarded(launch, "launch client").ConfigureAwait(false);
         await DisposeGuarded(workContext, "work-context source").ConfigureAwait(false);
+        await DisposeGuarded(pullRequests, "pull-request source").ConfigureAwait(false);
         try {
             signIn.OnCompleted();
             signIn.Dispose();

--- a/src/Capacitor.App/Services/ServerPullRequestSource.cs
+++ b/src/Capacitor.App/Services/ServerPullRequestSource.cs
@@ -1,0 +1,50 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.PullRequests;
+
+namespace Capacitor.App.Services;
+
+public sealed class ServerPullRequestSource : IPullRequestSource, IAsyncDisposable {
+    readonly AuthenticatedServerReads<PullRequestClient> _reads;
+    readonly Lock _lock = new();
+    readonly Dictionary<string, int> _missing = new(StringComparer.Ordinal);
+    long _generation;
+    public ServerPullRequestSource(ConfigRoot config, ProfileContext? profiles,
+        AuthenticatedServerReads<PullRequestClient>.ClientFactory? factory = null, TimeProvider? time = null) {
+        _reads = new(config, profiles, (http, url) => new PullRequestClient(http, url, time), factory, allowAutoRedirect: false);
+    }
+    public Task<PullRequestCapability> DiscoverAsync(bool refresh, CancellationToken ct) => _reads.ReadAsync((channel, token) => channel.DiscoverAsync(refresh, token),
+        read => read.Kind == PullRequestCapabilityKind.SignedOut, new PullRequestCapability(PullRequestCapabilityKind.SignedOut),
+        new PullRequestCapability(PullRequestCapabilityKind.Unavailable, Reason: "disposed"), ct);
+    public void ResetSession(string sessionId) { lock (_lock) { _generation++; _missing.Remove(sessionId); } }
+    public void InvalidateAuthentication() { lock (_lock) { _generation++; _missing.Clear(); } _reads.Invalidate(); }
+    public async Task<PullRequestRead<PullRequestLinkListDto>> ListAsync(string sessionId, CancellationToken ct) {
+        long generation;
+        lock (_lock) {
+            if (_missing.GetValueOrDefault(sessionId) >= 3) return new(PullRequestReadKind.SubjectUnavailable, Reason: "retries_stopped", AccessFailure: "invalid");
+            generation = _generation;
+        }
+        var read = await ReadAsync((channel, token) => channel.ListAsync(sessionId, token), ct).ConfigureAwait(false);
+        lock (_lock) {
+            if (generation != _generation) return read;
+            if (read.Kind == PullRequestReadKind.SubjectUnavailable) {
+                if (_missing.Count >= 1024 && !_missing.ContainsKey(sessionId)) _missing.Remove(_missing.Keys.First());
+                _missing[sessionId] = Math.Min(3, _missing.GetValueOrDefault(sessionId) + 1);
+                if (_missing[sessionId] == 3) read = read with { Reason = "retries_stopped" };
+            } else if (read.Kind == PullRequestReadKind.Ready) _missing.Remove(sessionId);
+        }
+        return read;
+    }
+    public Task<PullRequestRead<PullRequestLinkListDto>> LegacyLinksAsync(string sessionId, CancellationToken ct)
+        => ReadAsync((channel, token) => channel.LegacyLinksAsync(sessionId, token), ct);
+    public Task<PullRequestRead<PullRequestOverviewDto>> OverviewAsync(string sessionId, PullRequestSubjectDto subject, CancellationToken ct)
+        => ReadAsync((channel, token) => channel.OverviewAsync(sessionId, subject, token), ct);
+    public Task<PullRequestRead<PullRequestPageDto<T>>> PageAsync<T>(string sessionId, PullRequestSubjectDto subject, string section,
+        string? cursor, string? resolved, string? threadId, CancellationToken ct) where T : class
+        => ReadAsync((channel, token) => channel.PageAsync<T>(sessionId, subject, section, cursor, resolved, threadId, token), ct);
+    Task<PullRequestRead<T>> ReadAsync<T>(Func<PullRequestClient, CancellationToken, Task<PullRequestRead<T>>> read, CancellationToken ct) where T : class
+        => _reads.ReadAsync(read, value => value.Kind == PullRequestReadKind.SignedOut,
+            new PullRequestRead<T>(PullRequestReadKind.SignedOut, AccessFailure: "invalid"),
+            new PullRequestRead<T>(PullRequestReadKind.TransportFailure, Reason: "disposed", AccessFailure: "invalid"), ct);
+    public ValueTask DisposeAsync() => _reads.DisposeAsync();
+}

--- a/src/Capacitor.App/Services/ServerWorkContextSource.cs
+++ b/src/Capacitor.App/Services/ServerWorkContextSource.cs
@@ -1,185 +1,20 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
-using Capacitor.Cli.Core.Http;
 using Capacitor.Cli.Core.WorkItems;
-using Microsoft.Extensions.DependencyInjection;
 
 namespace Capacitor.App.Services;
 
-/// Reads through an authenticated client built from the profile's server URL and token store, the
-/// pair the launch client uses. Reads can overlap, so the client is held by lease: a signed-out
-/// result retires it for future borrows and the last borrower disposes it; disposal of the source
-/// stops new borrows, cancels active reads, awaits them, then disposes the live client.
 public sealed class ServerWorkContextSource : IWorkContextSource, IAsyncDisposable {
-    public delegate Task<(HttpClient Client, AuthStatus Status)> ClientFactory(
-        ConfigRoot config, ProfileContext profiles, string serverUrl, CancellationToken ct);
-
-    sealed class ClientLease(HttpClient client) {
-        public HttpClient Client { get; } = client;
-        public int  Borrowers;
-        public bool Retired;
-        public bool Disposed;
-    }
-
-    readonly ConfigRoot _config;
-    readonly ProfileContext? _profiles;
-    readonly ClientFactory _factory;
-    readonly SemaphoreSlim _buildGate = new(1, 1);
-    readonly object _lock = new();
-    readonly CancellationTokenSource _disposeCts = new();
-    readonly List<Task> _active = [];
-    ClientLease? _lease;
-    ServiceProvider? _lane;
-    bool _disposed;
+    public delegate Task<(HttpClient Client, AuthStatus Status)> ClientFactory(ConfigRoot config, ProfileContext profiles, string serverUrl, CancellationToken ct);
+    readonly AuthenticatedServerReads<WorkContextClient> _reads;
 
     public ServerWorkContextSource(ConfigRoot config, ProfileContext? profiles, ClientFactory? factory = null) {
-        _config   = config;
-        _profiles = profiles;
-        _factory  = factory ?? RegisteredLaneAsync;
+        _reads = new(config, profiles, (http, url) => new WorkContextClient(http, url),
+            factory is null ? null : (c, p, url, ct) => factory(c, p, url, ct));
     }
-
-    /// <summary>
-    /// The recovering lane, from a container of this source's own. The app holds no authenticated
-    /// container — that lane's handlers need a resolved server, which does not exist when the app
-    /// starts — so the one place that does have a server URL builds it, once, and disposes it here.
-    /// </summary>
-    async Task<(HttpClient Client, AuthStatus Status)> RegisteredLaneAsync(
-            ConfigRoot config, ProfileContext profiles, string serverUrl, CancellationToken ct) {
-        // Built under _buildGate, which BorrowAsync already holds, so no second lock is needed.
-        _lane ??= new ServiceCollection()
-            .AddSingleton(config)
-            .AddSingleton(profiles)
-            .AddSingleton(new CapacitorServer(serverUrl, config, profiles))
-            .AddCapacitorHttp()
-            .BuildValidated();
-
-        // The waiting lane, not the hook one: this client is leased for as long as the pane is open,
-        // so it has to outlive a token that expires under it. The status is what retires the lease.
-        var attempt = await _lane.GetRequiredService<ICapacitorHttpClient>().ForWaitAsync(ct).ConfigureAwait(false);
-
-        return (attempt.Client, attempt.Status);
-    }
-
-    /// Registered under the lock before it can complete, so a concurrent DisposeAsync either
-    /// sees it in the drain or refuses it; Monitor is re-entrant, so the synchronous prefix of
-    /// ReadCoreAsync taking the same lock is fine.
-    public Task<WorkContextRead> ReadAsync(string sessionId, CancellationToken ct) {
-        Task<WorkContextRead> task;
-        lock (_lock) {
-            if (_disposed) return Task.FromResult(WorkContextRead.Of(WorkContextReadKind.Unreachable, "disposed"));
-            task = ReadCoreAsync(sessionId, ct);
-            _active.Add(task);
-        }
-        task.ContinueWith(t => { lock (_lock) _active.Remove(t); }, TaskScheduler.Default);
-        return task;
-    }
-
-    async Task<WorkContextRead> ReadCoreAsync(string sessionId, CancellationToken ct) {
-        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, _disposeCts.Token);
-        var serverUrl = _profiles?.Resolution.ServerUrl;
-        if (_profiles is null || string.IsNullOrEmpty(serverUrl)) return WorkContextRead.Of(WorkContextReadKind.SignedOut);
-
-        ClientLease? lease;
-        try {
-            lease = await BorrowAsync(serverUrl, linked.Token).ConfigureAwait(false);
-        } catch (OperationCanceledException) when (_disposeCts.IsCancellationRequested && !ct.IsCancellationRequested) {
-            return WorkContextRead.Of(WorkContextReadKind.Unreachable, "disposed");
-        }
-        if (lease is null) return WorkContextRead.Of(WorkContextReadKind.SignedOut);
-
-        try {
-            var read = await WorkContextReader.ReadAsync(new WorkContextClient(lease.Client, serverUrl), sessionId, linked.Token).ConfigureAwait(false);
-            if (read.Kind == WorkContextReadKind.SignedOut) Retire(lease);
-            return read;
-        } catch (OperationCanceledException) when (_disposeCts.IsCancellationRequested && !ct.IsCancellationRequested) {
-            return WorkContextRead.Of(WorkContextReadKind.Unreachable, "disposed");
-        } finally {
-            Release(lease);
-        }
-    }
-
-    async Task<ClientLease?> BorrowAsync(string serverUrl, CancellationToken ct) {
-        await _buildGate.WaitAsync(ct).ConfigureAwait(false);
-        try {
-            lock (_lock) {
-                if (_lease is { Retired: false } live) {
-                    live.Borrowers++;
-                    return live;
-                }
-            }
-
-            var (client, status) = await _factory(_config, _profiles!, serverUrl, ct).ConfigureAwait(false);
-            if (status is not (AuthStatus.Ok or AuthStatus.NoAuthRequired)) {
-                client.Dispose();
-                return null;
-            }
-
-            var lease = new ClientLease(client) { Borrowers = 1 };
-            lock (_lock) {
-                if (_disposed) {
-                    client.Dispose();
-                    return null;
-                }
-                _lease = lease;
-            }
-            return lease;
-        } finally {
-            _buildGate.Release();
-        }
-    }
-
-    void Retire(ClientLease lease) {
-        lock (_lock) {
-            lease.Retired = true;
-            if (ReferenceEquals(_lease, lease)) _lease = null;
-        }
-    }
-
-    void Release(ClientLease lease) {
-        bool dispose;
-        lock (_lock) {
-            lease.Borrowers--;
-            dispose = lease.Retired && ClaimDisposal(lease);
-        }
-        if (dispose) lease.Client.Dispose();
-    }
-
-    /// Decided under the lock; the caller disposes outside it. True exactly once per lease, and
-    /// only once nobody borrows it.
-    static bool ClaimDisposal(ClientLease lease) {
-        if (lease.Borrowers != 0 || lease.Disposed) return false;
-        lease.Disposed = true;
-        return true;
-    }
-
-    public async ValueTask DisposeAsync() {
-        Task[] active;
-        ClientLease? lease;
-        lock (_lock) {
-            if (_disposed) return;
-            _disposed = true;
-            active = [.. _active];
-            lease  = _lease;
-            _lease = null;
-        }
-
-        _disposeCts.Cancel();
-        try { await Task.WhenAll(active).ConfigureAwait(false); }
-        catch (Exception) { /* each read reported its own outcome; only the drain matters here */ }
-
-        if (lease is not null) {
-            bool dispose;
-            lock (_lock) {
-                lease.Retired = true;
-                dispose = ClaimDisposal(lease);
-            }
-            if (dispose) lease.Client.Dispose();
-        }
-        // After the lease, never before: disposing the container retires the handler chain the
-        // borrowed client sends on.
-        if (_lane is not null) await _lane.DisposeAsync().ConfigureAwait(false);
-
-        _disposeCts.Dispose();
-        _buildGate.Dispose();
-    }
+    public Task<WorkContextRead> ReadAsync(string sessionId, CancellationToken ct) => _reads.ReadAsync(
+        (channel, token) => WorkContextReader.ReadAsync(channel, sessionId, token), read => read.Kind == WorkContextReadKind.SignedOut,
+        WorkContextRead.Of(WorkContextReadKind.SignedOut), WorkContextRead.Of(WorkContextReadKind.Unreachable, "disposed"), ct);
+    public ValueTask DisposeAsync() => _reads.DisposeAsync();
+    public void InvalidateAuthentication() => _reads.Invalidate();
 }

--- a/src/Capacitor.App/ViewModels/PullRequestChoice.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestChoice.cs
@@ -2,8 +2,8 @@ using Capacitor.Cli.Core.PullRequests;
 
 namespace Capacitor.App.ViewModels;
 
-public sealed record PullRequestChoice(PullRequestLinkDto Link) {
+public sealed record PullRequestChoice(PullRequestLinkDto Link, bool IsAvailable = true) {
     public PullRequestSubjectDto Subject { get; } = PullRequestWire.Subject(Link);
-    public string Label => $"{Link.Owner}/{Link.RepoName} #{Link.Number}";
+    public string Label => $"{Link.Owner}/{Link.RepoName} #{Link.Number}" + (IsAvailable ? "" : " · Unavailable");
     public override string ToString() => Label;
 }

--- a/src/Capacitor.App/ViewModels/PullRequestChoice.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestChoice.cs
@@ -1,0 +1,9 @@
+using Capacitor.Cli.Core.PullRequests;
+
+namespace Capacitor.App.ViewModels;
+
+public sealed record PullRequestChoice(PullRequestLinkDto Link) {
+    public PullRequestSubjectDto Subject { get; } = PullRequestWire.Subject(Link);
+    public string Label => $"{Link.Owner}/{Link.RepoName} #{Link.Number}";
+    public override string ToString() => Label;
+}

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Projections.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Projections.cs
@@ -5,7 +5,8 @@ using ReactiveUI;
 namespace Capacitor.App.ViewModels;
 
 public sealed partial class PullRequestContextViewModel {
-    public string Title => CanDisplay && _overview?.Title is { } title ? title : _selected?.Link.Title ?? _selected?.Label ?? "Pull requests";
+    public string Title => CanDisplay && _overview?.Title is { } title ? title
+        : _selected is { IsAvailable: true } choice ? choice.Link.Title ?? choice.Label : _selected?.Label ?? "Pull requests";
     public string Lifecycle => CanDisplay ? _overview?.Lifecycle switch { "draft" => "Draft", "open" => "Open", "merged" => "Merged", "closed" => "Closed", _ => "Unknown" } : "";
     public string Branches => CanDisplay ? (_overview?.HeadRef ?? "?") + " → " + (_overview?.BaseRef ?? "?") : "";
     public string FetchedLabel => CanDisplay && _overviewRead?.FetchedAt is { } at ? "Fetched " + at.ToLocalTime().ToString("HH:mm:ss", CultureInfo.CurrentCulture) : "";

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Projections.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Projections.cs
@@ -1,0 +1,128 @@
+using System.Globalization;
+using Capacitor.Cli.Core.PullRequests;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+public sealed partial class PullRequestContextViewModel {
+    public string Title => CanDisplay && _overview?.Title is { } title ? title : _selected?.Link.Title ?? _selected?.Label ?? "Pull requests";
+    public string Lifecycle => CanDisplay ? _overview?.Lifecycle switch { "draft" => "Draft", "open" => "Open", "merged" => "Merged", "closed" => "Closed", _ => "Unknown" } : "";
+    public string Branches => CanDisplay ? (_overview?.HeadRef ?? "?") + " → " + (_overview?.BaseRef ?? "?") : "";
+    public string FetchedLabel => CanDisplay && _overviewRead?.FetchedAt is { } at ? "Fetched " + at.ToLocalTime().ToString("HH:mm:ss", CultureInfo.CurrentCulture) : "";
+    public string AccessLabel => CanDisplay ? (_grace ? "Access refresh paused" : "Access checked for " + (_overview?.AccessCheckedFor ?? "linked GitHub account")) : "";
+    public string ReviewSummary => CanDisplay ? _overview?.ReviewDecision switch {
+        "approved" => "Approved", "changes_requested" => "Changes requested", "review_required" => "Review required", _ => "Review decision unknown"
+    } : "";
+    public string CheckSummary {
+        get {
+            if (!CanDisplay) return "";
+            var checks = _sections.GetValueOrDefault("checks");
+            if (checks is { Coverage: "complete", Stopped: false, Total.Kind: "exact", Completed: { } completed }
+                && checks.Head == _overview?.HeadSha && _time.GetUtcNow().UtcDateTime - completed < TimeSpan.FromSeconds(30)
+                && completed >= _overview?.Checks?.Availability.FetchedAt && checks.Pages.Sum(page => page.Rows.Length) == checks.Total.Value) {
+                var rows = checks.Pages.SelectMany(page => page.Rows).ToArray();
+                if (rows.Length == 0) return "No checks reported";
+                var failed = rows.Count(row => row.Outcome is "failure" or "timed_out" or "action_required");
+                var pending = rows.Count(row => row.Outcome == "pending");
+                var passed = rows.Count(row => row.Outcome == "success");
+                var other = rows.Length - failed - pending - passed;
+                return $"{failed} failed · {pending} pending · {passed} passed" + (other > 0 ? $" · {other} other" : "");
+            }
+            return _overview?.Checks?.Availability.Status == "ready" ? _overview.Checks.Rollup switch {
+                "success" => "GitHub summary: successful", "failure" => "GitHub summary: failing", "pending" => "GitHub summary: pending", _ => "GitHub summary: unknown"
+            } : "Checks unavailable";
+        }
+    }
+    public string? Description => CanDisplayReader && _section == "overview" ? _overview?.Description : null;
+    public bool DescriptionTruncated => CanDisplayReader && _overview?.DescriptionTruncated == true;
+    public string DescriptionNote => !CanDisplayReader ? "Refresh access to open PR content." : _overview?.Description is null ? "Description unavailable." : _overview.Description.Length == 0 ? "No description." : "";
+    public bool IsOverview => _section == "overview";
+    public bool IsThreads => _section == "threads";
+    public bool IsThreadComments => _section == "thread_comments";
+    public bool HasNotice => _notice.Length > 0;
+    public bool ShowsSignIn => _notice.StartsWith("Sign in", StringComparison.Ordinal);
+    public bool ShowsLinkGitHub => _notice.StartsWith("Link GitHub", StringComparison.Ordinal);
+    public bool ShowReaderContent => CanDisplayReader;
+    IReadOnlyList<PullRequestRow> _visibleRows = [];
+    public IReadOnlyList<PullRequestRow> Rows => _visibleRows;
+    public bool HasMore => CanReveal && CurrentSection is { Stopped: false, Next: not null };
+    public bool CanReloadEarlier => CanReveal && CurrentSection is { Stopped: false, Evicted: not null };
+    public string PageNote {
+        get {
+            if (_section == "overview") return "";
+            if (!CanDisplayReader) return "Refresh access to open PR content.";
+            if (CurrentSection is not { } state) return _pageRequests.Contains(SectionKey) ? "Loading…" : "Choose Refresh to load this section.";
+            if (state.Error is { } error) return error;
+            if (state.Coverage != "complete") return "Limited snapshot: an ordered subset. More may be available on GitHub.";
+            if (state.Pages.Count > 0 && state.Pages.Sum(page => page.Rows.Length) == 0) return _section switch {
+                "threads" when state.Excluded is { Kind: "exact", Value: > 0 } => $"No unresolved threads ({state.Excluded.Value} resolved).",
+                "threads" => IncludeResolved ? "No threads." : "No unresolved threads.", "checks" => "No checks reported.", "reviewers" => "No reviewers reported.",
+                "reviews" => "No published reviews.", _ => "No comments."
+            };
+            return "";
+        }
+    }
+    public string SnapshotLabel => CanDisplayReader && CurrentSection?.Completed is { } at
+        ? "Snapshot " + at.ToLocalTime().ToString("HH:mm:ss", CultureInfo.CurrentCulture) + (CurrentSection.Head is { Length: >= 7 } head ? " · " + head[..7] : "") : "";
+    public string SectionTitle => _section switch { "checks" => "Checks", "reviewers" => "Reviewers", "reviews" => "Published reviews",
+        "threads" => "Inline threads", "thread_comments" => "Thread replies", "conversation" => "Conversation", _ => "Description" };
+
+    void Notify() {
+        var rows = CanDisplayReader ? CurrentSection?.Pages.SelectMany(page => page.Rows).ToArray() ?? [] : [];
+        if (!_visibleRows.SequenceEqual(rows)) _visibleRows = rows;
+        foreach (var property in new[] { nameof(Notice), nameof(IsReading), nameof(HasChoice), nameof(IsLegacy), nameof(Section), nameof(CanReveal), nameof(CanDisplay),
+            nameof(Title), nameof(Lifecycle), nameof(Branches), nameof(FetchedLabel), nameof(AccessLabel), nameof(ReviewSummary), nameof(CheckSummary),
+            nameof(Description), nameof(DescriptionTruncated), nameof(DescriptionNote), nameof(IsOverview), nameof(IsThreads), nameof(IsThreadComments), nameof(IncludeResolved),
+            nameof(HasNotice), nameof(ShowsSignIn), nameof(ShowsLinkGitHub), nameof(ShowReaderContent), nameof(Rows), nameof(HasMore),
+            nameof(CanReloadEarlier), nameof(PageNote), nameof(SnapshotLabel), nameof(SectionTitle) }) this.RaisePropertyChanged(property);
+    }
+    static string Reason<T>(PullRequestRead<T> read) where T : class => read.Kind switch {
+        PullRequestReadKind.SignedOut => "Sign in to see pull requests.",
+        PullRequestReadKind.SubjectUnavailable => "This pull request is no longer linked or visible.",
+        PullRequestReadKind.InvalidProtocol => "The server returned an invalid PR response. Retry after updating the server and app.",
+        PullRequestReadKind.Ready or PullRequestReadKind.Stale => "Refreshing access before opening new content…",
+        _ => read.Reason switch {
+            "github_not_linked" => "Link GitHub in your account settings to read this pull request.",
+            "github_access_denied" => "Your linked GitHub account cannot read this repository.",
+            "disabled" => "PR reading is disabled for this workspace.",
+            "not_configured" => "PR reading is not configured for this workspace.",
+            "integration_capability_unavailable" => "The GitHub integration cannot read this PR. An operator can check its permissions.",
+            "rate_limited" or "budget_exhausted" => "GitHub reads are paused temporarily. Retry after the cooldown.",
+            "identity_changed" or "integration_changed" => "Access changed. Refresh to reload this pull request.",
+            _ => "Couldn't load pull request context. Retry when the server is reachable."
+        }
+    };
+    static string Author(PullRequestActorDto? actor) => actor is null ? "Unknown author" : actor.Kind == "team"
+        ? actor.Name ?? actor.Login ?? "Team" : actor.Login ?? actor.Name ?? "Unknown author";
+    static string Dated(DateTime? at) => at?.ToLocalTime().ToString("g", CultureInfo.CurrentCulture) ?? "";
+    static string Outcome(string? value) => value switch {
+        "success" => "Passed", "failure" => "Failed", "pending" => "Pending", "neutral" => "Neutral", "skipped" => "Skipped",
+        "cancelled" => "Cancelled", "timed_out" => "Timed out", "action_required" => "Action required", "stale" => "Stale", _ => "Unknown"
+    };
+    static string ReviewState(string? value) => value switch { "approved" => "Approved", "changes_requested" => "Changes requested",
+        "commented" => "Commented", "dismissed" => "Dismissed", _ => "Unknown review state" };
+    static PullRequestRow Unavailable(string id, string title, string? url, string? availability) => new(id, title, "", null, null, url,
+        availability == "redacted" ? "redacted" : "unavailable");
+    static PullRequestRow ToRow(PullRequestCommentDto item, PullRequestSubjectDto subject) => item.Availability == "available"
+        ? new(item.Id, Author(item.Author), Dated(item.CreatedAt), item.Body, null, PullRequestWire.PrLink(item.Url, subject), "available", item.BodyTruncated)
+        : Unavailable(item.Id, "Comment", PullRequestWire.PrLink(item.Url, subject), item.Availability);
+    static PullRequestRow ToRow(PullRequestReviewDto item, PullRequestSubjectDto subject) => item.Availability == "available" && item.State is not ("pending" or "PENDING")
+        ? new(item.Id, Author(item.Author), ReviewState(item.State) + " · " + Dated(item.SubmittedAt), item.Body, null, PullRequestWire.PrLink(item.Url, subject), "available", item.BodyTruncated)
+        : Unavailable(item.Id, "Review", PullRequestWire.PrLink(item.Url, subject), item.Availability);
+    static PullRequestRow ToRow(PullRequestReviewerDto item, PullRequestSubjectDto subject) => item.Availability == "available"
+        ? new(item.Id, Author(item.Actor), (item.Requested == true ? "Review requested · " : "") + ReviewState(item.ReviewState),
+            null, null, PullRequestWire.PrLink(item.Url, subject), "available")
+        : Unavailable(item.Id, "Reviewer", null, item.Availability);
+    static PullRequestRow ToRow(PullRequestCheckDto item, PullRequestSubjectDto subject) => item.Availability == "available"
+        ? new(item.Id, item.Name ?? "Unnamed check", Outcome(item.Outcome) + " · " + (item.AppName ?? item.Source ?? "Unknown source")
+            + (PullRequestWire.CheckLink(item.Url) is { } url ? " · " + new Uri(url).Host : ""),
+            null, null, PullRequestWire.CheckLink(item.Url), "available", IsCheck: true, Outcome: item.Outcome ?? "unknown")
+        : Unavailable(item.Id, "Check", PullRequestWire.CheckLink(item.Url), item.Availability) with { IsCheck = true, Outcome = "unknown" };
+    static PullRequestRow ToRow(PullRequestThreadDto item, PullRequestSubjectDto subject) => item.Availability == "available"
+        ? new(item.Id, (item.Path ?? "Unknown file") + (item.Line is { } line ? ":" + line.ToString(CultureInfo.InvariantCulture) : ""),
+            (item.IsResolved == true ? "Resolved" : item.IsResolved == false ? "Unresolved" : "Resolution unknown")
+            + (item.IsOutdated == true ? " · Outdated" : "") + " · " + Author(item.RootComment?.Availability == "available" ? item.RootComment.Author : null),
+            item.RootComment?.Availability == "available" ? item.RootComment.Body : null, item.DiffHunk, PullRequestWire.PrLink(item.Url, subject),
+            "available", item.HunkTruncated || item.RootComment?.BodyTruncated == true, IsThread: true)
+        : Unavailable(item.Id, "Thread", PullRequestWire.PrLink(item.Url, subject), item.Availability);
+}

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Reads.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Reads.cs
@@ -50,18 +50,28 @@ public sealed partial class PullRequestContextViewModel {
                 }
                 _retryAt = null;
                 _pollAfter = Math.Max(15, links.PollAfterSeconds);
-                var incoming = links.Data.Items.Select(link => new PullRequestChoice(link)).ToArray();
-                if (!_choices.SequenceEqual(incoming)) { _choices.Clear(); _choices.AddRange(incoming); }
+                var incoming = links.Data.Items.Select(link => new PullRequestChoice(link)).ToList();
                 var previous = _selected?.Subject;
                 var selected = _explicitSelection ? incoming.FirstOrDefault(choice => choice.Subject == previous) : null;
+                if (_explicitSelection && selected is null && _selected is not null) {
+                    selected = _selected with { IsAvailable = false };
+                    incoming.Insert(0, selected);
+                }
                 if (selected is null) {
                     var primary = _primaryRepo?.Invoke();
                     var matching = primary is null ? [] : incoming.Where(choice => choice.Link.RepoHash == primary && choice.Link.HeadRef == _branch && _branch is not null).ToArray();
                     selected = matching.Length == 1 ? matching[0] : incoming.FirstOrDefault();
                 }
+                _updatingChoices = true;
+                try {
+                    if (!_choices.SequenceEqual(incoming)) { _choices.Clear(); _choices.AddRange(incoming); }
+                } finally { _updatingChoices = false; }
                 if (previous != selected?.Subject) Select(selected);
                 else { _selected = selected; this.RaisePropertyChanged(nameof(Selected)); }
-                if (_legacy) { ClearProtected(); SetNotice("Open on GitHub. Native PR reading requires a compatible server and app."); }
+                if (selected is { IsAvailable: false }) {
+                    CancelReads(); ClearProtected(); SetNotice("This pull request is no longer linked or visible. Select another PR or retry.");
+                }
+                else if (_legacy) { ClearProtected(); SetNotice("Open on GitHub. Native PR reading requires a compatible server and app."); }
                 else if (selected is null) { ClearProtected(); SetNotice("No pull requests linked to this session."); }
                 else RequestOverview();
                 Notify();
@@ -70,7 +80,7 @@ public sealed partial class PullRequestContextViewModel {
     }
 
     void RequestOverview() {
-        if (_disposed || !_foreground || _legacy || _stopped || _overviewPending || _session is not { } session || _selected is not { } choice
+        if (_disposed || !_foreground || _legacy || _stopped || _overviewPending || _session is not { } session || _selected is not { IsAvailable: true } choice
             || _retryAt > _time.GetUtcNow().UtcDateTime || _lastOverview is { } last && _time.GetElapsedTime(last).TotalSeconds < 15) return;
         if (!PullRequestWire.IsGitHub(choice.Subject)) { ClearProtected(); SetNotice("Native reading is unavailable for this provider. Open the linked pull request in your browser."); return; }
         _overviewPending = true;

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Reads.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Reads.cs
@@ -1,0 +1,177 @@
+using Capacitor.Cli.Core.PullRequests;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+public sealed partial class PullRequestContextViewModel {
+    bool _refreshDiscovery;
+    bool _refreshPage;
+    PullRequestSectionState? CurrentSection => _sections.GetValueOrDefault(SectionKey);
+
+    void RequestRefresh(bool manual = false) {
+        if (_disposed || !_foreground || _session is not { } session) return;
+        if (manual) { _source.ResetSession(session); _stopped = false; _refreshDiscovery = true; _refreshPage = true; }
+        if (_stopped || _retryAt > _time.GetUtcNow().UtcDateTime) return;
+        if (_refreshing || _lastRefresh is { } last && _time.GetElapsedTime(last).TotalSeconds < 15) {
+            _queuedRefresh |= manual;
+            return;
+        }
+        var refresh = _refreshDiscovery;
+        _refreshDiscovery = false;
+        _queuedRefresh = false;
+        _refreshing = true;
+        _lastRefresh = _time.GetTimestamp();
+        Notify();
+        Start(async ct => {
+            var capability = await _source.DiscoverAsync(refresh, ct).ConfigureAwait(false);
+            var links = capability.Kind switch {
+                PullRequestCapabilityKind.Supported => await _source.ListAsync(session, ct).ConfigureAwait(false),
+                PullRequestCapabilityKind.Legacy or PullRequestCapabilityKind.Unsupported => await _source.LegacyLinksAsync(session, ct).ConfigureAwait(false),
+                _ => null
+            };
+            return () => {
+                _refreshing = false;
+                _legacy = capability.Kind is PullRequestCapabilityKind.Legacy or PullRequestCapabilityKind.Unsupported;
+                if (links is null) {
+                    _retryAt = capability.RetryAt;
+                    ClearProtected();
+                    SetNotice(capability.Kind == PullRequestCapabilityKind.SignedOut ? "Sign in to see pull requests."
+                        : "Couldn't discover pull request support. Retry when the server is reachable.");
+                    return;
+                }
+                if (links.Kind != PullRequestReadKind.Ready || links.Data is null) {
+                    if (links.Kind is PullRequestReadKind.SubjectUnavailable or PullRequestReadKind.SignedOut || links.AccessFailure is "invalid" or "denied") {
+                        CancelReads(); _choices.Clear(); _selected = null; ClearProtected();
+                        _stopped = links.Reason == "retries_stopped";
+                    } else EnterGrace();
+                    SetNotice(_stopped ? "This session's pull requests are unavailable. Use Retry to check again."
+                        : links.Kind == PullRequestReadKind.SignedOut ? "Sign in to see pull requests." : "Couldn't refresh the linked pull requests.");
+                    return;
+                }
+                _retryAt = null;
+                _pollAfter = Math.Max(15, links.PollAfterSeconds);
+                var incoming = links.Data.Items.Select(link => new PullRequestChoice(link)).ToArray();
+                if (!_choices.SequenceEqual(incoming)) { _choices.Clear(); _choices.AddRange(incoming); }
+                var previous = _selected?.Subject;
+                var selected = _explicitSelection ? incoming.FirstOrDefault(choice => choice.Subject == previous) : null;
+                if (selected is null) {
+                    var primary = _primaryRepo?.Invoke();
+                    var matching = primary is null ? [] : incoming.Where(choice => choice.Link.RepoHash == primary && choice.Link.HeadRef == _branch && _branch is not null).ToArray();
+                    selected = matching.Length == 1 ? matching[0] : incoming.FirstOrDefault();
+                }
+                if (previous != selected?.Subject) Select(selected);
+                else { _selected = selected; this.RaisePropertyChanged(nameof(Selected)); }
+                if (_legacy) { ClearProtected(); SetNotice("Open on GitHub. Native PR reading requires a compatible server and app."); }
+                else if (selected is null) { ClearProtected(); SetNotice("No pull requests linked to this session."); }
+                else RequestOverview();
+                Notify();
+            };
+        }, () => _refreshing = false);
+    }
+
+    void RequestOverview() {
+        if (_disposed || !_foreground || _legacy || _stopped || _overviewPending || _session is not { } session || _selected is not { } choice
+            || _retryAt > _time.GetUtcNow().UtcDateTime || _lastOverview is { } last && _time.GetElapsedTime(last).TotalSeconds < 15) return;
+        if (!PullRequestWire.IsGitHub(choice.Subject)) { ClearProtected(); SetNotice("Native reading is unavailable for this provider. Open the linked pull request in your browser."); return; }
+        _overviewPending = true;
+        _lastOverview = _time.GetTimestamp();
+        Notify();
+        Start(async ct => {
+            var read = await _source.OverviewAsync(session, choice.Subject, ct).ConfigureAwait(false);
+            return () => {
+                if (read.Kind is PullRequestReadKind.Ready or PullRequestReadKind.Stale && read.Data is not null && AcceptAccess(read)) {
+                    if (_overview?.HeadSha is { } old && old != read.Data.HeadSha) {
+                        foreach (var state in _sections.Values.Where(state => state.Key == "checks")) { state.Pages.Clear(); state.Stopped = true; state.Error = "The PR head changed. Refresh checks."; }
+                    }
+                    _overview = read.Data; _overviewRead = read;
+                    SetNotice(read.Kind == PullRequestReadKind.Stale ? "Showing an earlier snapshot while GitHub is unavailable." : "");
+                    if (_readerVisible && _section != "overview" && (CurrentSection is null || _refreshPage)) RequestPage(null, refresh: _refreshPage);
+                    _refreshPage = false;
+                } else Fail(read);
+            };
+        }, () => _overviewPending = false);
+    }
+
+    void RequestPage(string? cursor, bool refresh = false, bool earlier = false) {
+        if (_disposed || !CanReveal || _session is not { } session || _selected is not { } choice || _section == "overview"
+            || _retryAt > _time.GetUtcNow().UtcDateTime) return;
+        var key = SectionKey;
+        if (_pageRequests.Contains(key)) return;
+        if (!refresh && CurrentSection is { Stopped: true }) return;
+        var section = _section;
+        var filter = section == "threads" ? _resolved : null;
+        var thread = _thread;
+        _pageRequests.Add(key);
+        Notify();
+        switch (section) {
+            case "checks": Page<PullRequestCheckDto>(ToRow); break;
+            case "reviewers": Page<PullRequestReviewerDto>(ToRow); break;
+            case "reviews": Page<PullRequestReviewDto>(ToRow); break;
+            case "threads": Page<PullRequestThreadDto>(ToRow); break;
+            default: Page<PullRequestCommentDto>(ToRow); break;
+        }
+        void Page<T>(Func<T, PullRequestSubjectDto, PullRequestRow> project) where T : class => Start(async ct => {
+            var read = await _source.PageAsync<T>(session, choice.Subject, section, cursor, filter, thread, ct).ConfigureAwait(false);
+            return () => {
+                if (read.Kind is PullRequestReadKind.Ready or PullRequestReadKind.Stale && read.Data is { } page && AcceptAccess(read)) {
+                    var state = _sections.GetValueOrDefault(key) ?? new PullRequestSectionState(key);
+                    if (state.Snapshot is not null && state.Snapshot != page.SnapshotId && cursor is not null) { FailProtocol(); return; }
+                    if (refresh || state.Snapshot != page.SnapshotId) { state.Pages.Clear(); state.Earlier.Clear(); }
+                    var rows = page.Items.Select(item => project(item, choice.Subject)).ToArray();
+                    var existing = state.Pages.FindIndex(item => item.Cursor == page.PageCursor);
+                    var saved = new PullRequestSectionState.Page(page.PageCursor, page.NextCursor, rows, _time.GetTimestamp());
+                    if (existing >= 0) state.Pages[existing] = saved;
+                    else if (earlier) { state.Pages.Insert(0, saved); state.Earlier.Remove(page.PageCursor); }
+                    else {
+                        var known = state.Pages.SelectMany(p => p.Rows).Select(row => row.Id).ToHashSet(StringComparer.Ordinal);
+                        if (rows.Any(row => !known.Add(row.Id))) { FailProtocol(); return; }
+                        state.Pages.Add(saved);
+                    }
+                    state.Snapshot = page.SnapshotId; state.Started = page.SnapshotStartedAt; state.Completed = page.SnapshotCompletedAt;
+                    state.Fetched = read.FetchedAt; state.Head = page.HeadSha; state.Coverage = page.Coverage; state.CoverageReason = page.CoverageReason;
+                    state.Total = page.Total; state.Excluded = page.ExcludedByFilter; state.Stopped = false; state.Error = null;
+                    _sections[key] = state;
+                    EnforcePageBudget(state, saved, earlier);
+                    state.Next = state.Pages.LastOrDefault()?.Next;
+                    SetNotice(read.Kind == PullRequestReadKind.Stale ? "Showing an earlier page while GitHub is unavailable." : "");
+                } else if (read.Kind == PullRequestReadKind.Restart && read.Reason is not ("identity_changed" or "integration_changed")) {
+                    var state = _sections.GetValueOrDefault(key) ?? new PullRequestSectionState(key);
+                    state.Stopped = true; state.Error = read.Reason == "head_changed" ? "The PR head changed. Refresh checks." : "This snapshot can no longer load pages. Refresh to start again.";
+                    if (read.Reason == "head_changed") state.Pages.Clear();
+                    _sections[key] = state;
+                    Notify();
+                } else Fail(read);
+            };
+        }, () => _pageRequests.Remove(key));
+    }
+    void EnforcePageBudget(PullRequestSectionState state, PullRequestSectionState.Page newest, bool earlier) {
+        while (state.Pages.Count > 8) {
+            var evict = earlier ? state.Pages.Last(page => !ReferenceEquals(page, newest)) : state.Pages.First(page => !ReferenceEquals(page, newest));
+            Evict(state, evict, rememberEarlier: !earlier);
+        }
+        while (_sections.Values.Sum(section => section.Bytes) + 2L * (_overview?.Description?.Length ?? 0) > 32 * 1024 * 1024) {
+            var empty = _sections.Values.FirstOrDefault(section => section.Key != SectionKey && section.Pages.Count == 0);
+            if (empty is not null) { _sections.Remove(empty.Key); continue; }
+            var candidates = _sections.Values.Where(section => section.Pages.Count > 0)
+                .Select(section => (Section: section, Page: section.Pages[0]))
+                .Where(item => !ReferenceEquals(item.Page, newest)).OrderBy(item => item.Section.Key == SectionKey).ThenBy(item => item.Page.Touched).ToArray();
+            if (candidates.Length == 0) break;
+            var evict = candidates[0]; Evict(evict.Section, evict.Page, rememberEarlier: true);
+        }
+    }
+    static void Evict(PullRequestSectionState section, PullRequestSectionState.Page page, bool rememberEarlier) {
+        section.Pages.Remove(page);
+        if (rememberEarlier) {
+            if (section.Earlier.Count >= 5000) section.Earlier.RemoveAt(0);
+            section.Earlier.Add(page.Cursor);
+        }
+    }
+    void Fail<T>(PullRequestRead<T> read) where T : class {
+        _retryAt = read.RetryAt;
+        if (read.AccessFailure == "transient" || read.Kind is PullRequestReadKind.Ready or PullRequestReadKind.Stale
+            || read.AccessFailure is null && read.Reason is "timeout" or "provider_unavailable" or "rate_limited" or "budget_exhausted" or "capacity_exhausted") EnterGrace();
+        else ClearProtected();
+        SetNotice(Reason(read));
+    }
+    void FailProtocol() { ClearProtected(); SetNotice("The server returned an inconsistent PR response. Retry after updating the server and app."); }
+}

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
@@ -1,0 +1,272 @@
+using System.Reactive;
+using System.Reactive.Disposables;
+using System.Reactive.Disposables.Fluent;
+using System.Reactive.Linq;
+using Avalonia.Collections;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Core.PullRequests;
+using ReactiveUI;
+
+namespace Capacitor.App.ViewModels;
+
+public sealed partial class PullRequestContextViewModel : ReactiveObject {
+    sealed record Position(string Section, string? Thread, string Resolved, double Scroll, long Touched);
+    readonly IPullRequestSource _source;
+    readonly TimeProvider _time;
+    readonly IUrlOpener _opener;
+    readonly Action _openReader;
+    readonly Func<string?>? _primaryRepo;
+    readonly CompositeDisposable _subscriptions = new();
+    readonly HashSet<Task> _tasks = [];
+    readonly List<CancellationTokenSource> _retired = [];
+    readonly Dictionary<string, PullRequestSectionState> _sections = new(StringComparer.Ordinal);
+    readonly Dictionary<PullRequestSubjectDto, Position> _positions = [];
+    readonly HashSet<string> _pageRequests = new(StringComparer.Ordinal);
+    readonly AvaloniaList<PullRequestChoice> _choices = [];
+    readonly ITimer _timer;
+    CancellationTokenSource _cancel = new();
+    long _generation;
+    string? _session;
+    string? _branch;
+    PullRequestChoice? _selected;
+    bool _explicitSelection;
+    PullRequestOverviewDto? _overview;
+    PullRequestRead<PullRequestOverviewDto>? _overviewRead;
+    long _accessStarted;
+    int _accessSeconds;
+    long _graceStarted;
+    string? _graceSection;
+    bool _grace;
+    bool _hasDisplayed;
+    bool _foreground;
+    bool _readerVisible;
+    bool _masked = true;
+    bool _refreshing;
+    bool _overviewPending;
+    bool _queuedRefresh;
+    bool _stopped;
+    bool _disposed;
+    bool _legacy;
+    long? _lastRefresh;
+    long? _lastOverview;
+    DateTime? _retryAt;
+    int _pollAfter = 30;
+    string _section = "overview";
+    string? _thread;
+    string _notice = "Waiting for the session to register…";
+
+    public IAvaloniaReadOnlyList<PullRequestChoice> Choices => _choices;
+    public PullRequestChoice? Selected {
+        get => _selected;
+        set => Select(value, explicitSelection: true);
+    }
+    public string Notice => _notice;
+    public bool IsReading => _refreshing || _overviewPending || _pageRequests.Count > 0;
+    public bool HasChoice => _selected is not null;
+    public bool IsLegacy => _legacy;
+    public string Section => _section;
+    public double ScrollOffset { get; set; }
+    public bool CanReveal => _foreground && !_masked && Remaining > 0 && !_legacy;
+    public bool CanDisplay => _foreground && !_masked && (Remaining > 0 || _grace && _time.GetElapsedTime(_graceStarted) < TimeSpan.FromMinutes(5));
+    bool CanDisplayReader => _readerVisible && CanDisplay && (Remaining > 0 || _graceSection == SectionKey);
+    double Remaining => Math.Max(0, _accessSeconds - _time.GetElapsedTime(_accessStarted).TotalSeconds);
+    string SectionKey => _section == "thread_comments" ? _section + ":" + _thread : _section == "threads" ? _section + ":" + _resolved : _section;
+    string _resolved = "unresolved";
+    public bool IncludeResolved {
+        get => _resolved == "all";
+        set {
+            if (value == IncludeResolved || !CanReveal) return;
+            _resolved = value ? "all" : "unresolved";
+            this.RaisePropertyChanged();
+            ShowSection("threads");
+        }
+    }
+    public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+    public ReactiveCommand<Unit, Unit> OpenReaderCommand { get; }
+    public ReactiveCommand<string, Unit> ShowSectionCommand { get; }
+    public ReactiveCommand<Unit, Unit> LoadMoreCommand { get; }
+    public ReactiveCommand<Unit, Unit> ReloadEarlierCommand { get; }
+    public ReactiveCommand<PullRequestRow, Unit> ExpandThreadCommand { get; }
+    public ReactiveCommand<PullRequestRow, Unit> OpenRowCommand { get; }
+    public ReactiveCommand<Unit, Unit> OpenGitHubCommand { get; }
+    public ReactiveCommand<string, Unit> OpenBodyLinkCommand { get; }
+    public ReactiveCommand<Unit, Unit> SignInCommand { get; }
+    public ReactiveCommand<Unit, Unit> LinkGitHubCommand { get; }
+
+    public PullRequestContextViewModel(IObservable<AgentStatusDto?> presence, IPullRequestSource source, TimeProvider time, IUrlOpener opener,
+        Action openReader, Action? signIn = null, Action? linkGitHub = null, IObservable<Unit>? signInCompleted = null, Func<string?>? primaryRepo = null) {
+        _source = source;
+        _time = time;
+        _opener = opener;
+        _openReader = openReader;
+        _primaryRepo = primaryRepo;
+        RefreshCommand = ReactiveCommand.Create(() => RequestRefresh(manual: true));
+        OpenReaderCommand = ReactiveCommand.Create(() => { _openReader(); SetReaderVisible(true); });
+        ShowSectionCommand = ReactiveCommand.Create<string>(ShowSection);
+        LoadMoreCommand = ReactiveCommand.Create(() => { if (CurrentSection?.Next is { } cursor) RequestPage(cursor); });
+        ReloadEarlierCommand = ReactiveCommand.Create(() => { if (CurrentSection?.Evicted is { } cursor) RequestPage(cursor, earlier: true); });
+        ExpandThreadCommand = ReactiveCommand.Create<PullRequestRow>(row => {
+            if (!CanReveal || !row.IsThread) return;
+            _thread = row.Id;
+            ShowSection("thread_comments");
+        });
+        OpenRowCommand = ReactiveCommand.Create<PullRequestRow>(row => {
+            if (CanDisplayReader) LinkPolicy.Open(_opener, row.IsCheck ? PullRequestWire.CheckLink(row.Url) : _selected is null ? null : PullRequestWire.PrLink(row.Url, _selected.Subject));
+        });
+        OpenGitHubCommand = ReactiveCommand.Create(() => LinkPolicy.Open(_opener, PullRequestWire.SafeLink(_selected?.Link.Url)));
+        OpenBodyLinkCommand = ReactiveCommand.Create<string>(url => { if (CanDisplayReader) LinkPolicy.Open(_opener, PullRequestWire.BodyLink(url)); });
+        SignInCommand = ReactiveCommand.Create(() => signIn?.Invoke());
+        LinkGitHubCommand = ReactiveCommand.Create(() => linkGitHub?.Invoke());
+        _subscriptions.Add(RefreshCommand); _subscriptions.Add(OpenReaderCommand); _subscriptions.Add(ShowSectionCommand);
+        _subscriptions.Add(LoadMoreCommand); _subscriptions.Add(ReloadEarlierCommand); _subscriptions.Add(ExpandThreadCommand);
+        _subscriptions.Add(OpenRowCommand); _subscriptions.Add(OpenGitHubCommand); _subscriptions.Add(OpenBodyLinkCommand);
+        _subscriptions.Add(SignInCommand); _subscriptions.Add(LinkGitHubCommand);
+        presence.ObserveOn(RxSchedulers.MainThreadScheduler).Subscribe(dto => {
+            if (_disposed || dto is null) return;
+            _branch = dto.Branch;
+            if (dto.SessionId is not { Length: > 0 } id || _session == id) return;
+            CancelReads();
+            _session = id;
+            _choices.Clear();
+            _selected = null;
+            _explicitSelection = false;
+            _positions.Clear();
+            ClearProtected();
+            _stopped = false;
+            _lastRefresh = null;
+            SetNotice("Loading pull requests…");
+            RequestRefresh();
+        }).DisposeWith(_subscriptions);
+        signInCompleted?.ObserveOn(RxSchedulers.MainThreadScheduler).Subscribe(_ => {
+            if (_session is null || _disposed) return;
+            CancelReads(); ClearProtected(); _source.ResetSession(_session); _stopped = false; _lastRefresh = null; RequestRefresh(manual: true);
+        }).DisposeWith(_subscriptions);
+        _timer = time.CreateTimer(_ => Dispatcher.UIThread.Post(Tick), null, TimeSpan.FromSeconds(1), TimeSpan.FromSeconds(1));
+    }
+
+    public void SetForeground(bool foreground) {
+        if (_disposed || _foreground == foreground) return;
+        _foreground = foreground;
+        CancelReads();
+        _accessSeconds = 0;
+        _masked = true;
+        _grace = false;
+        _graceSection = null;
+        Notify();
+        if (foreground) { _lastRefresh = null; RequestRefresh(); }
+    }
+    public void Reconnected() {
+        if (_disposed) return;
+        _refreshDiscovery = true;
+        RequestRefresh();
+    }
+    public void SetReaderVisible(bool visible) {
+        if (_readerVisible == visible) return;
+        _readerVisible = visible;
+        if (!visible && _grace) _graceSection = null;
+        Notify();
+        if (visible && CanReveal && _section != "overview" && CurrentSection is null) RequestPage(null);
+    }
+    void Select(PullRequestChoice? choice, bool explicitSelection = false) {
+        if (_disposed || choice?.Subject == _selected?.Subject) return;
+        if (choice is not null && !_choices.Contains(choice)) return;
+        _explicitSelection = explicitSelection;
+        if (_selected is not null) {
+            if (_positions.Count >= 20 && !_positions.ContainsKey(_selected.Subject)) _positions.Remove(_positions.MinBy(x => x.Value.Touched).Key);
+            _positions[_selected.Subject] = new(_section, _thread, _resolved, ScrollOffset, _time.GetTimestamp());
+        }
+        CancelReads();
+        _selected = choice;
+        ClearProtected();
+        _section = "overview"; _thread = null; _resolved = "unresolved"; ScrollOffset = 0;
+        if (choice is not null && _positions.TryGetValue(choice.Subject, out var position)) {
+            _section = position.Section; _thread = position.Thread; _resolved = position.Resolved; ScrollOffset = position.Scroll;
+        }
+        this.RaisePropertyChanged(nameof(Selected));
+        Notify();
+        RequestOverview();
+    }
+    void ShowSection(string section) {
+        if (!CanReveal || section is not ("overview" or "checks" or "reviewers" or "reviews" or "threads" or "thread_comments" or "conversation")) return;
+        _section = section;
+        ScrollOffset = 0;
+        _openReader();
+        _readerVisible = true;
+        Notify();
+        if (section != "overview" && CurrentSection is null) RequestPage(null);
+    }
+    void Tick() {
+        if (_disposed || !_foreground) return;
+        if (!_masked && _accessSeconds > 0 && Remaining <= 0 && !_grace) EnterGrace();
+        if (_grace && _time.GetElapsedTime(_graceStarted) >= TimeSpan.FromMinutes(5)) { _masked = true; _grace = false; Notify(); }
+        if (_retryAt > _time.GetUtcNow().UtcDateTime || _stopped) return;
+        if (_queuedRefresh || _lastRefresh is null || _time.GetElapsedTime(_lastRefresh.Value).TotalSeconds >= Math.Max(30, _pollAfter)) RequestRefresh();
+        else if (Remaining <= 5 && !_legacy) RequestOverview();
+    }
+    void EnterGrace() {
+        _accessSeconds = 0;
+        if (!_hasDisplayed || !_foreground || _masked) { _masked = true; Notify(); return; }
+        if (!_grace) { _grace = true; _graceStarted = _time.GetTimestamp(); _graceSection = _readerVisible ? SectionKey : null; }
+        SetNotice("Access could not be refreshed. Showing the last view temporarily; opening more content is paused.");
+    }
+    bool AcceptAccess<T>(PullRequestRead<T> read) where T : class {
+        if (!read.CanReveal(_time) || read.Subject != _selected?.Subject) return false;
+        _accessStarted = read.RequestStarted;
+        _accessSeconds = read.AccessValidForSeconds;
+        _masked = false;
+        _grace = false;
+        _hasDisplayed = true;
+        _retryAt = read.RetryAt;
+        _pollAfter = Math.Max(15, read.PollAfterSeconds);
+        return true;
+    }
+    void ClearProtected() {
+        _overview = null; _overviewRead = null; _sections.Clear(); _accessSeconds = 0;
+        _masked = true; _grace = false; _hasDisplayed = false; _graceSection = null;
+        Notify();
+    }
+    void CancelReads() {
+        _generation++;
+        _cancel.Cancel();
+        if (_tasks.Count == 0) _cancel.Dispose();
+        else _retired.Add(_cancel);
+        _cancel = new();
+        _refreshing = false; _overviewPending = false; _pageRequests.Clear(); _lastOverview = null;
+    }
+    void Start(Func<CancellationToken, Task<Action>> operation, Action settled) {
+        var generation = _generation;
+        var token = _cancel.Token;
+        var task = Run();
+        _tasks.Add(task);
+        _ = task.ContinueWith(done => Dispatcher.UIThread.Post(() => {
+            _tasks.Remove(done);
+            if (_tasks.Count != 0 || _disposed) return;
+            foreach (var retired in _retired) retired.Dispose();
+            _retired.Clear();
+        }), TaskScheduler.Default);
+        async Task Run() {
+            try {
+                var apply = await operation(token).ConfigureAwait(false);
+                await Dispatcher.UIThread.InvokeAsync(() => { if (!_disposed && generation == _generation && !token.IsCancellationRequested) apply(); });
+            } catch (OperationCanceledException) { }
+            catch (Exception) {
+                await Dispatcher.UIThread.InvokeAsync(() => {
+                    if (!_disposed && generation == _generation) { ClearProtected(); SetNotice("Couldn't load pull request context. Retry when the server is reachable."); }
+                });
+            } finally {
+                await Dispatcher.UIThread.InvokeAsync(() => { if (!_disposed && generation == _generation) { settled(); Notify(); } });
+            }
+        }
+    }
+    void SetNotice(string value) { _notice = value; Notify(); }
+    public async Task TeardownAsync() {
+        if (_disposed) return;
+        _disposed = true;
+        _timer.Dispose(); _subscriptions.Dispose(); _cancel.Cancel();
+        try { await Task.WhenAll(_tasks.ToArray()); } catch (OperationCanceledException) { }
+        _cancel.Dispose(); foreach (var retired in _retired) retired.Dispose();
+        _tasks.Clear(); _retired.Clear(); _positions.Clear(); _choices.Clear(); ClearProtected();
+    }
+}

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
@@ -32,6 +32,7 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
     string? _branch;
     PullRequestChoice? _selected;
     bool _explicitSelection;
+    bool _updatingChoices;
     PullRequestOverviewDto? _overview;
     PullRequestRead<PullRequestOverviewDto>? _overviewRead;
     long _accessStarted;
@@ -60,7 +61,7 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
     public IAvaloniaReadOnlyList<PullRequestChoice> Choices => _choices;
     public PullRequestChoice? Selected {
         get => _selected;
-        set => Select(value, explicitSelection: true);
+        set { if (!_updatingChoices) Select(value, explicitSelection: true); }
     }
     public string Notice => _notice;
     public bool IsReading => _refreshing || _overviewPending || _pageRequests.Count > 0;
@@ -115,7 +116,11 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
         OpenRowCommand = ReactiveCommand.Create<PullRequestRow>(row => {
             if (CanDisplayReader) LinkPolicy.Open(_opener, row.IsCheck ? PullRequestWire.CheckLink(row.Url) : _selected is null ? null : PullRequestWire.PrLink(row.Url, _selected.Subject));
         });
-        OpenGitHubCommand = ReactiveCommand.Create(() => LinkPolicy.Open(_opener, PullRequestWire.SafeLink(_selected?.Link.Url)));
+        OpenGitHubCommand = ReactiveCommand.Create(() => {
+            if (_selected is { IsAvailable: true } choice)
+                LinkPolicy.Open(_opener, PullRequestWire.IsGitHub(choice.Subject)
+                    ? PullRequestWire.PrLink(choice.Link.Url, choice.Subject) : PullRequestWire.SafeLink(choice.Link.Url));
+        });
         OpenBodyLinkCommand = ReactiveCommand.Create<string>(url => { if (CanDisplayReader) LinkPolicy.Open(_opener, PullRequestWire.BodyLink(url)); });
         SignInCommand = ReactiveCommand.Create(() => signIn?.Invoke());
         LinkGitHubCommand = ReactiveCommand.Create(() => linkGitHub?.Invoke());

--- a/src/Capacitor.App/ViewModels/PullRequestRow.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestRow.cs
@@ -1,0 +1,11 @@
+namespace Capacitor.App.ViewModels;
+
+public sealed record PullRequestRow(string Id, string Title, string Detail, string? Body, string? Hunk, string? Url,
+    string Availability, bool Truncated = false, bool IsThread = false, bool IsCheck = false, string? Outcome = null) {
+    public bool HasBody => Availability == "available" && Body is { Length: > 0 };
+    public bool HasHunk => Availability == "available" && Hunk is { Length: > 0 };
+    public bool HasLink => Url is not null;
+    public string ItemNote => Availability switch { "available" => Truncated ? "Preview truncated — full text on GitHub." : "",
+        "redacted" => "This item is hidden.", _ => "This item could not be read." };
+    internal long Bytes => 256 + 2L * (Id.Length + Title.Length + Detail.Length + (Body?.Length ?? 0) + (Hunk?.Length ?? 0) + (Url?.Length ?? 0));
+}

--- a/src/Capacitor.App/ViewModels/PullRequestSectionState.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestSectionState.cs
@@ -1,0 +1,26 @@
+using Capacitor.Cli.Core.PullRequests;
+
+namespace Capacitor.App.ViewModels;
+
+internal sealed class PullRequestSectionState(string key) {
+    internal sealed record Page(string Cursor, string? Next, PullRequestRow[] Rows, long Touched) {
+        internal long Bytes => 256 + 2L * (Cursor.Length + (Next?.Length ?? 0)) + Rows.Sum(row => row.Bytes);
+    }
+    internal string Key { get; } = key;
+    internal List<Page> Pages { get; } = [];
+    internal string? Snapshot;
+    internal DateTime? Started;
+    internal DateTime? Completed;
+    internal DateTime? Fetched;
+    internal string? Head;
+    internal string Coverage = "limited";
+    internal string? CoverageReason;
+    internal PullRequestCountDto? Total;
+    internal PullRequestCountDto? Excluded;
+    internal string? Next;
+    internal bool Stopped;
+    internal string? Error;
+    internal List<string> Earlier { get; } = [];
+    internal string? Evicted => Earlier.LastOrDefault();
+    internal long Bytes => 512 + 2L * (Key.Length + (Snapshot?.Length ?? 0) + Earlier.Sum(cursor => cursor.Length)) + Pages.Sum(page => page.Bytes);
+}

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
@@ -252,6 +252,8 @@ public sealed partial class WorkContextViewModel {
     void ApplyLinks(WorkContextRead read) {
         if (read.SummaryFailed) return;
         if (read.Summary is not { } summary) return;
+        var primaryRepositories = summary.Repositories.Where(repository => repository.IsPrimary).ToArray();
+        PrimaryRepositoryHash = primaryRepositories.Length == 1 ? primaryRepositories[0].RepoHash : null;
 
         var cards = summary.PullRequests
             .Select(pr => Link(pr.Number, pr.Title, pr.Url))

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
@@ -21,6 +21,10 @@ public enum WorkContextPhase { WaitingForSession, Loading, Ready, NoWorkItem, Si
 /// read; a result applies only for the current lease, every lease is kept until its read settles
 /// so teardown can await them all, and every lease transition happens on the UI thread.
 public sealed partial class WorkContextViewModel : ReactiveObject {
+    public PullRequestContextViewModel? PullRequests { get; internal set; }
+    public bool HasPullRequestContext => PullRequests is not null;
+    public bool ShowsLegacyLinks => PullRequests is null;
+    public string? PrimaryRepositoryHash { get; private set; }
     internal static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(30);
     static readonly IReadOnlyList<HarnessOption> DefaultHarnessOptions = HostedHarnessCatalog.Build(null);
 
@@ -200,6 +204,7 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
         old?.Cts.Cancel();
         HasSession = true;
         SessionIdText = id;
+        PrimaryRepositoryHash = null;
         ClearServerProjections();
         IsStale = false;
         Phase = WorkContextPhase.Loading;

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -5,36 +5,17 @@ using System.Reactive.Linq;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Core.PullRequests;
 using DynamicData;
 using ReactiveUI;
 
 namespace Capacitor.App.ViewModels;
 
-public enum WorkspaceTab { Chat, Terminal }
+public enum WorkspaceTab { Chat, Terminal, PullRequest }
 
-/// The session workspace: header (title/repo/vendor chip) + Chat and Terminal tabs, for one agent
-/// id. Constructed once per workspace, like TerminalTabViewModel/HomeViewModel -- ctor-scoped, not
-/// WhenActivated -- since the header projections and the Terminal tab must be live from
-/// construction, not deferred to a window's activation.
-///
-/// Every header projection below derives from ONE Scan-based aggregate over a single Filter'd view
-/// of daemon.Agents.Connect() (filtered to this agent id, ObserveOn the UI scheduler BEFORE
-/// anything touches bound state -- the same rule every other daemon.Agents/Snapshots consumer in
-/// this app follows), multicast via Replay(1)/RefCount so the several OAPHs below share ONE
-/// subscription to the daemon's cache rather than each opening (and independently re-deriving
-/// state from) their own. Replay(1) specifically -- not Publish -- because the 8 downstream
-/// subscribers below all attach within the SAME synchronous constructor call: a plain Publish
-/// would only deliver an already-fired synchronous replay (e.g. the agent already being in the
-/// cache when this VM is built) to whichever subscriber happened to attach first, leaving the rest
-/// with no initial value until the NEXT change -- which may never come. Scan's own output already
-/// IS the complete current state (dto + sticky-ended), so replaying just the latest one to a late
-/// subscriber is exactly correct, unlike replaying a raw changeset to a fresh DynamicData query
-/// aggregator would be.
-///
-/// A removed or terminal-status agent freezes its LAST known dto rather than blanking the header
-/// back to placeholders -- SessionEnded flips (sticky, mirroring TerminalTabViewModel's own
-/// Exited/Failed stickiness) but Title/RepoLabelText/etc keep identifying the session
-/// that just ended instead of reverting to "—".
+/// Owns the persistent Chat, Terminal and PR surfaces for one agent. Presence is
+/// replayed as accumulated state so each subscriber receives an already-cached agent.
+/// Ended or removed agents retain their last known session context.
 public sealed class WorkspaceViewModel : ReactiveObject {
     const string UnresolvedKind = "unresolved";
 
@@ -71,6 +52,8 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     /// The right pane. Fed by the same presence stream as the header, so the daemon cache has one
     /// subscription per workspace, not two.
     public WorkContextViewModel WorkContext { get; }
+    public PullRequestContextViewModel? PullRequests { get; }
+    public bool ShowsPullRequestTab => PullRequests is not null;
 
     WorkspaceTab _activeTab = WorkspaceTab.Chat;
     public WorkspaceTab ActiveTab {
@@ -79,13 +62,19 @@ public sealed class WorkspaceViewModel : ReactiveObject {
             this.RaiseAndSetIfChanged(ref _activeTab, value);
             this.RaisePropertyChanged(nameof(IsChatActive));
             this.RaisePropertyChanged(nameof(IsTerminalActive));
+            this.RaisePropertyChanged(nameof(IsPullRequestActive));
+            this.RaisePropertyChanged(nameof(ShowsTerminalBanners));
+            PullRequests?.SetReaderVisible(value == WorkspaceTab.PullRequest);
         }
     }
     public bool IsChatActive => ActiveTab == WorkspaceTab.Chat;
     public bool IsTerminalActive => ActiveTab == WorkspaceTab.Terminal;
+    public bool IsPullRequestActive => ActiveTab == WorkspaceTab.PullRequest;
+    public bool ShowsTerminalBanners => !IsPullRequestActive && (IsTerminalActive || !ShowsTerminalTab);
 
     public ReactiveCommand<Unit, Unit> ShowChatCommand { get; }
     public ReactiveCommand<Unit, Unit> ShowTerminalCommand { get; }
+    public ReactiveCommand<Unit, Unit> ShowPullRequestCommand { get; }
 
     public ReactiveCommand<Unit, Unit> OpenInWebCommand { get; }
     public ReactiveCommand<Unit, Unit> StopCommand { get; }
@@ -101,7 +90,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
             string agentId, IDaemonClientService daemon, AgentActionService actions,
             TerminalAttachClientFactory factory, Func<ITerminalSurface> surfaceFactory, TimeProvider time,
             IUrlOpener opener, IPermissionService permissions, IWorkContextSource workContext,
-            Action? requestSignIn = null, IObservable<Unit>? signInCompleted = null) {
+            Action? requestSignIn = null, IObservable<Unit>? signInCompleted = null, IPullRequestSource? pullRequests = null, Action? linkGitHub = null) {
         AgentId = agentId;
         Terminal = new TerminalTabViewModel(agentId, daemon, factory, surfaceFactory, time);
 
@@ -113,6 +102,12 @@ public sealed class WorkspaceViewModel : ReactiveObject {
             .RefCount();
 
         WorkContext = new WorkContextViewModel(presence.Select(p => p.Dto), workContext, time, opener, requestSignIn, signInCompleted);
+        PullRequests = pullRequests is null ? null : new PullRequestContextViewModel(presence.Select(p => p.Dto), pullRequests, time, opener,
+            () => ActiveTab = WorkspaceTab.PullRequest, requestSignIn, linkGitHub, signInCompleted, () => WorkContext.PrimaryRepositoryHash);
+        WorkContext.PullRequests = PullRequests;
+        daemon.Status.Select(status => status.State).DistinctUntilChanged().Skip(1)
+            .Where(state => state == AttachState.Connected).ObserveOn(RxSchedulers.MainThreadScheduler)
+            .Subscribe(_ => PullRequests?.Reconnected()).DisposeWith(_disposables);
 
         presence.Select(p => p.Dto).Subscribe(dto => _latestDto = dto).DisposeWith(_disposables);
 
@@ -125,6 +120,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         _showsTerminalTab = presence.Select(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
             .ToProperty(this, x => x.ShowsTerminalTab, initialValue: false)
             .DisposeWith(_disposables);
+        presence.Subscribe(_ => this.RaisePropertyChanged(nameof(ShowsTerminalBanners))).DisposeWith(_disposables);
         // Blank whenever ShowsTerminalTab is true (or the dto isn't resolved yet): the note
         // replaces the Terminal tab button in the tab strip, so it must never render alongside it.
         _noTerminalNote = presence
@@ -144,8 +140,10 @@ public sealed class WorkspaceViewModel : ReactiveObject {
 
         ShowChatCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Chat; });
         ShowTerminalCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Terminal; });
+        ShowPullRequestCommand = ReactiveCommand.Create(() => { if (PullRequests is not null) ActiveTab = WorkspaceTab.PullRequest; });
         _disposables.Add(ShowChatCommand);
         _disposables.Add(ShowTerminalCommand);
+        _disposables.Add(ShowPullRequestCommand);
 
         OpenInWebCommand = ReactiveCommand.Create(() => actions.OpenInWeb(agentId));
         _disposables.Add(OpenInWebCommand);
@@ -193,6 +191,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     /// work-context pane, and Terminal last -- the caller that closes a workspace tab calls this once.
     public async Task TeardownAsync() {
         _disposables.Dispose();
+        if (PullRequests is { } pullRequests) await pullRequests.TeardownAsync();
         if (Chat is { } chat) await chat.TeardownAsync();
         await WorkContext.TeardownAsync();
         await Terminal.TeardownAsync();

--- a/src/Capacitor.App/Views/MainWindow.axaml.cs
+++ b/src/Capacitor.App/Views/MainWindow.axaml.cs
@@ -26,6 +26,7 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel> {
     // Defaults to false — the Activity flyout starts closed (MainWindow.axaml), so Activity is off
     // regardless of the window's own visibility.
     bool _activityOpen;
+    WorkspaceViewModel? _foregroundWorkspace;
 
     /// Assigned by App.BuildAndShowMainWindow (spec §11) — the SAME IAppNotifier instance
     /// AgentActionService pushes into, so the toast overlay and stderr mirroring are always in
@@ -100,14 +101,23 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel> {
         // DataContextProperty too — defensive: production always assigns DataContext before the
         // first Show(), but this keeps the check correct even if a caller (a test) does it the
         // other way around.
-        if (change.Property == IsVisibleProperty || change.Property == DataContextProperty) UpdateActivityVisibility();
+        if (change.Property == IsVisibleProperty || change.Property == DataContextProperty
+            || change.Property == IsActiveProperty || change.Property == WindowStateProperty) UpdateActivityVisibility();
     }
 
     // Activity polls only when it is ACTUALLY on screen: window visible AND the launcher pane
     // showing (Sessions surface, no workspace open) AND the flyout open — the same contract the
     // Activity tab's selection used to carry.
     void UpdateActivityVisibility() {
-        if (DataContext is MainWindowViewModel vm)
+        if (DataContext is MainWindowViewModel vm) {
             vm.Activity.OnTabVisibleChanged(_activityOpen && IsVisible && vm.IsSessionsView && vm.CurrentWorkspace is null);
+            var workspace = vm.IsSessionsView ? vm.CurrentWorkspace : null;
+            if (_foregroundWorkspace != workspace) _foregroundWorkspace?.PullRequests?.SetForeground(false);
+            _foregroundWorkspace = workspace;
+            workspace?.PullRequests?.SetForeground(IsVisible && IsActive && WindowState != Avalonia.Controls.WindowState.Minimized);
+        } else {
+            _foregroundWorkspace?.PullRequests?.SetForeground(false);
+            _foregroundWorkspace = null;
+        }
     }
 }

--- a/src/Capacitor.App/Views/PullRequestCard.axaml
+++ b/src/Capacitor.App/Views/PullRequestCard.axaml
@@ -1,0 +1,44 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Capacitor.App.ViewModels"
+             x:Class="Capacitor.App.Views.PullRequestCard"
+             x:DataType="vm:PullRequestContextViewModel">
+    <Border Margin="0,10,0,0" Padding="13" CornerRadius="10" BorderThickness="1"
+            Background="{StaticResource KcapSurfaceRaisedBrush}" BorderBrush="{StaticResource KcapBorderBrush}">
+        <StackPanel Spacing="8">
+            <Grid ColumnDefinitions="*,Auto">
+                <TextBlock Text="PULL REQUEST" FontSize="10" FontWeight="Bold" LetterSpacing="1"
+                           Foreground="{StaticResource KcapFaintBrush}" VerticalAlignment="Center" />
+                <Button Grid.Column="1" Content="Refresh" Command="{Binding RefreshCommand}" Padding="7,3" FontSize="11"
+                        Background="Transparent" BorderThickness="0" Foreground="{StaticResource KcapMutedBrush}" />
+            </Grid>
+            <ComboBox ItemsSource="{Binding Choices}" SelectedItem="{Binding Selected, Mode=TwoWay}"
+                      IsVisible="{Binding HasChoice}" HorizontalAlignment="Stretch" FontSize="11.5"
+                      AutomationProperties.Name="Linked pull request">
+                <ComboBox.ItemTemplate>
+                    <DataTemplate x:DataType="vm:PullRequestChoice">
+                        <TextBlock Text="{Binding Label}" TextTrimming="CharacterEllipsis" />
+                    </DataTemplate>
+                </ComboBox.ItemTemplate>
+            </ComboBox>
+            <TextBlock Text="{Binding Title}" FontSize="13" FontWeight="SemiBold" TextWrapping="Wrap" MaxLines="2"
+                       Foreground="{StaticResource KcapTextBrush}" />
+            <StackPanel Spacing="5" IsVisible="{Binding CanDisplay}">
+                <TextBlock Text="{Binding Lifecycle}" FontSize="11" FontWeight="Bold" Foreground="{StaticResource KcapPurpleBrush}" />
+                <TextBlock Text="{Binding Branches}" FontSize="11" TextTrimming="CharacterEllipsis" Foreground="{StaticResource KcapMutedBrush}" />
+                <TextBlock Text="{Binding CheckSummary}" FontSize="11.5" TextWrapping="Wrap" Foreground="{StaticResource KcapTextBrush}" />
+                <TextBlock Text="{Binding ReviewSummary}" FontSize="11.5" Foreground="{StaticResource KcapTextBrush}" />
+                <TextBlock Text="{Binding FetchedLabel}" FontSize="10.5" Foreground="{StaticResource KcapFaintBrush}" />
+            </StackPanel>
+            <TextBlock Text="{Binding Notice}" IsVisible="{Binding HasNotice}" FontSize="11.5" TextWrapping="Wrap"
+                       Foreground="{StaticResource KcapMutedBrush}" />
+            <StackPanel Orientation="Horizontal" Spacing="7">
+                <Button Content="Read PR" Command="{Binding OpenReaderCommand}" IsVisible="{Binding HasChoice}"
+                        IsEnabled="{Binding !IsLegacy}" Padding="10,5" FontSize="11.5" />
+                <Button Content="Open pull request" Command="{Binding OpenGitHubCommand}" IsVisible="{Binding HasChoice}" Padding="10,5" FontSize="11.5" />
+            </StackPanel>
+            <Button Content="Sign in" Command="{Binding SignInCommand}" IsVisible="{Binding ShowsSignIn}" HorizontalAlignment="Left" />
+            <Button Content="Link GitHub" Command="{Binding LinkGitHubCommand}" IsVisible="{Binding ShowsLinkGitHub}" HorizontalAlignment="Left" />
+        </StackPanel>
+    </Border>
+</UserControl>

--- a/src/Capacitor.App/Views/PullRequestCard.axaml.cs
+++ b/src/Capacitor.App/Views/PullRequestCard.axaml.cs
@@ -1,0 +1,7 @@
+using Avalonia.Controls;
+
+namespace Capacitor.App.Views;
+
+public partial class PullRequestCard : UserControl {
+    public PullRequestCard() => InitializeComponent();
+}

--- a/src/Capacitor.App/Views/PullRequestReader.axaml
+++ b/src/Capacitor.App/Views/PullRequestReader.axaml
@@ -1,0 +1,80 @@
+<UserControl xmlns="https://github.com/avaloniaui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             xmlns:vm="clr-namespace:Capacitor.App.ViewModels"
+             xmlns:views="clr-namespace:Capacitor.App.Views"
+             x:Class="Capacitor.App.Views.PullRequestReader"
+             x:DataType="vm:PullRequestContextViewModel"
+             Background="{StaticResource KcapCanvasBrush}">
+    <Grid RowDefinitions="Auto,Auto,*">
+        <StackPanel Margin="22,18,22,12" Spacing="8">
+            <Grid ColumnDefinitions="*,Auto,Auto">
+                <TextBlock Text="{Binding Title}" FontSize="19" FontWeight="SemiBold" TextWrapping="Wrap"
+                           Foreground="{StaticResource KcapTextBrush}" Margin="0,0,16,0" />
+                <Button Grid.Column="1" Content="Refresh" Command="{Binding RefreshCommand}" Margin="0,0,8,0" VerticalAlignment="Top" />
+                <Button Grid.Column="2" Content="Open on GitHub" Command="{Binding OpenGitHubCommand}" VerticalAlignment="Top" />
+            </Grid>
+            <TextBlock Text="{Binding Branches}" Foreground="{StaticResource KcapMutedBrush}" FontSize="12" />
+            <TextBlock Text="{Binding AccessLabel}" Foreground="{StaticResource KcapFaintBrush}" FontSize="11" />
+            <TextBlock Text="{Binding Notice}" IsVisible="{Binding HasNotice}" Foreground="{StaticResource KcapWarningBrush}"
+                       TextWrapping="Wrap" FontSize="12" />
+            <TextBlock Text="Read here. Reply, resolve, review, or view the full diff on GitHub."
+                       Foreground="{StaticResource KcapMutedBrush}" FontSize="11.5" TextWrapping="Wrap" />
+        </StackPanel>
+        <WrapPanel Grid.Row="1" Margin="22,0,22,10" IsEnabled="{Binding CanReveal}">
+            <Button Content="Description" Command="{Binding ShowSectionCommand}" CommandParameter="overview" Margin="0,0,6,6" />
+            <Button Content="Checks" Command="{Binding ShowSectionCommand}" CommandParameter="checks" Margin="0,0,6,6" />
+            <Button Content="Reviewers" Command="{Binding ShowSectionCommand}" CommandParameter="reviewers" Margin="0,0,6,6" />
+            <Button Content="Reviews" Command="{Binding ShowSectionCommand}" CommandParameter="reviews" Margin="0,0,6,6" />
+            <Button Content="Threads" Command="{Binding ShowSectionCommand}" CommandParameter="threads" Margin="0,0,6,6" />
+            <Button Content="Conversation" Command="{Binding ShowSectionCommand}" CommandParameter="conversation" Margin="0,0,6,6" />
+        </WrapPanel>
+        <ScrollViewer x:Name="ReaderScroll" Grid.Row="2" VerticalScrollBarVisibility="Auto" HorizontalScrollBarVisibility="Disabled">
+            <StackPanel Margin="22,0,22,24" Spacing="12">
+                <TextBlock Text="{Binding SectionTitle}" FontSize="15" FontWeight="SemiBold" Foreground="{StaticResource KcapTextBrush}" />
+                <StackPanel IsVisible="{Binding IsOverview}" Spacing="10">
+                    <TextBlock Text="{Binding DescriptionNote}" Foreground="{StaticResource KcapMutedBrush}" TextWrapping="Wrap" />
+                    <views:MarkdownView Text="{Binding Description}" OpenLink="{Binding OpenBodyLinkCommand}" />
+                    <TextBlock Text="Description preview truncated. Open on GitHub for the full text."
+                               IsVisible="{Binding DescriptionTruncated}" Foreground="{StaticResource KcapMutedBrush}" TextWrapping="Wrap" />
+                </StackPanel>
+                <CheckBox Content="Include resolved threads" IsChecked="{Binding IncludeResolved, Mode=TwoWay}"
+                          IsVisible="{Binding IsThreads}" IsEnabled="{Binding CanReveal}" />
+                <Button Content="Back to threads" Command="{Binding ShowSectionCommand}" CommandParameter="threads"
+                        IsVisible="{Binding IsThreadComments}" IsEnabled="{Binding CanReveal}" HorizontalAlignment="Left" />
+                <TextBlock Text="{Binding SnapshotLabel}" Foreground="{StaticResource KcapFaintBrush}" FontSize="11" />
+                <TextBlock Text="{Binding PageNote}" Foreground="{StaticResource KcapMutedBrush}" TextWrapping="Wrap" />
+                <Button Content="Reload earlier" Command="{Binding ReloadEarlierCommand}" IsVisible="{Binding CanReloadEarlier}" HorizontalAlignment="Left" />
+                <ItemsControl ItemsSource="{Binding Rows}">
+                    <ItemsControl.ItemTemplate>
+                        <DataTemplate x:DataType="vm:PullRequestRow">
+                            <Border Padding="15" Margin="0,0,0,12" CornerRadius="9" BorderThickness="1"
+                                    Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}">
+                                <StackPanel Spacing="9">
+                                    <TextBlock Text="{Binding Title}" FontWeight="SemiBold" Foreground="{StaticResource KcapTextBrush}" TextWrapping="Wrap" />
+                                    <TextBlock Text="{Binding Detail}" FontSize="11.5" Foreground="{StaticResource KcapMutedBrush}" TextWrapping="Wrap" />
+                                    <Border IsVisible="{Binding HasHunk}" Background="{StaticResource KcapSurfaceRaisedBrush}" Padding="10" CornerRadius="5">
+                                        <SelectableTextBlock Text="{Binding Hunk}" FontFamily="Menlo,Monaco,Consolas,monospace"
+                                                             FontSize="11" TextWrapping="Wrap" Foreground="{StaticResource KcapMutedBrush}" />
+                                    </Border>
+                                    <views:MarkdownView Text="{Binding Body}" IsVisible="{Binding HasBody}"
+                                        OpenLink="{Binding $parent[views:PullRequestReader].((vm:PullRequestContextViewModel)DataContext).OpenBodyLinkCommand}" />
+                                    <TextBlock Text="{Binding ItemNote}" FontSize="11.5" TextWrapping="Wrap" Foreground="{StaticResource KcapMutedBrush}" />
+                                    <StackPanel Orientation="Horizontal" Spacing="8">
+                                        <Button Content="Open source" IsVisible="{Binding HasLink}"
+                                                Command="{Binding $parent[views:PullRequestReader].((vm:PullRequestContextViewModel)DataContext).OpenRowCommand}"
+                                                CommandParameter="{Binding}" />
+                                        <Button Content="View replies" IsVisible="{Binding IsThread}"
+                                                IsEnabled="{Binding $parent[views:PullRequestReader].((vm:PullRequestContextViewModel)DataContext).CanReveal}"
+                                                Command="{Binding $parent[views:PullRequestReader].((vm:PullRequestContextViewModel)DataContext).ExpandThreadCommand}"
+                                                CommandParameter="{Binding}" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </DataTemplate>
+                    </ItemsControl.ItemTemplate>
+                </ItemsControl>
+                <Button Content="Load more" Command="{Binding LoadMoreCommand}" IsVisible="{Binding HasMore}" HorizontalAlignment="Left" />
+            </StackPanel>
+        </ScrollViewer>
+    </Grid>
+</UserControl>

--- a/src/Capacitor.App/Views/PullRequestReader.axaml.cs
+++ b/src/Capacitor.App/Views/PullRequestReader.axaml.cs
@@ -1,0 +1,35 @@
+using System.ComponentModel;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Capacitor.App.ViewModels;
+
+namespace Capacitor.App.Views;
+
+public partial class PullRequestReader : UserControl {
+    PullRequestContextViewModel? _model;
+    bool _restoring;
+    public PullRequestReader() {
+        InitializeComponent();
+        DataContextChanged += (_, _) => {
+            if (_model is not null) _model.PropertyChanged -= ModelChanged;
+            _model = DataContext as PullRequestContextViewModel;
+            if (_model is not null) _model.PropertyChanged += ModelChanged;
+        };
+        ReaderScroll.ScrollChanged += (_, _) => { if (!_restoring && _model?.ShowReaderContent == true) _model.ScrollOffset = ReaderScroll.Offset.Y; };
+    }
+    void ModelChanged(object? sender, PropertyChangedEventArgs change) {
+        if (change.PropertyName is not (nameof(PullRequestContextViewModel.Rows) or nameof(PullRequestContextViewModel.Section))) return;
+        var model = _model;
+        if (model is null || !model.ShowReaderContent) return;
+        var offset = model.ScrollOffset;
+        var subject = model.Selected?.Subject;
+        var section = model.Section;
+        Dispatcher.UIThread.Post(() => {
+            if (_model != model || !model.ShowReaderContent || model.Selected?.Subject != subject || model.Section != section) return;
+            _restoring = true;
+            ReaderScroll.Offset = new Vector(0, offset);
+            _restoring = false;
+        }, DispatcherPriority.Loaded);
+    }
+}

--- a/src/Capacitor.App/Views/WorkContextView.axaml
+++ b/src/Capacitor.App/Views/WorkContextView.axaml
@@ -1,6 +1,7 @@
 <UserControl xmlns="https://github.com/avaloniaui"
              xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
              xmlns:vm="clr-namespace:Capacitor.App.ViewModels"
+             xmlns:views="clr-namespace:Capacitor.App.Views"
              x:Class="Capacitor.App.Views.WorkContextView"
              x:DataType="vm:WorkContextViewModel"
              Background="{StaticResource KcapSurfaceBrush}">
@@ -246,7 +247,9 @@
                     </StackPanel>
                 </Border>
 
-                <ItemsControl x:Name="LinkCards" ItemsSource="{Binding Links}" ItemTemplate="{StaticResource LinkCard}" />
+                <ItemsControl x:Name="LinkCards" ItemsSource="{Binding Links}" ItemTemplate="{StaticResource LinkCard}" IsVisible="{Binding ShowsLegacyLinks}" />
+                <views:PullRequestCard DataContext="{Binding PullRequests}"
+                    IsVisible="{Binding $parent[views:WorkContextView].((vm:WorkContextViewModel)DataContext).HasPullRequestContext}" />
                 <ContentControl x:Name="IssueCard" Content="{Binding Issue}" ContentTemplate="{StaticResource LinkCard}" IsVisible="{Binding HasIssue}" />
 
                 <!-- Who's on it: the item's contributors, or this session's requester until an item has any. -->

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -60,15 +60,17 @@
              family-aware note in their place otherwise (it never names a vendor). -->
         <Border Grid.Row="1" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="0,1,0,1">
             <Grid Margin="20,0">
-                <StackPanel Orientation="Horizontal" Spacing="6" IsVisible="{Binding ShowsTerminalTab}"
+                <StackPanel Orientation="Horizontal" Spacing="6"
                             HorizontalAlignment="Left" VerticalAlignment="Center">
                     <Button x:Name="ChatTabButton" Content="Chat" Classes="tab" Classes.active="{Binding IsChatActive}"
-                            Command="{Binding ShowChatCommand}" />
+                            Command="{Binding ShowChatCommand}" IsVisible="{Binding ShowsTerminalTab}" />
                     <Button x:Name="TerminalTabButton" Content="Terminal" Classes="tab" Classes.active="{Binding IsTerminalActive}"
-                            Command="{Binding ShowTerminalCommand}" />
-                </StackPanel>
+                            Command="{Binding ShowTerminalCommand}" IsVisible="{Binding ShowsTerminalTab}" />
                 <TextBlock x:Name="NoTerminalNote" Text="{Binding NoTerminalNote}" IsVisible="{Binding !ShowsTerminalTab}"
                            Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5" VerticalAlignment="Center" />
+                    <Button x:Name="PullRequestTabButton" Content="Pull request" Classes="tab" Classes.active="{Binding IsPullRequestActive}"
+                            Command="{Binding ShowPullRequestCommand}" IsVisible="{Binding ShowsPullRequestTab}" />
+                </StackPanel>
             </Grid>
         </Border>
 
@@ -94,13 +96,7 @@
             <!-- A session with no tabs at all has no Terminal tab to activate, and these banners
                  are the only content its cell ever gets — so they stay up whenever the strip is
                  showing the muted note instead of the tabs. -->
-            <Panel x:Name="TerminalBanners">
-                <Panel.IsVisible>
-                    <MultiBinding Converter="{x:Static BoolConverters.Or}">
-                        <Binding Path="IsTerminalActive" />
-                        <Binding Path="!ShowsTerminalTab" />
-                    </MultiBinding>
-                </Panel.IsVisible>
+            <Panel x:Name="TerminalBanners" IsVisible="{Binding ShowsTerminalBanners}">
 
                 <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Connecting}"
                         Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="1"
@@ -170,6 +166,7 @@
                     </MultiBinding>
                 </views:ChatTabView.IsVisible>
             </views:ChatTabView>
+            <ContentControl x:Name="PullRequestHost" IsVisible="{Binding IsPullRequestActive}" />
         </Grid>
     </Grid>
     <views:WorkContextView x:Name="WorkContextHost" Grid.Column="1" DataContext="{Binding WorkContext}" />

--- a/src/Capacitor.App/Views/WorkspaceView.axaml.cs
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml.cs
@@ -9,15 +9,8 @@ using ReactiveUI;
 
 namespace Capacitor.App.Views;
 
-/// The session workspace: DataContext is supplied externally (a plainly-constructed
-/// WorkspaceViewModel) -- same contract as HomeView/MainWindow, this view never builds its own VM.
-///
-/// TerminalHost is SvcSystems.UI.Terminal's own TerminalControl, unwrapped: it already calls its
-/// Model's Resize(width, height, textWidth, textHeight) itself, from BOTH its ModelProperty change
-/// handler (a reattach's fresh Model gets sized to the control's CURRENT bounds immediately) and
-/// its inner surface's own OnSizeChanged (an actual window/pane resize). A bounds-changed handler
-/// here would only double-invoke Resize with worse (font-metric-unaware) width/height than the
-/// control's own _consoleTextSize-based computation.
+/// Receives a workspace model from navigation and retains each tab's native control.
+/// TerminalControl owns terminal resizing, including font metrics and reattachment.
 public partial class WorkspaceView : UserControl {
     IDisposable? _tabFocus;
 
@@ -36,17 +29,20 @@ public partial class WorkspaceView : UserControl {
                 && DataContext is WorkspaceViewModel { IsTerminalActive: true })
                 TerminalHost.Focus();
         };
-        // A session with no PTY has neither surface to focus, so nothing is posted until the chat
-        // tab exists — which is also the moment a workspace opened on Chat gets its composer
-        // focused, since the tab is already active by then.
+        // The PR reader is created on first use, including for sessions without a PTY.
         DataContextChanged += (_, _) => {
             _tabFocus?.Dispose();
-            _tabFocus = (DataContext as WorkspaceViewModel)?
+            PullRequestHost.Content = null;
+            var model = DataContext as WorkspaceViewModel;
+            _tabFocus = model?
                 .WhenAnyValue(vm => vm.ActiveTab, vm => vm.Chat)
-                .Where(pair => pair.Item2 is not null)
                 .Subscribe(pair => Dispatcher.UIThread.Post(() => {
-                    if (pair.Item1 == WorkspaceTab.Chat) ChatHost.FocusComposer();
-                    else TerminalHost.Focus();
+                    if (!ReferenceEquals(model, DataContext) || model?.ActiveTab != pair.Item1) return;
+                    if (pair.Item1 == WorkspaceTab.PullRequest && PullRequestHost.Content is null && model?.PullRequests is { } pullRequests)
+                        PullRequestHost.Content = new PullRequestReader { DataContext = pullRequests };
+                    if (PullRequestHost.Content is PullRequestReader reader) reader.IsVisible = pair.Item1 == WorkspaceTab.PullRequest;
+                    if (pair.Item1 == WorkspaceTab.Chat && pair.Item2 is not null) ChatHost.FocusComposer();
+                    else if (pair.Item1 == WorkspaceTab.Terminal) TerminalHost.Focus();
                 }, DispatcherPriority.Loaded));
         };
     }

--- a/src/Capacitor.Cli.Core/Auth/AuthModels.cs
+++ b/src/Capacitor.Cli.Core/Auth/AuthModels.cs
@@ -7,6 +7,9 @@ public record AuthDiscoveryResponse {
     [JsonPropertyName("provider")]
     public string Provider { get; init; } = "";
 
+    [JsonPropertyName("pull_request_reads_versions")]
+    public int[]? PullRequestReadsVersions { get; init; }
+
     [JsonPropertyName("authkit_domain")]
     public string? AuthKitDomain { get; init; }
 

--- a/src/Capacitor.Cli.Core/Http/CapacitorHttpClient.cs
+++ b/src/Capacitor.Cli.Core/Http/CapacitorHttpClient.cs
@@ -30,6 +30,9 @@ internal sealed class CapacitorHttpClient(
     public Task<AuthAttempt> ForWaitAsync(CancellationToken ct = default) =>
         AttemptAsync(CapacitorClients.Default, ct);
 
+    public Task<AuthAttempt> ForProtectedReadAsync(CancellationToken ct = default) =>
+        AttemptAsync(CapacitorClients.Memory, ct);
+
     async Task<AuthAttempt> AttemptAsync(string lane, CancellationToken ct) {
         // Answered before anything is spent: an unusable URL reaches no token store, no discovery and
         // no socket, and the caller's not-usable branch already knows what to do with it.

--- a/src/Capacitor.Cli.Core/Http/ICapacitorHttpClient.cs
+++ b/src/Capacitor.Cli.Core/Http/ICapacitorHttpClient.cs
@@ -46,6 +46,10 @@ public interface ICapacitorHttpClient {
     /// </summary>
     Task<AuthAttempt> ForWaitAsync(CancellationToken ct = default);
 
+    /// <summary>For protected reads: report auth status and recover a 401, but refuse redirects
+    /// that could substitute content from another origin.</summary>
+    Task<AuthAttempt> ForProtectedReadAsync(CancellationToken ct = default);
+
     /// <summary>
     /// For the session-start memory index: authenticated and recovering like a background client,
     /// but a 3xx ends the fetch rather than being followed. This body becomes the agent's injected

--- a/src/Capacitor.Cli.Core/PullRequests/IPullRequestSource.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/IPullRequestSource.cs
@@ -1,0 +1,11 @@
+namespace Capacitor.Cli.Core.PullRequests;
+
+public interface IPullRequestSource {
+    Task<PullRequestCapability> DiscoverAsync(bool refresh, CancellationToken ct);
+    void ResetSession(string sessionId);
+    Task<PullRequestRead<PullRequestLinkListDto>> ListAsync(string sessionId, CancellationToken ct);
+    Task<PullRequestRead<PullRequestLinkListDto>> LegacyLinksAsync(string sessionId, CancellationToken ct);
+    Task<PullRequestRead<PullRequestOverviewDto>> OverviewAsync(string sessionId, PullRequestSubjectDto subject, CancellationToken ct);
+    Task<PullRequestRead<PullRequestPageDto<T>>> PageAsync<T>(string sessionId, PullRequestSubjectDto subject, string section,
+        string? cursor, string? resolved, string? threadId, CancellationToken ct) where T : class;
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestActorDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestActorDto.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestActorDto {
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+    [JsonPropertyName("login")]
+    public string? Login { get; init; }
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestAvailabilityDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestAvailabilityDto.cs
@@ -1,0 +1,12 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestAvailabilityDto {
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+    [JsonPropertyName("fetched_at")]
+    public DateTime? FetchedAt { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestCapability.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestCapability.cs
@@ -1,5 +1,3 @@
 namespace Capacitor.Cli.Core.PullRequests;
 
-public enum PullRequestCapabilityKind { Supported, Legacy, Unsupported, Unavailable, SignedOut, InvalidProtocol }
-
 public sealed record PullRequestCapability(PullRequestCapabilityKind Kind, int? Version = null, string? Reason = null, DateTime? RetryAt = null);

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestCapability.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestCapability.cs
@@ -1,0 +1,5 @@
+namespace Capacitor.Cli.Core.PullRequests;
+
+public enum PullRequestCapabilityKind { Supported, Legacy, Unsupported, Unavailable, SignedOut, InvalidProtocol }
+
+public sealed record PullRequestCapability(PullRequestCapabilityKind Kind, int? Version = null, string? Reason = null, DateTime? RetryAt = null);

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestCapabilityKind.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestCapabilityKind.cs
@@ -1,0 +1,3 @@
+namespace Capacitor.Cli.Core.PullRequests;
+
+public enum PullRequestCapabilityKind { Supported, Legacy, Unsupported, Unavailable, SignedOut, InvalidProtocol }

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestCheckDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestCheckDto.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestCheckDto {
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+    [JsonPropertyName("availability")]
+    public required string Availability { get; init; }
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+    [JsonPropertyName("name")]
+    public string? Name { get; init; }
+    [JsonPropertyName("app_name")]
+    public string? AppName { get; init; }
+    [JsonPropertyName("app_id")]
+    public string? AppId { get; init; }
+    [JsonPropertyName("suite_id")]
+    public string? SuiteId { get; init; }
+    [JsonPropertyName("source")]
+    public string? Source { get; init; }
+    [JsonPropertyName("outcome")]
+    public string? Outcome { get; init; }
+    [JsonPropertyName("status")]
+    public string? Status { get; init; }
+    [JsonPropertyName("conclusion")]
+    public string? Conclusion { get; init; }
+    [JsonPropertyName("started_at")]
+    public DateTime? StartedAt { get; init; }
+    [JsonPropertyName("completed_at")]
+    public DateTime? CompletedAt { get; init; }
+    [JsonPropertyName("head_sha")]
+    public string? HeadSha { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestChecksSummaryDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestChecksSummaryDto.cs
@@ -1,0 +1,14 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestChecksSummaryDto {
+    [JsonPropertyName("availability")]
+    public required PullRequestAvailabilityDto Availability { get; init; }
+    [JsonPropertyName("rollup")]
+    public string? Rollup { get; init; }
+    [JsonPropertyName("head_sha")]
+    public string? HeadSha { get; init; }
+    [JsonPropertyName("counts")]
+    public Dictionary<string, PullRequestCountDto>? Counts { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestClient.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestClient.cs
@@ -31,11 +31,11 @@ public sealed class PullRequestClient(HttpClient http, string serverUrl, TimePro
                 if (!response.IsSuccessStatusCode) return Save(new(PullRequestCapabilityKind.Unavailable, Reason: "discovery_unavailable"));
                 using var document = await ReadDocumentAsync(response, linked.Token).ConfigureAwait(false);
                 var root = document.RootElement;
-                if (root.ValueKind != JsonValueKind.Object || !root.TryGetProperty("provider", out var provider)
-                    || provider.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(provider.GetString())) return Save(new(PullRequestCapabilityKind.InvalidProtocol));
+                if (!root.IsObject || !root.TryGetProperty("provider", out var provider)
+                    || !provider.IsString || string.IsNullOrWhiteSpace(provider.GetString())) return Save(new(PullRequestCapabilityKind.InvalidProtocol));
                 if (!root.TryGetProperty("pull_request_reads_versions", out var versions)) return Save(new(PullRequestCapabilityKind.Legacy));
-                if (versions.ValueKind != JsonValueKind.Array || versions.GetArrayLength() > 100
-                    || versions.EnumerateArray().Any(version => version.ValueKind != JsonValueKind.Number || !version.TryGetInt32(out var value) || value <= 0))
+                if (!versions.IsArray || versions.GetArrayLength() > 100
+                    || versions.EnumerateArray().Any(version => !version.IsNumber || !version.TryGetInt32(out var value) || value <= 0))
                     return Save(new(PullRequestCapabilityKind.InvalidProtocol));
                 return Save(versions.EnumerateArray().Any(version => version.GetInt32() == 1) ? new(PullRequestCapabilityKind.Supported, 1) : new(PullRequestCapabilityKind.Unsupported));
             } catch (OperationCanceledException) when (!ct.IsCancellationRequested) { return Save(new(PullRequestCapabilityKind.Unavailable, Reason: "timeout")); }
@@ -71,7 +71,7 @@ public sealed class PullRequestClient(HttpClient http, string serverUrl, TimePro
             if (response.StatusCode == HttpStatusCode.NotFound) return new(PullRequestReadKind.SubjectUnavailable, AccessFailure: "invalid");
             if (!response.IsSuccessStatusCode) return new(PullRequestReadKind.Unavailable, AccessFailure: (int)response.StatusCode >= 500 ? "transient" : "invalid");
             using var document = await ReadDocumentAsync(response, linked.Token).ConfigureAwait(false);
-            if (document.RootElement.TryGetProperty("pull_requests", out var links) && links.ValueKind != JsonValueKind.Array)
+            if (!document.RootElement.IsObject || document.RootElement.Prop("pull_requests") is { } links && !links.IsArray)
                 return Invalid<PullRequestLinkListDto>();
             var summary = document.Deserialize(CapacitorJsonContext.Default.SessionSummaryDto);
             if (summary is null || summary.SessionId != sessionId || summary.PullRequests is null

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestClient.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestClient.cs
@@ -1,0 +1,174 @@
+using System.Globalization;
+using System.Net;
+using System.Text.Json;
+using System.Text.Json.Serialization.Metadata;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed class PullRequestClient(HttpClient http, string serverUrl, TimeProvider? clock = null) : IPullRequestSource, IDisposable {
+    readonly Uri _base = ServerOrigin(serverUrl);
+    readonly TimeProvider _time = clock ?? TimeProvider.System;
+    readonly SemaphoreSlim _discoveryGate = new(1, 1);
+    PullRequestCapability? _capability;
+    long _discovered;
+    long _discoveryRevision;
+    int _discoveryFailures;
+    TimeSpan _discoveryDelay;
+
+    public async Task<PullRequestCapability> DiscoverAsync(bool refresh, CancellationToken ct) {
+        var revision = Volatile.Read(ref _discoveryRevision);
+        await _discoveryGate.WaitAsync(ct).ConfigureAwait(false);
+        try {
+            if (_capability is not null && (revision != _discoveryRevision || _time.GetElapsedTime(_discovered) <
+                (refresh && _discoveryFailures == 0 ? TimeSpan.FromSeconds(15) : _discoveryDelay))) return _capability;
+            using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(35), _time);
+            using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, deadline.Token);
+            try {
+                using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_base, "auth/config"));
+                using var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linked.Token).ConfigureAwait(false);
+                if (!SameOrigin(response)) return Save(new(PullRequestCapabilityKind.InvalidProtocol, Reason: "unexpected_origin"));
+                if (response.StatusCode == HttpStatusCode.Unauthorized) return Save(new(PullRequestCapabilityKind.SignedOut));
+                if (!response.IsSuccessStatusCode) return Save(new(PullRequestCapabilityKind.Unavailable, Reason: "discovery_unavailable"));
+                using var document = await ReadDocumentAsync(response, linked.Token).ConfigureAwait(false);
+                var root = document.RootElement;
+                if (root.ValueKind != JsonValueKind.Object || !root.TryGetProperty("provider", out var provider)
+                    || provider.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(provider.GetString())) return Save(new(PullRequestCapabilityKind.InvalidProtocol));
+                if (!root.TryGetProperty("pull_request_reads_versions", out var versions)) return Save(new(PullRequestCapabilityKind.Legacy));
+                if (versions.ValueKind != JsonValueKind.Array || versions.GetArrayLength() > 100
+                    || versions.EnumerateArray().Any(version => version.ValueKind != JsonValueKind.Number || !version.TryGetInt32(out var value) || value <= 0))
+                    return Save(new(PullRequestCapabilityKind.InvalidProtocol));
+                return Save(versions.EnumerateArray().Any(version => version.GetInt32() == 1) ? new(PullRequestCapabilityKind.Supported, 1) : new(PullRequestCapabilityKind.Unsupported));
+            } catch (OperationCanceledException) when (!ct.IsCancellationRequested) { return Save(new(PullRequestCapabilityKind.Unavailable, Reason: "timeout")); }
+            catch (Exception exception) when (exception is HttpRequestException or IOException) { return Save(new(PullRequestCapabilityKind.Unavailable, Reason: "discovery_unavailable")); }
+            catch (Exception exception) when (exception is JsonException or NotSupportedException) { return Save(new(PullRequestCapabilityKind.InvalidProtocol)); }
+        } finally { _discoveryGate.Release(); }
+    }
+    PullRequestCapability Save(PullRequestCapability value) {
+        var failed = value.Kind is PullRequestCapabilityKind.Unavailable or PullRequestCapabilityKind.InvalidProtocol;
+        _discoveryFailures = failed ? Math.Min(_discoveryFailures + 1, 3) : 0;
+        _discoveryDelay = TimeSpan.FromSeconds(_discoveryFailures switch { 1 => 30, 2 => 60, _ => 300 });
+        _capability = failed ? value with { RetryAt = (_time.GetUtcNow() + _discoveryDelay).UtcDateTime } : value;
+        _discovered = _time.GetTimestamp();
+        Interlocked.Increment(ref _discoveryRevision);
+        return _capability;
+    }
+
+    public Task<PullRequestRead<PullRequestLinkListDto>> ListAsync(string sessionId, CancellationToken ct) => ReadAsync<PullRequestLinkListDto>(
+        SessionPath(sessionId), null, ct);
+    public void ResetSession(string sessionId) { }
+
+    public async Task<PullRequestRead<PullRequestLinkListDto>> LegacyLinksAsync(string sessionId, CancellationToken ct) {
+        if (!PullRequestWire.ValidSegment(sessionId)) return Invalid<PullRequestLinkListDto>();
+        var capability = await DiscoverAsync(false, ct).ConfigureAwait(false);
+        if (capability.Kind is not (PullRequestCapabilityKind.Legacy or PullRequestCapabilityKind.Unsupported)) return Invalid<PullRequestLinkListDto>();
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(35), _time);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, deadline.Token);
+        try {
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_base, "api/sessions/" + Uri.EscapeDataString(sessionId) + "/summary"));
+            using var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linked.Token).ConfigureAwait(false);
+            if (!SameOrigin(response)) return Invalid<PullRequestLinkListDto>();
+            if (response.StatusCode == HttpStatusCode.Unauthorized) return new(PullRequestReadKind.SignedOut, AccessFailure: "invalid");
+            if (response.StatusCode == HttpStatusCode.NotFound) return new(PullRequestReadKind.SubjectUnavailable, AccessFailure: "invalid");
+            if (!response.IsSuccessStatusCode) return new(PullRequestReadKind.Unavailable, AccessFailure: (int)response.StatusCode >= 500 ? "transient" : "invalid");
+            using var document = await ReadDocumentAsync(response, linked.Token).ConfigureAwait(false);
+            if (document.RootElement.TryGetProperty("pull_requests", out var links) && links.ValueKind != JsonValueKind.Array)
+                return Invalid<PullRequestLinkListDto>();
+            var summary = document.Deserialize(CapacitorJsonContext.Default.SessionSummaryDto);
+            if (summary is null || summary.SessionId != sessionId || summary.PullRequests is null
+                || summary.PullRequests.Any(pr => pr is null || pr.Owner is null || pr.RepoName is null)) return Invalid<PullRequestLinkListDto>();
+            var rows = summary.PullRequests.Select(pr => Legacy(pr.RepoHash, pr.Owner, pr.RepoName, pr.Number, pr.Url, pr.Title, pr.HeadRef)).ToList();
+            if (summary.PrNumber is > 0 and var number && !rows.Any(row => row.Number == number
+                && string.Equals(row.Owner, summary.RepoOwner, StringComparison.OrdinalIgnoreCase) && string.Equals(row.RepoName, summary.RepoName, StringComparison.OrdinalIgnoreCase)))
+                rows.Add(Legacy("legacy", summary.RepoOwner ?? "unknown", summary.RepoName ?? "unknown", number, summary.PrUrl, summary.PrTitle, summary.RepoBranch));
+            if (rows.Count > 5000 || rows.Any(row => !PullRequestWire.ValidSubject(PullRequestWire.Subject(row)))) return Invalid<PullRequestLinkListDto>();
+            return new(PullRequestReadKind.Ready, new() { Items = rows.DistinctBy(row => (row.Owner, row.RepoName, row.Number))
+                .OrderBy(row => row.Owner, StringComparer.Ordinal).ThenBy(row => row.RepoName, StringComparer.Ordinal).ThenBy(row => row.Number).ToArray() },
+                FetchedAt: _time.GetUtcNow().UtcDateTime);
+        } catch (OperationCanceledException) when (!ct.IsCancellationRequested) { return new(PullRequestReadKind.TransportFailure, AccessFailure: "transient"); }
+        catch (Exception exception) when (exception is HttpRequestException or IOException) { return new(PullRequestReadKind.TransportFailure, AccessFailure: "transient"); }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException) { return Invalid<PullRequestLinkListDto>(); }
+    }
+    static PullRequestLinkDto Legacy(string hash, string owner, string name, int number, string? url, string? title, string? branch) {
+        var safe = PullRequestWire.SafeLink(url);
+        return new() { Provider = "unknown", Host = safe is null ? "unknown" : new Uri(safe).IdnHost, RepoHash = hash,
+            Owner = owner.ToLowerInvariant(), RepoName = name.ToLowerInvariant(), Number = number, Url = safe, Title = title, HeadRef = branch };
+    }
+    public Task<PullRequestRead<PullRequestOverviewDto>> OverviewAsync(string sessionId, PullRequestSubjectDto subject, CancellationToken ct)
+        => ReadAsync<PullRequestOverviewDto>(SubjectPath(sessionId, subject), subject, ct);
+    public Task<PullRequestRead<PullRequestPageDto<T>>> PageAsync<T>(string sessionId, PullRequestSubjectDto subject, string section,
+        string? cursor, string? resolved, string? threadId, CancellationToken ct) where T : class {
+        var path = SubjectPath(sessionId, subject);
+        var valid = section switch {
+            "checks" => typeof(T) == typeof(PullRequestCheckDto), "reviewers" => typeof(T) == typeof(PullRequestReviewerDto),
+            "reviews" => typeof(T) == typeof(PullRequestReviewDto), "threads" => typeof(T) == typeof(PullRequestThreadDto),
+            "conversation" or "thread_comments" => typeof(T) == typeof(PullRequestCommentDto), _ => false
+        };
+        if (path is null || !valid || cursor is not null && !PullRequestWire.ValidHandle(cursor)
+            || resolved is not null && (section != "threads" || resolved is not ("unresolved" or "all"))
+            || section == "thread_comments" && !PullRequestWire.ValidSegment(threadId)) return Task.FromResult(Invalid<PullRequestPageDto<T>>());
+        path += section == "thread_comments" ? "/threads/" + Uri.EscapeDataString(threadId!) + "/comments" : "/" + section;
+        if (cursor is not null) path += "?cursor=" + Uri.EscapeDataString(cursor);
+        if (resolved is not null) path += (cursor is null ? "?" : "&") + "resolved=" + Uri.EscapeDataString(resolved);
+        return ReadAsync<PullRequestPageDto<T>>(path, subject, ct);
+    }
+    static string? SessionPath(string session) => PullRequestWire.ValidSegment(session) ? "api/sessions/" + Uri.EscapeDataString(session) + "/pull-requests" : null;
+    static string? SubjectPath(string session, PullRequestSubjectDto subject) => SessionPath(session) is { } path && PullRequestWire.ValidSubject(subject)
+        ? path + "/" + Uri.EscapeDataString(subject.RepoHash) + "/" + subject.Number.ToString(CultureInfo.InvariantCulture) : null;
+
+    async Task<PullRequestRead<T>> ReadAsync<T>(string? path, PullRequestSubjectDto? subject, CancellationToken ct) where T : class {
+        if (path is null || PullRequestJsonContext.Default.GetTypeInfo(typeof(PullRequestEnvelopeDto<T>)) is not JsonTypeInfo<PullRequestEnvelopeDto<T>> info) return Invalid<T>();
+        var capability = await DiscoverAsync(false, ct).ConfigureAwait(false);
+        if (capability.Kind != PullRequestCapabilityKind.Supported) return new(PullRequestReadKind.Unavailable, Reason: "unsupported", AccessFailure: "invalid");
+        var started = _time.GetTimestamp();
+        using var deadline = new CancellationTokenSource(TimeSpan.FromSeconds(35), _time);
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct, deadline.Token);
+        try {
+            using var request = new HttpRequestMessage(HttpMethod.Get, new Uri(_base, path + (path.Contains('?', StringComparison.Ordinal) ? "&" : "?") + "version=1"));
+            using var response = await http.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, linked.Token).ConfigureAwait(false);
+            if (!SameOrigin(response)) return Invalid<T>("unexpected_origin");
+            var status = (int)response.StatusCode;
+            if (status == 401) return new(PullRequestReadKind.SignedOut, Subject: subject, AccessFailure: "invalid", StatusCode: status);
+            if (status == 404) return new(PullRequestReadKind.SubjectUnavailable, Subject: subject, AccessFailure: "invalid", StatusCode: status);
+            if (status is >= 300 and < 400) return Invalid<T>("unexpected_origin");
+            if (status is >= 500 or 429) return new(PullRequestReadKind.Unavailable, Subject: subject, Reason: "server_unavailable", AccessFailure: "transient", StatusCode: status);
+            using var document = await ReadDocumentAsync(response, linked.Token).ConfigureAwait(false);
+            if (!PullRequestWire.ValidJson(document.RootElement)) return Invalid<T>();
+            if (status == 409) {
+                var error = document.Deserialize(PullRequestJsonContext.Default.PullRequestErrorDto);
+                return error?.Error == "restart_required" ? new(PullRequestReadKind.Restart, Subject: subject, Reason: error.Reason, StatusCode: status) : Invalid<T>();
+            }
+            if (!response.IsSuccessStatusCode) return new(PullRequestReadKind.Unavailable, Subject: subject, Reason: "server_unavailable",
+                AccessFailure: status is >= 500 or 429 ? "transient" : "invalid", StatusCode: status);
+            var envelope = document.Deserialize(info);
+            if (envelope is null || envelope.Status is not ("ready" or "stale" or "unavailable") || envelope.AccessValidForSeconds is < 0 or > 30 || envelope.PollAfterSeconds < 0
+                || subject is not null && envelope.Subject != subject || subject is null && (envelope.Subject is not null || envelope.Status == "stale")) return Invalid<T>();
+            var failure = envelope.AccessFailure switch { null => null, "transient" => "transient", "denied" => "denied", _ => "invalid" };
+            if (envelope.Status == "unavailable" || failure is not null) return new(PullRequestReadKind.Unavailable, Subject: subject, Reason: envelope.Reason,
+                AccessFailure: failure, RetryAt: envelope.RetryAt, PollAfterSeconds: envelope.PollAfterSeconds, StatusCode: status);
+            if (envelope.Data is null || !PullRequestWire.ValidData(envelope.Data) || envelope.FetchedAt is null) return Invalid<T>();
+            return new(envelope.Status == "stale" ? PullRequestReadKind.Stale : PullRequestReadKind.Ready, envelope.Data, subject, envelope.FetchedAt,
+                envelope.Reason, null, envelope.RetryAt, envelope.PollAfterSeconds, envelope.AccessValidForSeconds, started, status);
+        } catch (OperationCanceledException) when (!ct.IsCancellationRequested) { return new(PullRequestReadKind.TransportFailure, Subject: subject, Reason: "timeout", AccessFailure: "transient"); }
+        catch (Exception exception) when (exception is HttpRequestException or IOException) { return new(PullRequestReadKind.TransportFailure, Subject: subject, AccessFailure: "transient"); }
+        catch (Exception exception) when (exception is JsonException or NotSupportedException) { return Invalid<T>(); }
+    }
+    bool SameOrigin(HttpResponseMessage response) => response.RequestMessage?.RequestUri is { } actual
+        && actual.Scheme == _base.Scheme && actual.IdnHost == _base.IdnHost && actual.Port == _base.Port && actual.UserInfo.Length == 0;
+    static Uri ServerOrigin(string url) {
+        var origin = new Uri(url.TrimEnd('/') + "/", UriKind.Absolute);
+        if (origin.Scheme is not ("http" or "https") || origin.UserInfo.Length != 0 || origin.Query.Length != 0 || origin.Fragment.Length != 0)
+            throw new ArgumentException("The server URL must be an HTTP or HTTPS origin without credentials, query or fragment.", nameof(url));
+        return origin;
+    }
+    static async Task<JsonDocument> ReadDocumentAsync(HttpResponseMessage response, CancellationToken ct) {
+        const int limit = 4 * 1024 * 1024;
+        if (response.Content.Headers.ContentLength > limit) throw new JsonException();
+        await using var input = await response.Content.ReadAsStreamAsync(ct).ConfigureAwait(false);
+        var bytes = new byte[limit + 1];
+        var count = await input.ReadAtLeastAsync(bytes, bytes.Length, false, ct).ConfigureAwait(false);
+        if (count > limit) throw new JsonException();
+        return JsonDocument.Parse(bytes.AsMemory(0, count), new JsonDocumentOptions { MaxDepth = 64 });
+    }
+    static PullRequestRead<T> Invalid<T>(string reason = "protocol_error") where T : class => new(PullRequestReadKind.InvalidProtocol, Reason: reason, AccessFailure: "invalid");
+    public void Dispose() => _discoveryGate.Dispose();
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestCommentDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestCommentDto.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestCommentDto {
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+    [JsonPropertyName("availability")]
+    public required string Availability { get; init; }
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+    [JsonPropertyName("author")]
+    public PullRequestActorDto? Author { get; init; }
+    [JsonPropertyName("body")]
+    public string? Body { get; init; }
+    [JsonPropertyName("body_truncated")]
+    public bool BodyTruncated { get; init; }
+    [JsonPropertyName("created_at")]
+    public DateTime? CreatedAt { get; init; }
+    [JsonPropertyName("updated_at")]
+    public DateTime? UpdatedAt { get; init; }
+    [JsonPropertyName("published_at")]
+    public DateTime? PublishedAt { get; init; }
+    [JsonPropertyName("reply_to_id")]
+    public string? ReplyToId { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestContract.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestContract.cs
@@ -1,0 +1,5 @@
+namespace Capacitor.Cli.Core.PullRequests;
+
+public static class PullRequestContract {
+    public const string FixtureSha256 = "5498995e39fc6bd0778dffa5db0e538b63eaf76be9133764f7d1c1d3cf373b5b";
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestConversationSummaryDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestConversationSummaryDto.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestConversationSummaryDto {
+    [JsonPropertyName("availability")]
+    public required PullRequestAvailabilityDto Availability { get; init; }
+    [JsonPropertyName("count")]
+    public PullRequestCountDto? Count { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestCountDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestCountDto.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestCountDto {
+    [JsonPropertyName("value")]
+    public int? Value { get; init; }
+    [JsonPropertyName("kind")]
+    public required string Kind { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestEnvelopeDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestEnvelopeDto.cs
@@ -1,0 +1,25 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestEnvelopeDto<T> where T : class {
+    [JsonPropertyName("status")]
+    public required string Status { get; init; }
+    [JsonPropertyName("subject")]
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public PullRequestSubjectDto? Subject { get; init; }
+    [JsonPropertyName("data")]
+    public T? Data { get; init; }
+    [JsonPropertyName("fetched_at")]
+    public DateTime? FetchedAt { get; init; }
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+    [JsonPropertyName("retry_at")]
+    public DateTime? RetryAt { get; init; }
+    [JsonPropertyName("poll_after_seconds")]
+    public int PollAfterSeconds { get; init; }
+    [JsonPropertyName("access_valid_for_seconds")]
+    public int AccessValidForSeconds { get; init; }
+    [JsonPropertyName("access_failure")]
+    public string? AccessFailure { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestErrorDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestErrorDto.cs
@@ -1,0 +1,10 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestErrorDto {
+    [JsonPropertyName("error")]
+    public required string Error { get; init; }
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestJsonContext.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestJsonContext.cs
@@ -1,0 +1,16 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+[JsonSourceGenerationOptions(GenerationMode = JsonSourceGenerationMode.Metadata)]
+[JsonSerializable(typeof(PullRequestEnvelopeDto<PullRequestLinkListDto>))]
+[JsonSerializable(typeof(PullRequestEnvelopeDto<PullRequestOverviewDto>))]
+[JsonSerializable(typeof(PullRequestEnvelopeDto<PullRequestPageDto<PullRequestCheckDto>>))]
+[JsonSerializable(typeof(PullRequestEnvelopeDto<PullRequestPageDto<PullRequestReviewerDto>>))]
+[JsonSerializable(typeof(PullRequestEnvelopeDto<PullRequestPageDto<PullRequestReviewDto>>))]
+[JsonSerializable(typeof(PullRequestEnvelopeDto<PullRequestPageDto<PullRequestThreadDto>>))]
+[JsonSerializable(typeof(PullRequestEnvelopeDto<PullRequestPageDto<PullRequestCommentDto>>))]
+[JsonSerializable(typeof(PullRequestEnvelopeDto<PullRequestPageDto<object>>))]
+[JsonSerializable(typeof(PullRequestEnvelopeDto<object>))]
+[JsonSerializable(typeof(PullRequestErrorDto))]
+public partial class PullRequestJsonContext : JsonSerializerContext;

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestLinkDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestLinkDto.cs
@@ -1,0 +1,24 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestLinkDto {
+    [JsonPropertyName("provider")]
+    public required string Provider { get; init; }
+    [JsonPropertyName("host")]
+    public required string Host { get; init; }
+    [JsonPropertyName("repo_hash")]
+    public required string RepoHash { get; init; }
+    [JsonPropertyName("owner")]
+    public required string Owner { get; init; }
+    [JsonPropertyName("repo_name")]
+    public required string RepoName { get; init; }
+    [JsonPropertyName("number")]
+    public required int Number { get; init; }
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+    [JsonPropertyName("head_ref")]
+    public string? HeadRef { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestLinkListDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestLinkListDto.cs
@@ -1,0 +1,8 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestLinkListDto {
+    [JsonPropertyName("items")]
+    public required PullRequestLinkDto[] Items { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestOverviewDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestOverviewDto.cs
@@ -1,0 +1,36 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestOverviewDto {
+    [JsonPropertyName("title")]
+    public string? Title { get; init; }
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+    [JsonPropertyName("lifecycle")]
+    public string? Lifecycle { get; init; }
+    [JsonPropertyName("is_draft")]
+    public bool? IsDraft { get; init; }
+    [JsonPropertyName("head_ref")]
+    public string? HeadRef { get; init; }
+    [JsonPropertyName("base_ref")]
+    public string? BaseRef { get; init; }
+    [JsonPropertyName("head_sha")]
+    public string? HeadSha { get; init; }
+    [JsonPropertyName("description")]
+    public string? Description { get; init; }
+    [JsonPropertyName("description_truncated")]
+    public bool DescriptionTruncated { get; init; }
+    [JsonPropertyName("updated_at")]
+    public DateTime? UpdatedAt { get; init; }
+    [JsonPropertyName("review_decision")]
+    public string? ReviewDecision { get; init; }
+    [JsonPropertyName("access_checked_for")]
+    public string? AccessCheckedFor { get; init; }
+    [JsonPropertyName("checks")]
+    public PullRequestChecksSummaryDto? Checks { get; init; }
+    [JsonPropertyName("reviews")]
+    public PullRequestReviewsSummaryDto? Reviews { get; init; }
+    [JsonPropertyName("conversation")]
+    public PullRequestConversationSummaryDto? Conversation { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestPageDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestPageDto.cs
@@ -1,0 +1,30 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestPageDto<T> where T : class {
+    [JsonPropertyName("snapshot_id")]
+    public required string SnapshotId { get; init; }
+    [JsonPropertyName("snapshot_started_at")]
+    public required DateTime SnapshotStartedAt { get; init; }
+    [JsonPropertyName("snapshot_completed_at")]
+    public required DateTime SnapshotCompletedAt { get; init; }
+    [JsonPropertyName("coverage")]
+    public required string Coverage { get; init; }
+    [JsonPropertyName("coverage_reason")]
+    public string? CoverageReason { get; init; }
+    [JsonPropertyName("head_sha")]
+    public string? HeadSha { get; init; }
+    [JsonPropertyName("total")]
+    public required PullRequestCountDto Total { get; init; }
+    [JsonPropertyName("excluded_by_filter")]
+    public required PullRequestCountDto ExcludedByFilter { get; init; }
+    [JsonPropertyName("items")]
+    public required T[] Items { get; init; }
+    [JsonPropertyName("page_cursor")]
+    public required string PageCursor { get; init; }
+    [JsonPropertyName("has_more")]
+    public required bool HasMore { get; init; }
+    [JsonPropertyName("next_cursor")]
+    public string? NextCursor { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestRead.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestRead.cs
@@ -1,7 +1,5 @@
 namespace Capacitor.Cli.Core.PullRequests;
 
-public enum PullRequestReadKind { Ready, Stale, Unavailable, Restart, SubjectUnavailable, SignedOut, TransportFailure, InvalidProtocol }
-
 public sealed record PullRequestRead<T>(PullRequestReadKind Kind, T? Data = null, PullRequestSubjectDto? Subject = null,
     DateTime? FetchedAt = null, string? Reason = null, string? AccessFailure = null, DateTime? RetryAt = null,
     int PollAfterSeconds = 30, int AccessValidForSeconds = 0, long RequestStarted = 0, int StatusCode = 0) where T : class {

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestRead.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestRead.cs
@@ -1,0 +1,11 @@
+namespace Capacitor.Cli.Core.PullRequests;
+
+public enum PullRequestReadKind { Ready, Stale, Unavailable, Restart, SubjectUnavailable, SignedOut, TransportFailure, InvalidProtocol }
+
+public sealed record PullRequestRead<T>(PullRequestReadKind Kind, T? Data = null, PullRequestSubjectDto? Subject = null,
+    DateTime? FetchedAt = null, string? Reason = null, string? AccessFailure = null, DateTime? RetryAt = null,
+    int PollAfterSeconds = 30, int AccessValidForSeconds = 0, long RequestStarted = 0, int StatusCode = 0) where T : class {
+    public double RemainingSeconds(TimeProvider time) => Math.Max(0, AccessValidForSeconds - time.GetElapsedTime(RequestStarted).TotalSeconds);
+    public bool CanReveal(TimeProvider time) => Kind is PullRequestReadKind.Ready or PullRequestReadKind.Stale
+        && Data is not null && AccessFailure is null && RemainingSeconds(time) >= 5;
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestReadKind.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestReadKind.cs
@@ -1,0 +1,3 @@
+namespace Capacitor.Cli.Core.PullRequests;
+
+public enum PullRequestReadKind { Ready, Stale, Unavailable, Restart, SubjectUnavailable, SignedOut, TransportFailure, InvalidProtocol }

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestReviewDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestReviewDto.cs
@@ -1,0 +1,28 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestReviewDto {
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+    [JsonPropertyName("availability")]
+    public required string Availability { get; init; }
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+    [JsonPropertyName("author")]
+    public PullRequestActorDto? Author { get; init; }
+    [JsonPropertyName("body")]
+    public string? Body { get; init; }
+    [JsonPropertyName("body_truncated")]
+    public bool BodyTruncated { get; init; }
+    [JsonPropertyName("state")]
+    public string? State { get; init; }
+    [JsonPropertyName("created_at")]
+    public DateTime? CreatedAt { get; init; }
+    [JsonPropertyName("submitted_at")]
+    public DateTime? SubmittedAt { get; init; }
+    [JsonPropertyName("updated_at")]
+    public DateTime? UpdatedAt { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestReviewerDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestReviewerDto.cs
@@ -1,0 +1,22 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestReviewerDto {
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+    [JsonPropertyName("availability")]
+    public required string Availability { get; init; }
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+    [JsonPropertyName("actor")]
+    public PullRequestActorDto? Actor { get; init; }
+    [JsonPropertyName("requested")]
+    public bool? Requested { get; init; }
+    [JsonPropertyName("review_state")]
+    public string? ReviewState { get; init; }
+    [JsonPropertyName("submitted_at")]
+    public DateTime? SubmittedAt { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestReviewsSummaryDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestReviewsSummaryDto.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestReviewsSummaryDto {
+    [JsonPropertyName("availability")]
+    public required PullRequestAvailabilityDto Availability { get; init; }
+    [JsonPropertyName("published")]
+    public PullRequestCountDto? Published { get; init; }
+    [JsonPropertyName("approved")]
+    public PullRequestCountDto? Approved { get; init; }
+    [JsonPropertyName("changes_requested")]
+    public PullRequestCountDto? ChangesRequested { get; init; }
+    [JsonPropertyName("outstanding_users")]
+    public PullRequestCountDto? OutstandingUsers { get; init; }
+    [JsonPropertyName("outstanding_teams")]
+    public PullRequestCountDto? OutstandingTeams { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestSubjectDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestSubjectDto.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestSubjectDto {
+    [JsonPropertyName("provider")]
+    public required string Provider { get; init; }
+    [JsonPropertyName("host")]
+    public required string Host { get; init; }
+    [JsonPropertyName("repo_hash")]
+    public required string RepoHash { get; init; }
+    [JsonPropertyName("owner")]
+    public required string Owner { get; init; }
+    [JsonPropertyName("repo_name")]
+    public required string RepoName { get; init; }
+    [JsonPropertyName("number")]
+    public required int Number { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestThreadDto.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestThreadDto.cs
@@ -1,0 +1,42 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public sealed record PullRequestThreadDto {
+    [JsonPropertyName("id")]
+    public required string Id { get; init; }
+    [JsonPropertyName("availability")]
+    public required string Availability { get; init; }
+    [JsonPropertyName("reason")]
+    public string? Reason { get; init; }
+    [JsonPropertyName("url")]
+    public string? Url { get; init; }
+    [JsonPropertyName("is_resolved")]
+    public bool? IsResolved { get; init; }
+    [JsonPropertyName("is_outdated")]
+    public bool? IsOutdated { get; init; }
+    [JsonPropertyName("path")]
+    public string? Path { get; init; }
+    [JsonPropertyName("diff_side")]
+    public string? DiffSide { get; init; }
+    [JsonPropertyName("start_diff_side")]
+    public string? StartDiffSide { get; init; }
+    [JsonPropertyName("line")]
+    public int? Line { get; init; }
+    [JsonPropertyName("start_line")]
+    public int? StartLine { get; init; }
+    [JsonPropertyName("original_line")]
+    public int? OriginalLine { get; init; }
+    [JsonPropertyName("original_start_line")]
+    public int? OriginalStartLine { get; init; }
+    [JsonPropertyName("subject_type")]
+    public string? SubjectType { get; init; }
+    [JsonPropertyName("diff_hunk")]
+    public string? DiffHunk { get; init; }
+    [JsonPropertyName("hunk_truncated")]
+    public bool HunkTruncated { get; init; }
+    [JsonPropertyName("root_comment")]
+    public PullRequestCommentDto? RootComment { get; init; }
+    [JsonPropertyName("comments")]
+    public PullRequestCountDto? Comments { get; init; }
+}

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestWire.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestWire.cs
@@ -29,19 +29,19 @@ public static class PullRequestWire {
         && uri.Scheme is "https" or "http" && uri.UserInfo.Length == 0 ? uri.AbsoluteUri : null;
 
     internal static bool ValidJson(JsonElement root) {
-        if (root.ValueKind == JsonValueKind.Array) return root.EnumerateArray().All(ValidJson);
-        if (root.ValueKind != JsonValueKind.Object) return true;
+        if (root.IsArray) return root.EnumerateArray().All(ValidJson);
+        if (!root.IsObject) return true;
         foreach (var field in root.EnumerateObject()) {
             if (field.Name is "fetched_at" or "retry_at" or "snapshot_started_at" or "snapshot_completed_at" or "created_at" or "updated_at"
                 or "submitted_at" or "started_at" or "completed_at" or "published_at") {
-                if (field.Value.ValueKind != JsonValueKind.Null && (field.Value.ValueKind != JsonValueKind.String || field.Value.GetString()?.EndsWith('Z') != true
+                if (!field.Value.IsNull && (!field.Value.IsString || field.Value.GetString()?.EndsWith('Z') != true
                     || !field.Value.TryGetDateTimeOffset(out var date) || date.Offset != TimeSpan.Zero)) return false;
             }
             if (field.Name == "kind" && root.TryGetProperty("value", out var number)) {
-                if (number.ValueKind != JsonValueKind.Null && (number.ValueKind != JsonValueKind.Number || !number.TryGetInt32(out var count) || count < 0)) return false;
-                if (field.Value.ValueKind == JsonValueKind.String && field.Value.GetString() == "unknown" && number.ValueKind != JsonValueKind.Null) return false;
+                if (!number.IsNull && (!number.IsNumber || !number.TryGetInt32(out var count) || count < 0)) return false;
+                if (field.Value.IsString && field.Value.GetString() == "unknown" && !number.IsNull) return false;
             }
-            if (field.Name == "counts" && field.Value.ValueKind == JsonValueKind.Object && !field.Value.EnumerateObject().All(x => ValidJson(x.Value))) return false;
+            if (field.Name == "counts" && field.Value.IsObject && !field.Value.EnumerateObject().All(x => ValidJson(x.Value))) return false;
             if (field.Name is "data" or "items" or "checks" or "reviews" or "conversation" or "availability" or "root_comment"
                 or "published" or "approved" or "changes_requested" or "outstanding_users" or "outstanding_teams" or "count" or "total" or "excluded_by_filter"
                 && !ValidJson(field.Value)) return false;

--- a/src/Capacitor.Cli.Core/PullRequests/PullRequestWire.cs
+++ b/src/Capacitor.Cli.Core/PullRequests/PullRequestWire.cs
@@ -1,0 +1,69 @@
+using System.Globalization;
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core.PullRequests;
+
+public static class PullRequestWire {
+    public static bool ValidSubject(PullRequestSubjectDto subject) => subject.Provider is { Length: > 0 and <= 100 }
+        && subject.Host is { Length: > 0 and <= 256 } && ValidSegment(subject.RepoHash)
+        && ValidSegment(subject.Owner) && ValidSegment(subject.RepoName) && subject.Number > 0;
+    public static bool ValidSegment(string? value) => value is { Length: > 0 and <= 256 }
+        && value is not ("." or "..") && !value.Any(c => char.IsControl(c) || c is '/' or '\\');
+    public static bool ValidHandle(string? value) => value is { Length: 64 } && value.All(char.IsAsciiHexDigitLower);
+    public static bool IsGitHub(PullRequestSubjectDto subject) => subject.Provider == "github" && subject.Host == "github.com";
+    public static PullRequestSubjectDto Subject(PullRequestLinkDto link) => new() { Provider = link.Provider, Host = link.Host,
+        RepoHash = link.RepoHash, Owner = link.Owner, RepoName = link.RepoName, Number = link.Number };
+    public static int? KnownCount(PullRequestCountDto? count) => count is { Kind: "exact" or "lower_bound", Value: >= 0 } ? count.Value : null;
+    public static string? SafeLink(string? value) => value is { Length: > 0 and <= 4096 } && Uri.TryCreate(value, UriKind.Absolute, out var uri)
+        && uri.Scheme == "https" && uri.UserInfo.Length == 0 && uri.IsDefaultPort ? uri.AbsoluteUri : null;
+    public static string? PrLink(string? value, PullRequestSubjectDto subject) {
+        if (SafeLink(value) is not { } safe) return null;
+        var uri = new Uri(safe);
+        var path = $"/{subject.Owner}/{subject.RepoName}/pull/{subject.Number.ToString(CultureInfo.InvariantCulture)}";
+        return uri.Host == "github.com" && (uri.AbsolutePath.TrimEnd('/').Equals(path, StringComparison.OrdinalIgnoreCase)
+            || uri.AbsolutePath.TrimEnd('/').Equals(path + "/files", StringComparison.OrdinalIgnoreCase)) ? safe : null;
+    }
+    public static string? CheckLink(string? value) => value is { Length: > 0 and <= 4096 } && Uri.TryCreate(value, UriKind.Absolute, out var uri)
+        && uri.Scheme == "https" && uri.UserInfo.Length == 0 ? uri.AbsoluteUri : null;
+    public static string? BodyLink(string? value) => value is { Length: > 0 and <= 4096 } && Uri.TryCreate(value, UriKind.Absolute, out var uri)
+        && uri.Scheme is "https" or "http" && uri.UserInfo.Length == 0 ? uri.AbsoluteUri : null;
+
+    internal static bool ValidJson(JsonElement root) {
+        if (root.ValueKind == JsonValueKind.Array) return root.EnumerateArray().All(ValidJson);
+        if (root.ValueKind != JsonValueKind.Object) return true;
+        foreach (var field in root.EnumerateObject()) {
+            if (field.Name is "fetched_at" or "retry_at" or "snapshot_started_at" or "snapshot_completed_at" or "created_at" or "updated_at"
+                or "submitted_at" or "started_at" or "completed_at" or "published_at") {
+                if (field.Value.ValueKind != JsonValueKind.Null && (field.Value.ValueKind != JsonValueKind.String || field.Value.GetString()?.EndsWith('Z') != true
+                    || !field.Value.TryGetDateTimeOffset(out var date) || date.Offset != TimeSpan.Zero)) return false;
+            }
+            if (field.Name == "kind" && root.TryGetProperty("value", out var number)) {
+                if (number.ValueKind != JsonValueKind.Null && (number.ValueKind != JsonValueKind.Number || !number.TryGetInt32(out var count) || count < 0)) return false;
+                if (field.Value.ValueKind == JsonValueKind.String && field.Value.GetString() == "unknown" && number.ValueKind != JsonValueKind.Null) return false;
+            }
+            if (field.Name == "counts" && field.Value.ValueKind == JsonValueKind.Object && !field.Value.EnumerateObject().All(x => ValidJson(x.Value))) return false;
+            if (field.Name is "data" or "items" or "checks" or "reviews" or "conversation" or "availability" or "root_comment"
+                or "published" or "approved" or "changes_requested" or "outstanding_users" or "outstanding_teams" or "count" or "total" or "excluded_by_filter"
+                && !ValidJson(field.Value)) return false;
+        }
+        return true;
+    }
+    internal static bool ValidData<T>(T value) where T : class => value switch {
+        PullRequestLinkListDto links => links.Items is { Length: <= 5000 } && links.Items.All(link => link is not null && ValidSubject(Subject(link))),
+        PullRequestOverviewDto => true,
+        PullRequestPageDto<PullRequestCheckDto> page => ValidPage(page, row => (row.Id, row.Availability)),
+        PullRequestPageDto<PullRequestReviewerDto> page => ValidPage(page, row => (row.Id, row.Availability)),
+        PullRequestPageDto<PullRequestReviewDto> page => ValidPage(page, row => (row.Id, row.Availability)),
+        PullRequestPageDto<PullRequestThreadDto> page => ValidPage(page, row => (row.Id, row.Availability)),
+        PullRequestPageDto<PullRequestCommentDto> page => ValidPage(page, row => (row.Id, row.Availability)),
+        _ => false
+    };
+    static bool ValidPage<T>(PullRequestPageDto<T> page, Func<T, (string Id, string Availability)> identity) where T : class {
+        if (!ValidHandle(page.SnapshotId) || !ValidHandle(page.PageCursor) || page.Items is not { Length: <= 50 }
+            || page.HasMore != !string.IsNullOrEmpty(page.NextCursor) || page.NextCursor is not null && !ValidHandle(page.NextCursor)
+            || page.HasMore && page.Items.Length == 0 || page.SnapshotCompletedAt < page.SnapshotStartedAt
+            || page.Total is null || page.ExcludedByFilter is null) return false;
+        var ids = new HashSet<string>(StringComparer.Ordinal);
+        return page.Items.All(row => row is not null && identity(row) is { Id: { Length: > 0 and <= 256 }, Availability: not null } item && ids.Add(item.Id));
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/FakePullRequestSource.cs
+++ b/test/Capacitor.App.Tests.Unit/FakePullRequestSource.cs
@@ -1,0 +1,56 @@
+using System.Globalization;
+using Capacitor.Cli.Core.PullRequests;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+internal sealed class FakePullRequestSource(FakeTimeProvider time) : IPullRequestSource {
+    public PullRequestLinkDto[] Links = [Link(1), Link(2)];
+    public int Lists;
+    public int Overviews;
+    public int Pages;
+    public int TotalPages = 3;
+    public string? Failure;
+    public string OverviewTitle = "Private PR";
+    public readonly Queue<Func<PullRequestSubjectDto, CancellationToken, Task<PullRequestRead<PullRequestOverviewDto>>>> OverviewResponses = new();
+    public readonly List<CancellationToken> OverviewTokens = [];
+    public Task<PullRequestCapability> DiscoverAsync(bool refresh, CancellationToken ct) => Task.FromResult(new PullRequestCapability(PullRequestCapabilityKind.Supported, 1));
+    public void ResetSession(string sessionId) { }
+    public Task<PullRequestRead<PullRequestLinkListDto>> ListAsync(string sessionId, CancellationToken ct) {
+        Lists++;
+        return Task.FromResult(new PullRequestRead<PullRequestLinkListDto>(PullRequestReadKind.Ready, new() { Items = Links }));
+    }
+    public Task<PullRequestRead<PullRequestLinkListDto>> LegacyLinksAsync(string sessionId, CancellationToken ct) => ListAsync(sessionId, ct);
+    public Task<PullRequestRead<PullRequestOverviewDto>> OverviewAsync(string sessionId, PullRequestSubjectDto subject, CancellationToken ct) {
+        Overviews++; OverviewTokens.Add(ct);
+        if (OverviewResponses.TryDequeue(out var response)) return response(subject, ct);
+        return Task.FromResult(Failure is null ? Overview(subject) : new PullRequestRead<PullRequestOverviewDto>(PullRequestReadKind.Unavailable,
+            Subject: subject, AccessFailure: Failure, Reason: Failure == "denied" ? "github_access_denied" : "timeout"));
+    }
+    public PullRequestRead<PullRequestOverviewDto> Overview(PullRequestSubjectDto subject, string? title = null) => new(PullRequestReadKind.Ready,
+        new() { Title = title ?? OverviewTitle, Description = "Private description", HeadSha = new string('a', 40), Lifecycle = "open",
+            Checks = new() { Availability = new() { Status = "ready", FetchedAt = time.GetUtcNow().UtcDateTime }, Rollup = "success" } },
+        subject, time.GetUtcNow().UtcDateTime, AccessValidForSeconds: 30, RequestStarted: time.GetTimestamp());
+    public Task<PullRequestRead<PullRequestPageDto<T>>> PageAsync<T>(string sessionId, PullRequestSubjectDto subject, string section,
+        string? cursor, string? resolved, string? threadId, CancellationToken ct) where T : class {
+        Pages++;
+        var page = cursor is null ? 0 : int.Parse(cursor[^8..], NumberStyles.HexNumber, CultureInfo.InvariantCulture);
+        var id = "item-" + page.ToString(CultureInfo.InvariantCulture);
+        object item = section switch {
+            "checks" => new PullRequestCheckDto { Id = id, Availability = "available", Name = "test", Outcome = "failure", HeadSha = new string('a', 40) },
+            "reviewers" => new PullRequestReviewerDto { Id = id, Availability = "available" },
+            "reviews" => new PullRequestReviewDto { Id = id, Availability = "available", Body = "Private review", State = "commented" },
+            "threads" => new PullRequestThreadDto { Id = id, Availability = "available", Path = "source.cs", DiffHunk = "+private code",
+                RootComment = new() { Id = "comment", Availability = "available", Body = "Private thread" } },
+            _ => new PullRequestCommentDto { Id = id, Availability = "available", Body = "Private comment" }
+        };
+        var next = page + 1 < TotalPages ? (page + 1).ToString("x64", CultureInfo.InvariantCulture) : null;
+        return Task.FromResult(new PullRequestRead<PullRequestPageDto<T>>(PullRequestReadKind.Ready, new() {
+            SnapshotId = new string('a', 64), SnapshotStartedAt = time.GetUtcNow().UtcDateTime, SnapshotCompletedAt = time.GetUtcNow().UtcDateTime,
+            Coverage = "complete", HeadSha = section == "checks" ? new string('a', 40) : null, Total = new() { Kind = "exact", Value = TotalPages },
+            ExcludedByFilter = new() { Kind = "exact", Value = 0 }, Items = [(T)item], PageCursor = page.ToString("x64", CultureInfo.InvariantCulture), NextCursor = next, HasMore = next is not null
+        }, subject, time.GetUtcNow().UtcDateTime, AccessValidForSeconds: 30, RequestStarted: time.GetTimestamp()));
+    }
+    public static PullRequestLinkDto Link(int number) => new() { Provider = "github", Host = "github.com", RepoHash = "hash",
+        Owner = "example", RepoName = "repo", Number = number, Url = $"https://github.com/example/repo/pull/{number}", Title = "Linked PR", HeadRef = "feature" };
+}

--- a/test/Capacitor.App.Tests.Unit/PullRequestContextViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PullRequestContextViewModelTests.cs
@@ -169,14 +169,63 @@ public class PullRequestContextViewModelTests {
         await h.Dispose();
     });
 
+    [Test]
+    public Task An_unlinked_explicit_selection_stays_unavailable_until_it_returns_or_the_user_selects_another_PR() => RunOnUiAsync(async () => {
+        var h = new Harness(); h.Push(); await h.Show(); h.Vm.SetReaderVisible(true);
+        h.Vm.Selected = h.Vm.Choices[1];
+        await WaitUntilAsync(() => h.Vm.CanReveal, what: "explicit PR admitted");
+        var removed = h.Source.Links[1];
+        h.Source.Links = [h.Source.Links[0]];
+        var overviews = h.Source.Overviews;
+        for (var refresh = 0; refresh < 2; refresh++) {
+            h.Time.Advance(TimeSpan.FromSeconds(16)); await h.Vm.RefreshCommand.Execute();
+            await WaitUntilAsync(() => !h.Vm.IsReading, what: "missing selection applied");
+            await Assert.That(h.Vm.Selected!.Subject.Number).IsEqualTo(2);
+            await Assert.That(h.Vm.Selected.IsAvailable).IsFalse();
+            await Assert.That(h.Vm.Description).IsNull();
+            await Assert.That(h.Vm.CanReveal).IsFalse();
+            await Assert.That(h.Source.Overviews).IsEqualTo(overviews);
+        }
+        await h.Vm.OpenGitHubCommand.Execute();
+        await Assert.That(h.Opener.Opened).IsEmpty();
+        h.Source.Links = [h.Source.Links[0], removed];
+        h.Time.Advance(TimeSpan.FromSeconds(16)); await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => h.Vm.CanReveal, what: "relinked selection admitted");
+        await Assert.That(h.Vm.Selected!.Subject.Number).IsEqualTo(2);
+        await Assert.That(h.Vm.Selected.IsAvailable).IsTrue();
+        h.Source.Links = [h.Source.Links[0]];
+        h.Time.Advance(TimeSpan.FromSeconds(16)); await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "selection removed again");
+        h.Vm.Selected = h.Vm.Choices.Single(choice => choice.Subject.Number == 1);
+        await WaitUntilAsync(() => h.Vm.CanReveal, what: "replacement explicitly selected");
+        await Assert.That(h.Vm.Selected!.Subject.Number).IsEqualTo(1);
+        await h.Dispose();
+    });
+
+    [Test]
+    [Arguments("https://example.com/example/repo/pull/1", false)]
+    [Arguments("https://github.com/example/repo/pull/99", false)]
+    [Arguments("https://github.com/example/other/pull/1", false)]
+    [Arguments("https://github.com/example/repo/pull/1", true)]
+    public Task The_main_GitHub_action_opens_only_the_selected_PR(string url, bool accepted) => RunOnUiAsync(async () => {
+        var h = new Harness();
+        h.Source.Links[0] = h.Source.Links[0] with { Url = url };
+        h.Push(); await h.Show();
+        await h.Vm.OpenGitHubCommand.Execute();
+        await Assert.That(h.Opener.Opened.Count).IsEqualTo(accepted ? 1 : 0);
+        if (accepted) await Assert.That(h.Opener.Opened[0]).IsEqualTo(url);
+        await h.Dispose();
+    });
+
     sealed class Harness {
         internal BehaviorSubject<AgentStatusDto?> Presence { get; } = new(null);
         internal FakeTimeProvider Time { get; } = new();
         internal FakePullRequestSource Source { get; }
+        internal RecordingOpener Opener { get; } = new();
         internal PullRequestContextViewModel Vm { get; }
         internal Harness(Func<string?>? primary = null) {
             Source = new(Time);
-            Vm = new(Presence, Source, Time, new RecordingOpener(), () => { }, primaryRepo: primary);
+            Vm = new(Presence, Source, Time, Opener, () => { }, primaryRepo: primary);
         }
         internal void Push() => Presence.OnNext(Agent("agent", "claude", hasTerminal: false, sessionId: "session", branch: "feature"));
         internal async Task Show() { Vm.SetForeground(true); await WaitUntilAsync(() => Vm.CanReveal, what: "PR overview admitted"); }

--- a/test/Capacitor.App.Tests.Unit/PullRequestContextViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PullRequestContextViewModelTests.cs
@@ -1,0 +1,185 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Avalonia.Threading;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Core.PullRequests;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+[NotInParallel("AvaloniaSession")]
+public class PullRequestContextViewModelTests {
+    [Test]
+    public Task Reads_start_only_in_the_foreground_and_focus_loss_masks_already_loaded_bodies() => RunOnUiAsync(async () => {
+        var h = new Harness();
+        h.Push();
+        await Assert.That(h.Source.Lists).IsEqualTo(0);
+        await h.Show();
+        h.Vm.SetReaderVisible(true);
+        await Assert.That(h.Vm.Description).IsEqualTo("Private description");
+        h.Vm.SetForeground(false);
+        await Assert.That(h.Vm.Description).IsNull();
+        await Assert.That(h.Vm.Rows).IsEmpty();
+        await Assert.That(h.Vm.CanReveal).IsFalse();
+        var calls = h.Source.Overviews;
+        h.Time.Advance(TimeSpan.FromMinutes(1));
+        Dispatcher.UIThread.RunJobs();
+        await Assert.That(h.Source.Overviews).IsEqualTo(calls);
+        await h.Dispose();
+    });
+
+    [Test]
+    public Task A_B_A_selection_cancels_the_old_request_and_rejects_its_late_result() => RunOnUiAsync(async () => {
+        var h = new Harness();
+        var old = new TaskCompletionSource<PullRequestRead<PullRequestOverviewDto>>();
+        h.Source.OverviewResponses.Enqueue((_, _) => old.Task);
+        h.Push(); h.Vm.SetForeground(true);
+        await WaitUntilAsync(() => h.Source.Overviews == 1, what: "first overview request");
+        var a = h.Vm.Choices[0]; var b = h.Vm.Choices[1];
+        h.Vm.Selected = b;
+        await WaitUntilAsync(() => h.Vm.CanReveal, what: "B admitted");
+        h.Source.OverviewTitle = "Current A";
+        h.Vm.Selected = a;
+        await WaitUntilAsync(() => h.Vm.Title == "Current A", what: "new A admitted");
+        old.SetResult(h.Source.Overview(a.Subject, "Old A"));
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "old request settles");
+        Dispatcher.UIThread.RunJobs();
+        await Assert.That(h.Source.OverviewTokens[0].IsCancellationRequested).IsTrue();
+        await Assert.That(h.Vm.Title).IsEqualTo("Current A");
+        await h.Dispose();
+    });
+
+    [Test]
+    public Task Transient_grace_retains_only_the_current_view_and_cannot_open_a_new_section() => RunOnUiAsync(async () => {
+        var h = new Harness(); h.Push(); await h.Show();
+        h.Vm.SetReaderVisible(true);
+        h.Source.Failure = "transient";
+        h.Time.Advance(TimeSpan.FromSeconds(21));
+        await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "access refresh fails");
+        await Assert.That(h.Vm.CanReveal).IsFalse();
+        await Assert.That(h.Vm.Description).IsEqualTo("Private description");
+        await h.Vm.ShowSectionCommand.Execute("reviews");
+        await Assert.That(h.Source.Pages).IsEqualTo(0);
+        h.Vm.SetReaderVisible(false); h.Vm.SetReaderVisible(true);
+        await Assert.That(h.Vm.Description).IsNull();
+        h.Time.Advance(TimeSpan.FromMinutes(6)); Dispatcher.UIThread.RunJobs();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "grace expires");
+        await Assert.That(h.Vm.CanDisplay).IsFalse();
+        await h.Dispose();
+    });
+
+    [Test]
+    public Task An_explicit_denial_clears_previously_visible_content_immediately() => RunOnUiAsync(async () => {
+        var h = new Harness(); h.Push(); await h.Show(); h.Vm.SetReaderVisible(true);
+        h.Source.Failure = "denied"; h.Time.Advance(TimeSpan.FromSeconds(16));
+        await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "denial applied");
+        await Assert.That(h.Vm.Description).IsNull();
+        await Assert.That(h.Vm.CanDisplay).IsFalse();
+        await Assert.That(h.Vm.Notice).Contains("cannot read");
+        await h.Dispose();
+    });
+
+    [Test]
+    public Task Explicit_selection_survives_list_refreshes_and_body_state_does_not_survive_PR_switches() => RunOnUiAsync(async () => {
+        var h = new Harness(); h.Push(); await h.Show(); h.Vm.SetReaderVisible(true);
+        h.Vm.Selected = h.Vm.Choices[1];
+        await WaitUntilAsync(() => h.Vm.CanReveal, what: "selected second PR");
+        await h.Vm.ShowSectionCommand.Execute("conversation");
+        await WaitUntilAsync(() => h.Vm.Rows.Count == 1, what: "comment page loaded");
+        h.Time.Advance(TimeSpan.FromSeconds(16)); await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "list refresh");
+        await Assert.That(h.Vm.Selected!.Subject.Number).IsEqualTo(2);
+        h.Vm.Selected = h.Vm.Choices[0];
+        await Assert.That(h.Vm.Rows).IsEmpty();
+        await h.Dispose();
+    });
+
+    [Test]
+    public Task A_section_keeps_eight_pages_and_exposes_a_reload_control_for_evicted_content() => RunOnUiAsync(async () => {
+        var h = new Harness(); h.Source.TotalPages = 12; h.Push(); await h.Show(); h.Vm.SetReaderVisible(true);
+        await h.Vm.ShowSectionCommand.Execute("conversation");
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "first page");
+        for (var page = 1; page < 10; page++) {
+            await h.Vm.LoadMoreCommand.Execute();
+            await WaitUntilAsync(() => !h.Vm.IsReading, what: "next page");
+        }
+        await Assert.That(h.Vm.Rows.Count).IsEqualTo(8);
+        await Assert.That(h.Vm.CanReloadEarlier).IsTrue();
+        await Assert.That(h.Vm.HasMore).IsTrue();
+        await h.Vm.ReloadEarlierCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "evicted page reloaded");
+        await Assert.That(h.Vm.Rows[0].Id).IsEqualTo("item-1");
+        await Assert.That(h.Vm.Rows.Count).IsEqualTo(8);
+        await h.Vm.LoadMoreCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "resume after reloading earlier");
+        await Assert.That(h.Vm.Rows[^1].Id).IsEqualTo("item-9");
+        await h.Dispose();
+    });
+
+    [Test]
+    public Task Complete_current_checks_take_precedence_over_a_conflicting_advisory_rollup() => RunOnUiAsync(async () => {
+        var h = new Harness(); h.Source.TotalPages = 1; h.Push(); await h.Show(); h.Vm.SetReaderVisible(true);
+        await Assert.That(h.Vm.CheckSummary).Contains("GitHub summary");
+        await h.Vm.ShowSectionCommand.Execute("checks");
+        await WaitUntilAsync(() => h.Vm.Rows.Count == 1, what: "checks page");
+        await Assert.That(h.Vm.CheckSummary).Contains("1 failed");
+        await Assert.That(h.Vm.CheckSummary).DoesNotContain("successful");
+        await h.Dispose();
+    });
+
+    [Test]
+    public Task Retry_refreshes_the_current_section_after_access_recovers() => RunOnUiAsync(async () => {
+        var h = new Harness(); h.Push(); await h.Show(); h.Vm.SetReaderVisible(true);
+        await h.Vm.ShowSectionCommand.Execute("reviews");
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "initial reviews");
+        var pages = h.Source.Pages;
+        h.Source.Failure = "transient"; h.Time.Advance(TimeSpan.FromSeconds(16));
+        await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "failed renewal");
+        await Assert.That(h.Vm.CanReveal).IsFalse();
+        h.Source.Failure = null; h.Time.Advance(TimeSpan.FromSeconds(16));
+        await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "recovered renewal");
+        await Assert.That(h.Vm.CanReveal).IsTrue();
+        await Assert.That(h.Source.Pages).IsEqualTo(pages + 1);
+        await h.Dispose();
+    });
+
+    [Test]
+    public Task A_late_primary_repository_hint_corrects_the_default_without_changing_an_explicit_choice() => RunOnUiAsync(async () => {
+        string? primary = null;
+        var h = new Harness(() => primary);
+        h.Source.Links[1] = h.Source.Links[1] with { RepoHash = "primary" };
+        h.Push(); await h.Show();
+        await Assert.That(h.Vm.Selected!.Subject.Number).IsEqualTo(1);
+        primary = "primary";
+        h.Time.Advance(TimeSpan.FromSeconds(16)); await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "primary repository selected");
+        await Assert.That(h.Vm.Selected!.Subject.Number).IsEqualTo(2);
+        h.Vm.Selected = h.Vm.Choices[0];
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "explicit selection admitted");
+        h.Time.Advance(TimeSpan.FromSeconds(16)); await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "explicit selection retained");
+        await Assert.That(h.Vm.Selected!.Subject.Number).IsEqualTo(1);
+        await h.Dispose();
+    });
+
+    sealed class Harness {
+        internal BehaviorSubject<AgentStatusDto?> Presence { get; } = new(null);
+        internal FakeTimeProvider Time { get; } = new();
+        internal FakePullRequestSource Source { get; }
+        internal PullRequestContextViewModel Vm { get; }
+        internal Harness(Func<string?>? primary = null) {
+            Source = new(Time);
+            Vm = new(Presence, Source, Time, new RecordingOpener(), () => { }, primaryRepo: primary);
+        }
+        internal void Push() => Presence.OnNext(Agent("agent", "claude", hasTerminal: false, sessionId: "session", branch: "feature"));
+        internal async Task Show() { Vm.SetForeground(true); await WaitUntilAsync(() => Vm.CanReveal, what: "PR overview admitted"); }
+        internal async Task Dispose() { await Vm.TeardownAsync(); Presence.Dispose(); }
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/PullRequestViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PullRequestViewSmokeTests.cs
@@ -1,0 +1,61 @@
+using System.Reactive.Linq;
+using Avalonia.Controls;
+using Avalonia.Threading;
+using Capacitor.App.ViewModels;
+using Capacitor.App.Views;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+[NotInParallel("AvaloniaSession")]
+public class PullRequestViewSmokeTests {
+    [Test]
+    [Arguments(true, false)]
+    [Arguments(false, false)]
+    [Arguments(true, true)]
+    [Arguments(false, true)]
+    public Task Reader_is_lazy_and_reusable_for_live_and_ended_sessions_with_or_without_a_terminal(bool terminal, bool ended) => RunOnUiAsync(async () => {
+        var daemon = new FakeDaemonClientService();
+        var attach = new FakeTerminalAttachClientFactory();
+        var time = new FakeTimeProvider();
+        var source = new FakePullRequestSource(time);
+        var vm = new WorkspaceViewModel("agent", daemon, NewActions(), attach.Factory, () => new FakeTerminalSurface(), time,
+            new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource(), pullRequests: source);
+        var view = new WorkspaceView { DataContext = vm };
+        var window = new Window { Content = view, Width = 1200, Height = 800 };
+        window.Show();
+        try {
+            daemon.Agents.AddOrUpdate(Agent("agent", "claude", terminal, sessionId: "session") with { Status = ended ? "Completed" : "Running" });
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            vm.PullRequests!.SetForeground(true);
+            await WaitUntilAsync(() => vm.PullRequests.CanReveal, what: "PR loaded");
+            Dispatcher.UIThread.RunJobs();
+            var host = view.FindControl<ContentControl>("PullRequestHost")!;
+            var terminalHost = view.FindControl<Control>("TerminalHost");
+            var chatHost = view.FindControl<ChatTabView>("ChatHost");
+            var chat = vm.Chat;
+            if (chat is not null) chat.ComposerText = "Unsent draft";
+            await Assert.That(host.Content).IsNull();
+            await vm.ShowPullRequestCommand.Execute();
+            Dispatcher.UIThread.RunJobs(); window.UpdateLayout();
+            var reader = host.Content;
+            await Assert.That(reader).IsTypeOf<PullRequestReader>();
+            await Assert.That(((Control)reader!).IsEffectivelyVisible).IsTrue();
+            await Assert.That(vm.ShowsTerminalBanners).IsFalse();
+            await Assert.That(vm.PullRequests.Description).IsEqualTo("Private description");
+            await vm.ShowChatCommand.Execute();
+            await vm.ShowPullRequestCommand.Execute();
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(ReferenceEquals(reader, host.Content)).IsTrue();
+            await Assert.That(ReferenceEquals(terminalHost, view.FindControl<Control>("TerminalHost"))).IsTrue();
+            await Assert.That(ReferenceEquals(chatHost, view.FindControl<ChatTabView>("ChatHost"))).IsTrue();
+            await Assert.That(ReferenceEquals(chat, vm.Chat)).IsTrue();
+            if (chat is not null) await Assert.That(chat.ComposerText).IsEqualTo("Unsent draft");
+            vm.PullRequests.SetForeground(false);
+            await Assert.That(vm.PullRequests.Description).IsNull();
+        } finally { window.Close(); await vm.TeardownAsync(); }
+    });
+}

--- a/test/Capacitor.App.Tests.Unit/ServerPullRequestSourceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerPullRequestSourceTests.cs
@@ -1,0 +1,58 @@
+using System.Net;
+using System.Text;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.PullRequests;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ServerPullRequestSourceTests {
+    [TempConfigRoot] public required TempConfigRoot Config { get; init; }
+
+    [Test]
+    public async Task Three_missing_reads_stop_only_that_session_and_retry_resets_it() {
+        using var handler = new Handler();
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root),
+            (_, _, _, _) => Task.FromResult((new HttpClient(handler), AuthStatus.Ok)));
+        for (var i = 0; i < 4; i++) await source.ListAsync("missing", default);
+        await Assert.That(handler.Lists).IsEqualTo(3);
+        await Assert.That((await source.ListAsync("healthy", default)).Kind).IsEqualTo(PullRequestReadKind.Ready);
+        source.ResetSession("missing");
+        await source.ListAsync("missing", default);
+        await Assert.That(handler.Lists).IsEqualTo(5);
+    }
+
+    [Test]
+    public async Task Sign_in_during_client_creation_cannot_publish_the_old_authenticated_client() {
+        using var handler = new Handler();
+        var gate = new TaskCompletionSource<(HttpClient, AuthStatus)>();
+        var calls = 0;
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), (_, _, _, _) => {
+            calls++;
+            return calls == 1 ? gate.Task : Task.FromResult((new HttpClient(new Handler()), AuthStatus.Ok));
+        });
+        var pending = source.DiscoverAsync(false, default);
+        source.InvalidateAuthentication();
+        gate.SetResult((new HttpClient(handler), AuthStatus.Ok));
+        await Assert.That((await pending).Kind).IsEqualTo(PullRequestCapabilityKind.SignedOut);
+        await Assert.That(handler.Disposed).IsTrue();
+        await Assert.That((await source.DiscoverAsync(false, default)).Kind).IsEqualTo(PullRequestCapabilityKind.Supported);
+        await Assert.That(calls).IsEqualTo(2);
+    }
+
+    sealed class Handler : HttpMessageHandler {
+        internal int Lists;
+        internal bool Disposed;
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+            var path = request.RequestUri!.AbsolutePath;
+            var discovery = path == "/auth/config";
+            if (!discovery) Lists++;
+            return Task.FromResult(new HttpResponseMessage(path.Contains("/missing/", StringComparison.Ordinal) ? HttpStatusCode.NotFound : HttpStatusCode.OK) {
+                RequestMessage = request,
+                Content = new StringContent(discovery ? """{"provider":"workos","pull_request_reads_versions":[1]}"""
+                    : """{"status":"ready","data":{"items":[]},"fetched_at":"2026-09-07T10:00:00Z","poll_after_seconds":30,"access_valid_for_seconds":0}""", Encoding.UTF8, "application/json")
+            });
+        }
+        protected override void Dispose(bool disposing) { Disposed = true; base.Dispose(disposing); }
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj
@@ -1,4 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
+    <ItemGroup>
+        <None Include="../fixtures/pull-request-reads-v1.json" Link="fixtures/pull-request-reads-v1.json" CopyToOutputDirectory="PreserveNewest" />
+    </ItemGroup>
     <PropertyGroup>
         <TargetFramework>net10.0</TargetFramework>
         <OutputType>Exe</OutputType>

--- a/test/Capacitor.Cli.Core.Tests.Unit/Http/CapacitorHttpContainerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Http/CapacitorHttpContainerTests.cs
@@ -420,6 +420,25 @@ public class CapacitorHttpContainerTests : IDisposable {
         await Assert.That(await response.Content.ReadAsStringAsync()).IsEqualTo("arrived");
     }
 
+    [Test]
+    public async Task Protected_reads_refuse_redirects_after_authentication() {
+        await AuthenticateAsync("tok_protected");
+        _server.Given(Request.Create().WithPath("/protected").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(302).WithHeader("Location", $"{Url}/substitute"));
+        _server.Given(Request.Create().WithPath("/substitute").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200));
+
+        using var sp = Container();
+        var attempt = await sp.GetRequiredService<ICapacitorHttpClient>().ForProtectedReadAsync();
+        using var client = attempt.Client;
+        using var response = await client.GetAsync($"{Url}/protected");
+
+        await Assert.That(attempt.Status).IsEqualTo(AuthStatus.Ok);
+        await Assert.That(response.StatusCode).IsEqualTo(HttpStatusCode.Redirect);
+        await Assert.That(RequestTo("/protected").RequestMessage.Headers!["Authorization"].Single()).IsEqualTo("Bearer tok_protected");
+        await Assert.That(_server.LogEntries.Any(e => e.RequestMessage.Path == "/substitute")).IsFalse();
+    }
+
     // ── The loopback lane ──────────────────────────────────────────────────────────────────────
 
     /// <summary>
@@ -631,7 +650,9 @@ public class CapacitorHttpContainerTests : IDisposable {
     /// on the first 401 would discard a leg that was still answerable.
     /// </summary>
     [Test]
-    public async Task The_waiting_lane_reports_its_status_and_still_recovers_a_401() {
+    [Arguments(false)]
+    [Arguments(true)]
+    public async Task Waiting_and_protected_reads_report_status_and_recover_a_401(bool protectedRead) {
         await AuthenticateAsync("tok_1");
 
         _server.Given(Request.Create().WithPath("/auth/refresh").UsingPost())
@@ -648,7 +669,8 @@ public class CapacitorHttpContainerTests : IDisposable {
 
         using var sp = Container();
 
-        var (client, status, _, _) = await sp.GetRequiredService<ICapacitorHttpClient>().ForWaitAsync();
+        var http = sp.GetRequiredService<ICapacitorHttpClient>();
+        var (client, status, _, _) = protectedRead ? await http.ForProtectedReadAsync() : await http.ForWaitAsync();
 
         using var waiting  = client;
         using var response = await waiting.GetAsync($"{Url}/api/flow");

--- a/test/Capacitor.Cli.Core.Tests.Unit/PullRequests/PullRequestClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/PullRequests/PullRequestClientTests.cs
@@ -1,0 +1,149 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using Capacitor.Cli.Core.PullRequests;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Core.Tests.Unit.PullRequests;
+
+public class PullRequestClientTests {
+    [Test]
+    public async Task Literal_contract_bundle_has_the_same_pinned_digest_as_the_server() {
+        var bytes = await File.ReadAllBytesAsync(FixturePath);
+        await Assert.That(Convert.ToHexStringLower(SHA256.HashData(bytes))).IsEqualTo(PullRequestContract.FixtureSha256);
+    }
+
+    [Test]
+    public async Task Literal_responses_are_validated_through_each_typed_read_route() {
+        using var fixture = JsonDocument.Parse(await File.ReadAllTextAsync(FixturePath));
+        var subject = fixture.RootElement.GetProperty("subject").Deserialize(PullRequestJsonContext.Default.PullRequestSubjectDto)!;
+        foreach (var example in fixture.RootElement.GetProperty("responses").EnumerateArray()) {
+            using var handler = new Handler { Body = example.GetProperty("body").GetRawText() };
+            using var http = new HttpClient(handler);
+            using var client = new PullRequestClient(http, "https://tenant.test");
+            var kind = example.GetProperty("route").GetString() switch {
+                "links" => (await client.ListAsync("session", default)).Kind,
+                "overview" => (await client.OverviewAsync("session", subject, default)).Kind,
+                "checks" => (await client.PageAsync<PullRequestCheckDto>("session", subject, "checks", null, null, null, default)).Kind,
+                "reviewers" => (await client.PageAsync<PullRequestReviewerDto>("session", subject, "reviewers", null, null, null, default)).Kind,
+                "reviews" => (await client.PageAsync<PullRequestReviewDto>("session", subject, "reviews", null, null, null, default)).Kind,
+                "threads" => (await client.PageAsync<PullRequestThreadDto>("session", subject, "threads", null, null, null, default)).Kind,
+                "thread_comments" => (await client.PageAsync<PullRequestCommentDto>("session", subject, "thread_comments", null, null, "PRRT_thread", default)).Kind,
+                _ => (await client.PageAsync<PullRequestCommentDto>("session", subject, "conversation", null, null, null, default)).Kind
+            };
+            await Assert.That(kind.ToString()).IsEqualTo(example.GetProperty("expected").GetString());
+            await Assert.That(handler.Paths.Skip(1).All(path => path.Contains("version=1", StringComparison.Ordinal))).IsTrue();
+        }
+    }
+
+    [Test]
+    public async Task Discovery_requires_a_well_formed_shared_version_before_any_new_route() {
+        using var fixture = JsonDocument.Parse(await File.ReadAllTextAsync(FixturePath));
+        foreach (var example in fixture.RootElement.GetProperty("discovery").EnumerateArray()) {
+            using var handler = new Handler { Discovery = example.GetProperty("body").GetRawText() };
+            using var http = new HttpClient(handler);
+            using var client = new PullRequestClient(http, "https://tenant.test");
+            var discovery = await client.DiscoverAsync(false, default);
+            await Assert.That(discovery.Kind.ToString()).IsEqualTo(example.GetProperty("kind").GetString());
+            if (discovery.Kind != PullRequestCapabilityKind.Supported) {
+                await client.ListAsync("session", default);
+                await Assert.That(handler.Paths.Count).IsEqualTo(1);
+            }
+        }
+    }
+
+    [Test]
+    public async Task Network_time_cannot_extend_a_response_access_lease() {
+        using var fixture = JsonDocument.Parse(await File.ReadAllTextAsync(FixturePath));
+        var subject = fixture.RootElement.GetProperty("subject").Deserialize(PullRequestJsonContext.Default.PullRequestSubjectDto)!;
+        var overview = fixture.RootElement.GetProperty("responses")[1].GetProperty("body").GetRawText();
+        var clock = new FakeTimeProvider();
+        using var handler = new Handler { Body = overview, BeforeBody = () => clock.Advance(TimeSpan.FromSeconds(16)) };
+        using var http = new HttpClient(handler);
+        using var client = new PullRequestClient(http, "https://tenant.test", clock);
+        var read = await client.OverviewAsync("session", subject, default);
+        await Assert.That(read.Kind).IsEqualTo(PullRequestReadKind.Ready);
+        await Assert.That(read.RemainingSeconds(clock)).IsEqualTo(4);
+        await Assert.That(read.CanReveal(clock)).IsFalse();
+    }
+
+    [Test]
+    public async Task Discovery_failures_back_off_without_turning_into_legacy_support() {
+        var clock = new FakeTimeProvider();
+        using var handler = new Handler { Discovery = "not-json" };
+        using var http = new HttpClient(handler);
+        using var client = new PullRequestClient(http, "https://tenant.test", clock);
+        await client.DiscoverAsync(false, default);
+        await client.DiscoverAsync(true, default);
+        await Assert.That(handler.Paths.Count).IsEqualTo(1);
+        clock.Advance(TimeSpan.FromSeconds(30));
+        await client.DiscoverAsync(false, default);
+        clock.Advance(TimeSpan.FromSeconds(59));
+        await client.DiscoverAsync(true, default);
+        await Assert.That(handler.Paths.Count).IsEqualTo(2);
+        clock.Advance(TimeSpan.FromSeconds(1));
+        await client.DiscoverAsync(false, default);
+        await Assert.That(handler.Paths.Count).IsEqualTo(3);
+    }
+
+    [Test]
+    public async Task A_non_JSON_gateway_failure_is_transient_and_an_off_origin_response_is_invalid() {
+        using var handler = new Handler { Status = HttpStatusCode.ServiceUnavailable, Body = "gateway unavailable" };
+        using var http = new HttpClient(handler);
+        using var client = new PullRequestClient(http, "https://tenant.test");
+        var outage = await client.ListAsync("session", default);
+        await Assert.That(outage.AccessFailure).IsEqualTo("transient");
+        handler.Redirect = true;
+        var redirected = await client.ListAsync("session", default);
+        await Assert.That(redirected.Kind).IsEqualTo(PullRequestReadKind.InvalidProtocol);
+    }
+
+    [Test]
+    public async Task Legacy_links_require_an_independently_admitted_session_summary() {
+        using var handler = new Handler {
+            Discovery = """{"provider":"workos"}""",
+            Body = """{"session_id":"session","pull_requests":[{"repo_hash":"hash","owner":"Example","repo_name":"Repo","number":7,"url":"https://github.com/Example/Repo/pull/7"}]}"""
+        };
+        using var http = new HttpClient(handler);
+        using var client = new PullRequestClient(http, "https://tenant.test");
+        var read = await client.LegacyLinksAsync("session", default);
+        await Assert.That(read.Kind).IsEqualTo(PullRequestReadKind.Ready);
+        await Assert.That(read.Data!.Items[0].Owner).IsEqualTo("example");
+        await Assert.That(read.AccessValidForSeconds).IsEqualTo(0);
+        await Assert.That(handler.Paths.Last()).IsEqualTo("/api/sessions/session/summary");
+        handler.Status = HttpStatusCode.Forbidden;
+        var denied = await client.LegacyLinksAsync("session", default);
+        await Assert.That(denied.Data).IsNull();
+        await Assert.That(denied.AccessFailure).IsEqualTo("invalid");
+    }
+
+    [Test]
+    [Arguments("null")]
+    [Arguments("[null]")]
+    public async Task Malformed_legacy_rows_are_rejected(string rows) {
+        using var handler = new Handler { Discovery = """{"provider":"workos"}""", Body = "{\"session_id\":\"session\",\"pull_requests\":" + rows + "}" };
+        using var http = new HttpClient(handler);
+        using var client = new PullRequestClient(http, "https://tenant.test");
+        await Assert.That((await client.LegacyLinksAsync("session", default)).Kind).IsEqualTo(PullRequestReadKind.InvalidProtocol);
+    }
+
+    static string FixturePath => Path.Combine(AppContext.BaseDirectory, "fixtures", "pull-request-reads-v1.json");
+    sealed class Handler : HttpMessageHandler {
+        internal string Discovery = """{"provider":"workos","pull_request_reads_versions":[1]}""";
+        internal string Body = "{}";
+        internal HttpStatusCode Status = HttpStatusCode.OK;
+        internal Action? BeforeBody;
+        internal bool Redirect;
+        internal List<string> Paths { get; } = [];
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken) {
+            Paths.Add(request.RequestUri!.PathAndQuery);
+            var discovery = request.RequestUri.AbsolutePath == "/auth/config";
+            if (!discovery) BeforeBody?.Invoke();
+            return Task.FromResult(new HttpResponseMessage(discovery ? HttpStatusCode.OK : Status) {
+                RequestMessage = Redirect ? new HttpRequestMessage(HttpMethod.Get, "https://foreign.test/result") : request,
+                Content = new StringContent(discovery ? Discovery : Body, Encoding.UTF8, "application/json")
+            });
+        }
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/PullRequests/PullRequestClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/PullRequests/PullRequestClientTests.cs
@@ -128,6 +128,18 @@ public class PullRequestClientTests {
         await Assert.That((await client.LegacyLinksAsync("session", default)).Kind).IsEqualTo(PullRequestReadKind.InvalidProtocol);
     }
 
+    [Test]
+    [Arguments("null")]
+    [Arguments("[]")]
+    [Arguments("true")]
+    [Arguments("42")]
+    public async Task Non_object_legacy_summaries_are_rejected_without_throwing(string body) {
+        using var handler = new Handler { Discovery = """{"provider":"workos"}""", Body = body };
+        using var http = new HttpClient(handler);
+        using var client = new PullRequestClient(http, "https://tenant.test");
+        await Assert.That((await client.LegacyLinksAsync("session", default)).Kind).IsEqualTo(PullRequestReadKind.InvalidProtocol);
+    }
+
     static string FixturePath => Path.Combine(AppContext.BaseDirectory, "fixtures", "pull-request-reads-v1.json");
     sealed class Handler : HttpMessageHandler {
         internal string Discovery = """{"provider":"workos","pull_request_reads_versions":[1]}""";

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorBracketedPasteTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorBracketedPasteTests.cs
@@ -5,19 +5,12 @@ using Capacitor.Cli.Daemon.Tests.Unit.Pty;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
 /// <summary>
-/// a pasted (large, multi-line) message written to a hosted agent's PTY as raw bytes
-/// followed by a carriage return often fails to submit — the CR races the still-ingesting
-/// paste and is folded into it as a literal newline, so the text sits in the composer until a
-/// later, isolated keystroke finishes it (Codex never submits at all; Claude ~50% of the time).
-/// The fix delivers the message as a bracketed paste (ESC[200~ … ESC[201~) so the TUI treats it
-/// as one block, then submits with the escalating carriage-return schedule (GitHub #349 — a
-/// single CR after the paste is unreliably folded into paste-finalization; the extra CRs are
-/// harmless empty-composer no-ops once submitted). This test drives
-/// <c>AgentOrchestrator.HandleSendInput</c> end-to-end through the
-/// <see cref="IHostedAgentRuntime"/> seam (<see cref="PtyHostedAgentRuntime"/> wrapping a fake
-/// PTY) and asserts the wire shape reaching the PTY.
+/// Messages reach the PTY as a bracketed paste followed by separate submit keystrokes,
+/// so a terminal still ingesting the paste can accept a later carriage return.
 /// </summary>
 public class AgentOrchestratorBracketedPasteTests {
+    [TempDir] public required TempDir Worktree { get; init; }
+
     const string PasteStart = "\x1b[200~";
     const string PasteEnd   = "\x1b[201~";
 
@@ -31,8 +24,8 @@ public class AgentOrchestratorBracketedPasteTests {
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 
         var agent = new AgentInstance(
-            "agent-paste", null, "", null, "/tmp", "codex",
-            new PtyHostedAgentRuntime("codex", pty, approvalsDisabled: true), new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource());
+            "agent-paste", null, "", null, Worktree.Path, "codex",
+            new PtyHostedAgentRuntime("codex", pty, approvalsDisabled: true), new WorktreeInfo(Worktree.Path, "", Worktree.Path, IsStandalone: true), new CancellationTokenSource());
         orch.RegisterAgentForTest(agent);
 
         await orch.HandleSendInputForTest(new SendInputCommand("agent-paste", message, null));

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorDisposeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorDisposeTests.cs
@@ -4,16 +4,8 @@ using Capacitor.Cli.Daemon.Tests.Unit.Pty;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
 /// <summary>
-/// <see cref="AgentOrchestrator.DisposeAsync"/> must be idempotent and non-throwing: the DI
-/// container tracks the singleton AND <c>DaemonRunner</c> disposes it explicitly, so it runs
-/// twice by construction on every shutdown — the same structural double-teardown that crashed
-/// <see cref="ServerConnection"/> (an ObjectDisposedException escaping into DI teardown aborts
-/// a NativeAOT process). The orchestrator's <c>_shutdownCts</c> was also never disposed; adding
-/// that Dispose without a run-once guard would recreate the crash exactly, so these contracts
-/// pin body-ran-once AND cts-ends-cancelled-and-disposed durably.
-///
-/// Uses <see cref="AgentOrchestratorHarness"/> for its orchestrator builder and
-/// server-connection capture.
+/// The DI container and daemon runner both dispose the orchestrator, so teardown must be
+/// idempotent and continue cleaning up children even when cancellation callbacks throw.
 /// </summary>
 public class AgentOrchestratorDisposeTests {
     [Test]
@@ -44,27 +36,27 @@ public class AgentOrchestratorDisposeTests {
 
     [Test]
     public async Task A_faulting_cancellation_callback_does_not_skip_child_teardown() {
+        using var tmp = new TempDir();
+        var worktree = tmp.CreateDir("worktree");
+        var sibling = tmp.CreateFile("unrelated.txt", "keep");
         var orch = AgentOrchestratorHarness.BuildOrchestrator(
             new CaptureServerConnection(), new SpyPtyProcessFactory(),
             new Dictionary<string, IHostedAgentLauncher>());
 
         var runtime = new FakeHostedAgentRuntime("claude", emitsTerminalOutput: false);
         orch.RegisterAgentForTest(new AgentInstance(
-            "agent-cb", null, "", null, "/tmp", "claude", runtime,
-            new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource()));
+            "agent-cb", null, "", null, worktree, "claude", runtime,
+            new WorktreeInfo(worktree, "", worktree, IsStandalone: true), new CancellationTokenSource()));
 
-        // A registered cancellation callback that throws faults CancelAsync's returned task
-        // (AggregateException per the CTS contract) even though the cancel itself succeeded.
-        // Uncontained, that fault would jump straight to the dispose finally — skipping the
-        // processor drain and ALL child termination/cleanup — and the run-once guard means the
-        // DI pass can never retry, stranding live child processes.
+        // A faulted cancellation must still drain the processor and clean up children;
+        // the run-once guard prevents a later disposal from retrying skipped work.
         orch.ShutdownCtsForTests.Token.Register(() => throw new InvalidOperationException("callback boom"));
 
         await orch.DisposeAsync(); // must not throw
 
-        // Containment proof: teardown continued past the faulted cancel — the child was
-        // terminated, and the finally still cancelled+disposed the CTS.
         await Assert.That(runtime.HasExited).IsTrue();
+        await Assert.That(File.Exists(sibling)).IsTrue();
+        await Assert.That(Directory.Exists(worktree)).IsFalse();
         await Assert.That(orch.ShutdownCtsForTests.IsCancellationRequested).IsTrue();
         await Assert.That(() => _ = orch.ShutdownCtsForTests.Token).Throws<ObjectDisposedException>();
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorLocalAttachTests.cs
@@ -520,13 +520,14 @@ public class AgentOrchestratorLocalAttachTests {
     [Arguments("antigravity")]
     [Arguments("cursor")]
     public async Task Attach_to_a_runtime_with_no_terminal_is_refused_by_name(string vendor) {
+        using var worktree = new TempDir();
         var server = new CaptureServerConnection();
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 
         var runtime = new NoRawInputRuntime(vendor);
         var agent = new AgentInstance(
-            "hosted-1", null, "", null, "/r", vendor,
-            runtime, new WorktreeInfo("/r", "", "/r", IsStandalone: true), new CancellationTokenSource()
+            "hosted-1", null, "", null, worktree.Path, vendor,
+            runtime, new WorktreeInfo(worktree.Path, "", worktree.Path, IsStandalone: true), new CancellationTokenSource()
         );
         orch.RegisterAgentForTest(agent);
 
@@ -557,6 +558,7 @@ public class AgentOrchestratorLocalAttachTests {
 
     [Test]
     public async Task Attach_to_a_terminal_runtime_that_rejects_raw_input_gets_an_error_frame_instead_of_crashing() {
+        using var worktree = new TempDir();
         var server = new CaptureServerConnection();
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 
@@ -565,8 +567,8 @@ public class AgentOrchestratorLocalAttachTests {
         // disagree.
         var runtime = new NoRawInputRuntime("claude", emitsTerminalOutput: true);
         var agent = new AgentInstance(
-            "pty-1", null, "", null, "/r", "claude",
-            runtime, new WorktreeInfo("/r", "", "/r", IsStandalone: true), new CancellationTokenSource()
+            "pty-1", null, "", null, worktree.Path, "claude",
+            runtime, new WorktreeInfo(worktree.Path, "", worktree.Path, IsStandalone: true), new CancellationTokenSource()
         );
         orch.RegisterAgentForTest(agent);
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorStopDiagnosticsTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorStopDiagnosticsTests.cs
@@ -5,15 +5,11 @@ using Microsoft.Extensions.Logging;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
 /// <summary>
-/// The vendor-neutral stop path's own diagnostics. <c>StopAgentCoreAsync</c> stops EVERY hosted
-/// vendor, so its graceful-exit-timeout warning must name the vendor that actually failed to exit —
-/// it used to say "claude" unconditionally, which mislabelled a Cursor (or Codex, or Copilot)
-/// reviewer in the one log line an operator reads to work out which reviewer wedged.
-///
-/// Uses <see cref="AgentOrchestratorHarness"/> for its orchestrator builder,
-/// server-connection capture, and no-op runtime double.
+/// Graceful-exit timeout diagnostics identify the vendor that failed to exit.
 /// </summary>
 public class AgentOrchestratorStopDiagnosticsTests {
+    [TempDir] public required TempDir Worktree { get; init; }
+
     sealed class CapturingOrchestratorLogger : ILogger<AgentOrchestrator> {
         public List<string> Messages { get; } = [];
         public IDisposable? BeginScope<TState>(TState state) where TState : notnull => null;
@@ -38,9 +34,9 @@ public class AgentOrchestratorStopDiagnosticsTests {
         // from WaitForExitAsync immediately — i.e. exactly the "graceful window elapsed without the
         // CLI exiting" state, with no real 15s wait.
         orch.RegisterAgentForTest(new AgentInstance(
-            $"agent-{vendor}", null, "", null, "/tmp", vendor,
+            $"agent-{vendor}", null, "", null, Worktree.Path, vendor,
             new FakeHostedAgentRuntime(vendor, emitsTerminalOutput: false),
-            new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource()));
+            new WorktreeInfo(Worktree.Path, "", Worktree.Path, IsStandalone: true), new CancellationTokenSource()));
 
         await orch.HandleStopAgent($"agent-{vendor}");
 
@@ -53,16 +49,15 @@ public class AgentOrchestratorStopDiagnosticsTests {
 
     [Test]
     public async Task Graceful_exit_timeout_warning_still_names_claude_for_a_claude_agent() {
-        // Guard against "fixing" the hardcoded name by removing the vendor from the message.
         var log = new CapturingOrchestratorLogger();
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
             new CaptureServerConnection(), new SpyPtyProcessFactory(),
             new Dictionary<string, IHostedAgentLauncher>(), logger: log);
 
         orch.RegisterAgentForTest(new AgentInstance(
-            "agent-claude", null, "", null, "/tmp", "claude",
+            "agent-claude", null, "", null, Worktree.Path, "claude",
             new FakeHostedAgentRuntime("claude", emitsTerminalOutput: false),
-            new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource()));
+            new WorktreeInfo(Worktree.Path, "", Worktree.Path, IsStandalone: true), new CancellationTokenSource()));
 
         await orch.HandleStopAgent("agent-claude");
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorVendorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorVendorTests.cs
@@ -59,17 +59,17 @@ public class AgentOrchestratorVendorTests {
 
     // re-registration is awaited inside RegisterDaemon before readiness is restored.
     // A transient per-agent failure must be retried (not swallowed on first try), so the agent's
-    // ownership is restored before the daemon flips ready — narrowing the "ready despite reregister
-    // failure" window qodo flagged.
+    // ownership is restored before the daemon flips ready.
     [Test]
     public async Task ReRegister_retries_a_transient_per_agent_failure_then_succeeds() {
+        using var worktree = new TempDir();
         var server = new CaptureServerConnection { AgentRegisteredFailTimes = 1 };
 
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 
         orch.RegisterAgentForTest(new AgentInstance(
-            "agent-rereg", null, "", null, "/tmp", "claude",
-            new PtyHostedAgentRuntime("claude", new StubPtyProcess()), new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource()
+            "agent-rereg", null, "", null, worktree.Path, "claude",
+            new PtyHostedAgentRuntime("claude", new StubPtyProcess()), new WorktreeInfo(worktree.Path, "", worktree.Path, IsStandalone: true), new CancellationTokenSource()
         ));
 
         // The orchestrator wires ReRegisterAgentsHook in its ctor; invoking it runs the same
@@ -84,13 +84,14 @@ public class AgentOrchestratorVendorTests {
     // not the vendor (a codex agent is not automatically app-server).
     [Test]
     public async Task ReRegister_reports_pty_transport_for_a_pty_codex_runtime() {
+        using var worktree = new TempDir();
         var server = new CaptureServerConnection();
 
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
 
         orch.RegisterAgentForTest(new AgentInstance(
-            "agent-codex-pty", null, "", null, "/tmp", "codex",
-            new PtyHostedAgentRuntime("codex", new StubPtyProcess()), new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource()
+            "agent-codex-pty", null, "", null, worktree.Path, "codex",
+            new PtyHostedAgentRuntime("codex", new StubPtyProcess()), new WorktreeInfo(worktree.Path, "", worktree.Path, IsStandalone: true), new CancellationTokenSource()
         ));
 
         await server.ReRegisterAgentsHook!();
@@ -542,6 +543,7 @@ public class AgentOrchestratorVendorTests {
 
     [Test]
     public async Task Reregistration_resends_the_same_applied_posture() {
+        using var worktree = new TempDir();
         // A server restart wipes the in-memory echo; the reconnect path rebuilds it from the
         // AgentInstance, so the pair must survive rather than silently becoming null.
         var server     = new CaptureServerConnection();
@@ -550,9 +552,9 @@ public class AgentOrchestratorVendorTests {
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, ptyFactory, new Dictionary<string, IHostedAgentLauncher>());
 
         orch.RegisterAgentForTest(new AgentInstance(
-            "agent-rereg-posture", null, "", null, "/tmp", "codex",
+            "agent-rereg-posture", null, "", null, worktree.Path, "codex",
             new PtyHostedAgentRuntime("codex", new StubPtyProcess()),
-            new WorktreeInfo("/tmp", "", "/tmp", IsStandalone: true), new CancellationTokenSource()
+            new WorktreeInfo(worktree.Path, "", worktree.Path, IsStandalone: true), new CancellationTokenSource()
         ) {
             SandboxPolicy = "danger-full-access", ApprovalPolicy = "never"
         });

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalPermissionBridgeInteractiveTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalPermissionBridgeInteractiveTests.cs
@@ -71,10 +71,11 @@ public class LocalPermissionBridgeInteractiveTests {
         await Assert.That(pending.SessionId).IsEqualTo(Session);
         await Assert.That(pending.AgentId).IsEqualTo("agent-1");
 
+        // Cancellation can only be asserted once the server await is in flight.
+        var ct = await awaitCts.Task.WaitAsync(TimeSpan.FromSeconds(30));
         await Assert.That(h.Broker.TrySettle(pending.RequestId, Allow, "allow", "app")).IsTrue();
         await Assert.That(await Harness.BehaviorOf(await response)).IsEqualTo("allow");
 
-        var ct = await awaitCts.Task.WaitAsync(TimeSpan.FromSeconds(30));
         await WaitUntil(() => ct.IsCancellationRequested, "the server await is cancelled");
         await WaitUntil(() => h.Server.Responds.Count == 1, "RespondToPermission is invoked");
         await Assert.That(h.Server.Responds[0].RequestId).IsEqualTo("srv-1");

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpoolDrainLoopTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpoolDrainLoopTests.cs
@@ -51,6 +51,9 @@ public class SpoolDrainLoopTests {
         public Task<AuthAttempt> ForWaitAsync(CancellationToken ct = default) =>
             Task.FromResult(new AuthAttempt(new HttpClient(), status, null, null));
 
+        public Task<AuthAttempt> ForProtectedReadAsync(CancellationToken ct = default) =>
+            Task.FromResult(new AuthAttempt(new HttpClient(), status, null, null));
+
         public Task<HttpClient> ForBackgroundAsync(CancellationToken ct = default) => Task.FromResult(new HttpClient());
 
         public Task<HttpClient> ForMemoryAsync(CancellationToken ct = default) => Task.FromResult(new HttpClient());

--- a/test/Capacitor.Tests.Helpers/FixedCapacitorHttpClient.cs
+++ b/test/Capacitor.Tests.Helpers/FixedCapacitorHttpClient.cs
@@ -18,6 +18,9 @@ public sealed class FixedCapacitorHttpClient : ICapacitorHttpClient {
     public Task<AuthAttempt> ForWaitAsync(CancellationToken ct = default) =>
         Task.FromResult(new AuthAttempt(new HttpClient(), AuthStatus.Ok, null, null));
 
+    public Task<AuthAttempt> ForProtectedReadAsync(CancellationToken ct = default) =>
+        Task.FromResult(new AuthAttempt(new HttpClient(), AuthStatus.Ok, null, null));
+
     public Task<HttpClient> ForBackgroundAsync(CancellationToken ct = default) =>
         Task.FromResult(new HttpClient());
 

--- a/test/Capacitor.Tests.Helpers/RecordingCapacitorHttpClient.cs
+++ b/test/Capacitor.Tests.Helpers/RecordingCapacitorHttpClient.cs
@@ -30,6 +30,9 @@ public sealed class RecordingCapacitorHttpClient(
     public Task<AuthAttempt> ForWaitAsync(CancellationToken ct = default) =>
         Task.FromResult(new AuthAttempt(Take(nameof(ForWaitAsync)), status, null, null));
 
+    public Task<AuthAttempt> ForProtectedReadAsync(CancellationToken ct = default) =>
+        Task.FromResult(new AuthAttempt(Take(nameof(ForProtectedReadAsync)), status, null, null));
+
     public Task<HttpClient> ForMemoryAsync(CancellationToken ct = default) =>
         Task.FromResult(Take(nameof(ForMemoryAsync)));
 

--- a/test/fixtures/pull-request-reads-v1.json
+++ b/test/fixtures/pull-request-reads-v1.json
@@ -1,0 +1,948 @@
+{
+  "format": "pull-request-reads-v1",
+  "subject": {
+    "provider": "github",
+    "host": "github.com",
+    "repo_hash": "0123456789abcdef",
+    "owner": "example",
+    "repo_name": "repo",
+    "number": 42
+  },
+  "requests": [
+    {
+      "method": "GET",
+      "path": "/api/sessions/session/pull-requests",
+      "status": 400,
+      "error": "protocol_version_required"
+    },
+    {
+      "method": "GET",
+      "path": "/api/sessions/session/pull-requests?version=",
+      "status": 400,
+      "error": "protocol_version_invalid"
+    },
+    {
+      "method": "GET",
+      "path": "/api/sessions/session/pull-requests?version=1&version=1",
+      "status": 400,
+      "error": "protocol_version_invalid"
+    },
+    {
+      "method": "GET",
+      "path": "/api/sessions/session/pull-requests?version=0",
+      "status": 400,
+      "error": "protocol_version_invalid"
+    },
+    {
+      "method": "GET",
+      "path": "/api/sessions/session/pull-requests?version=-1",
+      "status": 400,
+      "error": "protocol_version_invalid"
+    },
+    {
+      "method": "GET",
+      "path": "/api/sessions/session/pull-requests?version=2147483648",
+      "status": 400,
+      "error": "protocol_version_invalid"
+    },
+    {
+      "method": "GET",
+      "path": "/api/sessions/session/pull-requests?version=1.0",
+      "status": 400,
+      "error": "protocol_version_invalid"
+    },
+    {
+      "method": "GET",
+      "path": "/api/sessions/session/pull-requests?version=2",
+      "status": 400,
+      "error": "protocol_version_unsupported"
+    }
+  ],
+  "responses": [
+    {
+      "name": "links",
+      "route": "links",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "items": [
+            {
+              "provider": "github",
+              "host": "github.com",
+              "repo_hash": "0123456789abcdef",
+              "owner": "example",
+              "repo_name": "repo",
+              "number": 42,
+              "url": "https://github.com/example/repo/pull/42",
+              "title": "A linked PR",
+              "head_ref": "feature"
+            }
+          ]
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 0,
+        "access_failure": null
+      }
+    },
+    {
+      "name": "overview",
+      "route": "overview",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "title": "A linked PR",
+          "url": "https://github.com/example/repo/pull/42",
+          "lifecycle": "open",
+          "is_draft": false,
+          "head_ref": "feature",
+          "base_ref": "main",
+          "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+          "description": "Published description",
+          "description_truncated": false,
+          "updated_at": "2026-09-07T10:00:00Z",
+          "review_decision": "review_required",
+          "access_checked_for": "reader",
+          "checks": {
+            "availability": {
+              "status": "ready",
+              "reason": null,
+              "fetched_at": "2026-09-07T10:00:00Z"
+            },
+            "rollup": "failure",
+            "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "counts": {
+              "failure": {
+                "value": 1,
+                "kind": "lower_bound"
+              },
+              "future_outcome": {
+                "value": null,
+                "kind": "unknown"
+              }
+            }
+          },
+          "reviews": null,
+          "conversation": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "checks",
+      "route": "checks",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "snapshot_started_at": "2026-09-07T10:00:00Z",
+          "snapshot_completed_at": "2026-09-07T10:00:00Z",
+          "coverage": "complete",
+          "coverage_reason": null,
+          "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+          "total": {
+            "kind": "exact",
+            "value": 1
+          },
+          "excluded_by_filter": {
+            "kind": "exact",
+            "value": 0
+          },
+          "items": [
+            {
+              "id": "check_run:1",
+              "availability": "available",
+              "reason": null,
+              "url": "https://ci.example/build/1",
+              "name": "test",
+              "app_name": "Actions",
+              "app_id": "1",
+              "suite_id": "2",
+              "source": "check_run",
+              "outcome": "failure",
+              "status": "completed",
+              "conclusion": "failure",
+              "started_at": "2026-09-07T10:00:00Z",
+              "completed_at": "2026-09-07T10:00:00Z",
+              "head_sha": "cccccccccccccccccccccccccccccccccccccccc"
+            }
+          ],
+          "page_cursor": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "has_more": false,
+          "next_cursor": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "reviewers",
+      "route": "reviewers",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "snapshot_started_at": "2026-09-07T10:00:00Z",
+          "snapshot_completed_at": "2026-09-07T10:00:00Z",
+          "coverage": "complete",
+          "coverage_reason": null,
+          "head_sha": null,
+          "total": {
+            "kind": "exact",
+            "value": 1
+          },
+          "excluded_by_filter": {
+            "kind": "exact",
+            "value": 0
+          },
+          "items": [
+            {
+              "id": "U_reader",
+              "availability": "available",
+              "reason": null,
+              "url": null,
+              "actor": {
+                "id": "U_reader",
+                "kind": "user",
+                "login": "reader",
+                "name": null
+              },
+              "requested": true,
+              "review_state": "changes_requested",
+              "submitted_at": "2026-09-07T10:00:00Z"
+            }
+          ],
+          "page_cursor": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "has_more": false,
+          "next_cursor": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "reviews",
+      "route": "reviews",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "snapshot_started_at": "2026-09-07T10:00:00Z",
+          "snapshot_completed_at": "2026-09-07T10:00:00Z",
+          "coverage": "complete",
+          "coverage_reason": null,
+          "head_sha": null,
+          "total": {
+            "kind": "exact",
+            "value": 1
+          },
+          "excluded_by_filter": {
+            "kind": "exact",
+            "value": 0
+          },
+          "items": [
+            {
+              "id": "PRR_published",
+              "availability": "available",
+              "reason": null,
+              "url": "https://github.com/example/repo/pull/42#pullrequestreview-1",
+              "author": {
+                "id": "U_reader",
+                "kind": "user",
+                "login": "reader",
+                "name": null
+              },
+              "body": "Please adjust this.",
+              "body_truncated": false,
+              "state": "changes_requested",
+              "created_at": "2026-09-07T10:00:00Z",
+              "updated_at": "2026-09-07T10:00:00Z",
+              "submitted_at": "2026-09-07T10:00:00Z"
+            }
+          ],
+          "page_cursor": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "has_more": false,
+          "next_cursor": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "threads",
+      "route": "threads",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "snapshot_started_at": "2026-09-07T10:00:00Z",
+          "snapshot_completed_at": "2026-09-07T10:00:00Z",
+          "coverage": "complete",
+          "coverage_reason": null,
+          "head_sha": null,
+          "total": {
+            "kind": "exact",
+            "value": 1
+          },
+          "excluded_by_filter": {
+            "kind": "exact",
+            "value": 0
+          },
+          "items": [
+            {
+              "id": "PRRT_thread",
+              "availability": "available",
+              "reason": null,
+              "url": "https://github.com/example/repo/pull/42#discussion_r1",
+              "is_resolved": false,
+              "is_outdated": true,
+              "path": "src/sample.cs",
+              "diff_side": "right",
+              "start_diff_side": null,
+              "line": 5,
+              "start_line": null,
+              "original_line": 5,
+              "original_start_line": null,
+              "subject_type": "line",
+              "diff_hunk": "@@ -1 +1 @@\n+line",
+              "hunk_truncated": false,
+              "root_comment": {
+                "id": "IC_published",
+                "availability": "available",
+                "reason": null,
+                "url": "https://github.com/example/repo/pull/42#issuecomment-1",
+                "author": {
+                  "id": "U_reader",
+                  "kind": "user",
+                  "login": "reader",
+                  "name": null
+                },
+                "body": "Published **Markdown**. ![image](https://tracker.invalid/image)",
+                "body_truncated": false,
+                "created_at": "2026-09-07T10:00:00Z",
+                "updated_at": "2026-09-07T10:00:00Z",
+                "published_at": "2026-09-07T10:00:00Z",
+                "reply_to_id": null
+              },
+              "comments": {
+                "value": null,
+                "kind": "unknown"
+              }
+            }
+          ],
+          "page_cursor": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "has_more": false,
+          "next_cursor": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "conversation",
+      "route": "conversation",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "snapshot_started_at": "2026-09-07T10:00:00Z",
+          "snapshot_completed_at": "2026-09-07T10:00:00Z",
+          "coverage": "complete",
+          "coverage_reason": null,
+          "head_sha": null,
+          "total": {
+            "kind": "exact",
+            "value": 1
+          },
+          "excluded_by_filter": {
+            "kind": "exact",
+            "value": 0
+          },
+          "items": [
+            {
+              "id": "IC_published",
+              "availability": "available",
+              "reason": null,
+              "url": "https://github.com/example/repo/pull/42#issuecomment-1",
+              "author": {
+                "id": "U_reader",
+                "kind": "user",
+                "login": "reader",
+                "name": null
+              },
+              "body": "Published **Markdown**. ![image](https://tracker.invalid/image)",
+              "body_truncated": false,
+              "created_at": "2026-09-07T10:00:00Z",
+              "updated_at": "2026-09-07T10:00:00Z",
+              "published_at": "2026-09-07T10:00:00Z",
+              "reply_to_id": null
+            }
+          ],
+          "page_cursor": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "has_more": false,
+          "next_cursor": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "thread_comments",
+      "route": "thread_comments",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "snapshot_started_at": "2026-09-07T10:00:00Z",
+          "snapshot_completed_at": "2026-09-07T10:00:00Z",
+          "coverage": "complete",
+          "coverage_reason": null,
+          "head_sha": null,
+          "total": {
+            "kind": "exact",
+            "value": 1
+          },
+          "excluded_by_filter": {
+            "kind": "exact",
+            "value": 0
+          },
+          "items": [
+            {
+              "id": "IC_published",
+              "availability": "available",
+              "reason": null,
+              "url": "https://github.com/example/repo/pull/42#issuecomment-1",
+              "author": {
+                "id": "U_reader",
+                "kind": "user",
+                "login": "reader",
+                "name": null
+              },
+              "body": "Published **Markdown**. ![image](https://tracker.invalid/image)",
+              "body_truncated": false,
+              "created_at": "2026-09-07T10:00:00Z",
+              "updated_at": "2026-09-07T10:00:00Z",
+              "published_at": "2026-09-07T10:00:00Z",
+              "reply_to_id": null
+            }
+          ],
+          "page_cursor": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "has_more": false,
+          "next_cursor": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "unknown status",
+      "route": "overview",
+      "expected": "InvalidProtocol",
+      "body": {
+        "status": "future",
+        "data": {
+          "title": "A linked PR",
+          "url": "https://github.com/example/repo/pull/42",
+          "lifecycle": "open",
+          "is_draft": false,
+          "head_ref": "feature",
+          "base_ref": "main",
+          "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+          "description": "Published description",
+          "description_truncated": false,
+          "updated_at": "2026-09-07T10:00:00Z",
+          "review_decision": "review_required",
+          "access_checked_for": "reader",
+          "checks": {
+            "availability": {
+              "status": "ready",
+              "reason": null,
+              "fetched_at": "2026-09-07T10:00:00Z"
+            },
+            "rollup": "failure",
+            "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "counts": {
+              "failure": {
+                "value": 1,
+                "kind": "lower_bound"
+              },
+              "future_outcome": {
+                "value": null,
+                "kind": "unknown"
+              }
+            }
+          },
+          "reviews": null,
+          "conversation": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "unknown extension",
+      "route": "overview",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "title": "A linked PR",
+          "url": "https://github.com/example/repo/pull/42",
+          "lifecycle": "open",
+          "is_draft": false,
+          "head_ref": "feature",
+          "base_ref": "main",
+          "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+          "description": "Published description",
+          "description_truncated": false,
+          "updated_at": "2026-09-07T10:00:00Z",
+          "review_decision": "review_required",
+          "access_checked_for": "reader",
+          "checks": {
+            "availability": {
+              "status": "ready",
+              "reason": null,
+              "fetched_at": "2026-09-07T10:00:00Z"
+            },
+            "rollup": "failure",
+            "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "counts": {
+              "failure": {
+                "value": 1,
+                "kind": "lower_bound"
+              },
+              "future_outcome": {
+                "value": null,
+                "kind": "unknown"
+              }
+            }
+          },
+          "reviews": null,
+          "conversation": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        },
+        "future_extension": {
+          "created_at": "not a date"
+        }
+      }
+    },
+    {
+      "name": "unknown lifecycle",
+      "route": "overview",
+      "expected": "Ready",
+      "body": {
+        "status": "ready",
+        "data": {
+          "title": "A linked PR",
+          "url": "https://github.com/example/repo/pull/42",
+          "lifecycle": "future",
+          "is_draft": false,
+          "head_ref": "feature",
+          "base_ref": "main",
+          "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+          "description": "Published description",
+          "description_truncated": false,
+          "updated_at": "2026-09-07T10:00:00Z",
+          "review_decision": "review_required",
+          "access_checked_for": "reader",
+          "checks": {
+            "availability": {
+              "status": "ready",
+              "reason": null,
+              "fetched_at": "2026-09-07T10:00:00Z"
+            },
+            "rollup": "failure",
+            "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "counts": {
+              "failure": {
+                "value": 1,
+                "kind": "lower_bound"
+              },
+              "future_outcome": {
+                "value": null,
+                "kind": "unknown"
+              }
+            }
+          },
+          "reviews": null,
+          "conversation": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "negative count",
+      "route": "overview",
+      "expected": "InvalidProtocol",
+      "body": {
+        "status": "ready",
+        "data": {
+          "title": "A linked PR",
+          "url": "https://github.com/example/repo/pull/42",
+          "lifecycle": "open",
+          "is_draft": false,
+          "head_ref": "feature",
+          "base_ref": "main",
+          "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+          "description": "Published description",
+          "description_truncated": false,
+          "updated_at": "2026-09-07T10:00:00Z",
+          "review_decision": "review_required",
+          "access_checked_for": "reader",
+          "checks": {
+            "availability": {
+              "status": "ready",
+              "reason": null,
+              "fetched_at": "2026-09-07T10:00:00Z"
+            },
+            "rollup": "failure",
+            "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "counts": {
+              "failure": {
+                "value": -1,
+                "kind": "lower_bound"
+              },
+              "future_outcome": {
+                "value": null,
+                "kind": "unknown"
+              }
+            }
+          },
+          "reviews": null,
+          "conversation": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "inconsistent continuation",
+      "route": "thread_comments",
+      "expected": "InvalidProtocol",
+      "body": {
+        "status": "ready",
+        "data": {
+          "snapshot_id": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+          "snapshot_started_at": "2026-09-07T10:00:00Z",
+          "snapshot_completed_at": "2026-09-07T10:00:00Z",
+          "coverage": "complete",
+          "coverage_reason": null,
+          "head_sha": null,
+          "total": {
+            "kind": "exact",
+            "value": 1
+          },
+          "excluded_by_filter": {
+            "kind": "exact",
+            "value": 0
+          },
+          "items": [
+            {
+              "id": "IC_published",
+              "availability": "available",
+              "reason": null,
+              "url": "https://github.com/example/repo/pull/42#issuecomment-1",
+              "author": {
+                "id": "U_reader",
+                "kind": "user",
+                "login": "reader",
+                "name": null
+              },
+              "body": "Published **Markdown**. ![image](https://tracker.invalid/image)",
+              "body_truncated": false,
+              "created_at": "2026-09-07T10:00:00Z",
+              "updated_at": "2026-09-07T10:00:00Z",
+              "published_at": "2026-09-07T10:00:00Z",
+              "reply_to_id": null
+            }
+          ],
+          "page_cursor": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+          "has_more": true,
+          "next_cursor": null
+        },
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "non UTC timestamp",
+      "route": "overview",
+      "expected": "InvalidProtocol",
+      "body": {
+        "status": "ready",
+        "data": {
+          "title": "A linked PR",
+          "url": "https://github.com/example/repo/pull/42",
+          "lifecycle": "open",
+          "is_draft": false,
+          "head_ref": "feature",
+          "base_ref": "main",
+          "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+          "description": "Published description",
+          "description_truncated": false,
+          "updated_at": "2026-09-07T10:00:00Z",
+          "review_decision": "review_required",
+          "access_checked_for": "reader",
+          "checks": {
+            "availability": {
+              "status": "ready",
+              "reason": null,
+              "fetched_at": "2026-09-07T10:00:00Z"
+            },
+            "rollup": "failure",
+            "head_sha": "cccccccccccccccccccccccccccccccccccccccc",
+            "counts": {
+              "failure": {
+                "value": 1,
+                "kind": "lower_bound"
+              },
+              "future_outcome": {
+                "value": null,
+                "kind": "unknown"
+              }
+            }
+          },
+          "reviews": null,
+          "conversation": null
+        },
+        "fetched_at": "2026-09-07T12:00:00+02:00",
+        "reason": null,
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 20,
+        "access_failure": null,
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    },
+    {
+      "name": "denied",
+      "route": "overview",
+      "expected": "Unavailable",
+      "body": {
+        "status": "unavailable",
+        "data": null,
+        "fetched_at": "2026-09-07T10:00:00Z",
+        "reason": "github_access_denied",
+        "retry_at": null,
+        "poll_after_seconds": 30,
+        "access_valid_for_seconds": 0,
+        "access_failure": "denied",
+        "subject": {
+          "provider": "github",
+          "host": "github.com",
+          "repo_hash": "0123456789abcdef",
+          "owner": "example",
+          "repo_name": "repo",
+          "number": 42
+        }
+      }
+    }
+  ],
+  "discovery": [
+    {
+      "body": {
+        "provider": "None",
+        "pull_request_reads_versions": [
+          1,
+          2
+        ]
+      },
+      "kind": "Supported"
+    },
+    {
+      "body": {
+        "provider": "workos"
+      },
+      "kind": "Legacy"
+    },
+    {
+      "body": {
+        "provider": "GitHubApp",
+        "pull_request_reads_versions": [
+          2
+        ]
+      },
+      "kind": "Unsupported"
+    },
+    {
+      "body": {
+        "provider": "workos",
+        "pull_request_reads_versions": [
+          "1"
+        ]
+      },
+      "kind": "InvalidProtocol"
+    },
+    {
+      "body": {
+        "provider": "workos",
+        "pull_request_reads_versions": null
+      },
+      "kind": "InvalidProtocol"
+    }
+  ]
+}


### PR DESCRIPTION
Closes #811 — AI-2567

## What & why

Read linked pull requests in a compact sidebar card and a native workspace tab, including checks, reviews, threads and conversation. Chat drafts and terminal hosts survive tab switches. Explicit selections stay unavailable when unlinked; GitHub links are bound to the selected PR. Reads use tenant authentication, access expiry and foreground masking.

## Where to look

Deploy the compatible server (kurrent-io/kcap-server#1839) before releasing the desktop reader; charts: kurrent-io/kcap-deployments#614. Older servers retain safe external links. The shared HTTP factory disables redirects for authenticated PR reads.

## Verification

`dotnet` suites: desktop 1,548 passed; PR wire/client 13 passed; HTTP container 43 passed; Linux daemon 3,048 passed, 27 skipped. Regression probes reproduce and fix shared-temp deletion and early permission settlement. Release CLI NativeAOT publish succeeded without warnings. The literal wire fixture is pinned to LF for Windows. Native views inspected with synthetic data. Paired deployed smoke test remains pending.