### PR TITLE
Bump Avalonia, DotNext, MinVer, SQLitePCLRaw, Tomlyn and TUnit

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
     <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
     <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
     <PackageVersion Include="Duende.IdentityModel" Version="8.1.0" />
-    <PackageVersion Include="DotNext" Version="6.6.2" />
+    <PackageVersion Include="DotNext" Version="6.7.1" />
     <PackageVersion Include="DynamicData" Version="9.4.33" />
     <PackageVersion Include="Markdig" Version="1.3.2" />
     <PackageVersion Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.11" />
@@ -21,16 +21,16 @@
     <PackageVersion Include="Microsoft.Extensions.TimeProvider.Testing" Version="10.9.0" />
     <PackageVersion Include="Microsoft.Data.Sqlite" Version="10.0.11" />
     <PackageVersion Include="Kurrent.Agent.Schema" Version="0.5.0" />
-    <PackageVersion Include="MinVer" Version="7.0.0" />
+    <PackageVersion Include="MinVer" Version="8.0.0" />
     <PackageVersion Include="System.IO.Hashing" Version="10.0.11" />
-    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.3" />
+    <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
     <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />
     <PackageVersion Include="SvcSystems.UI.Terminal" Version="1.1.2" />
-    <PackageVersion Include="Tomlyn" Version="2.4.0" />
-    <PackageVersion Include="TUnit" Version="1.65.68" />
-    <PackageVersion Include="TUnit.Core" Version="1.65.68" />
+    <PackageVersion Include="Tomlyn" Version="2.10.1" />
+    <PackageVersion Include="TUnit" Version="1.66.27" />
+    <PackageVersion Include="TUnit.Core" Version="1.66.27" />
     <PackageVersion Include="WireMock.Net" Version="2.15.0" />
     <PackageVersion Include="XTerm.NET" Version="1.1.0" />
   </ItemGroup>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -3,10 +3,10 @@
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Avalonia" Version="12.1.1" />
-    <PackageVersion Include="Avalonia.Desktop" Version="12.1.1" />
-    <PackageVersion Include="Avalonia.Headless" Version="12.1.1" />
-    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.1" />
+    <PackageVersion Include="Avalonia" Version="12.1.2" />
+    <PackageVersion Include="Avalonia.Desktop" Version="12.1.2" />
+    <PackageVersion Include="Avalonia.Headless" Version="12.1.2" />
+    <PackageVersion Include="Avalonia.Themes.Fluent" Version="12.1.2" />
     <PackageVersion Include="Duende.IdentityModel.OidcClient" Version="7.1.0" />
     <PackageVersion Include="Duende.IdentityModel" Version="8.1.0" />
     <PackageVersion Include="DotNext" Version="6.7.1" />

--- a/src/Capacitor.Cli/Commands/SqliteNativeResolver.cs
+++ b/src/Capacitor.Cli/Commands/SqliteNativeResolver.cs
@@ -29,26 +29,26 @@ internal static class SqliteNativeResolver {
 
     /// <summary>
     /// Version of the native package that <c>SQLitePCLRaw.bundle_e_sqlite3</c> (see
-    /// <c>Directory.Packages.props</c>) actually restores — currently <c>SourceGear.sqlite3</c>
+    /// <c>Directory.Packages.props</c>) actually restores — the <c>SQLite</c> package
     /// (NOT <c>SQLitePCLRaw.lib.e_sqlite3</c>). These hashes are the exact bytes the AOT build
     /// links against, so they also match the per-RID library in the publish output. Doubles as
     /// the cache-bucket key so bumping the engine re-fetches instead of loading a stale lib.
     /// If you bump the bundle, regenerate <see cref="Assets"/> — the <c>SqliteNativeResolverTests</c>
     /// pin guard fails until you do.
     /// </summary>
-    internal const string EngineVersion = "3.50.4.5";
+    internal const string EngineVersion = "3.53.4";
 
     internal sealed record NativeAsset(string FileName, string AssetName, string Sha256);
 
-    /// <summary>RID → the pristine native library shipped by SourceGear.sqlite3, by SHA-256.</summary>
+    /// <summary>RID → the pristine native library shipped by the SQLite package, by SHA-256.</summary>
     internal static readonly IReadOnlyDictionary<string, NativeAsset> Assets =
         new Dictionary<string, NativeAsset>(StringComparer.Ordinal) {
-            ["osx-arm64"]        = new("libe_sqlite3.dylib", "libe_sqlite3-osx-arm64.dylib",      "7b319cd32435ab28c97041fad74b892be218e6f0f74790802105309c1ec515a9"),
-            ["linux-x64"]        = new("libe_sqlite3.so",    "libe_sqlite3-linux-x64.so",         "a5e8aed525023e6c209d37d3e762e2e76ed3a830464569a419abfc3cf12d7a6c"),
-            ["linux-arm64"]      = new("libe_sqlite3.so",    "libe_sqlite3-linux-arm64.so",       "1e3d72f01195cd8fc1e9f17a7d1e9a8fa589b390c08f81b4d3a7af721effe0eb"),
-            ["linux-musl-x64"]   = new("libe_sqlite3.so",    "libe_sqlite3-linux-musl-x64.so",    "73b683c168b3cdc68f1fd005645da7fdedf17895378c2b41903172e296a990c2"),
-            ["linux-musl-arm64"] = new("libe_sqlite3.so",    "libe_sqlite3-linux-musl-arm64.so",  "d881b6b8a258f5e3fe1419b46366fc1afd90e941818d30aa2d2cec650449fed0"),
-            ["win-x64"]          = new("e_sqlite3.dll",      "e_sqlite3-win-x64.dll",             "aabf85d7a8b416fb15203cb754fcfc9858c8f1dd3bbc7eab82335f6c362ba0d6"),
+            ["osx-arm64"]        = new("libe_sqlite3.dylib", "libe_sqlite3-osx-arm64.dylib",      "2b27f45233818ae11d97016ca2a16dffcf63a53c46f60bcd52b342fc187b0c83"),
+            ["linux-x64"]        = new("libe_sqlite3.so",    "libe_sqlite3-linux-x64.so",         "eddcd4aa561d5b8f252db77e8272e7d1aed96bcab9fda3f177ca542f916290bf"),
+            ["linux-arm64"]      = new("libe_sqlite3.so",    "libe_sqlite3-linux-arm64.so",       "66436d4bd02b1b1c25b964a744b5230122bca6a5d006aa80add129ef892c273a"),
+            ["linux-musl-x64"]   = new("libe_sqlite3.so",    "libe_sqlite3-linux-musl-x64.so",    "7d275542af8aac5a19f5a873da7cdadcc20c453fb52b7df57bd747e2f02ab92b"),
+            ["linux-musl-arm64"] = new("libe_sqlite3.so",    "libe_sqlite3-linux-musl-arm64.so",  "91e5ff240be8cdc24068c149754d3506dd3f7098cb0fd3d6606c4f0ce3b5fd42"),
+            ["win-x64"]          = new("e_sqlite3.dll",      "e_sqlite3-win-x64.dll",             "6ad8e149f8ce3ed3716402b4b3a2268ebbdc7b64391b5fafed747e03bb1b9418"),
         };
 
     static int _registered;

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SqliteNativeResolverTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SqliteNativeResolverTests.cs
@@ -13,7 +13,7 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 // directory and the pin lookup finds nothing.
 public class SqliteNativeResolverTests {
     /// <summary>
-    /// Drift guard for ALL shipped RIDs, not just the test runner's: the SourceGear.sqlite3
+    /// Drift guard for ALL shipped RIDs, not just the test runner's: the SQLite native
     /// package ships every runtime native after restore, so a single CI agent can validate
     /// all six pins. Catches a typo in (say) the macOS or musl-arm64 hash that linux/windows
     /// CI would otherwise miss, letting the release publish an asset users can't verify.
@@ -24,7 +24,7 @@ public class SqliteNativeResolverTests {
         foreach (var (rid, asset) in SqliteNativeResolver.Assets) {
             var pristine = PristineNativePath(rid);
             await Assert.That(File.Exists(pristine))
-                .IsTrue().Because($"restored SourceGear native expected at {pristine} — " +
+                .IsTrue().Because($"restored SQLite native expected at {pristine} — " +
                                   "if the bundle version changed, update EngineVersion + Assets pins");
             await Assert.That(Sha256(pristine)).IsEqualTo(asset.Sha256)
                 .Because($"pin for {rid} must match the restored native bytes");
@@ -91,14 +91,14 @@ public class SqliteNativeResolverTests {
 
     // --- helpers -----------------------------------------------------------
 
-    // SourceGear.sqlite3 is the native package SQLitePCLRaw.bundle_e_sqlite3 actually restores
-    // (NOT SQLitePCLRaw.lib.e_sqlite3). EngineVersion is its version; this path exists on any
+    // SQLite is the native package SQLitePCLRaw.bundle_e_sqlite3 actually restores (NOT
+    // SQLitePCLRaw.lib.e_sqlite3). EngineVersion is its version; this path exists on any
     // machine that restored the project, so the drift guard fails loudly if the bundle bumps.
     static string PristineNativePath(string rid) {
 #pragma warning disable RS0030 // the real package cache is what the drift guard reads
         var home = Environment.GetFolderPath(Environment.SpecialFolder.UserProfile);
 #pragma warning restore RS0030
-        return Path.Combine(home, ".nuget", "packages", "sourcegear.sqlite3",
+        return Path.Combine(home, ".nuget", "packages", "sqlite",
             SqliteNativeResolver.EngineVersion, "runtimes", rid, "native",
             SqliteNativeResolver.Assets[rid].FileName);
     }


### PR DESCRIPTION
Closes #815 — AI-2587

## What & why

Six NuGet packages had fallen behind their current releases.

| Package | From | To |
| --- | --- | --- |
| Avalonia (+ Desktop, Headless, Themes.Fluent) | 12.1.1 | 12.1.2 |
| DotNext | 6.6.2 | 6.7.1 |
| MinVer | 7.0.0 | 8.0.0 |
| SQLitePCLRaw.bundle_e_sqlite3 | 3.0.3 | 3.0.5 |
| Tomlyn | 2.4.0 | 2.10.1 |
| TUnit / TUnit.Core | 1.65.68 | 1.66.27 |

The SQLitePCLRaw bump is not version-only: 3.0.5 stops restoring `SourceGear.sqlite3` and takes the
native from the renamed `SQLite` package (same author, same layout), so `SqliteNativeResolver`'s
`EngineVersion`, its six SHA-256 pins and the drift guard's package-cache path all move together.

`ReactiveUI.Avalonia` deliberately stays at 12.0.3 rather than its version-matched 12.1.2, which
moves to ReactiveUI 24 — tracked separately.

## Where to look

The resolver pins double as release-asset verification: `release.yml` checks the native it stages
against these hashes, so a stale pin fails a release and not just the guard.

MinVer crosses a major and TUnit is the test framework itself, so the build succeeding vouches for
neither.

## Verification

`dotnet build Capacitor.slnx -warnaserror` — 15 projects, 0 warnings, 0 errors.

`dotnet publish src/Capacitor.Cli -c Release` — clean, no IL2026/IL3050. The binary reports
`kcap 0.11.40-alpha.0.9` off tag `v0.11.39`, so MinVer 8 derives the same version shape. Its staged
`libe_sqlite3.dylib` hashes to the new `osx-arm64` pin.

`Capacitor.Cli.Tests.Unit` (the suite CI failed on) 3990 passed / 0 failed; `Capacitor.App.Tests.Unit`
1548 passed / 0 failed. The full solution run is otherwise green apart from
`CodexAppServerSchemaConformanceTests.Installed_codex_schema_matches_the_vendored_pin`, which compares
the locally installed Codex CLI (0.153.4) against the vendored pin (0.147.0) — environment-dependent
and untouched by this diff.
