### PR TITLE
Remove the desktop app's daemon version-skew dialog

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,24 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## The desktop app no longer offers to restart or take over the daemon on a version mismatch
+
+The daemon already handles a CLI update by itself: it stats its own binary every 15 seconds, queues
+a restart-after-update when the size or mtime changes, and fires it the moment it is idle, through a
+launchd relaunch for a supervised unit or a self-respawn for a detached one. The app's dialog compared
+the daemon's version against the `kcap --version` it cached at launch, so after an npm update it
+fired *after* the daemon had already relaunched onto the new binary and offered to "update" it again.
+Accepting ran a full service replace, which boots out the launchd label and so kills the agents the
+idle gate was deliberately waiting for. And a failed accept cleared the once-per-run flag and kicked
+a reattach, whose Connected re-entered the check with the same pair and the decline claim already
+retracted: an accept that could not succeed (the CLI below the app's floor, say) re-opened the same
+dialog until the user declined. The 45 s hold after an update relaunch goes with it: it only ever
+narrowed the same false positive. The different-binary case, a unit pointing at a path the CLI no
+longer lives at, only arises from a manual or legacy install and stays with `kcap setup` and
+`kcap daemon service install --replace`; the onboarding wizard still offers that takeover when it
+finds a foreign unit. What remains in the controller is the startup matrix, reconciliation, and the
+Start button's dialoged repair.
+
 ## The desktop app ships as a signed DMG that updates itself
 
 The app bundles `kcap`, `kcap-daemon` and the PTY shim in `Contents/MacOS`, so the CLI beside the

--- a/docs/superpowers/specs/2026-08-10-ai1654-daemon-lifecycle-path-shim-design.md
+++ b/docs/superpowers/specs/2026-08-10-ai1654-daemon-lifecycle-path-shim-design.md
@@ -122,6 +122,11 @@ The CLI transaction owns verification and rollback. The app layers the UX confir
 
 ### 4.3 Skew → restart/takeover
 
+> **Removed.** The daemon restarts itself after a binary update (`RestartCoordinator`, idle-gated),
+> so the app no longer compares versions or offers a restart/takeover; the different-binary case
+> stays with `kcap setup` and the onboarding wizard. See `docs/CHANGES.md`. The text below is the
+> original design.
+
 **Triggers** (one code path): on every `Connected`, snapshot `Daemon.Version` ≠ cached CLI version; on `Unreachable(daemon_incompatible)` carrying a differing hello `DaemonVersion` (decision 6, deduped on `(reason, daemonVersion)` so null→v1/v1→v2 re-emit). `daemon_unreachable` never triggers offers.
 
 **Classification** (fresh status inside the gate): `unit_present` && canonical `binary_path` == canonical `install_binary_path` → **same-binary target** ("Restart daemon to update"); anything else → **different-binary** ("Take over management"). Path equality is *not* installer provenance; **both** copies carry the decision-3 replacement/recapture disclosure.

--- a/docs/superpowers/specs/2026-09-06-ai1653-app-distribution-design.md
+++ b/docs/superpowers/specs/2026-09-06-ai1653-app-distribution-design.md
@@ -203,6 +203,11 @@ Owns the schedule and the UX; runs only when `IsAvailable`.
 
 The app now carries a newer CLI than the running daemon, and two mechanisms already exist for that:
 
+> **Amended.** The skew dialog, the post-update grace and the version revalidation described below
+> were removed together with the app's version-skew check: the daemon's own idle restart is the
+> only mechanism, for a busy daemon too. See `docs/CHANGES.md`. The text below is the original
+> design.
+
 - **The daemon restarts itself when idle.** Its `RestartCoordinator` polls `Environment.ProcessPath` every 15 s; the bundle swap changes the size and mtime of the file at that path, which queues a restart-after-update that fires as soon as no hosted agent or eval is running. An app-managed daemon is supervised, so it exits and launchd's `KeepAlive` respawns it on the new binary. This is the same path an npm upgrade takes today, so headless behaviour is untouched. Agents survive the app's own restart by construction (the daemon is a LaunchAgent).
 - **The skew dialog covers a daemon that stays busy.** AI-1654's skew detection (`Connected` with a differing daemon version) classifies the unit as **same-binary** (the plist's path equals the new install path) and offers "Restart daemon to update"; declining is remembered per `(daemonVersion, cliVersion)` as today. A decline governs only the forced restart: the daemon's own idle restart still applies later, which is what a headless daemon does too.
 

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -1016,8 +1016,8 @@ public partial class App : Application {
         var surface = new LifecycleSurface(setLifecycleStatus, setLifecycleAttention, ConfirmLifecyclePromptAsync);
 
         var lifecycle = new DaemonLifecycleController(
-            service, cli, probe, store, surface, () => Task.FromResult(ValidProfileName(profile)), TimeProvider.System,
-            canonicalServer, runMutation, autoActionsPermanentlyClosed, holdSkewForUpdate: Program.UpdateRelaunch);
+            service, cli, probe, surface, () => Task.FromResult(ValidProfileName(profile)), TimeProvider.System,
+            canonicalServer, runMutation, autoActionsPermanentlyClosed);
 
         // The shim links to the RESOLVED ABSOLUTE path only — CliResolver's bare "kcap" PATH
         // fallback means there is nothing to link, so the offer and the menu item both stay off
@@ -1306,7 +1306,7 @@ public partial class App : Application {
         return tcs.Task;
     }
 
-    // ConfirmAndTakeoverAsync holds the operation gate across the whole ConfirmAsync await — a
+    // ConfirmAndReplaceAsync holds the operation gate across the whole ConfirmAsync await — a
     // dialog left open through a lifetime-cancel (app shutdown or DisposeAsync) must not leave the
     // gate (and therefore QuiescedAsync) blocked on a human who may never come back. Cancellation
     // can arrive on any thread, so the close is posted rather than called inline; the registration

--- a/src/Capacitor.App/Services/AppStateStore.cs
+++ b/src/Capacitor.App/Services/AppStateStore.cs
@@ -9,7 +9,6 @@ namespace Capacitor.App.Services;
 public sealed record AppState(
     bool ShimOffered = false,
     bool ShimDenied = false,
-    IReadOnlyList<string>? DeclinedTakeoverPairs = null,
     bool ConsentQuarantineAcked = false,
     // Absolute repo path -> vendor token. "" is the reserved key for the not-yet-in-a-repository
     // target (HomeViewModel.ScratchRepoPath) — a stored preference only, since the daemon does

--- a/src/Capacitor.App/Services/CliResolver.cs
+++ b/src/Capacitor.App/Services/CliResolver.cs
@@ -1,12 +1,8 @@
 namespace Capacitor.App.Services;
 
-/// One resolved CLI's identity: null Version disables skew detection for the run (multiline,
-/// malformed, or "unknown" `--version` output, or the query itself failing).
-public sealed record CliInfo(string? Path, string? Version);
-
-/// Where the app finds `kcap` to shell out to (spec §3.1, decision 1: everything through the
-/// CLI). Pure given its env/filesystem seams, so the lifecycle graph, the wizard and every later
-/// feature resolve through the same logic.
+/// Where the app finds `kcap` to shell out to (everything goes through the CLI). Pure given its
+/// env/filesystem seams, so the lifecycle graph, the wizard and every later feature resolve
+/// through the same logic.
 public static class CliResolver {
     /// KCAP_APP_CLI_PATH → the `kcap` beside this executable (the app bundle's Contents/MacOS) →
     /// "kcap" on PATH.
@@ -25,8 +21,9 @@ public static class CliResolver {
     }
 
     /// Strict: stdout must be exactly one non-empty line "kcap &lt;version&gt;"; multiline, a
-    /// missing "kcap " prefix, or a bare/"unknown" version all disable skew detection (null)
-    /// rather than let a malformed value flow into a version comparison.
+    /// missing "kcap " prefix, or a bare/"unknown" version all read as null (which the
+    /// compatibility floor treats as too old) rather than let a malformed value flow into a
+    /// version comparison.
     public static string? ParseVersion(string stdout) {
         var lines = stdout.Split('\n', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
         if (lines.Length != 1) return null;

--- a/src/Capacitor.App/Services/DaemonLifecycleController.cs
+++ b/src/Capacitor.App/Services/DaemonLifecycleController.cs
@@ -1,5 +1,4 @@
 using Capacitor.App.Services.Mutation;
-using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Core.Setup;
 
 namespace Capacitor.App.Services;
@@ -44,8 +43,7 @@ internal static class VerifyExitCodes {
 public sealed class DaemonLifecycleController : IAsyncDisposable {
     const string IncompatibleReason = "daemon_incompatible";
 
-    /// Decision 3: every unit rewrite this controller offers — same-binary or not — carries this
-    /// disclosure. Path equality is not installer provenance.
+    /// Every unit rewrite the app offers carries this disclosure.
     internal const string TakeoverDisclosure =
         "This replaces the existing daemon service and re-captures its settings; a failed replacement leaves it uninstalled rather than restored.";
 
@@ -56,15 +54,9 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
 
     internal static readonly TimeSpan TxnActiveRequeryDelay = TimeSpan.FromSeconds(2);
 
-    /// After an app update relaunch, the daemon's own restart coordinator replaces its binary
-    /// within a poll interval once idle — a skew offer inside this window would ask for
-    /// something already under way.
-    internal static readonly TimeSpan SkewHoldAfterUpdate = TimeSpan.FromSeconds(45);
-
     readonly IDaemonClientService _client;
     readonly IKcapCli _cli;
     readonly ILoginShellProbe _probe;
-    readonly IAppStateStore _store;
     readonly ILifecycleSurface _surface;
     readonly Func<Task<string?>> _resolveProfileName;
     readonly TimeProvider _time;
@@ -83,43 +75,33 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     readonly Lock _lock = new();
 
     IDisposable? _subscription;
-    IDisposable? _snapshotSubscription;
     bool _armClaimed;
     bool _disposed;
     int _generation;
     (AttachState State, string? Reason) _lastObserved = (AttachState.Connecting, null);
-    string? _latestSnapshotVersion;
-    bool _skewDialogShownThisRun;
-    Task _versionCached = Task.CompletedTask;
-    DateTimeOffset? _skewHoldUntil;
-    string? _heldSkewVersion;
-    bool _holdRecheckScheduled;
 
     public DaemonLifecycleController(
-            IDaemonClientService client, IKcapCli cli, ILoginShellProbe probe, IAppStateStore store,
+            IDaemonClientService client, IKcapCli cli, ILoginShellProbe probe,
             ILifecycleSurface surface, Func<Task<string?>> resolveProfileName, TimeProvider time,
             string? canonicalServer, Func<MutationRequest, CancellationToken, Task<MutationOutcome>> runMutation,
-            bool autoActionsPermanentlyClosed = false, bool holdSkewForUpdate = false) {
+            bool autoActionsPermanentlyClosed = false) {
         _client                        = client;
         _cli                           = cli;
         _probe                         = probe;
-        _store                         = store;
         _surface                       = surface;
         _resolveProfileName            = resolveProfileName;
         _time                          = time;
         _canonicalServer               = canonicalServer;
         _runMutation                   = runMutation;
         _autoActionsPermanentlyClosed  = autoActionsPermanentlyClosed;
-        _skewHoldUntil = holdSkewForUpdate ? time.GetUtcNow() + SkewHoldAfterUpdate : null;
     }
 
     /// Completes permanently on the first terminal attach outcome (Connected /
     /// daemon_incompatible / a completed daemon_unreachable startup branch). Consumed by later
-    /// tasks (shim offer timing, skew dialogs never stacking with startup work).
+    /// tasks (shim offer timing).
     public Task PhaseClosed => _phaseClosed.Task;
 
-    /// Cached once at Start(); null when the CLI is missing or --version failed. Consumed by the
-    /// skew classification below.
+    /// Cached once at Start(); null when the CLI is missing or --version failed.
     public string? CliVersion { get; private set; }
 
     /// Subscribes to the attach stream. MUST be called before the host calls
@@ -127,19 +109,8 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     /// starts after the pump has begun could miss the first terminal outcome the startup phase
     /// hinges on.
     public void Start() {
-        // DaemonClientService publishes a Connected snapshot to Snapshots BEFORE the matching
-        // Connected AttachStatus (no-stale-pin) — subscribing here first means OnAttachStatus's
-        // Connected case always reads an already-current _latestSnapshotVersion (spec §4.3).
-        _snapshotSubscription = _client.Snapshots.Subscribe(OnSnapshot);
-        _subscription         = _client.Status.Subscribe(OnAttachStatus);
-        // Held, not fire-and-forget: RunSkewCheckAsync awaits this — VersionAsync is a process
-        // spawn (tens of ms), the attach cycle a sub-ms local-socket dial, so the daemon path can
-        // plausibly win the race and reach the skew check before CliVersion is cached.
-        _versionCached = CacheVersionAsync();
-    }
-
-    void OnSnapshot(DaemonStatusDto snapshot) {
-        lock (_lock) _latestSnapshotVersion = snapshot.Daemon.Version;
+        _subscription = _client.Status.Subscribe(OnAttachStatus);
+        _ = CacheVersionAsync(); // never faults
     }
 
     async Task CacheVersionAsync() {
@@ -152,12 +123,8 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         }
     }
 
-    // Every AttachStatus transition bumps the generation and records the last-observed outcome —
-    // this ALWAYS happens, regardless of the once-per-run arm below. Only a TERMINAL outcome
-    // (never Connecting) can claim that arm, and only the FIRST one ever does — but the switch
-    // itself still runs for every later event: the arm gates startup AUTO-ACTION eligibility
-    // only, never event admission, so a later daemon_incompatible still reaches its
-    // skew/takeover case below unconditionally.
+    // Every AttachStatus transition bumps the generation and records the last-observed outcome;
+    // only the FIRST terminal outcome (never Connecting) claims the once-per-run arm and acts.
     void OnAttachStatus(AttachStatus status) {
         bool isFirstTerminalOutcome;
 
@@ -169,31 +136,21 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
             if (isFirstTerminalOutcome) _armClaimed = true;
         }
 
-        if (status.State == AttachState.Connecting) return;
+        if (!isFirstTerminalOutcome) return;
 
         switch (status.State) {
             case AttachState.Connected:
-                if (isFirstTerminalOutcome) {
-                    ClosePhase();
-                    _ = RunReconciliationAsync(attached: true);
-                }
-                // §4.3: every Connected, not just the first — the once-per-run dialog flag (not
-                // this arm) is what keeps a later Connected from stacking a second offer.
-                _ = RunSkewCheckAsync(LatestSnapshotVersion());
+                ClosePhase();
+                _ = RunReconciliationAsync(attached: true);
                 break;
             case AttachState.Unreachable when status.Reason == IncompatibleReason:
-                if (isFirstTerminalOutcome) {
-                    ClosePhase();
-                    _ = RunReconciliationAsync(attached: false);
-                }
-                _ = RunSkewCheckAsync(status.DaemonVersion); // every incompatible event, same reason as above
+                ClosePhase();
+                _ = RunReconciliationAsync(attached: false);
                 break;
             case AttachState.Unreachable:
                 // Closed: PhaseClosed still resolves here — only the startup matrix itself never admits.
-                if (isFirstTerminalOutcome) {
-                    if (_autoActionsPermanentlyClosed) ClosePhase();
-                    else _ = RunStartupBranchAsync((status.State, status.Reason));
-                }
+                if (_autoActionsPermanentlyClosed) ClosePhase();
+                else _ = RunStartupBranchAsync((status.State, status.Reason));
                 break;
         }
     }
@@ -211,8 +168,6 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
     /// a racing Connected arriving mid-query) and silently disable the attached-only checks for
     /// the run's only reconciliation pass.
     bool IsCurrentlyAttached() { lock (_lock) return _lastObserved.State == AttachState.Connected; }
-
-    string? LatestSnapshotVersion() { lock (_lock) return _latestSnapshotVersion; }
 
     async Task<bool> TryAcquireGateAsync(CancellationToken ct) {
         try {
@@ -413,206 +368,37 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         return outcome is MutationOutcome.Succeeded or MutationOutcome.SucceededAfterTimeout;
     }
 
-    /// §4.3: runs on every Connected (paired with the latest known snapshot version) and every
-    /// daemon_incompatible (paired with the hello DaemonVersion, spec decision 6) — never on a
-    /// plain daemon_unreachable, which doesn't call this at all. Equal/null versions, a null
-    /// cached CliVersion (§6: the version probe failed), an already-declined pair, and the
-    /// once-per-run dialog flag are all silent no-ops.
-    async Task RunSkewCheckAsync(string? daemonVersion) {
-        if (daemonVersion is null) return; // nothing to compare regardless of the cached CLI version
-        if (_cli.CliPath is null) return;
-        if (TryHoldSkew(daemonVersion)) return;
-
-        lock (_lock) {
-            if (_skewDialogShownThisRun) return;
-        }
-
-        // The attach cycle is a sub-ms local-socket dial; VersionAsync is a process spawn (tens
-        // of ms) — the first Connected/daemon_incompatible of a run can plausibly arrive before
-        // CliVersion is cached. CacheVersionAsync never faults, so this never throws.
-        await _versionCached.ConfigureAwait(false);
-        if (CliVersion is null || daemonVersion == CliVersion) return;
-
-        var pairKey = $"{daemonVersion}|{CliVersion}";
-        var state   = await _store.LoadAsync().ConfigureAwait(false);
-        if (state.DeclinedTakeoverPairs?.Contains(pairKey) == true) return;
-
-        if (!await TryAcquireGateAsync(_lifetime.Token).ConfigureAwait(false)) return;
-        try {
-            lock (_lock) {
-                if (_skewDialogShownThisRun) return; // a concurrent trigger already claimed this run's one dialog
-            }
-
-            var snap = await QueryStatusForActionAsync(_lifetime.Token).ConfigureAwait(false);
-            if (snap is null) return; // already surfaced by QueryStatusForActionAsync
-
-            var missing = await FailingSkewPreconditionAsync(snap, _lifetime.Token).ConfigureAwait(false);
-            if (missing is not null) {
-                _surface.Status(missing);
-                return;
-            }
-
-            var kind         = ClassifyTakeover(snap);
-            var terminalPath = await _probe.TerminalPathAsync(_lifetime.Token).ConfigureAwait(false);
-            var prompt       = new LifecyclePrompt(kind, daemonVersion, CliVersion, terminalPath is null, TakeoverDisclosure);
-
-            // §3.5 claim-before-show: persisted before ConfirmAsync so a crash while the dialog is
-            // open still suppresses a re-offer of this exact pair on the next run.
-            await PersistDeclineAsync(pairKey).ConfigureAwait(false);
-            lock (_lock) _skewDialogShownThisRun = true;
-
-            // The retract runs BEFORE the mutation (acceptance itself invalidates the decline
-            // claim), not after: RunLaneMutationAsync doesn't catch around the lane call, so an
-            // install that throws (shutdown mid-spawn, a process/IO fault, or a lane-lifetime
-            // cancellation) would skip a post-mutation retract entirely and leave an accepted pair
-            // mislabeled "declined" on disk. "Declined" must mean the user declined, full stop.
-            var (outcome, succeeded) = await ConfirmAndTakeoverAsync(
-                prompt, revalidate: fresh => ClassifyTakeover(fresh) == kind && !VersionsNowEqual(),
-                onAcceptedNotStale: () => RetractDeclineAsync(pairKey), _lifetime.Token).ConfigureAwait(false);
-
-            switch (outcome) {
-                case ConfirmOutcome.Declined:
-                    return; // the claim persisted above IS the decline memory
-                case ConfirmOutcome.Stale:
-                    // Never actually declined — retract the claim and let the next trigger re-offer.
-                    await RetractDeclineAsync(pairKey).ConfigureAwait(false);
-                    lock (_lock) _skewDialogShownThisRun = false;
-                    return;
-                case ConfirmOutcome.Attempted:
-                    if (!succeeded) lock (_lock) _skewDialogShownThisRun = false; // no resolution — re-offer
-                    return;
-            }
-        } catch (OperationCanceledException) {
-            // shutdown mid-check
-        } catch (Exception ex) {
-            Console.Error.WriteLine($"kcap: daemon lifecycle skew check failed unexpectedly: {ex.Message}");
-        } finally {
-            _gate.Release();
-        }
-    }
-
-    /// During the post-update hold every trigger is retained rather than dropped — an incompatible
-    /// daemon never produces a snapshot, and the attach client will not repeat an identical event.
-    bool TryHoldSkew(string? daemonVersion) {
-        lock (_lock) {
-            if (_skewHoldUntil is not { } until || _time.GetUtcNow() >= until) return false;
-
-            _heldSkewVersion = daemonVersion;
-            if (_holdRecheckScheduled) return true;
-
-            _holdRecheckScheduled = true;
-            _ = RunHeldSkewRecheckAsync(until - _time.GetUtcNow());
-            return true;
-        }
-    }
-
-    async Task RunHeldSkewRecheckAsync(TimeSpan delay) {
-        try {
-            await Task.Delay(delay, _time, _lifetime.Token).ConfigureAwait(false);
-        } catch (OperationCanceledException) {
-            return;
-        }
-
-        string? held;
-        lock (_lock) {
-            _skewHoldUntil = null;
-            held = _heldSkewVersion;
-        }
-
-        // A snapshot that arrived during the hold is fresher than the held evidence: an idle
-        // daemon has restarted by now and its new version ends the matter without a dialog.
-        await RunSkewCheckAsync(LatestSnapshotVersion() ?? held).ConfigureAwait(false);
-    }
-
-    enum ConfirmOutcome { Declined, Stale, Attempted }
-
-    /// The ONE accept path every unit rewrite in this controller goes through — skew's takeover
-    /// (§4.3) and Start's repair affordance (§4.4) both funnel here, so a future kind can never
-    /// grow a second `MutationVerb.Replace` call site. `onAcceptedNotStale`,
-    /// when given, runs after acceptance is confirmed fresh but BEFORE the mutation itself (skew's
-    /// decline-claim retract — see its own comment above).
-    ///
-    /// `revalidate`, when given, re-queries a FRESH status right before mutating and rejects a
-    /// classification that no longer matches what the dialog disclosed (spec §3.2: "evidence is
-    /// revalidated inside the gate immediately before mutating"). The generation-token check above
-    /// only catches changes that produced an attach event — a terminal replacing the plist/unit
-    /// directly (no attach event, generation unchanged) needs this second, disk-fresh check. Null
-    /// for the repair affordance, which discloses no classification to go stale.
-    async Task<(ConfirmOutcome Outcome, bool MutationSucceeded)> ConfirmAndTakeoverAsync(
-            LifecyclePrompt prompt, Func<ServiceSnapshot, bool>? revalidate, Func<Task>? onAcceptedNotStale,
-            CancellationToken ct) {
+    /// The ONE accept path for a unit rewrite this controller offers, so a future dialog can never
+    /// grow a second `MutationVerb.Replace` call site. A consent that outlived an attach transition
+    /// is discarded: the evidence the dialog disclosed may no longer hold.
+    async Task ConfirmAndReplaceAsync(LifecyclePrompt prompt, CancellationToken ct) {
         var gen0     = CurrentGeneration(); // captured immediately before ConfirmAsync (stale-consent check below)
         var accepted = await _surface.ConfirmAsync(prompt, ct).ConfigureAwait(false);
-        if (!accepted) return (ConfirmOutcome.Declined, false);
+        if (!accepted) return;
 
         if (CurrentGeneration() != gen0) {
             _surface.Status("The daemon changed while the prompt was open — canceled, nothing changed.");
-            return (ConfirmOutcome.Stale, false);
+            return;
         }
 
-        if (revalidate is not null) {
-            var fresh = await QueryStatusForActionAsync(ct).ConfigureAwait(false);
-            if (fresh is null) return (ConfirmOutcome.Stale, false); // already surfaced by QueryStatusForActionAsync
-            if (!revalidate(fresh)) {
-                _surface.Status("The daemon service changed while the prompt was open — canceled, nothing changed.");
-                return (ConfirmOutcome.Stale, false);
-            }
-        }
-
-        if (onAcceptedNotStale is not null) await onAcceptedNotStale().ConfigureAwait(false);
-
-        var succeeded = await RunLaneMutationAsync(MutationVerb.Replace, ct).ConfigureAwait(false);
-        return (ConfirmOutcome.Attempted, succeeded);
+        await RunLaneMutationAsync(MutationVerb.Replace, ct).ConfigureAwait(false);
     }
 
-    Task PersistDeclineAsync(string pairKey) =>
-        _store.UpdateAsync(s => s.DeclinedTakeoverPairs?.Contains(pairKey) == true
-            ? s
-            : s with { DeclinedTakeoverPairs = [.. s.DeclinedTakeoverPairs ?? [], pairKey] });
-
-    Task RetractDeclineAsync(string pairKey) =>
-        _store.UpdateAsync(s => s.DeclinedTakeoverPairs is null || !s.DeclinedTakeoverPairs.Contains(pairKey)
-            ? s
-            : s with { DeclinedTakeoverPairs = s.DeclinedTakeoverPairs.Where(p => p != pairKey).ToList() });
-
-    /// §4.1 preconditions the skew/takeover DIALOG itself needs — unlike FailingPreconditionAsync
-    /// (the silent-install row), an unknown terminal PATH is NOT one of them: decision 7 lets a
-    /// DIALOGED install proceed on disclosure (the prompt's PathDegraded) rather than block. A
-    /// missing install binary or an unresolvable profile, though, would make accept a guaranteed
-    /// coded viability failure — those still gate the offer itself.
-    async Task<string?> FailingSkewPreconditionAsync(ServiceSnapshot snap, CancellationToken ct) {
+    /// Preconditions the repair dialog needs — unlike FailingPreconditionAsync (the silent-install
+    /// row), an unknown terminal PATH is not one of them: a dialoged install proceeds on disclosure
+    /// (the prompt's PathDegraded) rather than blocking. A missing install binary or an
+    /// unresolvable profile would make accept a guaranteed coded viability failure, so those still
+    /// gate the offer itself.
+    async Task<string?> FailingRepairPreconditionAsync(ServiceSnapshot snap) {
         if (snap.InstallBinaryPath is null)
-            return "kcap can't resolve its own daemon binary — skipping the takeover offer.";
+            return "kcap can't resolve its own daemon binary — skipping the repair offer.";
 
         var profile = await _resolveProfileName().ConfigureAwait(false);
         if (profile is null)
-            return "No profile with a valid server URL is configured — skipping the takeover offer.";
+            return "No profile with a valid server URL is configured — skipping the repair offer.";
 
         return null;
     }
-
-    /// Classification (spec §4.3): unit_present &amp;&amp; canonical binary_path == canonical
-    /// install_binary_path is the ONLY same-binary case — path equality is not installer
-    /// provenance, so both kinds carry TakeoverDisclosure. A blank/whitespace path (e.g. a
-    /// foreign/hand-edited plist) is never treated as a match.
-    static string ClassifyTakeover(ServiceSnapshot snap) =>
-        snap.UnitPresent && !string.IsNullOrWhiteSpace(snap.BinaryPath) && !string.IsNullOrWhiteSpace(snap.InstallBinaryPath)
-            && CanonicalPath(snap.BinaryPath) == CanonicalPath(snap.InstallBinaryPath)
-            ? LifecyclePrompt.KindRestartUpdate
-            : LifecyclePrompt.KindTakeover;
-
-    static string CanonicalPath(string path) {
-        try {
-            var fullPath = Path.GetFullPath(path);
-            return new FileInfo(fullPath).ResolveLinkTarget(returnFinalTarget: true)?.FullName ?? fullPath;
-        } catch {
-            return path; // empty/invalid path, missing file, permission error, etc. — raw string compare
-        }
-    }
-
-    // The daemon may have restarted itself onto the new binary while the dialog was open — an
-    // accept then has nothing to do, and must not replace a unit that is already current.
-    bool VersionsNowEqual() => LatestSnapshotVersion() is { } current && current == CliVersion;
 
     /// Reconciliation (spec §3.2): surfaces every inconsistent combination found in one
     /// ServiceStatusAsync snapshot — never mutates. The attached-only checks only make sense (or
@@ -759,12 +545,10 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
             : "Daemon start did not finish. Press Retry.");
     }
 
-    /// §4.4 repair affordance: the SAME dialoged operation as skew's takeover
-    /// (ConfirmAndTakeoverAsync), entered from Start instead of a version mismatch — a plist/pid
-    /// combination Start refuses to silently mutate into. No daemon/CLI version pair applies here,
-    /// so the prompt carries neither.
+    /// The Start button's repair affordance: a plist/pid combination Start refuses to silently
+    /// mutate into is offered as a dialoged replace instead.
     async Task OfferRepairAsync(ServiceSnapshot snap, CancellationToken ct) {
-        var missing = await FailingSkewPreconditionAsync(snap, ct).ConfigureAwait(false);
+        var missing = await FailingRepairPreconditionAsync(snap).ConfigureAwait(false);
         if (missing is not null) {
             _surface.Status(missing);
             return;
@@ -773,7 +557,7 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         var terminalPath = await _probe.TerminalPathAsync(ct).ConfigureAwait(false);
         var prompt = new LifecyclePrompt(LifecyclePrompt.KindRepair, null, null, terminalPath is null, TakeoverDisclosure);
 
-        await ConfirmAndTakeoverAsync(prompt, revalidate: null, onAcceptedNotStale: null, ct).ConfigureAwait(false);
+        await ConfirmAndReplaceAsync(prompt, ct).ConfigureAwait(false);
     }
 
     /// App shutdown awaits this: completes once no mutation child is in flight. Does not itself
@@ -789,7 +573,6 @@ public sealed class DaemonLifecycleController : IAsyncDisposable {
         _disposed = true;
 
         _subscription?.Dispose();
-        _snapshotSubscription?.Dispose();
         _lifetime.Cancel();
         await QuiescedAsync().ConfigureAwait(false);
         _lifetime.Dispose();

--- a/src/Capacitor.App/Services/ILifecycleSurface.cs
+++ b/src/Capacitor.App/Services/ILifecycleSurface.cs
@@ -16,11 +16,10 @@ public interface ILifecycleSurface {
 }
 
 /// <param name="Kind">One of the Kind* consts below.</param>
-/// <param name="PathDegraded">Decision-7 disclosure when the terminal PATH is unknown.</param>
-/// <param name="Disclosure">Replacement/recapture text (decision 3).</param>
+/// <param name="PathDegraded">Disclosed when the terminal PATH is unknown.</param>
+/// <param name="Disclosure">Replacement/recapture text.</param>
 public sealed record LifecyclePrompt(
     string Kind, string? DaemonVersion, string? CliVersion, bool PathDegraded, string Disclosure) {
-    public const string KindRestartUpdate = "restart-update";
     public const string KindTakeover      = "takeover";
     public const string KindRepair        = "repair";
     public const string KindShim          = "shim";

--- a/src/Capacitor.App/ViewModels/LifecyclePromptViewModel.cs
+++ b/src/Capacitor.App/ViewModels/LifecyclePromptViewModel.cs
@@ -67,7 +67,6 @@ public sealed class LifecyclePromptViewModel : ReactiveObject {
     }
 
     internal static string TitleFor(string kind) => kind switch {
-        LifecyclePrompt.KindRestartUpdate => "Restart daemon to update",
         LifecyclePrompt.KindTakeover      => "Take over daemon management",
         LifecyclePrompt.KindShim          => "Install command-line tool",
         LifecyclePrompt.KindQuarantine    => "Corrupted consent claims file",

--- a/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMutationLaneWiringTests.cs
@@ -648,8 +648,6 @@ public class AppMutationLaneWiringTests {
             InstallVerifiedBehavior = (_, _) => Task.FromResult(new ProcessResult(28, "", "start_gate_reason=foreign_binary", false)),
         };
         var probe = new FakeLoginShellProbe();
-        using var tmp = new TempDir();
-        var store = new AppStateStore(tmp.PathTo("app-state.json"));
         var surface = new FakeLifecycleSurface { ConfirmBehavior = (_, _) => Task.FromResult(false) }; // decline
 
         {
@@ -660,7 +658,7 @@ public class AppMutationLaneWiringTests {
                 TimeProvider.System);
 
             await using var controller = new DaemonLifecycleController(
-                client, cli, probe, store, surface, () => Task.FromResult<string?>("default"), TimeProvider.System,
+                client, cli, probe, surface, () => Task.FromResult<string?>("default"), TimeProvider.System,
                 "https://kcap.example.com:443", lane.RunAsync);
 
             using var consumerCts = new CancellationTokenSource();

--- a/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupTests.cs
@@ -172,7 +172,7 @@ public class AppStartupTests {
     /// Fix-round-1 regression coverage (Task 21), carried forward against Task 22's REAL
     /// LifecyclePromptWindow/LifecyclePromptViewModel: the interim lifecycle prompt dialog used to
     /// ignore its ConfirmAsync CancellationToken entirely — the tcs only ever resolved on a button
-    /// click or the window's own Closed event. Since ConfirmAndTakeoverAsync holds the operation
+    /// click or the window's own Closed event. Since ConfirmAndReplaceAsync holds the operation
     /// gate across the whole ConfirmAsync await, a dialog left open through a lifetime-cancel (app
     /// shutdown) would hold that gate forever, and QuiescedAsync (the very backstop shutdown
     /// relies on) would never complete. WireDialogCancellation is the fix: a cancelled token

--- a/test/Capacitor.App.Tests.Unit/AppStateStoreTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStateStoreTests.cs
@@ -62,15 +62,14 @@ public class AppStateStoreTests {
 
         var tasks = Enumerable.Range(0, 50).Select(i =>
             store.UpdateAsync(s => s with {
-                DeclinedTakeoverPairs = [.. s.DeclinedTakeoverPairs ?? [], $"{i}.0.0|{i}.0.1"]
+                HarnessByRepo = new Dictionary<string, string>(s.HarnessByRepo ?? new Dictionary<string, string>()) { [$"/repo/{i}"] = "claude" }
             }));
         var results = await Task.WhenAll(tasks);
 
         await Assert.That(results.All(r => r)).IsTrue();
 
         var final = await store.LoadAsync();
-        await Assert.That(final.DeclinedTakeoverPairs!.Count).IsEqualTo(50);
-        await Assert.That(final.DeclinedTakeoverPairs!.Distinct().Count()).IsEqualTo(50);
+        await Assert.That(final.HarnessByRepo!.Count).IsEqualTo(50);
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonLifecycleControllerTests.cs
@@ -368,6 +368,27 @@ public class DaemonLifecycleControllerTests {
         await Assert.That(h.Cli.StatusCallCount).IsEqualTo(1);
     }
 
+    /// A reattach after the first Connected (the daemon relaunching itself onto a new binary, a
+    /// reconnect) is the client's business alone: no query, no dialog, no mutation.
+    [Test]
+    public async Task Later_connected_transitions_neither_query_nor_prompt() {
+        await using var h = new Harness();
+        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
+        h.Start();
+
+        h.PushConnected();
+        await h.Controller.PhaseClosed;
+        await WaitUntilAsync(() => h.Cli.StatusCallCount == 1, what: "the reconciliation query");
+
+        h.PushConnecting();
+        h.PushConnected();
+        await Task.Delay(50); // a negative: give a would-be second pass every chance to fire
+
+        await Assert.That(h.Cli.StatusCallCount).IsEqualTo(1);
+        await Assert.That(h.Surface.Prompts).IsEmpty();
+        await Assert.That(h.Lane.Requests).IsEmpty();
+    }
+
     // ---- reconciliation on immediate Connected ----
 
     [Test]
@@ -729,7 +750,7 @@ public class DaemonLifecycleControllerTests {
     }
 
     [Test]
-    public async Task StartAction_repair_accept_calls_replace_same_helper_as_takeover() {
+    public async Task StartAction_repair_accept_calls_replace() {
         await using var h = new Harness();
         h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
         h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed", daemonPid: 555));
@@ -842,555 +863,6 @@ public class DaemonLifecycleControllerTests {
         await startTask;
     }
 
-    // ---- §4.3 skew → restart/takeover ----
-
-    [Test]
-    public async Task Skew_connected_version_match_is_noop() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushSnapshot("1.0.0"); // matches FakeKcapCli's default VersionBehavior
-        h.PushConnected();
-
-        await h.Controller.PhaseClosed;
-        await Task.Delay(50); // give a wrongly-firing prompt every chance to appear
-        await Assert.That(h.Surface.Prompts).IsEmpty();
-    }
-
-    [Test]
-    public async Task Skew_connected_mismatch_same_canonical_binary_prompts_restart_update() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(
-            unitPresent: true, state: "installed", installBinaryPath: "/opt/kcap/kcapd", binaryPath: "/opt/kcap/kcapd"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushSnapshot("2.0.0");
-        h.PushConnected();
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the skew prompt");
-        await Assert.That(h.Surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindRestartUpdate);
-        await Assert.That(h.Surface.Prompts[0].DaemonVersion).IsEqualTo("2.0.0");
-        await Assert.That(h.Surface.Prompts[0].CliVersion).IsEqualTo("1.0.0");
-        await Assert.That(h.Surface.Prompts[0].Disclosure).IsEqualTo(DaemonLifecycleController.TakeoverDisclosure);
-    }
-
-    [Test]
-    public async Task Skew_connected_mismatch_different_binary_prompts_takeover() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(
-            unitPresent: true, state: "installed", installBinaryPath: "/opt/kcap/kcapd", binaryPath: "/usr/local/bin/kcapd-old"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushSnapshot("2.0.0");
-        h.PushConnected();
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the skew prompt");
-        await Assert.That(h.Surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindTakeover);
-        await Assert.That(h.Surface.Prompts[0].Disclosure).IsEqualTo(DaemonLifecycleController.TakeoverDisclosure);
-    }
-
-    [Test]
-    public async Task Skew_incompatible_version_mismatch_prompts() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the incompatible skew prompt");
-        await Assert.That(h.Surface.Prompts[0].DaemonVersion).IsEqualTo("0.9");
-    }
-
-    [Test]
-    public async Task Skew_version_flip_same_run_prompts_only_once() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the first skew prompt");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.95"); // a genuinely new pair
-        await Task.Delay(50); // give a second (wrongly-stacked) prompt every chance to appear
-
-        await Assert.That(h.Surface.Prompts.Count).IsEqualTo(1);
-    }
-
-    [Test]
-    public async Task Skew_daemon_unreachable_never_prompts() {
-        await using var h = new Harness();
-        // state:"running" is a no-mutation matrix row (Row1) — a mutating row would block this
-        // test's PhaseClosed wait on the lane, which nothing here resolves.
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(state: "running", jobPid: 1, daemonPid: 1));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(daemonVersion: "9.9.9"); // reason defaults to daemon_unreachable
-
-        await h.Controller.PhaseClosed;
-        await Task.Delay(50);
-        await Assert.That(h.Surface.Prompts).IsEmpty();
-    }
-
-    [Test]
-    public async Task Skew_cli_version_null_disables_detection() {
-        await using var h = new Harness();
-        h.Cli.VersionBehavior = _ => Task.FromResult<string?>(null);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version probe attempt");
-        await Assert.That(h.Controller.CliVersion).IsNull();
-
-        h.PushSnapshot("2.0.0");
-        h.PushConnected();
-
-        await h.Controller.PhaseClosed;
-        await Task.Delay(50);
-        await Assert.That(h.Surface.Prompts).IsEmpty();
-    }
-
-    [Test]
-    public async Task Skew_prompt_discloses_degraded_path_when_terminal_path_unknown() {
-        await using var h = new Harness();
-        h.Probe.TerminalPathBehavior = _ => Task.FromResult<string?>(null);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the skew prompt");
-        await Assert.That(h.Surface.Prompts[0].PathDegraded).IsTrue();
-    }
-
-    [Test]
-    public async Task Skew_accept_calls_replace_and_nothing_else() {
-        await using var h = new Harness();
-        h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-
-        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request");
-        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.Replace);
-    }
-
-    [Test]
-    public async Task Skew_decline_persists_pair_same_pair_no_prompt_new_pair_prompts() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the first skew prompt");
-
-        var afterDecline = await h.Store.LoadAsync();
-        await Assert.That(afterDecline.DeclinedTakeoverPairs).IsNotNull();
-        await Assert.That(afterDecline.DeclinedTakeoverPairs!).Contains("0.9|1.0.0");
-
-        // A fresh controller sharing the same store, offered the SAME pair, must not prompt.
-        var surface2 = new FakeLifecycleSurface();
-        var client2  = new FakeDaemonClientService();
-        var cli2     = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed")) };
-        await using var controller2 = new DaemonLifecycleController(
-            client2, cli2, new FakeLoginShellProbe(), h.Store, surface2, () => Task.FromResult<string?>("default"), h.Time,
-            h.CanonicalServer, new FakeMutationLane().RunAsync);
-        controller2.Start();
-        await WaitUntilAsync(() => cli2.VersionCallCount == 1, what: "controller2's version cache");
-
-        client2.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_incompatible", null, "0.9"));
-        await Task.Delay(50);
-        await Assert.That(surface2.Prompts).IsEmpty();
-
-        // A genuinely new pair (either version changed) offers again.
-        client2.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_incompatible", null, "0.95"));
-        await WaitUntilAsync(() => surface2.Prompts.Count == 1, what: "the new-pair prompt");
-    }
-
-    [Test]
-    public async Task Skew_stale_consent_between_show_and_accept_aborts_no_mutation() {
-        await using var h = new Harness();
-        var confirmTcs = new TaskCompletionSource<bool>();
-        h.Surface.ConfirmBehavior = (_, _) => confirmTcs.Task;
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the skew prompt shown");
-
-        h.PushUnreachable(); // a later, unrelated attach transition — moves the generation
-        confirmTcs.SetResult(true); // the user accepts what is now a stale offer
-
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the stale-consent abort status");
-        await Assert.That(h.Lane.Requests).IsEmpty();
-
-        // A stale accept was never a real decline — the claim-before-show pair is retracted...
-        var afterAbort = await h.Store.LoadAsync();
-        await Assert.That((afterAbort.DeclinedTakeoverPairs ?? []).Contains("0.9|1.0.0")).IsFalse();
-
-        // ...and the once-per-run flag is cleared so a fresh trigger re-offers (spec §6).
-        h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(false);
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 2, what: "the re-offered prompt");
-    }
-
-    // A terminal can replace the plist/unit while the dialog is open WITHOUT producing
-    // an attach event — the generation token alone is blind to this. Acceptance must re-query
-    // fresh status and re-classify before mutating; a classification flip aborts exactly like the
-    // generation-based stale-consent path above.
-    [Test]
-    public async Task Skew_accept_aborts_when_fresh_status_reclassifies_without_a_generation_bump() {
-        await using var h = new Harness();
-        var confirmTcs = new TaskCompletionSource<bool>();
-        h.Surface.ConfirmBehavior = (_, _) => confirmTcs.Task;
-        var sameBinary      = Snap(unitPresent: true, state: "installed", installBinaryPath: "/opt/kcap/kcapd", binaryPath: "/opt/kcap/kcapd");
-        var differentBinary = Snap(unitPresent: true, state: "installed", installBinaryPath: "/opt/kcap/kcapd", binaryPath: "/usr/local/bin/kcapd-old");
-        var noMutationRow   = Snap(state: "running", jobPid: 1, daemonPid: 1);
-        var next = noMutationRow; // swapped explicitly at each step below — never inferred from call count
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(next);
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        // Claim the once-per-run arm on a harmless no-mutation row first — the daemon_incompatible
-        // push below must NOT be the run's first terminal outcome, or it would ALSO fire a
-        // concurrent RunReconciliationAsync status query racing RunSkewCheckAsync's own two
-        // (dialog-build + in-gate revalidation), making "which call sees which snapshot"
-        // nondeterministic instead of exercising the intended sequence.
-        h.PushUnreachable();
-        await h.Controller.PhaseClosed;
-
-        next = sameBinary; // the dialog-build query below
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the skew prompt shown");
-        await Assert.That(h.Surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindRestartUpdate);
-
-        next = differentBinary; // a terminal silently replaced the plist mid-dialog — no attach event
-        confirmTcs.SetResult(true); // accept — generation is unchanged
-
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the reclassification abort status");
-        await Assert.That(h.Lane.Requests).IsEmpty();
-
-        // Never a real decline — the claim is retracted and the run flag cleared, same as the
-        // generation-based stale-consent path.
-        var afterAbort = await h.Store.LoadAsync();
-        await Assert.That((afterAbort.DeclinedTakeoverPairs ?? []).Contains("0.9|1.0.0")).IsFalse();
-
-        next = sameBinary;
-        h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(false);
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 2, what: "the re-offered prompt");
-    }
-
-    // Unchanged evidence between show and accept proceeds — the counterpart to the reclassification
-    // abort above. Distinct from Skew_accept_calls_replace_and_nothing_else: this one asserts the
-    // revalidation query itself ran (a StatusCallCount delta of 2) rather than just the eventual
-    // lane request.
-    [Test]
-    public async Task Skew_accept_with_unchanged_status_revalidates_then_proceeds() {
-        await using var h = new Harness();
-        h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
-        var installedSnap = Snap(unitPresent: true, state: "installed", installBinaryPath: "/opt/kcap/kcapd", binaryPath: "/opt/kcap/kcapd");
-        var noMutationRow = Snap(state: "running", jobPid: 1, daemonPid: 1);
-        var next = noMutationRow;
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(next);
-        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        // Claim the arm on a harmless no-mutation row first — see the comment on
-        // Skew_accept_aborts_when_fresh_status_reclassifies_without_a_generation_bump above for why
-        // daemon_incompatible must not be the run's first terminal outcome here.
-        h.PushUnreachable();
-        await h.Controller.PhaseClosed;
-        var statusCallsBeforeSkew = h.Cli.StatusCallCount;
-
-        next = installedSnap;
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-
-        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request");
-        await Assert.That(h.Lane.Requests[0].Verb).IsEqualTo(MutationVerb.Replace);
-        await Assert.That(h.Cli.StatusCallCount - statusCallsBeforeSkew).IsEqualTo(2); // the dialog query + the in-gate revalidation
-    }
-
-    [Test]
-    public async Task Skew_accept_coded_failure_retracts_claim_and_clears_run_flag() {
-        await using var h = new Harness();
-        h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Failed(21, "verify_viability_nope", RecoverySurface.Attention));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        // Lane.Behavior resolves immediately (Task.FromResult), and the retract is fully awaited
-        // BEFORE the mutation call (see the comment on the retract-before-mutation ordering
-        // above) — by the time the lane records the request, the retract has already landed.
-        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request attempt");
-
-        var afterFailure = await h.Store.LoadAsync();
-        await Assert.That((afterFailure.DeclinedTakeoverPairs ?? []).Contains("0.9|1.0.0")).IsFalse();
-        await Assert.That(h.Surface.StatusMessages).IsEmpty(); // channel-only now (round-1 review C-2)
-
-        // The run flag cleared too — a fresh trigger (a different pair, since this run's CLI
-        // version hasn't changed) still gets an offer.
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.95");
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 2, what: "the re-offered prompt after the coded failure");
-    }
-
-    [Test]
-    public async Task Skew_claim_persisted_before_confirm_resolves_survives_a_crash_at_dialog() {
-        await using var h = new Harness();
-        var confirmTcs = new TaskCompletionSource<bool>();
-        h.Surface.ConfirmBehavior = (_, _) => confirmTcs.Task;
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the dialog shown");
-
-        // The dialog is "open" (ConfirmAsync hasn't resolved) — simulate a crash right here: the
-        // claim must already be on disk, not waiting on the user's answer.
-        var midDialog = await h.Store.LoadAsync();
-        await Assert.That(midDialog.DeclinedTakeoverPairs).IsNotNull();
-        await Assert.That(midDialog.DeclinedTakeoverPairs!).Contains("0.9|1.0.0");
-
-        confirmTcs.SetResult(false); // let it resolve so disposal doesn't wait on it
-    }
-
-    [Test]
-    public async Task Skew_accept_retracts_the_claim_after_a_successful_takeover() {
-        await using var h = new Harness();
-        h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Lane.Behavior = (_, _) => Task.FromResult<MutationOutcome>(new MutationOutcome.Succeeded());
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request");
-
-        await WaitUntilAsync(
-            () => !(h.Store.LoadAsync().GetAwaiter().GetResult().DeclinedTakeoverPairs ?? []).Contains("0.9|1.0.0"),
-            what: "the claim retracted on acceptance");
-    }
-
-    [Test]
-    public async Task Skew_accept_retracts_the_claim_even_when_the_mutation_throws() {
-        await using var h = new Harness();
-        h.Surface.ConfirmBehavior = (_, _) => Task.FromResult(true);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        // Simulates a shutdown mid-spawn or a lane-lifetime cancellation — RunLaneMutationAsync
-        // does not catch around the lane call, so this propagates out of RunSkewCheckAsync's
-        // mutation step entirely.
-        h.Lane.Behavior = (_, _) => Task.FromException<MutationOutcome>(new OperationCanceledException("shutdown mid-install"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await WaitUntilAsync(() => h.Lane.Requests.Count == 1, what: "the takeover request attempt");
-
-        await WaitUntilAsync(
-            () => !(h.Store.LoadAsync().GetAwaiter().GetResult().DeclinedTakeoverPairs ?? []).Contains("0.9|1.0.0"),
-            what: "the claim retracted despite the mutation throwing");
-
-        // A fresh controller sharing the same store re-offers the same pair — accepted-but-failed
-        // must never read back as "the user declined".
-        var surface2 = new FakeLifecycleSurface();
-        var client2  = new FakeDaemonClientService();
-        var cli2     = new FakeKcapCli { StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed")) };
-        await using var controller2 = new DaemonLifecycleController(
-            client2, cli2, new FakeLoginShellProbe(), h.Store, surface2, () => Task.FromResult<string?>("default"), h.Time,
-            h.CanonicalServer, new FakeMutationLane().RunAsync);
-        controller2.Start();
-        await WaitUntilAsync(() => cli2.VersionCallCount == 1, what: "controller2's version cache");
-
-        client2.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_incompatible", null, "0.9"));
-        await WaitUntilAsync(() => surface2.Prompts.Count == 1, what: "the re-offered prompt");
-    }
-
-    [Test]
-    public async Task Skew_connected_before_version_probe_resolves_still_prompts_once_it_does() {
-        await using var h = new Harness();
-        var versionTcs = new TaskCompletionSource<string?>();
-        h.Cli.VersionBehavior = _ => versionTcs.Task;
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(
-            unitPresent: true, state: "installed", installBinaryPath: "/opt/kcap/kcapd", binaryPath: "/opt/kcap/kcapd"));
-        h.Start();
-
-        h.PushSnapshot("2.0.0");
-        h.PushConnected(); // the attach cycle wins the race — arrives before the version probe resolves
-
-        await Task.Delay(50); // give a wrongly-early (or wrongly-dropped) prompt every chance to appear
-        await Assert.That(h.Surface.Prompts).IsEmpty();
-
-        versionTcs.SetResult("1.0.0"); // the probe finally lands
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the skew prompt once the version probe resolves");
-    }
-
-    [Test]
-    public async Task Skew_classification_treats_empty_binary_path_as_takeover_without_throwing() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(
-            unitPresent: true, state: "installed", installBinaryPath: "/opt/kcap/kcapd", binaryPath: ""));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the skew prompt (no throw on empty path)");
-        await Assert.That(h.Surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindTakeover);
-    }
-
-    [Test]
-    public async Task Skew_classification_resolves_symlinks_to_the_same_canonical_target() {
-        await using var h = new Harness();
-        using var tmp = new TempDir();
-        var real = tmp.PathTo("kcapd-real");
-        File.WriteAllText(real, "binary");
-        var link = tmp.PathTo("kcapd-link");
-        File.CreateSymbolicLink(link, real);
-
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(
-            unitPresent: true, state: "installed", installBinaryPath: real, binaryPath: link));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the skew prompt");
-        await Assert.That(h.Surface.Prompts[0].Kind).IsEqualTo(LifecyclePrompt.KindRestartUpdate);
-    }
-
-    [Test]
-    public async Task Skew_missing_install_binary_path_precondition_fails_status_only_no_prompt() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed", installBinaryPath: null));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the missing-binary status line");
-        await Assert.That(h.Surface.Prompts).IsEmpty();
-    }
-
-    [Test]
-    public async Task Skew_missing_profile_precondition_fails_status_only_no_prompt() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.ProfileName = null;
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the missing-profile status line");
-        await Assert.That(h.Surface.Prompts).IsEmpty();
-    }
-
-    [Test]
-    public async Task Skew_hold_after_update_defers_the_prompt_until_the_window_closes() {
-        await using var h = new Harness(holdSkewForUpdate: true);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(
-            unitPresent: true, state: "installed", installBinaryPath: "/opt/kcap/kcapd", binaryPath: "/opt/kcap/kcapd"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushSnapshot("0.9.0");
-        h.PushConnected();
-        await Task.Delay(50);
-        await Assert.That(h.Surface.Prompts).IsEmpty();
-
-        h.Clock.Advance(DaemonLifecycleController.SkewHoldAfterUpdate);
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the deferred skew prompt");
-        await Assert.That(h.Surface.Prompts[0].DaemonVersion).IsEqualTo("0.9.0");
-    }
-
-    [Test]
-    public async Task Skew_hold_ends_quietly_when_the_daemon_restarted_itself() {
-        await using var h = new Harness(holdSkewForUpdate: true);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushSnapshot("0.9.0");
-        h.PushConnected();
-        h.PushSnapshot("1.0.0"); // the daemon's own restart-after-update landed during the hold
-        h.Clock.Advance(DaemonLifecycleController.SkewHoldAfterUpdate);
-        await Task.Delay(50);
-
-        await Assert.That(h.Surface.Prompts).IsEmpty();
-    }
-
-    [Test]
-    public async Task Skew_hold_keeps_incompatible_hello_evidence_and_prompts_once() {
-        await using var h = new Harness(holdSkewForUpdate: true);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushUnreachable(reason: "daemon_incompatible", daemonVersion: "0.9");
-        await Task.Delay(50);
-        await Assert.That(h.Surface.Prompts).IsEmpty();
-
-        h.Clock.Advance(DaemonLifecycleController.SkewHoldAfterUpdate);
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the deferred incompatible prompt");
-        await Assert.That(h.Surface.Prompts[0].DaemonVersion).IsEqualTo("0.9");
-        await Task.Delay(50);
-        await Assert.That(h.Surface.Prompts.Count).IsEqualTo(1);
-    }
-
-    [Test]
-    public async Task Skew_without_hold_prompts_immediately() {
-        await using var h = new Harness(holdSkewForUpdate: false);
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(unitPresent: true, state: "installed"));
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushSnapshot("2.0.0");
-        h.PushConnected();
-
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the immediate skew prompt");
-    }
-
-    [Test]
-    public async Task Skew_accept_after_the_daemon_caught_up_is_stale_and_retracts_the_claim() {
-        await using var h = new Harness();
-        h.Cli.StatusBehavior = _ => Task.FromResult<ServiceSnapshot?>(Snap(
-            unitPresent: true, state: "installed", installBinaryPath: "/opt/kcap/kcapd", binaryPath: "/opt/kcap/kcapd"));
-        var answer = new TaskCompletionSource<bool>();
-        h.Surface.ConfirmBehavior = (_, _) => answer.Task;
-        h.Start();
-        await WaitUntilAsync(() => h.Cli.VersionCallCount == 1, what: "the version cache");
-
-        h.PushSnapshot("2.0.0");
-        h.PushConnected();
-        await WaitUntilAsync(() => h.Surface.Prompts.Count == 1, what: "the skew prompt");
-
-        h.PushSnapshot("1.0.0"); // the daemon restarted itself while the dialog was open
-        answer.SetResult(true);
-        await WaitUntilAsync(() => h.Surface.StatusMessages.Count == 1, what: "the stale-consent status");
-
-        await Assert.That(h.Lane.Requests).IsEmpty();
-        var state = await h.Store.LoadAsync();
-        await Assert.That(state.DeclinedTakeoverPairs ?? []).IsEmpty();
-    }
-
     // ---- harness ----
 
     /// Records every MutationRequest the controller hands to `_runMutation` and lets a test
@@ -1416,9 +888,6 @@ public class DaemonLifecycleControllerTests {
         public readonly FakeLifecycleSurface Surface = new();
         public readonly FakeTimeProvider Clock = new(new DateTimeOffset(2026, 8, 10, 9, 0, 0, TimeSpan.Zero));
         public readonly TimerCountingTimeProvider Time;
-        readonly TempDir _tmp = new();
-        public string TempDir => _tmp.Path;
-        public readonly AppStateStore Store;
         public readonly FakeMutationLane Lane = new();
         public readonly DaemonLifecycleController Controller;
         public readonly string? CanonicalServer;
@@ -1426,17 +895,18 @@ public class DaemonLifecycleControllerTests {
         public string? ProfileName = "default";
 
         public Harness(
-                string? canonicalServer = "https://kcap.example.com:443", bool autoActionsPermanentlyClosed = false,
-                bool holdSkewForUpdate = false) {
+                string? canonicalServer = "https://kcap.example.com:443", bool autoActionsPermanentlyClosed = false) {
             CanonicalServer = canonicalServer;
             Time  = new TimerCountingTimeProvider(Clock);
-            Store = new AppStateStore(Path.Combine(TempDir, "app-state.json"));
             Controller = new DaemonLifecycleController(
-                Client, Cli, Probe, Store, Surface, () => Task.FromResult<string?>(ProfileName), Time,
-                CanonicalServer, Lane.RunAsync, autoActionsPermanentlyClosed, holdSkewForUpdate);
+                Client, Cli, Probe, Surface, () => Task.FromResult<string?>(ProfileName), Time,
+                CanonicalServer, Lane.RunAsync, autoActionsPermanentlyClosed);
         }
 
         public void Start() => Controller.Start();
+
+        public void PushConnecting() =>
+            Client.StatusSubject.OnNext(new AttachStatus(AttachState.Connecting, null, null));
 
         public void PushConnected() =>
             Client.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
@@ -1444,13 +914,7 @@ public class DaemonLifecycleControllerTests {
         public void PushUnreachable(string reason = "daemon_unreachable", string? daemonVersion = null) =>
             Client.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, reason, null, daemonVersion));
 
-        public void PushSnapshot(string version) =>
-            Client.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(version: version));
-
-        public async ValueTask DisposeAsync() {
-            await Controller.DisposeAsync();
-            _tmp.Dispose();
-        }
+        public ValueTask DisposeAsync() => Controller.DisposeAsync();
     }
 }
 

--- a/test/Capacitor.App.Tests.Unit/LifecyclePromptViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LifecyclePromptViewModelTests.cs
@@ -15,7 +15,6 @@ public class LifecyclePromptViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    [Arguments(LifecyclePrompt.KindRestartUpdate, "Restart daemon to update")]
     [Arguments(LifecyclePrompt.KindTakeover, "Take over daemon management")]
     [Arguments(LifecyclePrompt.KindRepair, "Repair daemon service")]
     [Arguments(LifecyclePrompt.KindQuarantine, "Corrupted consent claims file")]
@@ -65,7 +64,7 @@ public class LifecyclePromptViewModelTests {
     [NotInParallel("AvaloniaSession")]
     public async Task PathDegraded_false_renders_no_degraded_path_sentence() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
-            var vm = new LifecyclePromptViewModel(Prompt(LifecyclePrompt.KindRestartUpdate, pathDegraded: false), new TaskCompletionSource<bool>());
+            var vm = new LifecyclePromptViewModel(Prompt(LifecyclePrompt.KindRepair, pathDegraded: false), new TaskCompletionSource<bool>());
 
             await Assert.That(vm.PathDegraded).IsFalse();
             await Assert.That(vm.DegradedPathText).IsNull();


### PR DESCRIPTION
Closes #828 — AI-2603

## What & why

After a CLI update the app's "Restart daemon to update" dialog re-opened on every Continue until the user declined. The daemon already detects a replaced binary and relaunches itself once idle, so the offer duplicated that restart, compared the daemon against a CLI version cached at launch, and on a failed accept re-entered its own check through the reattach kick it had just fired. This removes the skew-triggered dialog and everything that only served it: the takeover classification, the declined-pair memory, the post-update hold, and the snapshot version tracking. The Start button's repair dialog, the wizard's takeover, and the app's own update flow stay.

## Where to look

The lifecycle controller now acts on the first terminal attach outcome only; every later transition is the client's business. Both design specs carry a note pointing at the change-notes entry.

## Verification

- On the reporting machine: `app-state.json` held the pair daemon `0.11.40` / CLI `0.11.39`, and the daemon log showed one restart today, queued by `RestartCoordinator` ("self-detected"), so the accepted replace never ran.
- `Capacitor.App.Tests.Unit` on the rebased branch: 1581 passed, 0 failed.
