### PR TITLE
Forward tool_use_id from the Claude permission hook to the daemon bridge

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -818,11 +818,12 @@ the transcript's tool name (Codex's rollout says `shell`, its hook says `Bash`),
 commands classified by `CodexCommandClassifier`, ported verbatim from the server into Core so the
 server can delete its copy on the next submodule bump. A row waiting on a permission shows an accent
 `?` in the outcome slot: `PermissionPendingDto` gains an optional `tool_use_id` the daemon reads from
-the hook body (Claude's PermissionRequest hook carries it; Codex's deliberately does not), and the
-view-model recomputes the marks from pending requests and running calls on every change, diffing
-against the last marks so a call that settles while its request is still pending is cleared rather
-than masked by its `✓`. A request without an id marks the agent's sole running call and abstains
-when two or more are running.
+the body posted to its bridge (Claude's PermissionRequest hook carries it, and the hook command's
+bridge payload — an allow-list, not the hook body — has to forward it; Codex's deliberately does
+not), and the view-model recomputes the marks from pending requests and running calls on every
+change, diffing against the last marks so a call that settles while its request is still pending is
+cleared rather than masked by its `✓`. A request without an id marks the agent's sole running call
+and abstains when two or more are running.
 
 ## Launch and stop command routing
 

--- a/src/Capacitor.Cli/Commands/PermissionRequestCommand.cs
+++ b/src/Capacitor.Cli/Commands/PermissionRequestCommand.cs
@@ -160,9 +160,10 @@ class PermissionRequestCommand(ConfigRoot config, ProfileContext profiles, ICapa
         return false;
     }
 
-    /// The server payload plus what the daemon's attribution ladder reads: agent_id when this
-    /// process runs inside a hosted agent, and the hook's cwd. The server-bound payload never
-    /// carries either.
+    /// The server payload plus what the daemon reads for attribution (agent_id when this process
+    /// runs inside a hosted agent, the hook's cwd) and for the pending card's tool_use_id, which
+    /// is what lets the desktop app retire the card once the transcript shows the tool's result.
+    /// The server-bound payload carries none of these.
     internal static JsonObject BuildBridgePayload(JsonNode node, string sessionId, string? agentId) {
         var payload = new JsonObject {
             ["session_id"]             = sessionId,
@@ -172,6 +173,7 @@ class PermissionRequestCommand(ConfigRoot config, ProfileContext profiles, ICapa
         };
         if (agentId is not null) payload["agent_id"] = agentId;
         if (node["cwd"] is JsonValue cwd && cwd.TryGetValue<string>(out var c)) payload["cwd"] = c;
+        if (node["tool_use_id"] is JsonValue toolUse && toolUse.TryGetValue<string>(out var id)) payload["tool_use_id"] = id;
         return payload;
     }
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/PermissionRequestCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/PermissionRequestCommandTests.cs
@@ -101,6 +101,20 @@ public class PermissionRequestCommandTests {
         await Assert.That(withoutAgent["cwd"]!.GetValue<string>()).IsEqualTo("/repo");
     }
 
+    /// <summary>
+    /// The Chat tab retires a card once the transcript shows a result for the request's tool_use_id,
+    /// and the daemon reads the id from this payload — an allow-list, so a card built without it
+    /// outlives the prompt it stood for until the agent exits.
+    /// </summary>
+    [Test]
+    public async Task Bridge_payload_forwards_the_hooks_tool_use_id() {
+        var node = System.Text.Json.Nodes.JsonNode.Parse("""{"session_id":"abc","tool_name":"Bash","tool_input":{"command":"ls"},"tool_use_id":"toolu_01X","cwd":"/repo"}""")!;
+        await Assert.That(PermissionRequestCommand.BuildBridgePayload(node, "abc", "agent-1")["tool_use_id"]!.GetValue<string>()).IsEqualTo("toolu_01X");
+
+        var withoutId = System.Text.Json.Nodes.JsonNode.Parse("""{"session_id":"abc","tool_name":"Bash","tool_input":{"command":"ls"}}""")!;
+        await Assert.That(PermissionRequestCommand.BuildBridgePayload(withoutId, "abc", "agent-1")["tool_use_id"]).IsNull();
+    }
+
     sealed class Accepting : HttpMessageHandler {
         protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) =>
             Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {


### PR DESCRIPTION
Closes #840 — AI-2626

## What & why

A permission prompt answered in the session's terminal (or dismissed by switching to auto mode there) stayed on the desktop Chat tab until the agent exited. The app retires a card once the transcript shows a `tool_result` for the request's `tool_use_id`, and the daemon reads that id from the body the Claude hook posts to its bridge — but that body is an allow-list of fields, and `tool_use_id` was not on it, so every Claude card reached the app with a null id and the withdraw could never fire. The hook command now forwards the id; the daemon, wire and app already handle it.

## Where to look

An older daemon ignores the extra field. A request from a Claude build that sends no `tool_use_id` still raises a card; it just cannot be retired by the transcript, as before.

## Verification

- New `Bridge_payload_forwards_the_hooks_tool_use_id` failed before the change (`NullReferenceException` on the missing field) and passes after.
- `Capacitor.Cli.Tests.Unit`: 4012 passed, 19 skipped (gated live), 0 failed.
- `dotnet publish -c Release` of `Capacitor.Cli`: no IL2026/IL3050 lines in the output, fresh osx-arm64 binary written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
