### PR TITLE
Stop the daemon hanging itself up when it kills an agent tree

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,10 +75,11 @@ Deliberate choices a change can silently undo — each looks like a bug until yo
 - **The daemon never stops a process in its own process group.** Every `Process.Start` child (Pi,
   Antigravity, ACP agents, git) shares the daemon's group, and a launch agent shares launchd's
   session: a stopped member at the moment a reparented grandchild exits makes the kernel SIGHUP
-  the whole group, daemon included. Tree kills go through `ProcessTree.Kill` (SIGKILL only), the
-  runtime's `Process.Kill(bool)` is banned in the daemon assembly, and a supervised or detached
-  daemon ignores SIGHUP outright — there is no terminal to hang up, and exiting 0 on it is an exit
-  launchd never restarts.
+  the whole group, daemon included. Tree kills go through `ProcessTree.Kill` (SIGKILL only,
+  children before parents, each pid identity-checked and signalled once), the runtime's
+  `Process.Kill(bool)` is banned in the daemon assembly, and a daemon with no terminal on any
+  standard stream ignores SIGHUP outright — there is nothing to hang up, and exiting 0 on it is an
+  exit launchd never restarts.
 
 ## Tech stack
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -72,6 +72,13 @@ Deliberate choices a change can silently undo — each looks like a bug until yo
   fixes the bytes each id hashes; the server dedups by them, and a session it has already ingested
   is never re-projected. A different derivation would append duplicates on the next re-import, so
   the leaf's fixed vectors pin every row and a change needs a migration, not a bump.
+- **The daemon never stops a process in its own process group.** Every `Process.Start` child (Pi,
+  Antigravity, ACP agents, git) shares the daemon's group, and a launch agent shares launchd's
+  session: a stopped member at the moment a reparented grandchild exits makes the kernel SIGHUP
+  the whole group, daemon included. Tree kills go through `ProcessTree.Kill` (SIGKILL only), the
+  runtime's `Process.Kill(bool)` is banned in the daemon assembly, and a supervised or detached
+  daemon ignores SIGHUP outright — there is no terminal to hang up, and exiting 0 on it is an exit
+  launchd never restarts.
 
 ## Tech stack
 

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,22 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## A hosted agent's teardown cannot hang up the daemon
+
+Stopping a Pi agent that outlived its grace period took the whole daemon down: the log showed
+SIGHUP thirty milliseconds after the agent's exit, the daemon shut down cooperatively with exit 0,
+and launchd, whose `KeepAlive` only restarts a failed exit, left it down. Nothing sent that signal.
+`Process.Kill(entireProcessTree: true)` SIGSTOPs each process before it looks for children, Pi and
+its `kcap mcp` bridge children live in the daemon's own process group, and a launch agent shares
+launchd's session. So the first bridge to exit after Pi, reparented to launchd, orphaned the
+daemon's group while a sibling was still stopped, and the kernel answered with SIGHUP and SIGCONT
+to every member. Two changes, each sufficient on its own. The daemon's tree kill is now
+`ProcessTree.Kill`, a SIGKILL-only walk over descendants, with the runtime's tree kill banned in the
+daemon assembly so no member of the group is ever stopped. And a supervised or detached daemon
+ignores SIGHUP, since without a terminal there is nothing to hang up; a foreground run keeps
+treating it as the terminal closing. forkpty agents were never exposed: `login_tty` puts them in
+their own session.
+
 ## The desktop app renders markdown through MarkView.Avalonia
 
 The hand-written Markdig-to-controls renderer covered the constructs agents emit and nothing else,

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -16,11 +16,14 @@ its `kcap mcp` bridge children live in the daemon's own process group, and a lau
 launchd's session. So the first bridge to exit after Pi, reparented to launchd, orphaned the
 daemon's group while a sibling was still stopped, and the kernel answered with SIGHUP and SIGCONT
 to every member. Two changes, each sufficient on its own. The daemon's tree kill is now
-`ProcessTree.Kill`, a SIGKILL-only walk over descendants, with the runtime's tree kill banned in the
-daemon assembly so no member of the group is ever stopped. And a supervised or detached daemon
-ignores SIGHUP, since without a terminal there is nothing to hang up; a foreground run keeps
-treating it as the terminal closing. forkpty agents were never exposed: `login_tty` puts them in
-their own session.
+`ProcessTree.Kill`: SIGKILL only, children before parents, each pid signalled once and only while
+it still carries the start identity captured when it was listed, with the runtime's tree kill banned
+in the daemon assembly so no member of the group is ever stopped. Without a stop a parent can still
+fork between its last listing and its own death, and that child is reparented out of reach; the
+child-first order keeps that window to two syscalls. And a daemon with no terminal on any standard
+stream ignores SIGHUP, since there is nothing to hang up; a run attached to a terminal keeps
+treating it as the terminal closing, whether or not it logs to a file. forkpty agents were never
+exposed: `login_tty` puts them in their own session.
 
 ## The desktop app renders markdown through MarkView.Avalonia
 

--- a/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpChildProcess.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Acp;
@@ -7,7 +8,7 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// <see cref="IAcpProcess"/> over a real <see cref="Process"/> — the <c>cursor-agent acp</c> child
 /// spawned by <see cref="Services.AcpHostedAgentRuntimeFactory"/>. Mirrors the
 /// terminate/wait semantics of <c>Pty.Unix.UnixPtyProcess</c>/<c>WinPtyProcess</c> (SIGTERM-then-kill
-/// via <see cref="Process.Kill(bool)"/>, bounded waits that return silently on timeout) but owns no
+/// via <see cref="ProcessTree.Kill(Process)"/>, bounded waits that return silently on timeout) but owns no
 /// terminal I/O — stdin/stdout carry ACP JSON-RPC frames, consumed by <see cref="AcpConnection"/>.
 ///
 /// Also owns a background drain of the child's redirected stderr. <c>cursor-agent</c> is spawned
@@ -169,7 +170,7 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
         try {
             if (_process.HasExited) return;
 
-            _process.Kill(entireProcessTree: true);
+            ProcessTree.Kill(_process);
         } catch {
             // Already exited/disposed, or the kill raced the exit — either way there's
             // nothing left to terminate.
@@ -185,7 +186,7 @@ internal sealed partial class AcpChildProcess : IAcpProcess {
 
         try {
             if (!_process.HasExited)
-                _process.Kill(entireProcessTree: true);
+                ProcessTree.Kill(_process);
         } catch {
             // Best-effort — already exited or inaccessible.
         }

--- a/src/Capacitor.Cli.Daemon/Acp/BorrowedReviewTokenCommand.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/BorrowedReviewTokenCommand.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Capacitor.Cli.Daemon.Services;
 
 namespace Capacitor.Cli.Daemon.Acp;
 
@@ -78,7 +79,7 @@ internal static class BorrowedReviewTokenCommand {
     }
 
     static void Kill(Process process) {
-        try { process.Kill(entireProcessTree: true); } catch (Exception) { /* already gone */ }
+        try { ProcessTree.Kill(process); } catch (Exception) { /* already gone */ }
     }
 
     /// <summary>Reads to EOF, keeping nothing.</summary>

--- a/src/Capacitor.Cli.Daemon/BannedSymbols.Daemon.txt
+++ b/src/Capacitor.Cli.Daemon/BannedSymbols.Daemon.txt
@@ -1,0 +1,1 @@
+M:System.Diagnostics.Process.Kill(System.Boolean);Use ProcessTree.Kill. The runtime's tree kill SIGSTOPs first, and a stopped member of the daemon's own process group makes the kernel SIGHUP the daemon when that group is orphaned.

--- a/src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj
+++ b/src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj
@@ -18,6 +18,9 @@
         <Using Include="Capacitor.Models.Transcripts" />
     </ItemGroup>
     <ItemGroup>
+        <AdditionalFiles Include="BannedSymbols.Daemon.txt" Visible="false" />
+    </ItemGroup>
+    <ItemGroup>
         <InternalsVisibleTo Include="Capacitor.Cli.Tests.Unit" />
         <InternalsVisibleTo Include="Capacitor.Cli.Daemon.Tests.Unit" />
         <InternalsVisibleTo Include="Capacitor.Cli.Tests.Integration" />

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -565,11 +565,7 @@ public static partial class DaemonRunner {
         builder.Services.AddSingleton<DetachedRespawnStrategy>();
         builder.Services.AddSingleton<ForegroundNoopStrategy>();
         builder.Services.AddSingleton<IRestartStrategy>(sp => {
-            var cfg        = sp.GetRequiredService<DaemonConfig>();
-            var hasLogFile = cfg.OriginalArgs.Contains("--log-file");
-            var mode       = SupervisionDetector.DetectCurrent(DaemonStore.Sanitize(cfg.Name), hasLogFile);
-
-            return mode switch {
+            return Supervision(sp.GetRequiredService<DaemonConfig>()) switch {
                 SupervisionMode.Supervised => sp.GetRequiredService<SupervisedExitStrategy>(),
                 SupervisionMode.Detached   => sp.GetRequiredService<DetachedRespawnStrategy>(),
                 _                          => sp.GetRequiredService<ForegroundNoopStrategy>(),
@@ -683,7 +679,7 @@ public static partial class DaemonRunner {
         // tears down the logging pipeline. Lifetime is captured so SIGHUP
         // (terminal closed) can be turned into a cooperative StopApplication
         // — without that, the host's finally-block cleanup never runs.
-        RegisterDeathRattle(logger, lifetime);
+        RegisterDeathRattle(logger, lifetime, Supervision(config));
 
         // Lifetime-driven log lines — pair with the AppDomain/signal hooks so
         // we can distinguish a cooperative StopApplication (e.g. NameInUse,
@@ -1105,6 +1101,11 @@ public static partial class DaemonRunner {
     internal static bool IsSupervised(string resolvedName) =>
         SupervisionDetector.DetectCurrent(DaemonStore.Sanitize(resolvedName), hasLogFile: false)
             == SupervisionMode.Supervised;
+
+    /// <summary>How this daemon was launched, with the log-file hint that tells a detached run from a
+    /// foreground one.</summary>
+    static SupervisionMode Supervision(DaemonConfig cfg) =>
+        SupervisionDetector.DetectCurrent(DaemonStore.Sanitize(cfg.Name), cfg.OriginalArgs.Contains("--log-file"));
 
     /// <summary>
     /// Exit code for the local name-lock refusal (another kcap-daemon already holds
@@ -1536,7 +1537,7 @@ public static partial class DaemonRunner {
                 ArgumentList = { "--version" }
             });
             if (process is null || !process.WaitForExit(timeoutMs)) {
-                try { process?.Kill(entireProcessTree: true); } catch { }
+                try { if (process is not null) ProcessTree.Kill(process); } catch { }
                 return null;
             }
             var output = process.StandardOutput.ReadToEnd().Trim();
@@ -1656,19 +1657,27 @@ public static partial class DaemonRunner {
     [LoggerMessage(Level = LogLevel.Warning, Message = "Received POSIX signal {Signal} — requesting cooperative shutdown")]
     static partial void LogPosixSignal(ILogger logger, PosixSignal signal);
 
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Received POSIX signal {Signal} — ignored: a {Mode} daemon has no terminal to hang up")]
+    static partial void LogPosixSignalIgnored(ILogger logger, PosixSignal signal, SupervisionMode mode);
+
     /// <summary>
-    /// Wires AppDomain + TaskScheduler + POSIX-signal hooks so whenever the
-    /// daemon process is going away we get a last log line before the runtime
-    /// tears down. Without these, the only signal we'd see is "the log ends" —
-    /// indistinguishable between SIGTERM, SIGHUP (terminal closed), OOM kill,
-    /// an unobserved Task FailFast, or a clean StopApplication. SIGHUP is the
-    /// top suspect for "daemon dies silently after a foreground run", since
-    /// ConsoleLifetime doesn't register for it and the OS default is SIGTERM
-    /// the process. Routing it through <paramref name="lifetime"/> turns the
-    /// hard kill into a cooperative shutdown so the cleanup finally-block
-    /// gets to run.
+    /// Which POSIX signals become a cooperative shutdown. SIGHUP is a hangup only for a foreground
+    /// run, which has a terminal to lose. A supervised or detached daemon has none, and the kernel
+    /// still delivers SIGHUP to every member of the daemon's own process group when that group is
+    /// orphaned while one member is stopped. Shutting down on it exits 0, which launchd's
+    /// <c>KeepAlive SuccessfulExit=false</c> reads as deliberate and never restarts.
     /// </summary>
-    static void RegisterDeathRattle(ILogger logger, IHostApplicationLifetime lifetime) {
+    internal static bool SignalRequestsShutdown(PosixSignal signal, SupervisionMode mode) =>
+        signal != PosixSignal.SIGHUP || mode == SupervisionMode.Foreground;
+
+    /// <summary>
+    /// Wires AppDomain, TaskScheduler and POSIX-signal hooks so a daemon that is going away leaves
+    /// a last log line saying why: SIGTERM, a hangup, an unobserved-task FailFast and a clean
+    /// StopApplication are otherwise indistinguishable from "the log ends". A signal that
+    /// <see cref="SignalRequestsShutdown"/> accepts is routed through <paramref name="lifetime"/>
+    /// so the host's cleanup runs instead of the OS default termination.
+    /// </summary>
+    static void RegisterDeathRattle(ILogger logger, IHostApplicationLifetime lifetime, SupervisionMode supervision) {
         AppDomain.CurrentDomain.UnhandledException += (_, args) => {
             if (args.ExceptionObject is Exception ex) {
                 DeathRattle($"AppDomain.UnhandledException (terminating={args.IsTerminating}): {ex.GetType().Name}: {ex.Message}");
@@ -1690,25 +1699,26 @@ public static partial class DaemonRunner {
             LogProcessExit(logger);
         };
 
-        // POSIX signal hooks. ConsoleLifetime already wires SIGINT and SIGTERM
-        // to lifetime.StopApplication(); our registration is additive (multiple
-        // PosixSignalRegistration handlers all run) so it just guarantees a
-        // log line lands before the cooperative shutdown begins. SIGHUP and
-        // SIGQUIT are NOT caught by ConsoleLifetime, so for those we both log
-        // AND call StopApplication ourselves — otherwise the OS would terminate
-        // us before the host's finally-block could run.
+        // ConsoleLifetime already wires SIGINT and SIGTERM to StopApplication; registrations are
+        // additive, so this one adds the log line. SIGHUP and SIGQUIT are not caught by
+        // ConsoleLifetime, so for those this handler is the only thing between the signal and the
+        // OS default of terminating the process.
         //
-        // The returned PosixSignalRegistration IS the registration's lifetime
-        // anchor — if it's GC'd and finalized the handler unregisters silently
-        // and the signal goes back to its default OS action (terminate the
-        // process for SIGHUP, etc). Root them in a static list so they live
-        // as long as the DaemonRunner type — i.e. the process.
+        // The returned PosixSignalRegistration is the registration's lifetime anchor: finalized, it
+        // unregisters silently and the signal falls back to its OS default. They are rooted in a
+        // static list so they live as long as the process.
         foreach (var signal in new[] { PosixSignal.SIGINT, PosixSignal.SIGTERM, PosixSignal.SIGHUP, PosixSignal.SIGQUIT }) {
             try {
                 _signalRegistrations.Add(PosixSignalRegistration.Create(signal, ctx => {
+                    ctx.Cancel = true;
+
+                    if (!SignalRequestsShutdown(ctx.Signal, supervision)) {
+                        LogPosixSignalIgnored(logger, ctx.Signal, supervision);
+                        return;
+                    }
+
                     DeathRattle($"Received POSIX signal {ctx.Signal} — requesting cooperative shutdown");
                     LogPosixSignal(logger, ctx.Signal);
-                    ctx.Cancel = true;
                     lifetime.StopApplication();
                 }));
             } catch (PlatformNotSupportedException) {

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -565,7 +565,11 @@ public static partial class DaemonRunner {
         builder.Services.AddSingleton<DetachedRespawnStrategy>();
         builder.Services.AddSingleton<ForegroundNoopStrategy>();
         builder.Services.AddSingleton<IRestartStrategy>(sp => {
-            return Supervision(sp.GetRequiredService<DaemonConfig>()) switch {
+            var cfg        = sp.GetRequiredService<DaemonConfig>();
+            var hasLogFile = cfg.OriginalArgs.Contains("--log-file");
+            var mode       = SupervisionDetector.DetectCurrent(DaemonStore.Sanitize(cfg.Name), hasLogFile);
+
+            return mode switch {
                 SupervisionMode.Supervised => sp.GetRequiredService<SupervisedExitStrategy>(),
                 SupervisionMode.Detached   => sp.GetRequiredService<DetachedRespawnStrategy>(),
                 _                          => sp.GetRequiredService<ForegroundNoopStrategy>(),
@@ -679,7 +683,7 @@ public static partial class DaemonRunner {
         // tears down the logging pipeline. Lifetime is captured so SIGHUP
         // (terminal closed) can be turned into a cooperative StopApplication
         // — without that, the host's finally-block cleanup never runs.
-        RegisterDeathRattle(logger, lifetime, Supervision(config));
+        RegisterDeathRattle(logger, lifetime, AttachedToTerminal());
 
         // Lifetime-driven log lines — pair with the AppDomain/signal hooks so
         // we can distinguish a cooperative StopApplication (e.g. NameInUse,
@@ -1101,11 +1105,6 @@ public static partial class DaemonRunner {
     internal static bool IsSupervised(string resolvedName) =>
         SupervisionDetector.DetectCurrent(DaemonStore.Sanitize(resolvedName), hasLogFile: false)
             == SupervisionMode.Supervised;
-
-    /// <summary>How this daemon was launched, with the log-file hint that tells a detached run from a
-    /// foreground one.</summary>
-    static SupervisionMode Supervision(DaemonConfig cfg) =>
-        SupervisionDetector.DetectCurrent(DaemonStore.Sanitize(cfg.Name), cfg.OriginalArgs.Contains("--log-file"));
 
     /// <summary>
     /// Exit code for the local name-lock refusal (another kcap-daemon already holds
@@ -1657,18 +1656,24 @@ public static partial class DaemonRunner {
     [LoggerMessage(Level = LogLevel.Warning, Message = "Received POSIX signal {Signal} — requesting cooperative shutdown")]
     static partial void LogPosixSignal(ILogger logger, PosixSignal signal);
 
-    [LoggerMessage(Level = LogLevel.Warning, Message = "Received POSIX signal {Signal} — ignored: a {Mode} daemon has no terminal to hang up")]
-    static partial void LogPosixSignalIgnored(ILogger logger, PosixSignal signal, SupervisionMode mode);
+    [LoggerMessage(Level = LogLevel.Warning, Message = "Received POSIX signal {Signal} — ignored: no terminal is attached to hang up")]
+    static partial void LogPosixSignalIgnored(ILogger logger, PosixSignal signal);
 
     /// <summary>
-    /// Which POSIX signals become a cooperative shutdown. SIGHUP is a hangup only for a foreground
-    /// run, which has a terminal to lose. A supervised or detached daemon has none, and the kernel
-    /// still delivers SIGHUP to every member of the daemon's own process group when that group is
-    /// orphaned while one member is stopped. Shutting down on it exits 0, which launchd's
+    /// Which POSIX signals become a cooperative shutdown. SIGHUP is a hangup only when a standard
+    /// stream is a terminal. Under launchd or systemd none is, and the kernel still delivers SIGHUP
+    /// to every member of the daemon's own process group when that group is orphaned while one
+    /// member is stopped. Shutting down on it exits 0, which launchd's
     /// <c>KeepAlive SuccessfulExit=false</c> reads as deliberate and never restarts.
     /// </summary>
-    internal static bool SignalRequestsShutdown(PosixSignal signal, SupervisionMode mode) =>
-        signal != PosixSignal.SIGHUP || mode == SupervisionMode.Foreground;
+    internal static bool SignalRequestsShutdown(PosixSignal signal, bool attachedToTerminal) =>
+        signal != PosixSignal.SIGHUP || attachedToTerminal;
+
+    /// <summary>Whether any standard stream is a terminal. Read once at startup: a hangup does not
+    /// change what the descriptors are, and a foreground run keeps the CLI's terminal even when it
+    /// logs to a file.</summary>
+    static bool AttachedToTerminal() =>
+        !(Console.IsInputRedirected && Console.IsOutputRedirected && Console.IsErrorRedirected);
 
     /// <summary>
     /// Wires AppDomain, TaskScheduler and POSIX-signal hooks so a daemon that is going away leaves
@@ -1677,7 +1682,7 @@ public static partial class DaemonRunner {
     /// <see cref="SignalRequestsShutdown"/> accepts is routed through <paramref name="lifetime"/>
     /// so the host's cleanup runs instead of the OS default termination.
     /// </summary>
-    static void RegisterDeathRattle(ILogger logger, IHostApplicationLifetime lifetime, SupervisionMode supervision) {
+    static void RegisterDeathRattle(ILogger logger, IHostApplicationLifetime lifetime, bool attachedToTerminal) {
         AppDomain.CurrentDomain.UnhandledException += (_, args) => {
             if (args.ExceptionObject is Exception ex) {
                 DeathRattle($"AppDomain.UnhandledException (terminating={args.IsTerminating}): {ex.GetType().Name}: {ex.Message}");
@@ -1712,8 +1717,8 @@ public static partial class DaemonRunner {
                 _signalRegistrations.Add(PosixSignalRegistration.Create(signal, ctx => {
                     ctx.Cancel = true;
 
-                    if (!SignalRequestsShutdown(ctx.Signal, supervision)) {
-                        LogPosixSignalIgnored(logger, ctx.Signal, supervision);
+                    if (!SignalRequestsShutdown(ctx.Signal, attachedToTerminal)) {
+                        LogPosixSignalIgnored(logger, ctx.Signal);
                         return;
                     }
 

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs
@@ -1128,7 +1128,7 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
         // LAST, and gated on MEASURED quiescence rather than an assumption of it. The callback removes
         // the per-launch HOME, which holds the reviewer's own conversation JSONL — the caller's diff,
-        // source excerpts and findings. Kill(entireProcessTree: true) is not atomic against a
+        // source excerpts and findings. ProcessTree.Kill is not atomic against a
         // grandchild forked between tree enumeration and signal, and agy's children include its MCP
         // stdio servers, so a survivor past these budgets is a real shape rather than a hypothetical.
         //

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
@@ -593,7 +593,7 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
 /// <summary>
 /// <see cref="IAgyTurnProcess"/> over a real <see cref="Process"/> — ONE <c>agy -p</c> turn. Mirrors
 /// <see cref="AcpChildProcess"/>'s terminate/wait semantics (SIGTERM-then-kill via
-/// <see cref="Process.Kill(bool)"/>, bounded waits that return silently on timeout), and honours the
+/// <see cref="ProcessTree.Kill(Process)"/>, bounded waits that return silently on timeout), and honours the
 /// two contracts <see cref="IAgyTurnProcess"/> states: <see cref="DisposeAsync"/> is idempotent, and
 /// <see cref="TerminateAsync"/> is safe after it — the runtime can reach both on the same instance
 /// microseconds apart when a stop races a turn's own unwinding.
@@ -736,7 +736,7 @@ internal sealed partial class AgyTurnProcess : IAgyTurnProcess, IAgyTurnDiagnost
         try {
             if (_process.HasExited) return;
 
-            _process.Kill(entireProcessTree: true);
+            ProcessTree.Kill(_process);
         } catch {
             // Already exited, already disposed (the contract explicitly permits this call after
             // DisposeAsync), or the kill raced the exit — nothing left to terminate either way.
@@ -749,14 +749,14 @@ internal sealed partial class AgyTurnProcess : IAgyTurnProcess, IAgyTurnDiagnost
     public async ValueTask DisposeAsync() {
         if (Interlocked.Exchange(ref _disposed, 1) != 0) return;   // idempotent, per the interface contract
 
-        // No bounded wait after the kill, deliberately. Kill(entireProcessTree: true) is SIGKILL on
+        // No bounded wait after the kill, deliberately. ProcessTree.Kill is SIGKILL on
         // POSIX, which no child can catch or defer, so the death is already effectively synchronous
         // with the call — a wait here was measured to change nothing observable against a real child.
         // Callers that need a CONFIRMED exit terminate first and read HasExited while the handle is
         // still valid (see AntigravityHostedAgentRuntime.ProcessTurnAsync's teardown), which is the
         // only place that reading is truthful anyway.
         try {
-            if (!_process.HasExited) _process.Kill(entireProcessTree: true);
+            if (!_process.HasExited) ProcessTree.Kill(_process);
         } catch {
             // Best-effort — already exited or inaccessible.
         }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexMcpInventory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexMcpInventory.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text.Json.Nodes;
+using Capacitor.Cli.Daemon.Services;
 
 namespace Capacitor.Cli.Daemon.Harness.Codex;
 
@@ -54,7 +55,7 @@ internal static class CodexMcpInventory {
             stderr = process.StandardError.ReadToEnd();
 
             if (!process.WaitForExit(TimeoutMs)) {
-                try { process.Kill(entireProcessTree: true); } catch { /* best-effort */ }
+                try { ProcessTree.Kill(process); } catch { /* best-effort */ }
 
                 throw new CodexReviewerMcpIsolationException(
                     $"'{codexPath} mcp list --json' timed out while enumerating the reviewer's inherited MCP servers.");

--- a/src/Capacitor.Cli.Daemon/Harness/Pi/IPiRpcProcess.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Pi/IPiRpcProcess.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using System.Runtime.CompilerServices;
 using System.Text;
 using Capacitor.Cli.Daemon.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Harness.Pi;
@@ -83,7 +84,7 @@ internal interface IPiRpcProcess : IAsyncDisposable {
 /// <see cref="IPiRpcProcess"/> over a real <see cref="Process"/> — the long-lived <c>pi</c> child
 /// backing one hosted Pi session for its whole lifetime. Mirrors <c>AgyTurnProcess</c>'s
 /// terminate/wait/dispose semantics (an immediate kill of the whole process tree via
-/// <see cref="Process.Kill(bool)"/> — not a graceful signal first — bounded waits that return
+/// <see cref="ProcessTree.Kill(Process)"/> — not a graceful signal first — bounded waits that return
 /// silently on timeout, idempotent dispose, terminate-safe-after-dispose) and its bounded stderr
 /// diagnostics capture, but differs in the one place the two runtimes differ: stdin.
 /// <c>AgyTurnProcess</c> closes it the instant the child spawns (a fresh exec-per-turn process that
@@ -256,7 +257,7 @@ internal sealed partial class PiRpcProcess : IPiRpcProcess {
         try {
             if (_process.HasExited) return;
 
-            _process.Kill(entireProcessTree: true);
+            ProcessTree.Kill(_process);
         } catch {
             // Already exited, already disposed (the contract explicitly permits this call after
             // DisposeAsync), or the kill raced the exit — nothing left to terminate either way.
@@ -277,12 +278,12 @@ internal sealed partial class PiRpcProcess : IPiRpcProcess {
         // dead pipe that will never accept more bytes.
         //
         // No bounded wait after the kill, deliberately — see AgyTurnProcess's identical comment.
-        // Kill(entireProcessTree: true) is an immediate kill (SIGKILL on POSIX), which no child can
+        // ProcessTree.Kill is an immediate kill (SIGKILL on POSIX), which no child can
         // catch or defer, so the death is already effectively synchronous with the call. Callers
         // that need a CONFIRMED exit terminate first and read HasExited while the handle is still
         // valid.
         try {
-            if (!_process.HasExited) _process.Kill(entireProcessTree: true);
+            if (!_process.HasExited) ProcessTree.Kill(_process);
         } catch {
             // Best-effort — already exited or inaccessible.
         }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2658,7 +2658,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             try {
                 await proc.WaitForExitAsync(cts.Token);
             } catch (OperationCanceledException) {
-                try { proc.Kill(true); } catch {
+                try { ProcessTree.Kill(proc); } catch {
                     /* best-effort */
                 }
 

--- a/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessReaper.cs
@@ -174,7 +174,7 @@ internal static class ProcessReaper {
 
         if (OperatingSystem.IsWindows()) {
             if (!hard) {
-                try { using var p = System.Diagnostics.Process.GetProcessById(pid); p.Kill(entireProcessTree: true); }
+                try { ProcessTree.Kill(pid); }
                 catch { /* gone / unkillable */ }
             }
 

--- a/src/Capacitor.Cli.Daemon/Services/ProcessTree.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessTree.cs
@@ -1,0 +1,132 @@
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using Capacitor.Cli.Daemon.Pty.Unix;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// SIGKILLs a process and every descendant without stopping any of them first.
+/// <para><c>Process.Kill(entireProcessTree: true)</c> SIGSTOPs each process before it looks for children. A stopped
+/// member of the daemon's own process group is what makes the kernel hang up the whole group, the daemon
+/// included, the moment that group becomes orphaned. On macOS a launch agent shares launchd's session, so
+/// the exit of a grandchild that was reparented to launchd orphans the daemon's group, and every
+/// <c>Process.Start</c> child (Pi, Antigravity, ACP agents, git) lives in that group. The runtime's tree
+/// kill is banned in this assembly for that reason; Windows has neither process groups nor SIGSTOP, so it
+/// still uses it.</para>
+/// </summary>
+internal static partial class ProcessTree {
+    public static void Kill(Process process) {
+        try { if (process.HasExited) return; } catch (InvalidOperationException) { return; }
+
+        if (OperatingSystem.IsWindows()) {
+#pragma warning disable RS0030 // no SIGSTOP on Windows, so the runtime's tree kill is the right tool there
+            process.Kill(entireProcessTree: true);
+#pragma warning restore RS0030
+            return;
+        }
+
+        Kill(process.Id);
+    }
+
+    public static void Kill(int pid) {
+        if (pid <= 0) return;
+
+        if (OperatingSystem.IsWindows()) {
+            try { using var process = Process.GetProcessById(pid); Kill(process); }
+            catch (ArgumentException) { /* already gone */ }
+            return;
+        }
+
+        var doomed = new HashSet<int> { pid };
+
+        // A process can fork between the walk and its kill, and its children are reparented away the
+        // moment it dies, so walk again after killing until a pass finds nothing new.
+        for (var pass = 0; pass < 3; pass++) {
+            var grew = doomed.UnionWithCount(DescendantsOf(doomed)) > 0;
+
+            foreach (var p in doomed) UnixPtyInterop.kill(p, UnixPtyInterop.SIGKILL);
+
+            if (!grew && pass > 0) break;
+        }
+    }
+
+    /// <summary>Every descendant of <paramref name="pid"/>: children, grandchildren and so on, never
+    /// <paramref name="pid"/> itself.</summary>
+    internal static IReadOnlySet<int> Descendants(int pid) => DescendantsOf([pid]);
+
+    static HashSet<int> DescendantsOf(IReadOnlyCollection<int> roots) {
+        var found = new HashSet<int>();
+        if (roots.Count == 0) return found;
+
+        var childrenOf = OperatingSystem.IsMacOS() ? MacChildren : LinuxChildrenSnapshot();
+        var queue      = new Queue<int>(roots);
+
+        while (queue.TryDequeue(out var parent))
+            foreach (var child in childrenOf(parent))
+                if (!roots.Contains(child) && found.Add(child)) queue.Enqueue(child);
+
+        return found;
+    }
+
+    static int UnionWithCount(this HashSet<int> set, IEnumerable<int> items) {
+        var added = 0;
+        foreach (var item in items) if (set.Add(item)) added++;
+        return added;
+    }
+
+    // ── macOS: libproc lists a process's children directly ───────────────────────────────────────
+
+    [LibraryImport("libproc", EntryPoint = "proc_listchildpids")]
+    private static unsafe partial int proc_listchildpids(int ppid, int* buffer, int buffersize);
+
+    /// <summary>Returns a count of pids, not bytes; a count equal to the capacity means the buffer
+    /// was too small.</summary>
+    static unsafe IEnumerable<int> MacChildren(int parent) {
+        var buffer = new int[256];
+
+        while (true) {
+            int count;
+            fixed (int* p = buffer) count = proc_listchildpids(parent, p, buffer.Length * sizeof(int));
+
+            if (count < 0) return [];
+            if (count < buffer.Length) return buffer[..count];
+
+            buffer = new int[buffer.Length * 2];
+        }
+    }
+
+    // ── Linux: one /proc scan, then a parent → children map ───────────────────────────────────────
+
+    static Func<int, IEnumerable<int>> LinuxChildrenSnapshot() {
+        var childrenOf = new Dictionary<int, List<int>>();
+
+        foreach (var dir in Directory.EnumerateDirectories("/proc")) {
+            if (!int.TryParse(Path.GetFileName(dir), NumberStyles.None, CultureInfo.InvariantCulture, out var pid)) continue;
+            if (LinuxParentOf(pid) is not { } parent) continue;
+
+            if (!childrenOf.TryGetValue(parent, out var list)) childrenOf[parent] = list = [];
+            list.Add(pid);
+        }
+
+        return parent => childrenOf.TryGetValue(parent, out var list) ? list : [];
+    }
+
+    /// <summary>The ppid field of <c>/proc/{pid}/stat</c>: the token after the state, which follows
+    /// the last <c>)</c> because the command name can contain spaces and parentheses.</summary>
+    static int? LinuxParentOf(int pid) {
+        try {
+            var stat      = File.ReadAllText($"/proc/{pid}/stat");
+            var afterComm = stat.LastIndexOf(')');
+            if (afterComm < 0) return null;
+
+            var fields = stat[(afterComm + 1)..].Split(' ', StringSplitOptions.RemoveEmptyEntries);
+
+            return fields.Length > 1 && int.TryParse(fields[1], NumberStyles.None, CultureInfo.InvariantCulture, out var parent)
+                ? parent
+                : null;
+        } catch {
+            return null; // the process left between the directory listing and the read
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/ProcessTree.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ProcessTree.cs
@@ -6,16 +6,25 @@ using Capacitor.Cli.Daemon.Pty.Unix;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// SIGKILLs a process and every descendant without stopping any of them first.
-/// <para><c>Process.Kill(entireProcessTree: true)</c> SIGSTOPs each process before it looks for children. A stopped
-/// member of the daemon's own process group is what makes the kernel hang up the whole group, the daemon
-/// included, the moment that group becomes orphaned. On macOS a launch agent shares launchd's session, so
-/// the exit of a grandchild that was reparented to launchd orphans the daemon's group, and every
-/// <c>Process.Start</c> child (Pi, Antigravity, ACP agents, git) lives in that group. The runtime's tree
-/// kill is banned in this assembly for that reason; Windows has neither process groups nor SIGSTOP, so it
-/// still uses it.</para>
+/// SIGKILLs a process and every descendant, children before parents, each verified by start identity.
+/// <para><c>Process.Kill(entireProcessTree: true)</c> SIGSTOPs each process before it looks for children.
+/// A stopped member of the daemon's own process group is what makes the kernel hang up the whole
+/// group, the daemon included, the moment that group becomes orphaned: on macOS a launch agent shares
+/// launchd's session, so the exit of a grandchild that was reparented to launchd orphans the daemon's
+/// group, and every <c>Process.Start</c> child (Pi, Antigravity, ACP agents, git) lives in that group.
+/// The runtime's tree kill is banned in this assembly for that reason; Windows has neither process
+/// groups nor SIGSTOP, so it still uses it.</para>
+/// <para>Nothing is stopped here, so a parent can fork between a listing and its own death, and that
+/// child is reparented out of reach. Killing children first and re-listing the parent until it shows
+/// nothing new keeps the window to the two syscalls between the last listing and the parent's
+/// SIGKILL. A pid is signalled only while it still carries the identity captured when it was listed,
+/// and never twice, so a recycled pid is never a target.</para>
 /// </summary>
 internal static partial class ProcessTree {
+    /// <summary>Re-listings of a parent after its known children are dead, before it is killed
+    /// regardless; bounds a parent that keeps forking.</summary>
+    const int MaxRescans = 3;
+
     public static void Kill(Process process) {
         try { if (process.HasExited) return; } catch (InvalidOperationException) { return; }
 
@@ -38,42 +47,30 @@ internal static partial class ProcessTree {
             return;
         }
 
-        var doomed = new HashSet<int> { pid };
+        if (ProcessIdentity.Capture(pid) is { } identity) KillSubtree(pid, identity);
+    }
 
-        // A process can fork between the walk and its kill, and its children are reparented away the
-        // moment it dies, so walk again after killing until a pass finds nothing new.
-        for (var pass = 0; pass < 3; pass++) {
-            var grew = doomed.UnionWithCount(DescendantsOf(doomed)) > 0;
+    static void KillSubtree(int pid, string identity) {
+        var seen = new HashSet<int>();
 
-            foreach (var p in doomed) UnixPtyInterop.kill(p, UnixPtyInterop.SIGKILL);
+        for (var rescan = 0; rescan <= MaxRescans; rescan++) {
+            var fresh = false;
 
-            if (!grew && pass > 0) break;
+            foreach (var child in Children(pid)) {
+                if (!seen.Add(child)) continue; // handled on an earlier pass; a zombie stays listed until its parent dies
+
+                fresh = true;
+                if (ProcessIdentity.Capture(child) is { } childIdentity) KillSubtree(child, childIdentity);
+            }
+
+            if (!fresh) break;
         }
+
+        if (ProcessIdentity.Matches(pid, identity)) UnixPtyInterop.kill(pid, UnixPtyInterop.SIGKILL);
     }
 
-    /// <summary>Every descendant of <paramref name="pid"/>: children, grandchildren and so on, never
-    /// <paramref name="pid"/> itself.</summary>
-    internal static IReadOnlySet<int> Descendants(int pid) => DescendantsOf([pid]);
-
-    static HashSet<int> DescendantsOf(IReadOnlyCollection<int> roots) {
-        var found = new HashSet<int>();
-        if (roots.Count == 0) return found;
-
-        var childrenOf = OperatingSystem.IsMacOS() ? MacChildren : LinuxChildrenSnapshot();
-        var queue      = new Queue<int>(roots);
-
-        while (queue.TryDequeue(out var parent))
-            foreach (var child in childrenOf(parent))
-                if (!roots.Contains(child) && found.Add(child)) queue.Enqueue(child);
-
-        return found;
-    }
-
-    static int UnionWithCount(this HashSet<int> set, IEnumerable<int> items) {
-        var added = 0;
-        foreach (var item in items) if (set.Add(item)) added++;
-        return added;
-    }
+    static IEnumerable<int> Children(int parent) =>
+        OperatingSystem.IsMacOS() ? MacChildren(parent) : LinuxChildren(parent);
 
     // ── macOS: libproc lists a process's children directly ───────────────────────────────────────
 
@@ -82,7 +79,7 @@ internal static partial class ProcessTree {
 
     /// <summary>Returns a count of pids, not bytes; a count equal to the capacity means the buffer
     /// was too small.</summary>
-    static unsafe IEnumerable<int> MacChildren(int parent) {
+    static unsafe int[] MacChildren(int parent) {
         var buffer = new int[256];
 
         while (true) {
@@ -96,24 +93,17 @@ internal static partial class ProcessTree {
         }
     }
 
-    // ── Linux: one /proc scan, then a parent → children map ───────────────────────────────────────
+    // ── Linux: the ppid field of every /proc/{pid}/stat ───────────────────────────────────────────
 
-    static Func<int, IEnumerable<int>> LinuxChildrenSnapshot() {
-        var childrenOf = new Dictionary<int, List<int>>();
-
+    static IEnumerable<int> LinuxChildren(int parent) {
         foreach (var dir in Directory.EnumerateDirectories("/proc")) {
             if (!int.TryParse(Path.GetFileName(dir), NumberStyles.None, CultureInfo.InvariantCulture, out var pid)) continue;
-            if (LinuxParentOf(pid) is not { } parent) continue;
-
-            if (!childrenOf.TryGetValue(parent, out var list)) childrenOf[parent] = list = [];
-            list.Add(pid);
+            if (LinuxParentOf(pid) == parent) yield return pid;
         }
-
-        return parent => childrenOf.TryGetValue(parent, out var list) ? list : [];
     }
 
-    /// <summary>The ppid field of <c>/proc/{pid}/stat</c>: the token after the state, which follows
-    /// the last <c>)</c> because the command name can contain spaces and parentheses.</summary>
+    /// <summary>The token after the state, which follows the last <c>)</c> because the command name
+    /// can contain spaces and parentheses.</summary>
     static int? LinuxParentOf(int pid) {
         try {
             var stat      = File.ReadAllText($"/proc/{pid}/stat");

--- a/src/Capacitor.Cli.Daemon/Services/RepoMatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Services/RepoMatcher.cs
@@ -198,7 +198,7 @@ internal partial class RepoMatcher(DaemonConfig config, ILogger<RepoMatcher> log
         try {
             await proc.WaitForExitAsync(timeoutCts.Token);
         } catch (OperationCanceledException) {
-            try { proc.Kill(true); } catch {
+            try { ProcessTree.Kill(proc); } catch {
                 /* best-effort */
             }
 

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ExclusionPlan.cs
@@ -283,7 +283,7 @@ public partial class WorktreeManager {
     /// </summary>
     static async Task TerminateAndDrainAsync(Process process, params Task[] pumps) {
         using var budget = new CancellationTokenSource(CleanupBudget);
-        try { if (!process.HasExited) process.Kill(entireProcessTree: true); }
+        try { if (!process.HasExited) ProcessTree.Kill(process); }
         catch { /* already gone, or tree enumeration failed — the direct kill below is the fallback */ }
         // Tree termination can fail while killing the process itself still succeeds, and returning from
         // here with a live owned child is a leak: disposing Process does not terminate it.

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ReviewContext.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.ReviewContext.cs
@@ -452,7 +452,7 @@ public partial class WorktreeManager {
             await process.WaitForExitAsync(timeoutCts.Token);
             await stdoutTask;
         } catch (OperationCanceledException) {
-            try { process.Kill(entireProcessTree: true); } catch { }
+            try { ProcessTree.Kill(process); } catch { }
             throw new InvalidOperationException(
                 $"git {string.Join(' ', args)} timed out after {timeout.TotalSeconds:F0}s");
         }

--- a/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
+++ b/src/Capacitor.Cli.Daemon/Services/WorktreeManager.cs
@@ -1494,7 +1494,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
             try {
                 await proc.WaitForExitAsync(cts.Token);
             } catch (OperationCanceledException) {
-                try { proc.Kill(true); } catch {
+                try { ProcessTree.Kill(proc); } catch {
                     /* best-effort */
                 }
 
@@ -1596,7 +1596,7 @@ public partial class WorktreeManager(DaemonConfig config, ILogger<WorktreeManage
         try {
             await proc.WaitForExitAsync(cts.Token);
         } catch (OperationCanceledException) {
-            try { proc.Kill(true); } catch { /* best-effort */ }
+            try { ProcessTree.Kill(proc); } catch { /* best-effort */ }
 
             // Kill is asynchronous. Wait for it to land before unwinding: a caller may hold the
             // worktree metadata gate, whose whole point is that no other git touches this repo's

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerSignalPolicyTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerSignalPolicyTests.cs
@@ -1,0 +1,39 @@
+using System.Runtime.InteropServices;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit;
+
+/// <summary>
+/// <see cref="DaemonRunner.SignalRequestsShutdown"/>: which POSIX signals become a cooperative shutdown.
+/// SIGHUP is a hangup only for a foreground run, which has a terminal to lose. A supervised or detached
+/// daemon has none, and the kernel still delivers SIGHUP to every member of the daemon's own process
+/// group when that group is orphaned while one member is stopped. Shutting down on it exits 0, which
+/// launchd's <c>KeepAlive SuccessfulExit=false</c> reads as deliberate and never restarts.
+/// </summary>
+public class DaemonRunnerSignalPolicyTests {
+    [Test]
+    [Arguments(SupervisionMode.Supervised)]
+    [Arguments(SupervisionMode.Detached)]
+    public async Task SIGHUP_is_ignored_by_a_daemon_without_a_terminal(SupervisionMode mode) {
+        await Assert.That(DaemonRunner.SignalRequestsShutdown(PosixSignal.SIGHUP, mode)).IsFalse();
+    }
+
+    [Test]
+    public async Task SIGHUP_stops_a_foreground_run() {
+        await Assert.That(DaemonRunner.SignalRequestsShutdown(PosixSignal.SIGHUP, SupervisionMode.Foreground)).IsTrue();
+    }
+
+    [Test]
+    [Arguments(PosixSignal.SIGINT,  SupervisionMode.Supervised)]
+    [Arguments(PosixSignal.SIGTERM, SupervisionMode.Supervised)]
+    [Arguments(PosixSignal.SIGQUIT, SupervisionMode.Supervised)]
+    [Arguments(PosixSignal.SIGINT,  SupervisionMode.Detached)]
+    [Arguments(PosixSignal.SIGTERM, SupervisionMode.Detached)]
+    [Arguments(PosixSignal.SIGQUIT, SupervisionMode.Detached)]
+    [Arguments(PosixSignal.SIGINT,  SupervisionMode.Foreground)]
+    [Arguments(PosixSignal.SIGTERM, SupervisionMode.Foreground)]
+    [Arguments(PosixSignal.SIGQUIT, SupervisionMode.Foreground)]
+    public async Task Every_other_signal_stops_the_daemon_whatever_the_mode(PosixSignal signal, SupervisionMode mode) {
+        await Assert.That(DaemonRunner.SignalRequestsShutdown(signal, mode)).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerSignalPolicyTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerSignalPolicyTests.cs
@@ -1,39 +1,33 @@
 using System.Runtime.InteropServices;
-using Capacitor.Cli.Daemon.Services;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit;
 
 /// <summary>
 /// <see cref="DaemonRunner.SignalRequestsShutdown"/>: which POSIX signals become a cooperative shutdown.
-/// SIGHUP is a hangup only for a foreground run, which has a terminal to lose. A supervised or detached
-/// daemon has none, and the kernel still delivers SIGHUP to every member of the daemon's own process
-/// group when that group is orphaned while one member is stopped. Shutting down on it exits 0, which
-/// launchd's <c>KeepAlive SuccessfulExit=false</c> reads as deliberate and never restarts.
+/// SIGHUP is a hangup only when a standard stream is a terminal. Under launchd or systemd none is, and
+/// the kernel still delivers SIGHUP to every member of the daemon's own process group when that group
+/// is orphaned while one member is stopped. Shutting down on it exits 0, which launchd's
+/// <c>KeepAlive SuccessfulExit=false</c> reads as deliberate and never restarts.
 /// </summary>
 public class DaemonRunnerSignalPolicyTests {
     [Test]
-    [Arguments(SupervisionMode.Supervised)]
-    [Arguments(SupervisionMode.Detached)]
-    public async Task SIGHUP_is_ignored_by_a_daemon_without_a_terminal(SupervisionMode mode) {
-        await Assert.That(DaemonRunner.SignalRequestsShutdown(PosixSignal.SIGHUP, mode)).IsFalse();
+    public async Task SIGHUP_is_ignored_without_a_terminal() {
+        await Assert.That(DaemonRunner.SignalRequestsShutdown(PosixSignal.SIGHUP, attachedToTerminal: false)).IsFalse();
     }
 
     [Test]
-    public async Task SIGHUP_stops_a_foreground_run() {
-        await Assert.That(DaemonRunner.SignalRequestsShutdown(PosixSignal.SIGHUP, SupervisionMode.Foreground)).IsTrue();
+    public async Task SIGHUP_stops_a_daemon_attached_to_a_terminal() {
+        await Assert.That(DaemonRunner.SignalRequestsShutdown(PosixSignal.SIGHUP, attachedToTerminal: true)).IsTrue();
     }
 
     [Test]
-    [Arguments(PosixSignal.SIGINT,  SupervisionMode.Supervised)]
-    [Arguments(PosixSignal.SIGTERM, SupervisionMode.Supervised)]
-    [Arguments(PosixSignal.SIGQUIT, SupervisionMode.Supervised)]
-    [Arguments(PosixSignal.SIGINT,  SupervisionMode.Detached)]
-    [Arguments(PosixSignal.SIGTERM, SupervisionMode.Detached)]
-    [Arguments(PosixSignal.SIGQUIT, SupervisionMode.Detached)]
-    [Arguments(PosixSignal.SIGINT,  SupervisionMode.Foreground)]
-    [Arguments(PosixSignal.SIGTERM, SupervisionMode.Foreground)]
-    [Arguments(PosixSignal.SIGQUIT, SupervisionMode.Foreground)]
-    public async Task Every_other_signal_stops_the_daemon_whatever_the_mode(PosixSignal signal, SupervisionMode mode) {
-        await Assert.That(DaemonRunner.SignalRequestsShutdown(signal, mode)).IsTrue();
+    [Arguments(PosixSignal.SIGINT,  false)]
+    [Arguments(PosixSignal.SIGTERM, false)]
+    [Arguments(PosixSignal.SIGQUIT, false)]
+    [Arguments(PosixSignal.SIGINT,  true)]
+    [Arguments(PosixSignal.SIGTERM, true)]
+    [Arguments(PosixSignal.SIGQUIT, true)]
+    public async Task Every_other_signal_stops_the_daemon_with_or_without_a_terminal(PosixSignal signal, bool attachedToTerminal) {
+        await Assert.That(DaemonRunner.SignalRequestsShutdown(signal, attachedToTerminal)).IsTrue();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ProcessTreeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ProcessTreeTests.cs
@@ -1,0 +1,98 @@
+using System.Diagnostics;
+using System.Globalization;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// <see cref="ProcessTree"/>: the daemon's tree kill. It has to reach grandchildren (a hosted agent's
+/// bridge children, a shell's jobs) through a parent that is killed first, and it does so with SIGKILL
+/// alone. The tree here is <c>sh -c 'sleep &amp; sleep &amp; wait'</c>; the grandchildren are located
+/// through <c>ps</c> so the walk under test is checked against an independent view.
+/// </summary>
+[ParallelLimiter<SubprocessLimit>]
+public class ProcessTreeTests {
+    [Test]
+    public async Task Descendants_include_the_grandchildren() {
+        if (OperatingSystem.IsWindows()) return;
+
+        using var root = StartTree();
+        var grandchildren = await WaitForChildrenAsync(root.Id, 2);
+
+        var found = ProcessTree.Descendants(root.Id);
+
+        await Assert.That(found).Contains(grandchildren[0]);
+        await Assert.That(found).Contains(grandchildren[1]);
+        await Assert.That(found).DoesNotContain(root.Id);
+
+        ProcessTree.Kill(root);
+        root.WaitForExit(5000);
+    }
+
+    [Test]
+    public async Task Kill_ends_the_whole_tree() {
+        if (OperatingSystem.IsWindows()) return;
+
+        using var root = StartTree();
+        var grandchildren = await WaitForChildrenAsync(root.Id, 2);
+
+        ProcessTree.Kill(root);
+
+        await Assert.That(root.WaitForExit(5000)).IsTrue();
+        await Assert.That(await WaitUntilGoneAsync(grandchildren)).IsTrue();
+    }
+
+    [Test]
+    public async Task Kill_of_an_exited_process_does_nothing() {
+        using var done = Process.Start(new ProcessStartInfo("sh", ["-c", "exit 0"]) { UseShellExecute = false })!;
+        done.WaitForExit();
+
+        ProcessTree.Kill(done);
+
+        await Assert.That(done.HasExited).IsTrue();
+    }
+
+    static Process StartTree() =>
+        Process.Start(new ProcessStartInfo("sh", ["-c", "sleep 300 & sleep 300 & wait"]) { UseShellExecute = false })!;
+
+    /// <summary>Children of <paramref name="parent"/> as <c>ps</c> sees them, once at least
+    /// <paramref name="count"/> exist.</summary>
+    static async Task<List<int>> WaitForChildrenAsync(int parent, int count) {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
+
+        while (true) {
+            var children = ChildrenViaPs(parent);
+            if (children.Count >= count) return children;
+            if (DateTime.UtcNow > deadline) throw new TimeoutException($"pid {parent} never showed {count} children; saw {children.Count}");
+            await Task.Delay(50);
+        }
+    }
+
+    static List<int> ChildrenViaPs(int parent) {
+        using var ps = Process.Start(new ProcessStartInfo("ps", ["-axo", "pid=,ppid="]) {
+            UseShellExecute = false, RedirectStandardOutput = true,
+        })!;
+        var output = ps.StandardOutput.ReadToEnd();
+        ps.WaitForExit();
+
+        var children = new List<int>();
+        foreach (var line in output.Split('\n', StringSplitOptions.RemoveEmptyEntries)) {
+            var fields = line.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (fields.Length == 2 && int.Parse(fields[1], CultureInfo.InvariantCulture) == parent)
+                children.Add(int.Parse(fields[0], CultureInfo.InvariantCulture));
+        }
+
+        return children;
+    }
+
+    static async Task<bool> WaitUntilGoneAsync(IEnumerable<int> pids) {
+        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
+
+        while (pids.Any(ProcessIdentity.IsAlive)) {
+            if (DateTime.UtcNow > deadline) return false;
+            await Task.Delay(50);
+        }
+
+        return true;
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ProcessTreeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ProcessTreeTests.cs
@@ -5,41 +5,42 @@ using Capacitor.Cli.Daemon.Services;
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
 /// <summary>
-/// <see cref="ProcessTree"/>: the daemon's tree kill. It has to reach grandchildren (a hosted agent's
-/// bridge children, a shell's jobs) through a parent that is killed first, and it does so with SIGKILL
-/// alone. The tree here is <c>sh -c 'sleep &amp; sleep &amp; wait'</c>; the grandchildren are located
-/// through <c>ps</c> so the walk under test is checked against an independent view.
+/// <see cref="ProcessTree"/>: the daemon's tree kill has to reach every level below a parent that is
+/// killed after its children, with SIGKILL alone. The trees are shells with backgrounded
+/// <c>sleep</c>s; their descendants are located through <c>ps</c>, so the walk under test is checked
+/// against an independent view, and each is pinned by <see cref="PidIdentity"/> so a recycled pid can
+/// fake neither survival nor death.
 /// </summary>
 [ParallelLimiter<SubprocessLimit>]
 public class ProcessTreeTests {
     [Test]
-    public async Task Descendants_include_the_grandchildren() {
+    public async Task Kill_ends_children_and_grandchildren() {
         if (OperatingSystem.IsWindows()) return;
 
-        using var root = StartTree();
-        var grandchildren = await WaitForChildrenAsync(root.Id, 2);
-
-        var found = ProcessTree.Descendants(root.Id);
-
-        await Assert.That(found).Contains(grandchildren[0]);
-        await Assert.That(found).Contains(grandchildren[1]);
-        await Assert.That(found).DoesNotContain(root.Id);
-
-        ProcessTree.Kill(root);
-        root.WaitForExit(5000);
-    }
-
-    [Test]
-    public async Task Kill_ends_the_whole_tree() {
-        if (OperatingSystem.IsWindows()) return;
-
-        using var root = StartTree();
-        var grandchildren = await WaitForChildrenAsync(root.Id, 2);
+        using var root = StartTree("sleep 300 & sleep 300 & wait");
+        var grandchildren = await PinChildrenAsync(root.Id, 2);
 
         ProcessTree.Kill(root);
 
         await Assert.That(root.WaitForExit(5000)).IsTrue();
-        await Assert.That(await WaitUntilGoneAsync(grandchildren)).IsTrue();
+        foreach (var (pid, identity) in grandchildren)
+            await PidIdentity.WaitUntilGoneAsync(pid, identity, TimeSpan.FromSeconds(5));
+    }
+
+    [Test]
+    public async Task Kill_reaches_the_third_level() {
+        if (OperatingSystem.IsWindows()) return;
+
+        using var root = StartTree("sh -c 'sleep 300 & sleep 300 & wait' & wait");
+        var (shell, shellIdentity) = (await PinChildrenAsync(root.Id, 1)).Single();
+        var leaves = await PinChildrenAsync(shell, 2);
+
+        ProcessTree.Kill(root);
+
+        await Assert.That(root.WaitForExit(5000)).IsTrue();
+        await PidIdentity.WaitUntilGoneAsync(shell, shellIdentity, TimeSpan.FromSeconds(5));
+        foreach (var (pid, identity) in leaves)
+            await PidIdentity.WaitUntilGoneAsync(pid, identity, TimeSpan.FromSeconds(5));
     }
 
     [Test]
@@ -52,17 +53,17 @@ public class ProcessTreeTests {
         await Assert.That(done.HasExited).IsTrue();
     }
 
-    static Process StartTree() =>
-        Process.Start(new ProcessStartInfo("sh", ["-c", "sleep 300 & sleep 300 & wait"]) { UseShellExecute = false })!;
+    static Process StartTree(string script) =>
+        Process.Start(new ProcessStartInfo("sh", ["-c", script]) { UseShellExecute = false })!;
 
-    /// <summary>Children of <paramref name="parent"/> as <c>ps</c> sees them, once at least
-    /// <paramref name="count"/> exist.</summary>
-    static async Task<List<int>> WaitForChildrenAsync(int parent, int count) {
+    /// <summary>The children of <paramref name="parent"/> as <c>ps</c> sees them, once at least
+    /// <paramref name="count"/> exist, each pinned to its incarnation while it is known alive.</summary>
+    static async Task<List<(int Pid, string Identity)>> PinChildrenAsync(int parent, int count) {
         var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(10);
 
         while (true) {
             var children = ChildrenViaPs(parent);
-            if (children.Count >= count) return children;
+            if (children.Count >= count) return children.Select(pid => (pid, PidIdentity.Capture(pid))).ToList();
             if (DateTime.UtcNow > deadline) throw new TimeoutException($"pid {parent} never showed {count} children; saw {children.Count}");
             await Task.Delay(50);
         }
@@ -83,16 +84,5 @@ public class ProcessTreeTests {
         }
 
         return children;
-    }
-
-    static async Task<bool> WaitUntilGoneAsync(IEnumerable<int> pids) {
-        var deadline = DateTime.UtcNow + TimeSpan.FromSeconds(5);
-
-        while (pids.Any(ProcessIdentity.IsAlive)) {
-            if (DateTime.UtcNow > deadline) return false;
-            await Task.Delay(50);
-        }
-
-        return true;
     }
 }


### PR DESCRIPTION
Closes #837 — AI-2621

## What & why

Stopping a Pi agent that outlived its 3 s grace took the daemon down: SIGHUP arrived 36 ms after the agent's exit, the daemon shut down cooperatively with exit 0, and launchd's `KeepAlive SuccessfulExit=false` never restarts a clean exit. The runtime's tree kill SIGSTOPs each process before it enumerates children; Pi and its `kcap mcp` bridges share the daemon's process group, and a launch agent shares launchd's session, so the first bridge to exit after Pi orphans the daemon's group while a sibling is still stopped, and the kernel hangs up every member. Two changes, each sufficient alone: `ProcessTree.Kill` is a SIGKILL-only descendant walk and the runtime's tree kill is banned in the daemon assembly; and a supervised or detached daemon ignores SIGHUP, having no terminal to hang up. A foreground run keeps its cooperative shutdown.

## Where to look

`ProcessTree.Kill` walks again after killing: a process can fork between the walk and its own death, and its children reparent away the moment it dies. Without SIGSTOP that window can only be narrowed. The CLI keeps the runtime's tree kill; it is short-lived and out of scope.

## Verification

Under `launchctl submit` (session 1, own process group, parent launchd), a parent spawning `sh -c 'sleep & sleep & wait'` and tree-killing it:

| kill | SIGHUP to parent | grandchildren left |
|---|---|---|
| `Process.Kill(entireProcessTree: true)` | 2/2 runs, ~85 ms | 0 |
| daemon's `ProcessTree.Kill`, loaded from the Debug build | 0/2 runs | 0 |

Daemon unit suite: 3056 passed, 1 failed (`Installed_codex_schema_matches_the_vendored_pin`: local codex newer than the vendored pin, unrelated). `dotnet publish -c Release` of the daemon: no IL2026/IL3050 warnings.
