### PR TITLE
Show in the desktop app when the daemon has a restart queued

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,19 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## The desktop app shows when the daemon has a restart queued
+
+After a CLI update a busy daemon keeps running the old binary until it is idle, and the app said
+nothing about it. The session rail's daemon indicator and the tray header now carry "update pending"
+while the daemon's own restart-pending marker exists and the app is attached to that daemon, with the
+rail tooltip spelling out that the restart happens once no agents are running. The signal is the
+marker file the daemon writes when it queues the restart and its successor deletes at startup, read
+the same way `kcap daemon status` reads it: nothing about a queued restart travels over the status
+socket, so the app re-reads the file on every attach transition and on a 15-second poll matching the
+daemon's own binary poll. It is a passive marker only. There is no button and no forced restart,
+because forcing one would take the running agents down with it, which is exactly what the daemon's
+idle gate exists to avoid.
+
 ## The desktop app no longer offers to restart or take over the daemon on a version mismatch
 
 The daemon already handles a CLI update by itself: it stats its own binary every 15 seconds, queues

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -147,6 +147,7 @@ public partial class App : Application {
     // subscriber above IS disposed. Held so the consent prompt and the activity feed share the
     // same 1 Hz heartbeat.
     UiTicker? _ticker;
+    DaemonRestartPendingWatcher? _restartPending;
     // Wizard-first mode only (spec decision 2): the sign-in driver shutdown cancels and awaits
     // before anything is disposed, the Import step whose in-flight run shutdown must also kill
     // (spec §7 — closing the window never navigates through ImportStepViewModel.CanLeaveAsync), and
@@ -260,7 +261,7 @@ public partial class App : Application {
             Console.Error.WriteLine($"kcap app failed to start: {ex}");
             await _workspaceTeardown.DrainAsync();
             await HandleStartupFailureAsync(
-                desktop, ex, _service, _shutdown, [_tray, _trayVm, _promptCoordinator, _consent, _permissions, _activity, _home, _rail, _pause], _lifecycle, _lane);
+                desktop, ex, _service, _shutdown, [_tray, _trayVm, _promptCoordinator, _consent, _permissions, _activity, _home, _rail, _pause, _restartPending], _lifecycle, _lane);
             await DisposeServerClientsAsync(); // after _home above
             // all already disposed above — never let a later OnShutdownRequested (e.g. Cmd+Q
             // while the error window is up) dispose any of them a second time
@@ -393,6 +394,11 @@ public partial class App : Application {
         // below) because PauseController/AgentActionService, constructed further down, need it.
         var ops      = new LocalControlOps(_daemonStore, service.DaemonName);
         var notifier = new AppNotifier();
+
+        var restartPending = new DaemonRestartPendingWatcher(
+            _daemonStore, service.DaemonName, service.Status, TimeProvider.System, _shutdown.Token);
+        restartPending.Start();
+        _restartPending = restartPending;
 
         // spec: BehaviorSubjects, not plain Subjects — MainWindowViewModel and
         // TrayViewModel don't exist yet at this point in StartAsync (built further down), so a
@@ -530,7 +536,7 @@ public partial class App : Application {
                 requestSignIn: requestSignIn,
                 lifecycleAttention: lifecycleAttention,
                 directory: directory, remoteAgents: remoteAgents, lane: serverLane,
-                viewerId: viewerId, localMachineId: machineId),
+                viewerId: viewerId, localMachineId: machineId, restartPending: restartPending.Pending),
             // Both close paths release the workspace: hide-to-tray keeps the window (and its
             // attach) alive, a real close discards the window the next Show() would rebuild.
             releaseWorkspace: window => (window.DataContext as MainWindowViewModel)?.CloseWorkspace());
@@ -555,7 +561,8 @@ public partial class App : Application {
             lifecycleAttention: lifecycleAttention, shimOfferable: shimOffer.Offerable,
             installShim: shimOffer.RunManualInstallAsync, permissions: permissions,
             remote: TrayViewModel.SummaryFrom(directory),
-            updateMenu: _updates.MenuItem, updateAction: _updates.RunMenuActionAsync);
+            updateMenu: _updates.MenuItem, updateAction: _updates.RunMenuActionAsync,
+            restartPending: restartPending.Pending);
         _tray = new TrayIconManager(this, _trayVm);
     }
 
@@ -948,7 +955,7 @@ public partial class App : Application {
             IObservable<string?>? lifecycleAttention = null,
             IAgentDirectory? directory = null, IRemoteAgentsService? remoteAgents = null,
             IServerLane? lane = null, Func<CancellationToken, Task<string?>>? viewerId = null,
-            string? localMachineId = null) {
+            string? localMachineId = null, IObservable<bool>? restartPending = null) {
         // Notifier is set on the WINDOW (spec §11 toast overlay), not the ViewModel — the toast
         // is a View-level concern (WindowNotificationManager lives on MainWindow) independent of
         // the VM's WhenActivated-scoped projections.
@@ -988,7 +995,7 @@ public partial class App : Application {
             service, shutdownToken, activity, startAction, lifecycleStatus, home: home,
             navigation: navigation, trackWorkspaceTeardown: trackWorkspaceTeardown, workspaceFactory: workspaceFactory,
             rail: rail, tenantName: tenantName, lifecycleAttention: lifecycleAttention,
-            laneStatus: lane?.Status);
+            laneStatus: lane?.Status, restartPending: restartPending);
         var window = new MainWindow {
             DataContext = vm,
             Notifier = notifier,
@@ -1493,7 +1500,7 @@ public partial class App : Application {
             // disposed one. A resolve already in flight was cancelled by _shutdown at the top of
             // OnShutdownRequested and settles on the ViewModel's silent-abort path.
             await DisposeUiThenConfirmShutdownAsync(
-                [_tray, _trayVm, _promptCoordinator, _consent, _permissions, _activity, _home, _rail, _pause],
+                [_tray, _trayVm, _promptCoordinator, _consent, _permissions, _activity, _home, _rail, _pause, _restartPending],
                 DisposeLifecycleAndServiceAsync, () => _shutdownConfirmed = true, desktop, _exitCode,
                 applyOnExit: () => _updates?.ApplyPendingOnExit());
         } else {

--- a/src/Capacitor.App/Services/DaemonRestartPendingWatcher.cs
+++ b/src/Capacitor.App/Services/DaemonRestartPendingWatcher.cs
@@ -1,0 +1,61 @@
+using System.Reactive.Linq;
+using System.Reactive.Subjects;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.App.Services;
+
+/// Whether the daemon has a restart-after-update queued, read from the marker file it writes
+/// and its successor deletes at startup — the same source `kcap daemon status` reads, since
+/// nothing about a queued restart travels over the status socket. Re-read on every attach
+/// transition and on a poll matching the daemon's own binary poll.
+public sealed class DaemonRestartPendingWatcher : IDisposable {
+    internal static readonly TimeSpan PollInterval = TimeSpan.FromSeconds(15);
+
+    readonly DaemonStore _store;
+    readonly string _daemonName;
+    readonly IObservable<AttachStatus> _status;
+    readonly TimeProvider _time;
+    readonly CancellationToken _lifetime;
+    readonly BehaviorSubject<bool> _pending = new(false);
+    readonly Lock _lock = new();
+    IDisposable? _subscription;
+
+    public DaemonRestartPendingWatcher(
+            DaemonStore store, string daemonName, IObservable<AttachStatus> status, TimeProvider time,
+            CancellationToken lifetime) {
+        _store      = store;
+        _daemonName = daemonName;
+        _status     = status;
+        _time       = time;
+        _lifetime   = lifetime;
+    }
+
+    /// True while the marker exists. Replays the current value to a new subscriber.
+    public IObservable<bool> Pending => _pending.DistinctUntilChanged();
+
+    public void Start() {
+        Refresh();
+        _subscription = _status.Subscribe(_ => Refresh());
+        _ = PollAsync();
+    }
+
+    // Both the attach stream and the poll call this from their own threads; the subject's
+    // OnNext must never overlap.
+    void Refresh() {
+        var pending = DaemonRestartMarker.TryRead(_store, _daemonName) is not null;
+        lock (_lock) _pending.OnNext(pending);
+    }
+
+    async Task PollAsync() {
+        try {
+            while (!_lifetime.IsCancellationRequested) {
+                await Task.Delay(PollInterval, _time, _lifetime).ConfigureAwait(false);
+                Refresh();
+            }
+        } catch (OperationCanceledException) {
+            // shutdown
+        }
+    }
+
+    public void Dispose() => _subscription?.Dispose();
+}

--- a/src/Capacitor.App/Services/DaemonRestartPendingWatcher.cs
+++ b/src/Capacitor.App/Services/DaemonRestartPendingWatcher.cs
@@ -15,10 +15,13 @@ public sealed class DaemonRestartPendingWatcher : IDisposable {
     readonly string _daemonName;
     readonly IObservable<AttachStatus> _status;
     readonly TimeProvider _time;
-    readonly CancellationToken _lifetime;
+    // Owned, so disposal ends the poll even when the caller's lifetime token is never cancelled
+    // (startup-failure cleanup disposes the graph's pieces without cancelling it).
+    readonly CancellationTokenSource _lifetime;
     readonly BehaviorSubject<bool> _pending = new(false);
     readonly Lock _lock = new();
     IDisposable? _subscription;
+    bool _disposed;
 
     public DaemonRestartPendingWatcher(
             DaemonStore store, string daemonName, IObservable<AttachStatus> status, TimeProvider time,
@@ -27,7 +30,7 @@ public sealed class DaemonRestartPendingWatcher : IDisposable {
         _daemonName = daemonName;
         _status     = status;
         _time       = time;
-        _lifetime   = lifetime;
+        _lifetime   = CancellationTokenSource.CreateLinkedTokenSource(lifetime);
     }
 
     /// True while the marker exists. Replays the current value to a new subscriber.
@@ -36,26 +39,39 @@ public sealed class DaemonRestartPendingWatcher : IDisposable {
     public void Start() {
         Refresh();
         _subscription = _status.Subscribe(_ => Refresh());
-        _ = PollAsync();
+        // The token value stays readable after Dispose has disposed its source; the source's
+        // Token property would not.
+        _ = PollAsync(_lifetime.Token);
     }
 
-    // Both the attach stream and the poll call this from their own threads; the subject's
-    // OnNext must never overlap.
+    // The attach stream and the poll call this from their own threads. The read sits inside the
+    // lock with the publish: read outside it, two callers could publish their observations in
+    // the reverse order of their reads and briefly resurrect a marker that was already gone.
     void Refresh() {
-        var pending = DaemonRestartMarker.TryRead(_store, _daemonName) is not null;
-        lock (_lock) _pending.OnNext(pending);
-    }
-
-    async Task PollAsync() {
-        try {
-            while (!_lifetime.IsCancellationRequested) {
-                await Task.Delay(PollInterval, _time, _lifetime).ConfigureAwait(false);
-                Refresh();
-            }
-        } catch (OperationCanceledException) {
-            // shutdown
+        lock (_lock) {
+            if (_disposed) return;
+            _pending.OnNext(DaemonRestartMarker.TryRead(_store, _daemonName) is not null);
         }
     }
 
-    public void Dispose() => _subscription?.Dispose();
+    async Task PollAsync(CancellationToken ct) {
+        try {
+            while (!ct.IsCancellationRequested) {
+                await Task.Delay(PollInterval, _time, ct).ConfigureAwait(false);
+                Refresh();
+            }
+        } catch (OperationCanceledException) {
+            // shutdown or disposal
+        }
+    }
+
+    public void Dispose() {
+        lock (_lock) {
+            if (_disposed) return;
+            _disposed = true;
+        }
+        _subscription?.Dispose();
+        _lifetime.Cancel();
+        _lifetime.Dispose();
+    }
 }

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -351,9 +351,12 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
                 .DisposeWith(disposables);
 
             // Only while attached: a marker left by a daemon we cannot reach says nothing about
-            // what the user is looking at.
+            // what the user is looking at. The watcher publishes from its poll thread, so it is
+            // marshalled like status/snapshots above before it touches a bound property.
             var pendingWhileConnected = status
-                .CombineLatest(restartPending ?? Observable.Return(false), (st, pending) => pending && st.State == AttachState.Connected)
+                .CombineLatest(
+                    (restartPending ?? Observable.Return(false)).ObserveOn(RxSchedulers.MainThreadScheduler),
+                    (st, pending) => pending && st.State == AttachState.Connected)
                 .DistinctUntilChanged();
 
             _restartPending = pendingWhileConnected

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -94,6 +94,16 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     ObservableAsPropertyHelper<string>? _agentCountText;
     public string AgentCountText => _agentCountText?.Value ?? "—";
 
+    internal const string RestartPendingMessage = "Daemon update pending — it restarts once no agents are running.";
+
+    // The daemon has a restart-after-update queued (DaemonRestartPendingWatcher) and we are
+    // attached to it: a passive marker only, the restart is the daemon's own.
+    ObservableAsPropertyHelper<bool>? _restartPending;
+    public bool RestartPending => _restartPending?.Value ?? false;
+
+    ObservableAsPropertyHelper<string?>? _restartPendingText;
+    public string? RestartPendingText => _restartPendingText?.Value;
+
     ObservableAsPropertyHelper<AttachState>? _state;
     public AttachState State => _state?.Value ?? AttachState.Connecting;
 
@@ -229,6 +239,9 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
     /// The app's own server lane (IServerLane.Status), for the footer's ServerLaneTip diagnostic.
     /// Null means the tip never sets — every existing caller without a live lane.
     /// </param>
+    /// <param name="restartPending">
+    /// DaemonRestartPendingWatcher.Pending. Null means the indicator never shows.
+    /// </param>
     public MainWindowViewModel(
             IDaemonClientService service,
             CancellationToken shutdownToken, ActivityViewModel activity, Func<CancellationToken, Task>? startAction = null,
@@ -236,7 +249,7 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
             NavigationGate? navigation = null, Action<Func<Task>>? trackWorkspaceTeardown = null,
             Func<string, WorkspaceViewModel>? workspaceFactory = null, SessionRailViewModel? rail = null,
             string? tenantName = null, IObservable<string?>? lifecycleAttention = null,
-            IObservable<ServerLaneStatus>? laneStatus = null) {
+            IObservable<ServerLaneStatus>? laneStatus = null, IObservable<bool>? restartPending = null) {
         _service = service;
         _time = time ?? TimeProvider.System;
         Activity = activity;
@@ -335,6 +348,20 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
                     ? $"{t.snap.Daemon.ActiveAgents} of {t.snap.Daemon.MaxAgents} agents"
                     : "—")
                 .ToProperty(this, x => x.AgentCountText, "—")
+                .DisposeWith(disposables);
+
+            // Only while attached: a marker left by a daemon we cannot reach says nothing about
+            // what the user is looking at.
+            var pendingWhileConnected = status
+                .CombineLatest(restartPending ?? Observable.Return(false), (st, pending) => pending && st.State == AttachState.Connected)
+                .DistinctUntilChanged();
+
+            _restartPending = pendingWhileConnected
+                .ToProperty(this, x => x.RestartPending, false)
+                .DisposeWith(disposables);
+
+            _restartPendingText = pendingWhileConnected.Select(p => p ? RestartPendingMessage : null)
+                .ToProperty(this, x => x.RestartPendingText, (string?)null)
                 .DisposeWith(disposables);
 
             _state = status.Select(s => s.State)

--- a/src/Capacitor.App/ViewModels/TrayViewModel.cs
+++ b/src/Capacitor.App/ViewModels/TrayViewModel.cs
@@ -24,6 +24,8 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
     // the APP is the older side — so the UI must not prescribe an upgrade direction.
     const string SkewMessage = "app and daemon are incompatible — make sure both are up to date";
 
+    internal const string RestartPendingSuffix = "update pending";
+
     readonly IPauseController _pause;
     readonly CompositeDisposable _disposables = new();
 
@@ -79,13 +81,18 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
     /// The server lane's live-agent summary (an IAgentDirectory, via SummaryFrom below). Null
     /// (every pre-existing test) keeps ProjectAggregate's verdict identical to Project's.
     /// </param>
+    /// <param name="restartPending">
+    /// DaemonRestartPendingWatcher.Pending. Null (most tests) means the header never carries the
+    /// suffix.
+    /// </param>
     public TrayViewModel(
             IDaemonClientService service, IPauseController pause, AgentActionService actions, IConsentService consent,
             Action? openMainWindow = null, Action? quit = null, Action? openReviewPrompts = null,
             IObservable<string?>? lifecycleAttention = null, IObservable<bool>? shimOfferable = null,
             Func<Task>? installShim = null, IPermissionService? permissions = null,
             IObservable<RemoteTraySummary>? remote = null,
-            IObservable<UpdateMenuItem>? updateMenu = null, Func<Task>? updateAction = null) {
+            IObservable<UpdateMenuItem>? updateMenu = null, Func<Task>? updateAction = null,
+            IObservable<bool>? restartPending = null) {
         _pause = pause;
 
         TogglePauseCommand = ReactiveCommand.Create<bool>(pause.RequestToggle);
@@ -132,19 +139,26 @@ public sealed class TrayViewModel : ReactiveObject, IDisposable {
         var update = updateMenu ?? Observable.Return(new UpdateMenuItem(false, ""));
         var withUpdate = withShim.CombineLatest(update, (model, item) => model with { UpdateItemLabel = item.Visible ? item.Label : null });
 
+        // The daemon's own queued restart-after-update, shown only while attached to it: a
+        // marker left by a daemon we cannot reach says nothing about the header's subject.
+        var pendingWhileConnected = service.Status
+            .CombineLatest(restartPending ?? Observable.Return(false), (status, pending) => pending && status.State == AttachState.Connected);
+        var withRestartPending = withUpdate.CombineLatest(pendingWhileConnected,
+            (model, pending) => pending ? model with { Header = $"{model.Header} · {RestartPendingSuffix}" } : model);
+
         // Status, snapshots (seeded above), pause.State, consent.PendingCount, attention,
-        // pendingSummary, remoteSummary, shim, and update are all replay-1-shaped (seed on
-        // subscribe), so CombineLatest emits synchronously on subscribe — captured here as the
-        // OAPH's initial value so MenuModel is never default(TrayMenuModel) (null) before
+        // pendingSummary, remoteSummary, shim, update, and restartPending are all replay-1-shaped
+        // (seed on subscribe), so CombineLatest emits synchronously on subscribe — captured here
+        // as the OAPH's initial value so MenuModel is never default(TrayMenuModel) (null) before
         // RxSchedulers.MainThreadScheduler delivers the ObserveOn'd copy below. The
         // synchronous-emission assumption rests on IPauseController.State's,
         // IConsentService.PendingCount's, IPermissionService.Summary's, and SummaryFrom's
         // documented replay-on-subscribe contracts, which a future implementation could violate —
         // defended below rather than left to surface as an unexplained NRE on first MenuModel access.
         TrayMenuModel? seed = null;
-        using (withUpdate.Subscribe(v => seed = v)) { }
+        using (withRestartPending.Subscribe(v => seed = v)) { }
 
-        _menuModel = withUpdate
+        _menuModel = withRestartPending
             .ObserveOn(RxSchedulers.MainThreadScheduler)
             .ToProperty(this, x => x.MenuModel, seed ?? throw new InvalidOperationException(
                 "IPauseController.State, IConsentService.PendingCount, and IPermissionService.Summary must replay a value on subscribe."))

--- a/src/Capacitor.App/Views/SessionRailView.axaml
+++ b/src/Capacitor.App/Views/SessionRailView.axaml
@@ -76,6 +76,8 @@
                         <TextBlock Text="{Binding ServerLaneTip}" TextWrapping="Wrap"
                                    Foreground="{StaticResource KcapWarningBrush}"
                                    IsVisible="{Binding ServerLaneTip, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                        <TextBlock Text="{Binding RestartPendingText}" TextWrapping="Wrap"
+                                   IsVisible="{Binding RestartPendingText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                     </StackPanel>
                 </ToolTip.Tip>
                 <DockPanel Margin="16,10,16,14" Background="Transparent">
@@ -90,6 +92,11 @@
                         <TextBlock x:Name="RailTenantText" Text="{Binding TenantName}" FontSize="11.5"
                                    Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center"
                                    IsVisible="{Binding TenantName, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                        <TextBlock Text="·" FontSize="11.5" Foreground="{StaticResource KcapFaintBrush}"
+                                   IsVisible="{Binding RestartPending}" />
+                        <TextBlock Text="update pending" FontSize="11.5"
+                                   Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center"
+                                   IsVisible="{Binding RestartPending}" />
                     </StackPanel>
                 </DockPanel>
             </Border>

--- a/test/Capacitor.App.Tests.Unit/DaemonRestartPendingWatcherTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonRestartPendingWatcherTests.cs
@@ -1,0 +1,98 @@
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The watcher reads the daemon's restart-pending marker file, the same source `kcap daemon
+/// status` reads: nothing about a queued restart travels over the status socket.
+public class DaemonRestartPendingWatcherTests {
+    const string Name = "daemon-a";
+
+    [TempDaemonPaths] public required TempDaemonStore Daemons { get; init; }
+
+    static async Task WaitUntilAsync(Func<bool> condition, string what) {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+        while (!condition()) {
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"Timed out waiting for: {what}");
+            await Task.Delay(10);
+        }
+    }
+
+    static DaemonRestartMarker Marker() =>
+        new("1.2.3", "self-detected", new DateTimeOffset(2026, 9, 9, 11, 5, 58, TimeSpan.Zero));
+
+    sealed class Harness : IDisposable {
+        public readonly Subject<AttachStatus> Status = new();
+        public readonly FakeTimeProvider Clock = new(new DateTimeOffset(2026, 9, 9, 12, 0, 0, TimeSpan.Zero));
+        public readonly TimerCountingTimeProvider Time;
+        public readonly DaemonRestartPendingWatcher Watcher;
+        public readonly List<bool> Seen = [];
+        readonly CancellationTokenSource _lifetime = new();
+        IDisposable? _subscription;
+
+        public Harness(DaemonStore store) {
+            Time    = new TimerCountingTimeProvider(Clock);
+            Watcher = new DaemonRestartPendingWatcher(store, Name, Status, Time, _lifetime.Token);
+        }
+
+        public void Start() {
+            Watcher.Start();
+            _subscription = Watcher.Pending.Subscribe(Seen.Add);
+        }
+
+        public void Dispose() {
+            _subscription?.Dispose();
+            _lifetime.Cancel();
+            Watcher.Dispose();
+            _lifetime.Dispose();
+        }
+    }
+
+    [Test]
+    public async Task Reports_a_marker_already_present_when_started() {
+        DaemonRestartMarker.Write(Daemons.Store, Name, Marker());
+        using var h = new Harness(Daemons.Store);
+
+        h.Start();
+
+        await Assert.That(h.Seen).IsEquivalentTo([true]);
+    }
+
+    [Test]
+    public async Task Sees_a_marker_written_later_on_the_next_poll() {
+        using var h = new Harness(Daemons.Store);
+        h.Start();
+        await Assert.That(h.Seen).IsEquivalentTo([false]);
+
+        DaemonRestartMarker.Write(Daemons.Store, Name, Marker());
+        await WaitUntilAsync(() => h.Time.TimersCreated >= 1, what: "the poll to be armed");
+        h.Clock.Advance(DaemonRestartPendingWatcher.PollInterval);
+
+        await WaitUntilAsync(() => h.Seen[^1], what: "the marker to be seen on the poll");
+    }
+
+    [Test]
+    public async Task Clears_on_an_attach_transition_once_the_marker_is_gone() {
+        DaemonRestartMarker.Write(Daemons.Store, Name, Marker());
+        using var h = new Harness(Daemons.Store);
+        h.Start();
+
+        DaemonRestartMarker.Delete(Daemons.Store, Name);
+        h.Status.OnNext(new AttachStatus(AttachState.Connected, null, []));
+
+        await Assert.That(h.Seen).IsEquivalentTo([true, false]);
+    }
+
+    [Test]
+    public async Task Rereads_that_find_the_same_state_emit_nothing() {
+        using var h = new Harness(Daemons.Store);
+        h.Start();
+
+        h.Status.OnNext(new AttachStatus(AttachState.Connecting, null, null));
+        h.Status.OnNext(new AttachStatus(AttachState.Connected, null, []));
+
+        await Assert.That(h.Seen).IsEquivalentTo([false]);
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/DaemonRestartPendingWatcherTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DaemonRestartPendingWatcherTests.cs
@@ -85,6 +85,21 @@ public class DaemonRestartPendingWatcherTests {
         await Assert.That(h.Seen).IsEquivalentTo([true, false]);
     }
 
+    /// Disposal alone must end the poll: startup-failure cleanup disposes the watcher without
+    /// cancelling the lifetime token it was given.
+    [Test]
+    public async Task Dispose_stops_the_poll_without_the_lifetime_token() {
+        using var h = new Harness(Daemons.Store);
+        h.Start();
+        await WaitUntilAsync(() => h.Time.TimersCreated >= 1, what: "the poll to be armed");
+
+        h.Watcher.Dispose();
+        h.Clock.Advance(DaemonRestartPendingWatcher.PollInterval);
+        await Task.Delay(50); // a negative: give a surviving loop every chance to re-arm
+
+        await Assert.That(h.Time.TimersCreated).IsEqualTo(1);
+    }
+
     [Test]
     public async Task Rereads_that_find_the_same_state_emit_nothing() {
         using var h = new Harness(Daemons.Store);

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -63,6 +63,50 @@ public class MainWindowViewModelTests {
         });
     }
 
+    // ---- daemon restart pending (the daemon's own queued restart-after-update) ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Restart_pending_marks_the_indicator_while_connected() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var restartPending = new BehaviorSubject<bool>(false);
+            var vm = new MainWindowViewModel(service, CancellationToken.None, TestActivity.New(), restartPending: restartPending);
+            using var activation = vm.Activator.Activate();
+
+            service.SnapshotsSubject.OnNext(Snap());
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, null));
+            await Assert.That(vm.RestartPending).IsFalse();
+            await Assert.That(vm.RestartPendingText).IsNull();
+
+            restartPending.OnNext(true);
+
+            await Assert.That(vm.RestartPending).IsTrue();
+            await Assert.That(vm.RestartPendingText).IsEqualTo(MainWindowViewModel.RestartPendingMessage);
+
+            restartPending.OnNext(false);
+
+            await Assert.That(vm.RestartPending).IsFalse();
+            await Assert.That(vm.RestartPendingText).IsNull();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Restart_pending_is_hidden_while_not_connected() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var restartPending = new BehaviorSubject<bool>(true);
+            var vm = new MainWindowViewModel(service, CancellationToken.None, TestActivity.New(), restartPending: restartPending);
+            using var activation = vm.Activator.Activate();
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+
+            await Assert.That(vm.RestartPending).IsFalse();
+            await Assert.That(vm.RestartPendingText).IsNull();
+        });
+    }
+
     // ---- VersionDisplay (spec: SEMVER only, everything from the first '+' is build metadata) ----
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -63,8 +63,6 @@ public class MainWindowViewModelTests {
         });
     }
 
-    // ---- daemon restart pending (the daemon's own queued restart-after-update) ----
-
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Restart_pending_marks_the_indicator_while_connected() {

--- a/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
@@ -39,6 +39,43 @@ public class TrayViewModelTests {
     static AgentActionService NewActions(FakeDaemonClientService service, ScriptedLocalControlOps? ops = null) =>
         new(ops ?? new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener(), service.SnapshotsSubject, CancellationToken.None, NeverConfirm.Confirm);
 
+    // ---- daemon restart pending (the daemon's own queued restart-after-update) ----
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Restart_pending_suffixes_the_header_while_connected() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var restartPending = new BehaviorSubject<bool>(false);
+            using var vm = new TrayViewModel(service, new FakePauseController(), NewActions(service), new FakeConsentService(), restartPending: restartPending);
+
+            service.SnapshotsSubject.OnNext(Snap("connected", 2));
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, []));
+            await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: connected — 2 agent(s) running");
+
+            restartPending.OnNext(true);
+            await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: connected — 2 agent(s) running · update pending");
+            await Assert.That(vm.MenuModel.State).IsEqualTo(TrayState.Running);
+
+            restartPending.OnNext(false);
+            await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: connected — 2 agent(s) running");
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Restart_pending_leaves_the_header_alone_while_not_connected() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var service = new FakeDaemonClientService();
+            var restartPending = new BehaviorSubject<bool>(true);
+            using var vm = new TrayViewModel(service, new FakePauseController(), NewActions(service), new FakeConsentService(), restartPending: restartPending);
+
+            service.StatusSubject.OnNext(new AttachStatus(AttachState.Unreachable, "daemon_unreachable", null));
+
+            await Assert.That(vm.MenuModel.Header).IsEqualTo("daemon-a: not running");
+        });
+    }
+
     // ---- §4 state matrix ----
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TrayViewModelTests.cs
@@ -39,8 +39,6 @@ public class TrayViewModelTests {
     static AgentActionService NewActions(FakeDaemonClientService service, ScriptedLocalControlOps? ops = null) =>
         new(ops ?? new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener(), service.SnapshotsSubject, CancellationToken.None, NeverConfirm.Confirm);
 
-    // ---- daemon restart pending (the daemon's own queued restart-after-update) ----
-
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Restart_pending_suffixes_the_header_while_connected() {


### PR DESCRIPTION
Closes #830 — AI-2604

## What & why

A busy daemon keeps running the old binary after a CLI update until it is idle, and the app showed nothing about it. The session rail's daemon indicator and the tray header now carry "update pending" while the daemon's restart-pending marker exists and the app is attached to that daemon; the rail tooltip says the restart happens once no agents are running. Passive only: no button and no forced restart, which would take the running agents down.

## Where to look

`DaemonRestartPendingWatcher` reads the marker file the daemon writes and its successor deletes, the same file `kcap daemon status` reads, on every attach transition and on a 15-second poll matching the daemon's own binary poll. Both view models gate the indicator on being attached, so a marker left by an unreachable daemon shows nothing.

## Verification

`Capacitor.App.Tests.Unit`: 1616 passed, 0 failed. The eight new tests cover the marker present at start, written later and seen on the poll, cleared on an attach transition, no repeat emissions, and both surfaces showing and hiding the indicator with attach state.
