### PR TITLE
Move to ReactiveUI 24 so Avalonia and its bindings track together

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -25,7 +25,7 @@
     <PackageVersion Include="System.IO.Hashing" Version="10.0.11" />
     <PackageVersion Include="SQLitePCLRaw.bundle_e_sqlite3" Version="3.0.5" />
     <PackageVersion Include="NSubstitute" Version="6.2.0" />
-    <PackageVersion Include="ReactiveUI.Avalonia" Version="12.0.3" />
+    <PackageVersion Include="ReactiveUI.Avalonia.Reactive" Version="12.1.2" />
     <PackageVersion Include="Spectre.Console" Version="0.55.2" />
     <PackageVersion Include="SvcSystems.UI.Terminal" Version="1.1.2" />
     <PackageVersion Include="Tomlyn" Version="2.10.1" />

--- a/src/Capacitor.App/Capacitor.App.csproj
+++ b/src/Capacitor.App/Capacitor.App.csproj
@@ -17,7 +17,7 @@
         <PackageReference Include="Avalonia" />
         <PackageReference Include="Avalonia.Desktop" />
         <PackageReference Include="Avalonia.Themes.Fluent" />
-        <PackageReference Include="ReactiveUI.Avalonia" />
+        <PackageReference Include="ReactiveUI.Avalonia.Reactive" />
         <PackageReference Include="DynamicData" />
         <PackageReference Include="Markdig" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" />

--- a/src/Capacitor.App/Program.cs
+++ b/src/Capacitor.App/Program.cs
@@ -1,5 +1,5 @@
 using Avalonia;
-using ReactiveUI.Avalonia;
+using ReactiveUI.Avalonia.Reactive;
 
 namespace Capacitor.App;
 

--- a/src/Capacitor.App/Services/Onboarding/WizardLifecycleSurface.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardLifecycleSurface.cs
@@ -1,4 +1,4 @@
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.Services.Onboarding;
 

--- a/src/Capacitor.App/Services/UiTicker.cs
+++ b/src/Capacitor.App/Services/UiTicker.cs
@@ -1,5 +1,5 @@
 using System.Reactive.Linq;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.Services;
 

--- a/src/Capacitor.App/ViewModels/ActivityViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ActivityViewModel.cs
@@ -4,7 +4,7 @@ using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData.Binding;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/ChatItems.cs
+++ b/src/Capacitor.App/ViewModels/ChatItems.cs
@@ -1,7 +1,7 @@
 using System.ComponentModel;
 using System.Reactive;
 using Avalonia.Collections;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -13,7 +13,7 @@ using Capacitor.App.Services;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ConsentPromptViewModel.cs
@@ -6,7 +6,7 @@ using System.Reactive.Subjects;
 using Capacitor.App.Services;
 using DynamicData;
 using DynamicData.Binding;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/HomeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/HomeViewModel.cs
@@ -10,7 +10,7 @@ using Capacitor.Cli.Core.Harness.Claude;
 using Capacitor.Remote.Models;
 using DynamicData;
 using DynamicData.Binding;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/LifecyclePromptViewModel.cs
+++ b/src/Capacitor.App/ViewModels/LifecyclePromptViewModel.cs
@@ -2,7 +2,7 @@ using System.Reactive;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Capacitor.App.Services;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -4,7 +4,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Avalonia.Media;
 using Capacitor.App.Services;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/Onboarding/AgentsStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/AgentsStepViewModel.cs
@@ -4,7 +4,7 @@ using Capacitor.App.Services;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Core.Setup;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels.Onboarding;
 

--- a/src/Capacitor.App/ViewModels/Onboarding/ConnectStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/ConnectStepViewModel.cs
@@ -1,6 +1,6 @@
 using Capacitor.App.Services.Onboarding;
 using Capacitor.Cli.Core.Auth;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels.Onboarding;
 

--- a/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DaemonStepViewModel.cs
@@ -4,7 +4,7 @@ using Capacitor.App.Services.Mutation;
 using Capacitor.App.Services.Onboarding;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.LocalIpc;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels.Onboarding;
 

--- a/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DefaultsStepViewModel.cs
@@ -1,6 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels.Onboarding;
 

--- a/src/Capacitor.App/ViewModels/Onboarding/DoneStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/DoneStepViewModel.cs
@@ -1,4 +1,4 @@
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels.Onboarding;
 

--- a/src/Capacitor.App/ViewModels/Onboarding/ImportStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/ImportStepViewModel.cs
@@ -4,7 +4,7 @@ using System.Reactive.Linq;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Harness;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels.Onboarding;
 

--- a/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/OnboardingViewModel.cs
@@ -1,7 +1,7 @@
 using System.Reactive;
 using System.Reactive.Linq;
 using Capacitor.App.Services.Onboarding;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels.Onboarding;
 

--- a/src/Capacitor.App/ViewModels/Onboarding/ShimStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/ShimStepViewModel.cs
@@ -1,7 +1,7 @@
 using System.Reactive;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.Setup;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels.Onboarding;
 

--- a/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
+++ b/src/Capacitor.App/ViewModels/Onboarding/SignInStepViewModel.cs
@@ -3,7 +3,7 @@ using System.Reactive;
 using Capacitor.App.Services;
 using Capacitor.App.Services.Onboarding;
 using Capacitor.Cli.Core.Auth;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels.Onboarding;
 

--- a/src/Capacitor.App/ViewModels/PendingCardViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PendingCardViewModel.cs
@@ -1,7 +1,7 @@
 using System.Reactive.Disposables;
 using System.Reactive.Subjects;
 using Capacitor.App.Services;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/PermissionCardViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PermissionCardViewModel.cs
@@ -3,7 +3,7 @@ using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Projections.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Projections.cs
@@ -1,6 +1,6 @@
 using System.Globalization;
 using Capacitor.Cli.Core.PullRequests;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Reads.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Reads.cs
@@ -1,5 +1,5 @@
 using Capacitor.Cli.Core.PullRequests;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
@@ -7,7 +7,7 @@ using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Core.PullRequests;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
+++ b/src/Capacitor.App/ViewModels/QuestionCardViewModel.cs
@@ -4,7 +4,7 @@ using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/RailRepoViewModel.cs
+++ b/src/Capacitor.App/ViewModels/RailRepoViewModel.cs
@@ -5,7 +5,7 @@ using System.Reactive.Linq;
 using Capacitor.App.Services;
 using DynamicData;
 using DynamicData.Binding;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/RailSessionViewModel.cs
+++ b/src/Capacitor.App/ViewModels/RailSessionViewModel.cs
@@ -5,7 +5,7 @@ using System.Reactive.Linq;
 using Avalonia.Media;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.LocalIpc;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/RailWorktreeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/RailWorktreeViewModel.cs
@@ -7,7 +7,7 @@ using System.Reactive.Linq;
 using Capacitor.App.Services;
 using DynamicData;
 using DynamicData.Binding;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/SessionRailViewModel.cs
+++ b/src/Capacitor.App/ViewModels/SessionRailViewModel.cs
@@ -8,7 +8,7 @@ using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
 using DynamicData.Binding;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TerminalTabViewModel.cs
@@ -4,7 +4,7 @@ using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 using System.Reactive;
 
 namespace Capacitor.App.ViewModels;

--- a/src/Capacitor.App/ViewModels/TrayViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TrayViewModel.cs
@@ -5,7 +5,7 @@ using System.Reactive.Linq;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.LocalIpc;
 using DynamicData;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/WorkContextItems.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextItems.cs
@@ -2,7 +2,7 @@ using System.Globalization;
 using System.Reactive;
 using System.Reactive.Linq;
 using Capacitor.App.Services;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
@@ -2,7 +2,7 @@ using System.Reactive;
 using Avalonia.Collections;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Core.WorkItems;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
@@ -8,7 +8,7 @@ using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Core.WorkItems;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -7,7 +7,7 @@ using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Core.PullRequests;
 using DynamicData;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.ViewModels;
 

--- a/src/Capacitor.App/Views/ConsentPromptWindow.axaml.cs
+++ b/src/Capacitor.App/Views/ConsentPromptWindow.axaml.cs
@@ -3,8 +3,8 @@ using System.Reactive.Linq;
 using Avalonia.Controls.Notifications;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
-using ReactiveUI;
-using ReactiveUI.Avalonia;
+using ReactiveUI.Reactive;
+using ReactiveUI.Avalonia.Reactive;
 
 namespace Capacitor.App.Views;
 

--- a/src/Capacitor.App/Views/LifecyclePromptWindow.axaml.cs
+++ b/src/Capacitor.App/Views/LifecyclePromptWindow.axaml.cs
@@ -1,7 +1,7 @@
 using System.Reactive.Disposables.Fluent;
 using Capacitor.App.ViewModels;
-using ReactiveUI;
-using ReactiveUI.Avalonia;
+using ReactiveUI.Reactive;
+using ReactiveUI.Avalonia.Reactive;
 
 namespace Capacitor.App.Views;
 

--- a/src/Capacitor.App/Views/MainWindow.axaml.cs
+++ b/src/Capacitor.App/Views/MainWindow.axaml.cs
@@ -4,8 +4,8 @@ using Avalonia;
 using Avalonia.Controls.Notifications;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
-using ReactiveUI;
-using ReactiveUI.Avalonia;
+using ReactiveUI.Reactive;
+using ReactiveUI.Avalonia.Reactive;
 
 namespace Capacitor.App.Views;
 

--- a/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml.cs
+++ b/src/Capacitor.App/Views/Onboarding/OnboardingWindow.axaml.cs
@@ -1,8 +1,8 @@
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using Capacitor.App.ViewModels.Onboarding;
-using ReactiveUI;
-using ReactiveUI.Avalonia;
+using ReactiveUI.Reactive;
+using ReactiveUI.Avalonia.Reactive;
 
 namespace Capacitor.App.Views.Onboarding;
 

--- a/src/Capacitor.App/Views/TrayIconManager.cs
+++ b/src/Capacitor.App/Views/TrayIconManager.cs
@@ -1,7 +1,7 @@
 using Avalonia;
 using Avalonia.Controls;
 using Capacitor.App.ViewModels;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.Views;
 

--- a/src/Capacitor.App/Views/WorkspaceView.axaml.cs
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml.cs
@@ -5,7 +5,7 @@ using Avalonia.Data.Converters;
 using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.Views;
 

--- a/test/Capacitor.App.Tests.Unit/AgentsImportStepsTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentsImportStepsTests.cs
@@ -273,7 +273,7 @@ public class ImportStepViewModelTests {
         public ImportVendorRow Row(string label) => Vm.Vendors.First(r => r.Label == label);
     }
 
-    static bool CanExecute<TParam, TResult>(ReactiveUI.ReactiveCommand<TParam, TResult> command) {
+    static bool CanExecute<TParam, TResult>(ReactiveUI.Reactive.ReactiveCommand<TParam, TResult> command) {
         var value = false;
         using var subscription = command.CanExecute.Subscribe(v => value = v); // replayed on subscribe
         return value;

--- a/test/Capacitor.App.Tests.Unit/AvaloniaSession.cs
+++ b/test/Capacitor.App.Tests.Unit/AvaloniaSession.cs
@@ -1,7 +1,10 @@
 using Avalonia;
 using Avalonia.Headless;
-using ReactiveUI;
-using ReactiveUI.Avalonia;
+using Avalonia.Threading;
+using ReactiveUI.Primitives.Reactive.Concurrency;
+using ReactiveUI.Reactive;
+using ReactiveUI.Reactive.Builder;
+using ReactiveUI.Avalonia.Reactive;
 using System.Reactive.Concurrency;
 
 namespace Capacitor.App.Tests.Unit;
@@ -18,31 +21,36 @@ internal static class AvaloniaSession {
     }
 
     static readonly Lazy<HeadlessUnitTestSession> Session =
-        new(() => {
-            var session = HeadlessUnitTestSession.StartNew(typeof(TestAppBuilder));
-            // Defensive, decompiler-verified: ReactiveUI.Avalonia's UseReactiveUI() only applies
-            // WithAvalonia()'s AvaloniaScheduler wiring by calling ReactiveUIBuilder.BuildApp()
-            // when Avalonia.AppBuilder.HasBeenBuilt is still false at that point in the pipeline
-            // — and in this headless test process that flag can already be true (MTP/Avalonia
-            // test infra builds its own AppBuilder earlier), silently skipping the wiring. When
-            // that happens RxSchedulers.MainThreadScheduler is left at ReactiveUI's own default
-            // (System.Reactive.Concurrency.DefaultScheduler — a background/thread-pool
-            // scheduler), NOT the real Avalonia dispatcher, and every ObserveOn(RxSchedulers.
-            // MainThreadScheduler) call in the app would silently deliver off the UI thread —
-            // reproduced directly: constructing a MainWindowViewModel/MainWindow and publishing
-            // a Status transition crashed with Avalonia's VerifyAccess() thread-affinity check,
-            // from a System.Reactive DefaultScheduler.LongRunning worker thread. Set it
-            // explicitly here so the baseline scheduler outside WithImmediateRxScheduler is
-            // ALWAYS the real one, regardless of what UseReactiveUI's internal gating decided.
-            RxSchedulers.MainThreadScheduler = AvaloniaScheduler.Instance;
-            return session;
-        });
+        new(static () => HeadlessUnitTestSession.StartNew(typeof(TestAppBuilder)),
+            LazyThreadSafetyMode.ExecutionAndPublication);
+
+    /// ReactiveUI's builder state is process-global and effectively one-shot: whatever ran first
+    /// keeps its registrations, so every later test inherits an Avalonia scheduler bound to a
+    /// dispatcher nothing pumps — no ObserveOn(RxSchedulers.MainThreadScheduler) ever delivers and
+    /// the failure reads as a dead pipeline rather than a scheduler. Rebuilding on the UI thread
+    /// per dispatch is what ReactiveUI.Avalonia's own headless harness does; assigning
+    /// MainThreadScheduler by hand instead loses to the builder.
+    static void RebuildReactiveUI() {
+        ReactiveUIBuilder.ResetBuilderStateForTests();
+        RxAppBuilder.CreateReactiveUIBuilder().WithAvalonia().WithCoreServices().BuildApp();
+        // WithAvalonia registers AvaloniaScheduler.Instance, a static whose Dispatcher is captured
+        // at type init — under a headless session that is not Dispatcher.UIThread, and rebuilding
+        // cannot change it. Left alone, every ObserveOn(RxSchedulers.MainThreadScheduler) posts to
+        // a dispatcher nothing pumps: no value is delivered and it reads as a dead pipeline.
+        RxSchedulers.MainThreadScheduler = _immediatePinned
+            ? ImmediateScheduler.Instance
+            : new AvaloniaScheduler(Dispatcher.UIThread);
+    }
+
+    /// A rebuild happens on every dispatch, so WithImmediateRxScheduler's swap has to survive one
+    /// whichever way the two are nested.
+    static bool _immediatePinned;
 
     public static Task<T> DispatchAsync<T>(Func<T> body) =>
-        Session.Value.Dispatch(body, CancellationToken.None);
+        Session.Value.Dispatch(() => { RebuildReactiveUI(); return body(); }, CancellationToken.None);
 
     public static Task DispatchAsync(Action body) =>
-        Session.Value.Dispatch(() => { body(); return true; }, CancellationToken.None);
+        Session.Value.Dispatch(() => { RebuildReactiveUI(); body(); return true; }, CancellationToken.None);
 
     /// Async-body variant: HeadlessUnitTestSession.Dispatch's Func&lt;Task&lt;T&gt;&gt; overload
     /// runs `body` on the UI thread and, if it doesn't complete synchronously, pumps a
@@ -51,7 +59,7 @@ internal static class AvaloniaSession {
     /// its continuation back onto this same pumped loop instead of deadlocking, unlike a raw
     /// `.GetAwaiter().GetResult()` block on the UI thread.
     public static Task<T> DispatchAsync<T>(Func<Task<T>> body) =>
-        Session.Value.Dispatch(body, CancellationToken.None);
+        Session.Value.Dispatch(() => { RebuildReactiveUI(); return body(); }, CancellationToken.None);
 
     /// Pins RxSchedulers.MainThreadScheduler to an immediate System.Reactive IScheduler for
     /// the body and RESTORES the prior scheduler in finally (it is process-global). This is
@@ -60,18 +68,18 @@ internal static class AvaloniaSession {
     /// moved the ambient scheduler off the classic static `RxApp` type onto `RxSchedulers`;
     /// `RxApp` scheduler properties no longer exist in this ReactiveUI line.)
     public static async Task WithImmediateRxScheduler(Func<Task> body) {
-        // Force the (lazy, process-wide) session to actually start BEFORE snapshotting "prior" —
-        // the Session factory above is what pins RxSchedulers.MainThreadScheduler to the real
-        // AvaloniaScheduler. If this were the FIRST scheduler-touching call in the whole test
-        // run, capturing "prior" before that pin would snapshot whatever System.Reactive's
-        // unconfigured default is instead, and the `finally` below would then "restore" the
-        // global to that wrong value forever — corrupting every later test that assumes the
-        // real dispatcher scheduler is live outside this method.
+        // Start the process-wide session before snapshotting "prior": outside a dispatch nothing
+        // has configured MainThreadScheduler yet, and the finally below would restore that
+        // unconfigured default over the real one for every later test.
         _ = Session.Value;
 
         IScheduler prior = RxSchedulers.MainThreadScheduler;
+        _immediatePinned = true;
         RxSchedulers.MainThreadScheduler = ImmediateScheduler.Instance;
-        try { await body(); } finally { RxSchedulers.MainThreadScheduler = prior; }
+        try { await body(); } finally {
+            _immediatePinned = false;
+            RxSchedulers.MainThreadScheduler = prior;
+        }
     }
 
     /// The standard wrapper for tests that need BOTH pieces at once: WithImmediateRxScheduler

--- a/test/Capacitor.App.Tests.Unit/AvaloniaSessionTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AvaloniaSessionTests.cs
@@ -19,15 +19,15 @@ public class AvaloniaSessionTests {
         // snapshotting "prior" before that pin would capture System.Reactive's unconfigured
         // default instead, and the restore assertion below would then fail.
         await AvaloniaSession.DispatchAsync(() => 0);
-        var prior = ReactiveUI.RxSchedulers.MainThreadScheduler;
+        var prior = ReactiveUI.Reactive.RxSchedulers.MainThreadScheduler;
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             string? seen = null;
             using var _ = System.Reactive.Linq.Observable.Return("published-on-background")
-                .ObserveOn(ReactiveUI.RxSchedulers.MainThreadScheduler)
+                .ObserveOn(ReactiveUI.Reactive.RxSchedulers.MainThreadScheduler)
                 .Subscribe(v => seen = v);
             await Task.Yield();
             await Assert.That(seen).IsEqualTo("published-on-background"); // immediate scheduler delivered synchronously
         });
-        await Assert.That(ReferenceEquals(ReactiveUI.RxSchedulers.MainThreadScheduler, prior)).IsTrue(); // restored
+        await Assert.That(ReferenceEquals(ReactiveUI.Reactive.RxSchedulers.MainThreadScheduler, prior)).IsTrue(); // restored
     }
 }

--- a/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
@@ -22,6 +22,9 @@ public class ChatComposerTests {
         var chat = new ChatTabViewModel("a1", daemon, terminal, TranscriptChat.For("claude"), opener, time, new FakePermissionService());
         daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(supportedVendors: ["claude", "codex"]));
         daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo", model: "claude-opus-5") with { Status = "Running" });
+        // The Avalonia scheduler always posts, even when the caller is already on the UI thread,
+        // so the resolve does not start until the dispatcher runs.
+        Dispatcher.UIThread.RunJobs();
         await (terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
         var client = factory.Created.Single();
         await client.TriggerAttached([]);

--- a/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ConsentPromptViewModelTests.cs
@@ -4,7 +4,7 @@ using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
 using Microsoft.Extensions.Time.Testing;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 using TUnit.Assertions.Enums;
 using static Capacitor.App.Tests.Unit.ConsentEntries;
 

--- a/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewModelTests.cs
@@ -5,7 +5,7 @@ using Capacitor.App.ViewModels;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Remote.Models;
 using DynamicData;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.Tests.Unit;
 

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -42,43 +42,44 @@ public class MainWindowSmokeTests {
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task MainWindow_renders_the_connection_word_and_tenant_not_the_identity_block() {
-        await AvaloniaSession.WithImmediateRxScheduler(async () => {
-            var rendered = await AvaloniaSession.DispatchAsync(() => {
-                var service = new FakeDaemonClientService();
-                service.SnapshotsSubject.OnNext(Snap(
-                    daemon: "daemon-a", version: "1.2.3", serverUrl: "http://localhost:9999",
-                    connection: "connected", active: 1, max: 5));
-                service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
+        // Rendered text, so no immediate scheduler: an OAPH delivered immediately notifies
+        // before its value is readable, and a binding that reads on the notification keeps the
+        // stale one. The dispatcher scheduler sets the value first, as it does in the app.
+        var rendered = await AvaloniaSession.DispatchAsync(() => {
+            var service = new FakeDaemonClientService();
+            service.SnapshotsSubject.OnNext(Snap(
+                daemon: "daemon-a", version: "1.2.3", serverUrl: "http://localhost:9999",
+                connection: "connected", active: 1, max: 5));
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
 
-                var (actions, _) = NewActions(service);
-                var vm = new MainWindowViewModel(service, CancellationToken.None, TestActivity.New(),
-                    tenantName: "kurrent");
-                var window = new MainWindow { DataContext = vm };
-                window.Show();
-                // Control.Loaded is POSTED at DispatcherPriority.Loaded (Avalonia defers it, it
-                // never fires synchronously from Show()) — pump the dispatcher so it actually
-                // runs before reading bound text. This is what drives ReactiveWindow<T>'s
-                // built-in Loaded->ViewModel.Activator.Activate() wiring.
-                Dispatcher.UIThread.RunJobs();
+            var (actions, _) = NewActions(service);
+            var vm = new MainWindowViewModel(service, CancellationToken.None, TestActivity.New(),
+                tenantName: "kurrent");
+            var window = new MainWindow { DataContext = vm };
+            window.Show();
+            // Control.Loaded is POSTED at DispatcherPriority.Loaded (Avalonia defers it, it
+            // never fires synchronously from Show()) — pump the dispatcher so it actually
+            // runs before reading bound text. This is what drives ReactiveWindow<T>'s
+            // built-in Loaded->ViewModel.Activator.Activate() wiring.
+            Dispatcher.UIThread.RunJobs();
 
-                var texts = string.Join('\n', window.GetVisualDescendants()
-                    .OfType<TextBlock>()
-                    .Select(t => t.Text ?? ""));
+            var texts = string.Join('\n', window.GetVisualDescendants()
+                .OfType<TextBlock>()
+                .Select(t => t.Text ?? ""));
 
-                window.Close();
-                Dispatcher.UIThread.RunJobs(); // flush the deferred Unloaded post so the VM's WhenActivated-scoped subscriptions actually get disposed before the next test runs
+            window.Close();
+            Dispatcher.UIThread.RunJobs(); // flush the deferred Unloaded post so the VM's WhenActivated-scoped subscriptions actually get disposed before the next test runs
 
-                return texts;
-            });
-
-            // The rail footer is the one daemon indicator: word + tenant on screen, the identity
-            // block (name/version/URL) demoted to its hover tooltip — rendered text must NOT
-            // carry it.
-            await Assert.That(rendered).Contains("Connected");
-            await Assert.That(rendered).Contains("kurrent");
-            await Assert.That(rendered).DoesNotContain("daemon-a");
-            await Assert.That(rendered).DoesNotContain("http://localhost:9999");
+            return texts;
         });
+
+        // The rail footer is the one daemon indicator: word + tenant on screen, the identity
+        // block (name/version/URL) demoted to its hover tooltip — rendered text must NOT
+        // carry it.
+        await Assert.That(rendered).Contains("Connected");
+        await Assert.That(rendered).Contains("kurrent");
+        await Assert.That(rendered).DoesNotContain("daemon-a");
+        await Assert.That(rendered).DoesNotContain("http://localhost:9999");
     }
 
     /// Regression coverage for a Critical bug found in review: canStart/canRetry were built

--- a/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MarkdownBlocksTests.cs
@@ -8,7 +8,7 @@ using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Capacitor.App.Views;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 using TUnit.Assertions.Enums;
 using static Capacitor.App.Tests.Unit.AvaloniaSession;
 

--- a/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingViewModelTests.cs
@@ -5,7 +5,7 @@ using Avalonia.Threading;
 using Avalonia.VisualTree;
 using Capacitor.App.ViewModels.Onboarding;
 using Capacitor.App.Views.Onboarding;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 using TUnit.Assertions.Enums;
 
 namespace Capacitor.App.Tests.Unit;

--- a/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
@@ -9,7 +9,7 @@ using Capacitor.App.ViewModels.Onboarding;
 using Capacitor.App.Views.Onboarding;
 using Capacitor.Cli.Core.Auth;
 using Microsoft.Extensions.Time.Testing;
-using ReactiveUI;
+using ReactiveUI.Reactive;
 
 namespace Capacitor.App.Tests.Unit;
 

--- a/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalTabViewModelTests.cs
@@ -40,6 +40,10 @@ public class TerminalTabViewModelTests {
         var vm = Build(daemon, factory, time, agentId, surfaceFactory);
 
         daemon.Agents.AddOrUpdate(Agent(agentId, vendor, hasTerminal));
+        // The Avalonia scheduler always posts, even when the caller is already on the UI thread,
+        // so the resolve does not start until the dispatcher runs. Callers under an immediate
+        // scheduler are unaffected; this is what the thread-identity tests need.
+        Dispatcher.UIThread.RunJobs();
         await (vm.PendingResolveWorkForTesting ?? Task.CompletedTask);
 
         return (daemon, factory, time, vm, factory.Created.Single());


### PR DESCRIPTION
Closes #818 — AI-2590

## What & why

`ReactiveUI.Avalonia` was held at 12.0.3 while Avalonia moved to 12.1.2, because the version-matched
release moves to ReactiveUI 24. This takes the compatibility distribution,
`ReactiveUI.Avalonia.Reactive` 12.1.2, which keeps our System.Reactive types — the default
distribution would mean rewriting 286 `Unit`, 73 `BehaviorSubject` and 51 `ObservableAsPropertyHelper`
uses to `RxVoid`/`Signal<T>`/`ISequencer`. Almost all of the diff is the resulting using rename.

The headless harness now follows ReactiveUI.Avalonia's own builder pattern instead of assigning a
scheduler by hand. `WithAvalonia()` registers `AvaloniaScheduler.Instance`, a static whose
`Dispatcher` is captured at type init and is not the headless session's, so it is overridden after
the rebuild; left alone, every `ObserveOn` posts where nothing pumps and no value is ever delivered.

## Where to look

`AvaloniaSession.cs` is the whole of the behavioural change. The new scheduler always posts and never
delivers inline even when already on the UI thread, which is why two setup helpers now pump the
dispatcher before awaiting — tests that run under the immediate scheduler never saw the difference.

## Verification

`dotnet build Capacitor.slnx -warnaserror` — 0 warnings, 0 errors.

`dotnet test --solution Capacitor.slnx` — 12043 passed, 68 skipped. The one failure is
`CodexAppServerSchemaConformanceTests.Installed_codex_schema_matches_the_vendored_pin`, which
compares the locally installed Codex CLI against the vendored pin; it is environment-dependent and
untouched here.

The migrated app runs: the rail footer renders `Connected`, its status dot and the hosted count, all
`ObservableAsPropertyHelper`-driven, so the binding path is exercised end to end.
