### PR TITLE
[AI-2643] Advertise the transport a daemon hosts interactive Codex on

### DIFF
--- a/src/Capacitor.Cli.Core/Models.cs
+++ b/src/Capacitor.Cli.Core/Models.cs
@@ -2092,7 +2092,12 @@ public sealed record UnattendedVendorCapability(
     // (CodexLaunchPosture on LaunchAgentCommand). Defaults false — a legacy or mid-rollout daemon is
     // never widened to "supported" by any fallback, so the server refuses posture selection rather
     // than sending a block that would be silently ignored.
-    bool SupportsLaunchPosture = false
+    bool SupportsLaunchPosture = false,
+    // The transport this daemon hosts an INTERACTIVE launch of this vendor on ("pty" | "app-server").
+    // The server records it as the launch's expected runtime transport and refuses a registration
+    // that claims anything else, so it must come from the same decision the launch router uses.
+    // Null from a daemon that does not advertise it, which the server reads as pty. Codex only.
+    string? InteractiveTransport = null
 );
 
 public readonly record struct AgentRegistered(

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1443,7 +1443,10 @@ public static partial class DaemonRunner {
                 ReviewerModelPolicyVersion: modelResolver?.PolicyVersion,
                 // Caller-selected launch posture, advertised per vendor rather than per platform —
                 // the seam is platform-neutral, and only the Codex launcher honours a posture block.
-                SupportsLaunchPosture: string.Equals(vendor, "codex", StringComparison.Ordinal)));
+                SupportsLaunchPosture: string.Equals(vendor, "codex", StringComparison.Ordinal),
+                InteractiveTransport: string.Equals(vendor, "codex", StringComparison.Ordinal)
+                    ? Harness.Codex.CodexTransportDecision.InteractiveTransport(config)
+                    : null));
         }
         return capabilities;
     }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -72,10 +72,14 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
     ///
     /// <para>Interactive is stated positively — neither a review flow nor a PR review — rather than as
     /// "not a review flow": the launch classes here are review-flow, PR review and interactive, so the
-    /// negative form would sweep PR review along with it and widen the opt-in past what it names.</para></summary>
+    /// negative form would sweep PR review along with it and widen the opt-in past what it names. The
+    /// interactive branch reads <see cref="CodexTransportDecision.InteractiveTransport"/>, the same
+    /// function the daemon advertises to the server — which refuses a registration whose transport
+    /// differs from the advertisement.</para></summary>
     internal bool UsesAppServer(RuntimeStartContext ctx) =>
         _config.CodexAppServerActive
-     && (ctx.IsReviewFlow || (_config.CodexAppServerInteractive && !ctx.IsReview));
+     && (ctx.IsReviewFlow
+         || (!ctx.IsReview && CodexTransportDecision.InteractiveTransport(_config) == CodexTransportDecision.AppServer));
 
     public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
         // §2.7 B4: resume is app-server-only (thread/resume). A resume request routed to the PTY path can't

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTransportDecision.cs
@@ -37,6 +37,14 @@ internal static class CodexTransportDecision {
             config.CodexAppServerInteractive = IsInteractiveOptIn(interactive);
     }
 
+    /// <summary>The transport this daemon hosts an INTERACTIVE Codex launch on. The launch router
+    /// (<see cref="CodexHostedAgentRuntimeFactory.UsesAppServer"/>) and the capability advertisement
+    /// (<c>DaemonRunner.ComputeUnattendedVendorCapabilities</c>) both read this one function: the server
+    /// records the advertised value as the launch's expected transport and refuses a registration that
+    /// claims anything else, so routing and advertisement cannot be allowed to diverge.</summary>
+    public static string InteractiveTransport(Capacitor.Cli.Daemon.DaemonConfig config) =>
+        config.CodexAppServerActive && config.CodexAppServerInteractive ? AppServer : Pty;
+
     /// <summary>Resolves the effective transport: app-server only when selected AND the installed
     /// build meets <see cref="VersionFloor"/>. An unknown/unparseable version fails toward PTY.</summary>
     public static bool UsesAppServer(string? transport, string? cliVersion) =>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerInteractiveTransportAdvertisementTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerInteractiveTransportAdvertisementTests.cs
@@ -1,0 +1,47 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit;
+
+/// <summary>The codex capability advertises the interactive transport the router will actually use, and
+/// no other vendor advertises one. The server records the advertised value as the launch's expected
+/// transport, so an advertisement that disagreed with routing would refuse every interactive launch.</summary>
+public class DaemonRunnerInteractiveTransportAdvertisementTests {
+    sealed class FakeFactory(string vendor) : IHostedAgentRuntimeFactory {
+        public string CliPath            => "";   // empty: no version probe is spawned
+        public string Vendor             { get; } = vendor;
+        public bool   SupportsUnattended => true;
+
+        public bool IsAvailable() => true;
+
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) =>
+            throw new NotSupportedException("not exercised by this test");
+    }
+
+    static IReadOnlyList<UnattendedVendorCapability> Advertised(DaemonConfig config) =>
+        DaemonRunner.ComputeUnattendedVendorCapabilities(
+            [new FakeFactory("codex"), new FakeFactory("claude")], config, advertised: ["codex", "claude"]);
+
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(true,  false)]
+    [Arguments(false, true)]
+    [Arguments(true,  true)]
+    public async Task Codex_advertises_the_interactive_transport_the_router_uses(bool active, bool optIn) {
+        var config = new DaemonConfig { CodexAppServerActive = active, CodexAppServerInteractive = optIn };
+
+        var codex = Advertised(config).Single(c => c.Vendor == "codex");
+
+        await Assert.That(codex.InteractiveTransport).IsEqualTo(CodexTransportDecision.InteractiveTransport(config));
+    }
+
+    [Test]
+    public async Task Other_vendors_advertise_no_interactive_transport() {
+        var config = new DaemonConfig { CodexAppServerActive = true, CodexAppServerInteractive = true };
+
+        var claude = Advertised(config).Single(c => c.Vendor == "claude");
+
+        await Assert.That(claude.InteractiveTransport).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -149,6 +149,26 @@ public class CodexHostedAgentRuntimeFactoryTests {
     public async Task Interactive_opt_in_accepts_only_affirmative_spellings(string? value, bool expected) =>
         await Assert.That(CodexTransportDecision.IsInteractiveOptIn(value)).IsEqualTo(expected);
 
+    /// <summary>Routing and advertisement are two halves of one fact. The server records the advertised
+    /// interactive transport as the launch's expected transport and refuses a registration that claims
+    /// otherwise, so if the router ever disagreed with <see cref="CodexTransportDecision.InteractiveTransport"/>
+    /// every interactive launch on that daemon would be stopped at registration.</summary>
+    [Test]
+    [Arguments(false, false)]
+    [Arguments(true,  false)]
+    [Arguments(false, true)]
+    [Arguments(true,  true)]
+    public async Task Interactive_routing_and_the_advertised_interactive_transport_are_one_fact(bool active, bool optIn) {
+        using var wt = new TempDir();
+        var config  = new DaemonConfig { CodexAppServerActive = active, CodexAppServerInteractive = optIn, Version = "0.146.0" };
+        var factory = new CodexHostedAgentRuntimeFactory(NewLauncher(), new RecordingPtyFactory(), config, NullLoggerFactory.Instance, null);
+
+        var routed     = factory.UsesAppServer(Ctx(isReviewFlow: false, wt.Path));
+        var advertised = CodexTransportDecision.InteractiveTransport(config) == CodexTransportDecision.AppServer;
+
+        await Assert.That(routed).IsEqualTo(advertised);
+    }
+
     [Test]
     public async Task Pty_transport_delegates_a_review_flow_to_the_pty_factory() {
         using var wt = new TempDir();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexHostedAgentRuntimeFactoryTests.cs
@@ -159,11 +159,11 @@ public class CodexHostedAgentRuntimeFactoryTests {
     [Arguments(false, true)]
     [Arguments(true,  true)]
     public async Task Interactive_routing_and_the_advertised_interactive_transport_are_one_fact(bool active, bool optIn) {
-        using var wt = new TempDir();
         var config  = new DaemonConfig { CodexAppServerActive = active, CodexAppServerInteractive = optIn, Version = "0.146.0" };
         var factory = new CodexHostedAgentRuntimeFactory(NewLauncher(), new RecordingPtyFactory(), config, NullLoggerFactory.Instance, null);
 
-        var routed     = factory.UsesAppServer(Ctx(isReviewFlow: false, wt.Path));
+        // The routing decision never touches the worktree, so a path under the injected home is enough.
+        var routed     = factory.UsesAppServer(Ctx(isReviewFlow: false, Home.PathTo("interactive-routing")));
         var advertised = CodexTransportDecision.InteractiveTransport(config) == CodexTransportDecision.AppServer;
 
         await Assert.That(routed).IsEqualTo(advertised);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTransportDecisionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTransportDecisionTests.cs
@@ -81,4 +81,16 @@ public class CodexTransportDecisionTests {
         await Assert.That(transportOnly.CodexTransport).IsEqualTo("app-server");
         await Assert.That(transportOnly.CodexAppServerInteractive).IsFalse();
     }
+
+    /// <summary>The one function both the launch router and the advertisement read: app-server only when
+    /// the transport resolved active AND this daemon opted interactive in.</summary>
+    [Test]
+    [Arguments(false, false, "pty")]
+    [Arguments(true,  false, "pty")]
+    [Arguments(false, true,  "pty")]
+    [Arguments(true,  true,  "app-server")]
+    public async Task InteractiveTransport_is_app_server_only_when_active_and_opted_in(bool active, bool optIn, string expected) {
+        var config = new DaemonConfig { CodexAppServerActive = active, CodexAppServerInteractive = optIn };
+        await Assert.That(CodexTransportDecision.InteractiveTransport(config)).IsEqualTo(expected);
+    }
 }


### PR DESCRIPTION
No GitHub issue — AI-2643

## What & why

The server records an interactive launch's expected runtime transport before dispatch and refuses a registration that claims anything else. It has always recorded `pty`, because nothing told it otherwise — so a daemon that opts its interactive Codex launches into app-server (`KCAP_CODEX_APPSERVER_INTERACTIVE`) is stopped at registration ~200 ms after spawn, on every launch. The codex capability now advertises `interactive_transport` so the server can expect what this daemon will actually do. Server half: kcap-server AI-2643.

## Where to look

`CodexTransportDecision.InteractiveTransport` is the one function both the launch router and the advertisement read. If those two ever disagreed, every interactive launch on that daemon would be refused — the test `Interactive_routing_and_the_advertised_interactive_transport_are_one_fact` exists to make that impossible to ship.

## Verification

- `CodexTransportDecisionTests`, `CodexHostedAgentRuntimeFactoryTests`, `DaemonRunnerInteractiveTransportAdvertisementTests`: 71 tests, 0 failed.
- Mutant "advertise pty unconditionally" → `Codex_advertises_the_interactive_transport_the_router_uses(True, True)` fails. Mutant "drop the Active guard from the decision" → the one-fact test fails on `(active=false, optIn=true)`. Both reverted, green.
- Live reproduction of the refusal (kcap 0.11.40, daemon `codex-appserver-test`, kurrent.kcap.ai): agents `e0b2d24e` and `b7da2ac2` each spawned, then `Stopping agent` 140–220 ms later before the ACP bind.
