### PR TITLE
Show chat and composer for hosted sessions without a PTY

### DIFF
--- a/docs/superpowers/plans/2026-09-09-ai2197-non-pty-chat-and-composer.md
+++ b/docs/superpowers/plans/2026-09-09-ai2197-non-pty-chat-and-composer.md
@@ -1,0 +1,3965 @@
+# Non-PTY Chat and Composer (Slice A) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Every non-PTY hosted session (Cursor, Copilot, Gemini, Kiro, OpenCode, Antigravity, Pi, Codex app-server) gets a Chat tab that renders its transcript and a composer that sends follow-ups, in the desktop app, with parity to the PTY path wherever the transport allows.
+
+**Architecture:** The daemon appends every accepted `AcpEventEnvelope` to a per-agent JSONL journal under its state directory and reports the path as `transcript_path` plus a new `transcript_format`; the app tails it with the existing `JsonlTail` through a new passthrough projection. Input rides one new one-shot local frame (`SendText`/`SendTextAck`) routed into the same delivery core the server-origin `SendInput` uses. The app's composer gains an abstraction (`ChatInput`) with a terminal implementation for PTY and a frame implementation for everything else.
+
+**Tech Stack:** .NET 10 (NativeAOT), System.Threading.Channels, System.Text.Json source generation, Avalonia + ReactiveUI + DynamicData, TUnit, `Microsoft.Extensions.Time.Testing.FakeTimeProvider`.
+
+**Spec:** `docs/superpowers/specs/2026-09-09-ai2197-non-pty-chat-and-composer-design.md` (read it first; every task below cites the section it implements).
+
+## Global Constraints
+
+- Build, test and publish with `~/.dotnet/dotnet` (.NET 10); the `dotnet` on PATH is 8.0. Run one suite with `~/.dotnet/dotnet run --project test/<Suite>/<Suite>.csproj -- --treenode-filter '/*/*/<Class>/*'`.
+- `FrameType` is append-only: `SendText = 22`, `SendTextAck = 80`. Never renumber anything.
+- `LocalControlCapabilities.Current` gains `"input/1"` in the SAME commit as the `LocalControlServer` `case FrameType.SendText`.
+- `AgentStatusDto` gains exactly one trailing member `string? TranscriptFormat = null` (`transcript_format`), always emitted; values `"vendor"` / `"envelopes"`.
+- Journal path: `<DaemonStore.StateDirectory(config.Name)>/transcripts/<lowercase sha256 hex of agent id>.jsonl`. Journal channel: `BoundedChannelOptions(4096) { FullMode = Wait, SingleReader = true, SingleWriter = false }`. `Complete` grace 2 s. Path-lock bound 2 s. Retention 30 days, sweep every 24 h.
+- Frame limits: `text` over 256 KiB of UTF-8 → `too_large`. Reason tokens exactly as the spec table: `malformed`, `text_empty`, `too_large`, `no_such_agent`, `protected_kind`, `not_running`, `reaper_claimed`, `reaper_claimed_late`, `queue_full`, `stop_failed`, `delivery_failed`; client-side `transport`.
+- App wording (verbatim): "Update the daemon to view this session", "Update the app to view this session", "Update the daemon to send messages from the app", "delivery unconfirmed — check the chat before sending again", "agent is no longer running", "read-only participant", "the agent's input queue is full, try again shortly".
+- No Linear ids in C# or comments (`bash scripts/check-linear-ids.sh` before every commit). Commit subjects: `one clause (#839)`, ≤80 chars including the reference; `#839` is the GitHub mirror of AI-2625 and is the only reference to use.
+- Comments: scarce, no history, no spec coordinates (CLAUDE.md "Comments"). One type per file, named after the type.
+- Never read an agent-owned file with a write-denying open: journal writes use `FileShare.ReadWrite | FileShare.Delete`; tests that read a journal use `FileStream` with `FileShare.ReadWrite | FileShare.Delete`.
+- Worktree git: `/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 <args>`, one command per invocation, no heredocs. Every commit ends with `Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>`.
+- After daemon or Core changes: `~/.dotnet/dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'` must print nothing.
+
+## File structure
+
+Core (`src/Capacitor.Cli.Core/`), shared by daemon and app:
+
+| File | Responsibility |
+|---|---|
+| `PlatformPaths.cs` (moved from `App/ViewModels/TrayModels.cs`) | one platform path comparison rule |
+| `SessionIds.cs` | `Canonical(string?)`: GUID → `N` form, else trimmed unchanged |
+| `LocalIpc/FrameType.cs`, `LocalFrame.cs`, `FrameCodec.cs` | `SendText`/`SendTextAck` frames |
+| `LocalIpc/InputIpc.cs` | `SendTextDto`, `SendTextAckDto`, `SendTextReasons`, `InputIpcJsonContext`, `InputWire` |
+| `LocalIpc/StatusIpc.cs` | `AgentStatusDto.TranscriptFormat`, `TranscriptFormats` |
+| `LocalIpc/LocalControlOps.cs` | `ILocalControlOps.SendTextAsync`, `SendTextResult` |
+| `EnvelopeJournalFormat.cs` | the JSONL line encoding both sides use |
+| `IChatTranscriptProjection.cs` | the reader interface the chat tab consumes |
+| `EnvelopeJournalProjection.cs` | passthrough projection over journal lines |
+| `TranscriptChat.cs` | `TranscriptChatProjection : IChatTranscriptProjection`, `TranscriptChat.Journal` |
+| `WorkItems/WorkContextIds.cs` | delegates to `SessionIds.Canonical` |
+
+Daemon (`src/Capacitor.Cli.Daemon/Services/` unless noted):
+
+| File | Responsibility |
+|---|---|
+| `AgentFileNames.cs` | `For(agentId)`: the shared hashed file name |
+| `JournalPathLocks.cs` | ref-counted per-path `SemaphoreSlim` leases |
+| `JournalItem.cs` | `(AcpEventEnvelope Envelope, int GapBefore)` |
+| `TranscriptJournal.cs` | bounded queue + writer task + `Open`/`Record`/`CompleteAsync` |
+| `TranscriptJournalSweep.cs` | `BackgroundService`: 30-day reap, startup + every 24 h |
+| `InputNotAdmittedException.cs` | typed refusal from a runtime that will not queue or write |
+| `InputDelivery.cs` | the delivery core's outcome (`InputDeliveryOutcome`) |
+| `AgentOrchestrator.cs` | journal construction, snapshot fields, PTY gating, `DeliverInputAsync`, `SendInputDropReason.QueueFull` |
+| `AgentOrchestrator.LocalIpc.cs` | `HandleLocalSendTextAsync`, `transcript_format` in the snapshot |
+| `LocalControlServer.cs`, `LocalControlCapabilities.cs` | `SendText` routing + `input/1` |
+| `IHostedAgentRuntimeFactory.cs` | `RuntimeStartContext.Journal` |
+| `AcpHostedAgentRuntime.cs`, `AcpHostedAgentRuntimeFactory.cs` | journal at `EmitEnvelope`; `InputNotAdmittedException` |
+| `Harness/Pi/PiRpcHostedAgentRuntime.cs`, `…Factory.cs` | journal at `Write` under a write lock |
+| `Harness/Antigravity/AntigravityHostedAgentRuntime.cs`, `…Factory.cs` | `TimeProvider`, worker `user_message`, journal at `Write`, `InputNotAdmittedException` |
+| `Harness/Codex/CodexForwardBuffer.cs`, `CodexAppServerHostedAgentRuntime.cs`, `CodexHostedAgentRuntimeFactory.cs`, `CodexTurnInputDispatcher.cs` | journal at `Emit`; `WriteCanonicalBlocking → bool`; refuse after `FaultAll` |
+| `DaemonRunner.cs` | registers the sweep, runs it once after the orphan reap |
+
+App (`src/Capacitor.App/`):
+
+| File | Responsibility |
+|---|---|
+| `ViewModels/AgentPresence.cs` | `internal sealed record AgentPresence(AgentStatusDto? Dto, bool SessionEnded)` |
+| `ViewModels/ChatInput.cs` | abstract composer channel |
+| `ViewModels/TerminalChatInput.cs` | PTY channel over `TerminalTabViewModel` |
+| `ViewModels/LocalFrameChatInput.cs` | `SendText` channel over `ILocalControlOps` |
+| `ViewModels/ChatTranscriptSource.cs` | resolves `(projection, unavailable note)` from a dto |
+| `ViewModels/ChatTabViewModel.cs` | takes `IChatTranscriptProjection?` + `ChatInput`; clear-on-ack |
+| `ViewModels/WorkspaceViewModel.cs` | Chat for every session; channel by `has_terminal` |
+| `Views/WorkspaceView.axaml` | Chat gates removed; tab-strip note removed |
+| `Services/TerminalAttach.cs` | `SendAvailability.Unsupported` |
+| `App.axaml.cs` | passes `ops` into `BuildWorkspace` |
+
+Tests mirror these paths under `test/Capacitor.Cli.Core.Tests.Unit/`, `test/Capacitor.Cli.Daemon.Tests.Unit/`, `test/Capacitor.App.Tests.Unit/` (the App test project is flat: no `ViewModels/` subfolder).
+
+---
+
+## Part A — Core
+
+### Task 1: Move `PlatformPaths` to Core
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/PlatformPaths.cs`
+- Modify: `src/Capacitor.App/ViewModels/TrayModels.cs` (delete the `PlatformPaths` class, lines 27–62)
+- Modify (usings only, if the namespace is not already imported): `src/Capacitor.App/ViewModels/SessionRailViewModel.cs`, `RailWorktreeViewModel.cs`, `HomeViewModel.cs`, `src/Capacitor.App/Services/AgentDirectory.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/PlatformPathsTests.cs`
+
+**Interfaces:**
+- Produces: `Capacitor.Cli.Core.PlatformPaths` with `static readonly StringComparer Comparer`, `static string Normalize(string)`, `static string Leaf(string)` — identical bodies to today's app class.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class PlatformPathsTests {
+    [Test]
+    public async Task Trailing_separator_is_ignored_by_the_comparer() {
+        await Assert.That(PlatformPaths.Comparer.Equals("/a/b", "/a/b/")).IsTrue();
+        await Assert.That(PlatformPaths.Comparer.GetHashCode("/a/b")).IsEqualTo(PlatformPaths.Comparer.GetHashCode("/a/b/"));
+    }
+
+    [Test]
+    public async Task Leaf_is_the_last_segment_after_normalization() {
+        await Assert.That(PlatformPaths.Leaf("/a/b/")).IsEqualTo("b");
+        await Assert.That(PlatformPaths.Normalize("/a/b/")).IsEqualTo("/a/b");
+    }
+
+    [Test]
+    public async Task Case_rule_follows_the_platform() {
+        var equal = PlatformPaths.Comparer.Equals("/A", "/a");
+        await Assert.That(equal).IsEqualTo(!OperatingSystem.IsLinux());
+    }
+}
+```
+
+- [ ] **Step 2: Run it to verify it fails**
+
+Run: `~/.dotnet/dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter '/*/*/PlatformPathsTests/*'`
+Expected: build error `The name 'PlatformPaths' does not exist`.
+
+- [ ] **Step 3: Create the Core file and delete the app copy**
+
+`src/Capacitor.Cli.Core/PlatformPaths.cs`:
+
+```csharp
+namespace Capacitor.Cli.Core;
+
+/// One platform path rule for every surface: case-insensitive on Windows and macOS, case-sensitive
+/// on Linux, and a trailing directory separator never distinguishes two paths.
+public static class PlatformPaths {
+    public static readonly StringComparer Comparer = new TrailingSeparatorComparer(
+        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+
+    public static string Normalize(string path) =>
+        string.IsNullOrEmpty(path) ? path : Path.TrimEndingDirectorySeparator(path);
+
+    public static string Leaf(string path) => Path.GetFileName(Normalize(path));
+
+    sealed class TrailingSeparatorComparer(StringComparer inner) : StringComparer {
+        public override int Compare(string? x, string? y) {
+            if (ReferenceEquals(x, y)) return 0;
+            if (x is null) return -1;
+            if (y is null) return 1;
+            return inner.Compare(Normalize(x), Normalize(y));
+        }
+
+        public override bool Equals(string? x, string? y) {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+            return inner.Equals(Normalize(x), Normalize(y));
+        }
+
+        public override int GetHashCode(string obj) => inner.GetHashCode(Normalize(obj));
+    }
+}
+```
+
+Delete the `PlatformPaths` class from `TrayModels.cs` (keep `RepoLabel` and `CheckoutLabel`). The five app files already compile against the name; add `using Capacitor.Cli.Core;` to any that lack it (`TrayModels.cs`, `SessionRailViewModel.cs`, `RailWorktreeViewModel.cs`, `HomeViewModel.cs`, `AgentDirectory.cs`).
+
+- [ ] **Step 4: Build both projects and run the tests**
+
+Run: `~/.dotnet/dotnet build src/Capacitor.App/Capacitor.App.csproj` then the Step 2 command.
+Expected: build clean; 3 tests PASS. Also run `--treenode-filter '/*/*/RepoLabelTests/*'` and `'/*/*/SessionRailViewModelTests/*'` in the App suite: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add -A src/Capacitor.Cli.Core/PlatformPaths.cs src/Capacitor.App test/Capacitor.Cli.Core.Tests.Unit/PlatformPathsTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Move PlatformPaths into Core (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 2: `SessionIds.Canonical` and `WorkContextIds` delegation
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/SessionIds.cs`
+- Modify: `src/Capacitor.Cli.Core/WorkItems/WorkContextIds.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/SessionIdsTests.cs`, `test/Capacitor.Cli.Core.Tests.Unit/WorkItems/WorkContextIdsTests.cs` (create if absent)
+
+**Interfaces:**
+- Produces: `public static class SessionIds { public static string? Canonical(string? id); }` — null/whitespace → null; parses as GUID → `g.ToString("N")`; otherwise `id.Trim()`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`SessionIdsTests.cs`:
+
+```csharp
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class SessionIdsTests {
+    [Test]
+    public async Task Dashed_guid_becomes_its_n_form() =>
+        await Assert.That(SessionIds.Canonical("8BC7255F-2453-4EFD-A733-0AF4B6AE9F20")).IsEqualTo("8bc7255f24534efda7330af4b6ae9f20");
+
+    [Test]
+    public async Task Opaque_id_is_returned_trimmed_and_unchanged() =>
+        await Assert.That(SessionIds.Canonical("  sess-1 ")).IsEqualTo("sess-1");
+
+    [Test]
+    public async Task Null_and_blank_are_null() {
+        await Assert.That(SessionIds.Canonical(null)).IsNull();
+        await Assert.That(SessionIds.Canonical("   ")).IsNull();
+    }
+}
+```
+
+`WorkItems/WorkContextIdsTests.cs`:
+
+```csharp
+namespace Capacitor.Cli.Core.Tests.Unit.WorkItems;
+
+public class WorkContextIdsTests {
+    [Test]
+    public async Task Guid_session_id_reaches_the_route_in_n_form() =>
+        await Assert.That(WorkContextIds.CanonicalSessionId("8bc7255f-2453-4efd-a733-0af4b6ae9f20")).IsEqualTo("8bc7255f24534efda7330af4b6ae9f20");
+
+    [Test]
+    public async Task Opaque_dashed_id_reaches_the_route_unchanged() =>
+        await Assert.That(WorkContextIds.CanonicalSessionId("sess-1")).IsEqualTo("sess-1");
+
+    [Test]
+    public async Task Dot_segments_and_blanks_are_still_rejected() {
+        await Assert.That(WorkContextIds.CanonicalSessionId(".")).IsNull();
+        await Assert.That(WorkContextIds.CanonicalSessionId("..")).IsNull();
+        await Assert.That(WorkContextIds.CanonicalSessionId(" ")).IsNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `~/.dotnet/dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter '/*/*/SessionIdsTests/*'`
+Expected: build error on `SessionIds`.
+
+- [ ] **Step 3: Implement**
+
+`src/Capacitor.Cli.Core/SessionIds.cs`:
+
+```csharp
+namespace Capacitor.Cli.Core;
+
+/// The session id the server files a session under: a GUID in any spelling collapses to its 32-hex
+/// form, and an opaque vendor id (an ACP `sess-1`) is kept as written — stripping its dashes would
+/// name a session the server has never seen.
+public static class SessionIds {
+    public static string? Canonical(string? id) {
+        if (string.IsNullOrWhiteSpace(id)) return null;
+        var trimmed = id.Trim();
+        return Guid.TryParse(trimmed, out var g) ? g.ToString("N") : trimmed;
+    }
+}
+```
+
+`WorkContextIds.cs`: replace the `CanonicalSessionId` body:
+
+```csharp
+    public static string? CanonicalSessionId(string? raw) => Validate(SessionIds.Canonical(raw));
+```
+
+- [ ] **Step 4: Run tests**
+
+Run the Step 2 command plus `--treenode-filter '/*/*/WorkContextIdsTests/*'` and `'/*/*/WorkContextClientTests/*'`.
+Expected: all PASS (the client test `Assignments_route_strips_dashes_and_parses_the_rows` uses a GUID, which still lands dashless).
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Core/SessionIds.cs src/Capacitor.Cli.Core/WorkItems/WorkContextIds.cs test/Capacitor.Cli.Core.Tests.Unit/SessionIdsTests.cs test/Capacitor.Cli.Core.Tests.Unit/WorkItems/WorkContextIdsTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Canonicalize session ids as the server does (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 3: `transcript_format` on `AgentStatusDto`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs`
+
+**Interfaces:**
+- Produces: `AgentStatusDto(..., bool? AwaitingInput = null, string? TranscriptFormat = null)`; `public static class TranscriptFormats { public const string Vendor = "vendor"; public const string Envelopes = "envelopes"; }`.
+
+- [ ] **Step 1: Update the pinned JSON and add tests**
+
+In `StatusIpcJsonTests.cs`, every pinned string that ends `"awaiting_input":null}` gains `,"transcript_format":null` before the closing brace (lines 32 ×2 agents, 110, 111, 142, 143). Add:
+
+```csharp
+    [Test]
+    public async Task Transcript_format_is_the_trailing_member_and_always_emitted() {
+        var vendor    = new AgentStatusDto("a", "agent", "claude", null, "Running", null, null, null, DateTime.UnixEpoch, null, null, TranscriptFormat: TranscriptFormats.Vendor);
+        var envelopes = vendor with { TranscriptFormat = TranscriptFormats.Envelopes };
+        var unset     = vendor with { TranscriptFormat = null };
+
+        await Assert.That(JsonSerializer.Serialize(vendor, StatusIpcJsonContext.Default.AgentStatusDto)).EndsWith(""","awaiting_input":null,"transcript_format":"vendor"}""");
+        await Assert.That(JsonSerializer.Serialize(envelopes, StatusIpcJsonContext.Default.AgentStatusDto)).EndsWith(""","transcript_format":"envelopes"}""");
+        await Assert.That(JsonSerializer.Serialize(unset, StatusIpcJsonContext.Default.AgentStatusDto)).EndsWith(""","transcript_format":null}""");
+    }
+
+    [Test]
+    public async Task Old_agent_json_without_transcript_format_deserializes_to_null() {
+        var json = """{"id":"a","kind":"agent","vendor":"codex","repo_path":null,"status":"Live","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T00:00:00Z","model":null,"requester_display":null,"awaiting_input":true}""";
+        var dto = JsonSerializer.Deserialize(json, StatusIpcJsonContext.Default.AgentStatusDto)!;
+        await Assert.That(dto.TranscriptFormat).IsNull();
+        await Assert.That(dto.AwaitingInput).IsEqualTo(true);
+    }
+```
+
+If `StatusIpcJsonContext` has no `AgentStatusDto` type-info accessor, add `[JsonSerializable(typeof(AgentStatusDto))]` to the context (the nested type is already generated; the attribute only exposes the accessor).
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `~/.dotnet/dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter '/*/*/StatusIpcJsonTests/*'`
+Expected: build error (`TranscriptFormat`).
+
+- [ ] **Step 3: Implement**
+
+In `StatusIpc.cs`, after `bool? AwaitingInput = null` add:
+
+```csharp
+    // Which reader a client uses for TranscriptPath: TranscriptFormats.Vendor for a PTY runtime's own
+    // file, TranscriptFormats.Envelopes for the daemon-written envelope journal. Always emitted by a
+    // current daemon, so null means an older daemon and nothing else.
+    string? TranscriptFormat = null);
+```
+
+and beside `WorkLocationText`:
+
+```csharp
+/// Wire tokens for <see cref="AgentStatusDto.TranscriptFormat"/>, compared literally by every client.
+public static class TranscriptFormats {
+    public const string Vendor    = "vendor";
+    public const string Envelopes = "envelopes";
+}
+```
+
+- [ ] **Step 4: Run tests**
+
+Run the Step 2 command. Expected: PASS. Also build the daemon and app: `~/.dotnet/dotnet build src/Capacitor.Cli.Daemon/Capacitor.Cli.Daemon.csproj && ~/.dotnet/dotnet build src/Capacitor.App/Capacitor.App.csproj` — PASS (trailing optional member).
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Report transcript_format on the agent status row (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 4: `EnvelopeJournalFormat`
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/EnvelopeJournalFormat.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/EnvelopeJournalFormatTests.cs`
+
+**Interfaces:**
+- Produces: `public static class EnvelopeJournalFormat { public static string Write(AcpEventEnvelope e); public static bool TryRead(string line, out AcpEventEnvelope envelope); public const int SupportedContractVersion = 1; }` — `Write` uses `CapacitorJsonContext.Default.AcpEventEnvelope` (snake_case, the server's bytes). `TryRead` validates structurally: JSON object, non-null non-empty `kind`, `contract_version` equal to 1 (absent counts as 1, the record's default).
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class EnvelopeJournalFormatTests {
+    [Test]
+    public async Task Round_trip_pins_the_bytes() {
+        var e = new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: "hi", TimestampIso: "2026-09-09T10:00:00.000Z");
+        var line = EnvelopeJournalFormat.Write(e);
+        await Assert.That(line).StartsWith("""{"contract_version":1,"seq":0,"kind":"user_message","text":"hi",""");
+        await Assert.That(line).Contains("\"timestamp_iso\":\"2026-09-09T10:00:00.000Z\"");
+        await Assert.That(line).DoesNotContain("\n");
+        await Assert.That(EnvelopeJournalFormat.TryRead(line, out var back)).IsTrue();
+        await Assert.That(back).IsEqualTo(e);
+    }
+
+    [Test]
+    [Arguments("not json")]
+    [Arguments("{}")]
+    [Arguments("42")]
+    [Arguments("[]")]
+    [Arguments("""{"contract_version":1,"kind":null}""")]
+    [Arguments("""{"contract_version":1,"kind":""}""")]
+    [Arguments("""{"contract_version":2,"kind":"user_message","text":"x"}""")]
+    public async Task Structurally_invalid_lines_are_rejected(string line) =>
+        await Assert.That(EnvelopeJournalFormat.TryRead(line, out _)).IsFalse();
+
+    [Test]
+    public async Task Unknown_kind_on_a_v1_line_is_accepted() {
+        await Assert.That(EnvelopeJournalFormat.TryRead("""{"contract_version":1,"kind":"future_kind"}""", out var e)).IsTrue();
+        await Assert.That(e.Kind).IsEqualTo("future_kind");
+    }
+
+    [Test]
+    public async Task Missing_contract_version_reads_as_v1() =>
+        await Assert.That(EnvelopeJournalFormat.TryRead("""{"kind":"assistant_text","text":"a"}""", out _)).IsTrue();
+}
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `~/.dotnet/dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj -- --treenode-filter '/*/*/EnvelopeJournalFormatTests/*'`
+Expected: build error.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core;
+
+/// One envelope per JSONL line, the same bytes the server receives. Validity is decided here, not by
+/// the deserializer: a record struct decodes from `{}` or a null `kind` without complaint, and a
+/// later contract version may reuse a known kind with different fields.
+public static class EnvelopeJournalFormat {
+    public const int SupportedContractVersion = 1;
+
+    public static string Write(AcpEventEnvelope envelope) =>
+        JsonSerializer.Serialize(envelope, CapacitorJsonContext.Default.AcpEventEnvelope);
+
+    public static bool TryRead(string line, out AcpEventEnvelope envelope) {
+        envelope = default;
+        try {
+            using var doc = JsonDocument.Parse(line);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return false;
+            if (!root.TryGetProperty("kind", out var kind) || kind.ValueKind != JsonValueKind.String || string.IsNullOrEmpty(kind.GetString())) return false;
+            if (root.TryGetProperty("contract_version", out var version)
+             && (version.ValueKind != JsonValueKind.Number || !version.TryGetInt32(out var v) || v != SupportedContractVersion)) return false;
+            envelope = JsonSerializer.Deserialize(line, CapacitorJsonContext.Default.AcpEventEnvelope);
+            return true;
+        } catch (JsonException) {
+            return false;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests** — Step 2 command. Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Core/EnvelopeJournalFormat.cs test/Capacitor.Cli.Core.Tests.Unit/EnvelopeJournalFormatTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Add the envelope journal line format (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 5: `IChatTranscriptProjection`, `EnvelopeJournalProjection`, `TranscriptChat.Journal`
+
+**Files:**
+- Create: `src/Capacitor.Cli.Core/IChatTranscriptProjection.cs`, `src/Capacitor.Cli.Core/EnvelopeJournalProjection.cs`
+- Modify: `src/Capacitor.Cli.Core/TranscriptChat.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/EnvelopeJournalProjectionTests.cs`
+
+**Interfaces:**
+- Produces:
+
+```csharp
+public interface IChatTranscriptProjection {
+    TranscriptContext CreateContext(string sessionId, string? agentId);
+    IReadOnlyList<AcpEventEnvelope> Project(string line, int lineNumber, DateTimeOffset receivedAt, TranscriptContext context);
+}
+public sealed class EnvelopeJournalProjection : IChatTranscriptProjection { … }   // Project throws FormatException on an invalid line
+public static class TranscriptChat { public static readonly IChatTranscriptProjection Journal; public static TranscriptChatProjection? For(string vendor); }
+```
+
+`TranscriptChatProjection` implements the interface with its existing two members unchanged.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Models.Transcripts;
+
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class EnvelopeJournalProjectionTests {
+    static readonly IChatTranscriptProjection Sut = TranscriptChat.Journal;
+
+    [Test]
+    [Arguments(AcpEventKind.UserMessage)]
+    [Arguments(AcpEventKind.AssistantText)]
+    [Arguments(AcpEventKind.SystemNote)]
+    [Arguments(AcpEventKind.ToolCall)]
+    [Arguments(AcpEventKind.Usage)]
+    [Arguments("future_kind")]
+    public async Task Every_kind_passes_through_as_one_envelope(string kind) {
+        var line = EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: kind, Text: "t", ToolCallId: "c1"));
+        var context = Sut.CreateContext("s", "a1");
+        var result = Sut.Project(line, 1, DateTimeOffset.UnixEpoch, context);
+        await Assert.That(result).Count().IsEqualTo(1);
+        await Assert.That(result[0].Kind).IsEqualTo(kind);
+    }
+
+    [Test]
+    public async Task Malformed_line_throws_so_the_tab_logs_it_once() {
+        var context = Sut.CreateContext("s", null);
+        await Assert.That(() => Sut.Project("{}", 1, DateTimeOffset.UnixEpoch, context)).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task Context_is_stateless_and_reusable() {
+        var context = Sut.CreateContext("s", null);
+        context.BeginBatch();
+        var line = EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "x"));
+        await Assert.That(Sut.Project(line, 1, DateTimeOffset.UnixEpoch, context)).Count().IsEqualTo(1);
+        await Assert.That(Sut.Project(line, 2, DateTimeOffset.UnixEpoch, context)).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Vendor_registry_is_unchanged() {
+        await Assert.That(TranscriptChat.For("claude")).IsNotNull();
+        await Assert.That(TranscriptChat.For("gemini")).IsNull();
+        IChatTranscriptProjection asInterface = TranscriptChat.For("codex")!;
+        await Assert.That(asInterface).IsNotNull();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — filter `EnvelopeJournalProjectionTests`; expected: build error.
+
+- [ ] **Step 3: Implement**
+
+`IChatTranscriptProjection.cs`:
+
+```csharp
+using Capacitor.Models.Transcripts;
+
+namespace Capacitor.Cli.Core;
+
+/// What the chat tab needs from any transcript reader: a per-file context and a line-to-envelopes step.
+public interface IChatTranscriptProjection {
+    TranscriptContext CreateContext(string sessionId, string? agentId);
+    IReadOnlyList<AcpEventEnvelope> Project(string line, int lineNumber, DateTimeOffset receivedAt, TranscriptContext context);
+}
+```
+
+`EnvelopeJournalProjection.cs`:
+
+```csharp
+using Capacitor.Models.Transcripts;
+
+namespace Capacitor.Cli.Core;
+
+/// Journal lines are already envelopes: no vendor rules, no dedupe, one envelope per valid line.
+public sealed class EnvelopeJournalProjection : IChatTranscriptProjection {
+    sealed class StatelessContext : TranscriptContext;
+
+    public TranscriptContext CreateContext(string sessionId, string? agentId) => new StatelessContext();
+
+    public IReadOnlyList<AcpEventEnvelope> Project(string line, int lineNumber, DateTimeOffset receivedAt, TranscriptContext context) =>
+        EnvelopeJournalFormat.TryRead(line, out var envelope)
+            ? [envelope]
+            : throw new FormatException($"line {lineNumber} is not a v{EnvelopeJournalFormat.SupportedContractVersion} envelope");
+}
+```
+
+`TranscriptChat.cs`: `public sealed class TranscriptChatProjection(...) : IChatTranscriptProjection` (bodies unchanged), and in `TranscriptChat` add `public static readonly IChatTranscriptProjection Journal = new EnvelopeJournalProjection();`. If `TranscriptContext` is not already reachable from Core, add `using Capacitor.Models.Transcripts;` (Core already references the transcripts project through `TranscriptProjection`).
+
+- [ ] **Step 4: Run tests** — filter `EnvelopeJournalProjectionTests`; expected PASS. Build the app project to confirm `ChatTabViewModel` still compiles against `TranscriptChatProjection`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Core/IChatTranscriptProjection.cs src/Capacitor.Cli.Core/EnvelopeJournalProjection.cs src/Capacitor.Cli.Core/TranscriptChat.cs test/Capacitor.Cli.Core.Tests.Unit/EnvelopeJournalProjectionTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Read envelope journals through a chat projection (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 6: `SendText` / `SendTextAck` frames and DTOs
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/FrameType.cs`, `LocalFrame.cs`, `FrameCodec.cs`
+- Create: `src/Capacitor.Cli.Core/LocalIpc/InputIpc.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/FrameCodecInputTests.cs`, `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/InputWireContractsTests.cs`
+
+**Interfaces:**
+- Produces:
+
+```csharp
+public enum FrameType : byte { …, SendText = 22, …, SendTextAck = 80 }
+public static LocalFrame LocalFrame.InputJson(FrameType type, string json);
+public sealed record SendTextDto(string AgentId, string Text);
+public sealed record SendTextAckDto(bool Ok, string? Reason, string? Error, string? Outcome = null);
+public static class SendTextReasons { Malformed="malformed", TextEmpty="text_empty", TooLarge="too_large", NoSuchAgent="no_such_agent", ProtectedKind="protected_kind", NotRunning="not_running", ReaperClaimed="reaper_claimed", ReaperClaimedLate="reaper_claimed_late", QueueFull="queue_full", StopFailed="stop_failed", DeliveryFailed="delivery_failed", Transport="transport" }
+public static class SendTextOutcomes { Delivered="delivered", Stopped="stopped" }
+public static class InputWire { public const int MaxTextBytes = 256 * 1024; public static bool IsStructurallyValid(SendTextDto? dto); }
+public partial class InputIpcJsonContext : JsonSerializerContext   // snake_case; SendTextDto + SendTextAckDto
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+`FrameCodecInputTests.cs`:
+
+```csharp
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Core.Tests.Unit.LocalIpc;
+
+public class FrameCodecInputTests {
+    static async Task<LocalFrame> RoundTrip(LocalFrame f) {
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, f, CancellationToken.None);
+        ms.Position = 0;
+        return (await FrameCodec.ReadAsync(ms, CancellationToken.None))!;
+    }
+
+    [Test]
+    [Arguments(FrameType.SendText)]
+    [Arguments(FrameType.SendTextAck)]
+    public async Task Input_frames_roundtrip_with_text_payload(FrameType type) {
+        var f = await RoundTrip(LocalFrame.InputJson(type, """{"k":"v"}"""));
+        await Assert.That(f.Type).IsEqualTo(type);
+        await Assert.That(f.Text).IsEqualTo("""{"k":"v"}""");
+    }
+
+    [Test]
+    public async Task Input_frame_values_are_stable_wire_bytes() {
+#pragma warning disable TUnitAssertions0005
+        await Assert.That((byte)FrameType.SendText).IsEqualTo((byte)22);
+        await Assert.That((byte)FrameType.SendTextAck).IsEqualTo((byte)80);
+#pragma warning restore TUnitAssertions0005
+    }
+}
+```
+
+`InputWireContractsTests.cs`:
+
+```csharp
+using System.Text.Json;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Core.Tests.Unit.LocalIpc;
+
+public class InputWireContractsTests {
+    [Test]
+    public async Task Send_text_serializes_snake_case() =>
+        await Assert.That(JsonSerializer.Serialize(new SendTextDto("a1", "hello"), InputIpcJsonContext.Default.SendTextDto))
+            .IsEqualTo("""{"agent_id":"a1","text":"hello"}""");
+
+    [Test]
+    public async Task Ack_serializes_every_member_with_outcome_last() {
+        await Assert.That(JsonSerializer.Serialize(new SendTextAckDto(true, null, null, SendTextOutcomes.Delivered), InputIpcJsonContext.Default.SendTextAckDto))
+            .IsEqualTo("""{"ok":true,"reason":null,"error":null,"outcome":"delivered"}""");
+        await Assert.That(JsonSerializer.Serialize(new SendTextAckDto(false, SendTextReasons.QueueFull, "full", null), InputIpcJsonContext.Default.SendTextAckDto))
+            .IsEqualTo("""{"ok":false,"reason":"queue_full","error":"full","outcome":null}""");
+    }
+
+    [Test]
+    public async Task Ack_without_outcome_deserializes_to_null_outcome() {
+        var ack = JsonSerializer.Deserialize("""{"ok":true,"reason":null,"error":null}""", InputIpcJsonContext.Default.SendTextAckDto)!;
+        await Assert.That(ack.Ok).IsTrue();
+        await Assert.That(ack.Outcome).IsNull();
+    }
+
+    [Test]
+    [Arguments("{}")]
+    [Arguments("""{"agent_id":"a1"}""")]
+    [Arguments("""{"agent_id":null,"text":"x"}""")]
+    [Arguments("""{"agent_id":"a1","text":null}""")]
+    public async Task Missing_or_null_members_are_structurally_invalid(string json) {
+        var dto = JsonSerializer.Deserialize(json, InputIpcJsonContext.Default.SendTextDto);
+        await Assert.That(InputWire.IsStructurallyValid(dto)).IsFalse();
+    }
+
+    [Test]
+    public async Task Empty_text_is_structurally_valid_so_the_handler_can_name_it() =>
+        await Assert.That(InputWire.IsStructurallyValid(new SendTextDto("a1", ""))).IsTrue();
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — filters `FrameCodecInputTests` and `InputWireContractsTests`; expected: build errors.
+
+- [ ] **Step 3: Implement**
+
+`FrameType.cs`: after `PermissionResolve = 21,` add
+
+```csharp
+    // Composer input for a hosted agent — one-shot; the ack lands when the daemon's delivery settles.
+    SendText = 22, // Text = SendTextDto JSON
+```
+
+after `PermissionAck = 79,` add
+
+```csharp
+    SendTextAck = 80, // Text = SendTextAckDto JSON, reply to SendText
+```
+
+`LocalFrame.cs`: add
+
+```csharp
+    /// Constructs a SendText or SendTextAck frame, whose payload is UTF-8 JSON (snake_case via
+    /// InputIpcJsonContext) carried in Text — see InputIpc.cs.
+    public static LocalFrame InputJson(FrameType type, string json) => new(type) { Text = json };
+```
+
+`FrameCodec.cs`: in both `Encode` and `Decode`, extend the text-payload arm: after `or FrameType.PermissionPending or FrameType.PermissionResolved or FrameType.PermissionAck` insert `or FrameType.SendText or FrameType.SendTextAck` (before the `=>`).
+
+`InputIpc.cs`:
+
+```csharp
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// JSON payloads for the composer input frames. snake_case on the wire; every member always emitted.
+public sealed record SendTextDto(string AgentId, string Text);
+
+/// Reason is one of SendTextReasons when Ok is false; Outcome is one of SendTextOutcomes when Ok is true.
+public sealed record SendTextAckDto(bool Ok, string? Reason, string? Error, string? Outcome = null);
+
+public static class SendTextReasons {
+    public const string Malformed         = "malformed";
+    public const string TextEmpty         = "text_empty";
+    public const string TooLarge          = "too_large";
+    public const string NoSuchAgent       = "no_such_agent";
+    public const string ProtectedKind     = "protected_kind";
+    public const string NotRunning        = "not_running";
+    public const string ReaperClaimed     = "reaper_claimed";
+    public const string ReaperClaimedLate = "reaper_claimed_late";
+    public const string QueueFull         = "queue_full";
+    public const string StopFailed        = "stop_failed";
+    public const string DeliveryFailed    = "delivery_failed";
+    /// Client-side only: the request or the reply never crossed the socket.
+    public const string Transport         = "transport";
+}
+
+public static class SendTextOutcomes {
+    public const string Delivered = "delivered";
+    public const string Stopped   = "stopped";
+}
+
+public static class InputWire {
+    /// One frame is one buffer, where PTY input streams under the PTY's own flow control.
+    public const int MaxTextBytes = 256 * 1024;
+
+    /// STJ source-gen leaves a missing member null and `{}` decodes fine; emptiness is the handler's call.
+    public static bool IsStructurallyValid(SendTextDto? dto) =>
+        dto is not null && dto.AgentId is not null && dto.Text is not null;
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(SendTextDto))]
+[JsonSerializable(typeof(SendTextAckDto))]
+public partial class InputIpcJsonContext : JsonSerializerContext;
+```
+
+- [ ] **Step 4: Run tests** — the two filters plus `FrameCodecTests` and `FrameCodecPermissionTests`; expected PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Core/LocalIpc/FrameType.cs src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs src/Capacitor.Cli.Core/LocalIpc/InputIpc.cs test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/FrameCodecInputTests.cs test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/InputWireContractsTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Add the SendText local frames and their payloads (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 7: `ILocalControlOps.SendTextAsync`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs`
+- Modify (add the member so they compile): `src/Capacitor.App/Services/Onboarding/WizardLateBinding.cs` (`LateBoundLocalControlOps` delegates: `bind().SendTextAsync(agentId, text, ct)`), `test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs`
+- Test: `test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/LocalControlOpsTests.cs`
+
+**Interfaces:**
+- Produces: `public sealed record SendTextResult(bool Ok, string? Reason, string? Error, string? Outcome);` and `Task<SendTextResult> SendTextAsync(string agentId, string text, CancellationToken ct)` on `ILocalControlOps`. No reply timeout: EOF, `InvalidDataException`, `IOException`, `SocketException` → `Ok=false, Reason="transport", Error=message, Outcome=null`; the caller's cancellation propagates as `OperationCanceledException`; an `Error` frame → `Ok=false, Reason="transport", Error=frame text`.
+- `ScriptedLocalControlOps` gains `ArmSendText()` / `QueueSendText(SendTextResult)` / `SendTextCalls` / `SendTextPayloads` in the existing arm-then-trigger style.
+
+- [ ] **Step 1: Write the failing tests** (append to `LocalControlOpsTests`, reusing `ScriptedOpsServer`, `Sock()` and the Windows guard the file already uses)
+
+```csharp
+    static ConnScript SendTextAckThen(string json, Action<string>? capture = null) => async (_, s, ct) => {
+        var f = await FrameCodec.ReadAsync(s, ct);
+        if (f?.Type == FrameType.SendText) {
+            capture?.Invoke(f.Text);
+            await FrameCodec.WriteAsync(s, LocalFrame.InputJson(FrameType.SendTextAck, json), ct);
+        }
+    };
+
+    [Test]
+    public async Task SendText_passes_all_four_ack_members_through() {
+        if (OperatingSystem.IsWindows()) return;
+        string? sent = null;
+        await WithOpsAsync([SendTextAckThen("""{"ok":true,"reason":null,"error":null,"outcome":"stopped"}""", j => sent = j)], async ops => {
+            var result = await ops.SendTextAsync("a1", "/quit", CancellationToken.None);
+            await Assert.That(result).IsEqualTo(new SendTextResult(true, null, null, "stopped"));
+            await Assert.That(sent).IsEqualTo("""{"agent_id":"a1","text":"/quit"}""");
+        });
+    }
+
+    [Test]
+    public async Task SendText_maps_eof_to_transport() {
+        if (OperatingSystem.IsWindows()) return;
+        await WithOpsAsync([Eof()], async ops => {
+            var result = await ops.SendTextAsync("a1", "hi", CancellationToken.None);
+            await Assert.That(result.Ok).IsFalse();
+            await Assert.That(result.Reason).IsEqualTo(SendTextReasons.Transport);
+            await Assert.That(result.Outcome).IsNull();
+        });
+    }
+
+    [Test]
+    public async Task SendText_waits_past_the_reply_timeout_for_a_late_ack() {
+        if (OperatingSystem.IsWindows()) return;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ConnScript late = async (_, s, ct) => {
+            await FrameCodec.ReadAsync(s, ct);
+            await release.Task;
+            await FrameCodec.WriteAsync(s, LocalFrame.InputJson(FrameType.SendTextAck, """{"ok":true,"reason":null,"error":null,"outcome":"delivered"}"""), ct);
+        };
+        await WithOpsAsync([late], async ops => {
+            var pending = ops.SendTextAsync("a1", "hi", CancellationToken.None);
+            await Task.Delay(300);
+            await Assert.That(pending.IsCompleted).IsFalse();
+            release.SetResult();
+            await Assert.That((await pending).Outcome).IsEqualTo("delivered");
+        }, configure: ops => { ops.ReplyTimeout = TimeSpan.FromMilliseconds(50); ops.StopReplyTimeout = TimeSpan.FromMilliseconds(50); });
+    }
+
+    [Test]
+    public async Task SendText_cancellation_closes_the_connection_and_propagates() {
+        if (OperatingSystem.IsWindows()) return;
+        var closed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ConnScript holdUntilEof = async (_, s, ct) => {
+            await FrameCodec.ReadAsync(s, ct);
+            var eof = await FrameCodec.ReadAsync(s, ct); // null once the client closes
+            if (eof is null) closed.SetResult();
+        };
+        using var cts = new CancellationTokenSource();
+        await WithOpsAsync([holdUntilEof], async ops => {
+            var pending = ops.SendTextAsync("a1", "hi", cts.Token);
+            await Task.Delay(100);
+            cts.Cancel();
+            await Assert.That(async () => await pending).Throws<OperationCanceledException>();
+            await closed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        });
+    }
+```
+
+(`WithOpsAsync`, `Eof()` and `ConnScript` already exist in the file; `SendTextAckThen` is the new building block above.)
+
+- [ ] **Step 2: Run to verify failure** — filter `LocalControlOpsTests`; expected: build error (`SendTextAsync`).
+
+- [ ] **Step 3: Implement**
+
+In `LocalControlOps.cs`, after `StopAgentResult`:
+
+```csharp
+/// The SendTextAck's four members verbatim; Reason is "transport" when the exchange itself failed.
+public sealed record SendTextResult(bool Ok, string? Reason, string? Error, string? Outcome);
+```
+
+Add to `ILocalControlOps`: `Task<SendTextResult> SendTextAsync(string agentId, string text, CancellationToken ct);`
+
+Implementation (the reply timeout is `Timeout.InfiniteTimeSpan`: the ack arrives when the delivery settles):
+
+```csharp
+    public async Task<SendTextResult> SendTextAsync(string agentId, string text, CancellationToken ct) {
+        var json = JsonSerializer.Serialize(new SendTextDto(agentId, text), InputIpcJsonContext.Default.SendTextDto);
+        LocalFrame reply;
+        try {
+            reply = await ExchangeAsync(LocalFrame.InputJson(FrameType.SendText, json), Timeout.InfiniteTimeSpan, ct);
+        } catch (LocalControlOpsException ex) {
+            return new SendTextResult(false, SendTextReasons.Transport, ex.Message, null);
+        }
+        switch (reply.Type) {
+            case FrameType.SendTextAck:
+                var ack = DeserializeOrThrow(reply.Text, InputIpcJsonContext.Default.SendTextAckDto, "malformed send text ack reply");
+                if (ack is null) return new SendTextResult(false, SendTextReasons.Transport, "malformed send text ack reply", null);
+                return new SendTextResult(ack.Ok, ack.Reason, ack.Error, ack.Outcome);
+            case FrameType.Error:
+                return new SendTextResult(false, SendTextReasons.Transport, reply.Text, null);
+            default:
+                return new SendTextResult(false, SendTextReasons.Transport, $"unexpected daemon response to send text ({reply.Type})", null);
+        }
+    }
+```
+
+`ExchangeAsync` must accept an infinite reply timeout: `new CancellationTokenSource(replyTimeout, _time)` already accepts `Timeout.InfiniteTimeSpan`; verify and leave it. `DeserializeOrThrow` throws `LocalControlOpsException` on bad JSON — wrap the `SendTextAck` case in `try { … } catch (LocalControlOpsException ex) { return new SendTextResult(false, SendTextReasons.Transport, ex.Message, null); }`.
+
+`LateBoundLocalControlOps`: `public Task<SendTextResult> SendTextAsync(string agentId, string text, CancellationToken ct) => bind().SendTextAsync(agentId, text, ct);`
+
+`ScriptedLocalControlOps` (App tests): add a `Queue<TaskCompletionSource<SendTextResult>> _sendTexts`, `public int SendTextCalls;`, `public readonly List<(string AgentId, string Text)> SendTextPayloads = [];`, `ArmSendText()`, `QueueSendText(SendTextResult r)`, and
+
+```csharp
+    public Task<SendTextResult> SendTextAsync(string agentId, string text, CancellationToken ct) {
+        SendTextCalls++;
+        SendTextPayloads.Add((agentId, text));
+        if (ct.IsCancellationRequested) return Task.FromCanceled<SendTextResult>(ct);
+        var tcs = _sendTexts.Count > 0 ? _sendTexts.Dequeue() : throw new InvalidOperationException("arm SendText first");
+        return tcs.Task.WaitAsync(ct);
+    }
+```
+
+- [ ] **Step 4: Run tests** — `LocalControlOpsTests` filter; build the App project and App tests (`~/.dotnet/dotnet build test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj`). Expected: PASS / clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs src/Capacitor.App/Services/Onboarding/WizardLateBinding.cs test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/LocalControlOpsTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Send composer text over the local control socket (#839)" -m "The ack lands only when the daemon's delivery settles, so this exchange has no reply timeout; the caller's token is the only bound." -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+## Part B — Daemon: the envelope journal
+
+### Task 8: `AgentFileNames.For`
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/AgentFileNames.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs` (delete its private `SafeName`, call `AgentFileNames.For`)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentFileNamesTests.cs`
+
+**Interfaces:**
+- Produces: `internal static class AgentFileNames { public static string For(string agentId); }` — lowercase SHA-256 hex of the UTF-8 agent id (`""` for null), 64 chars, no extension.
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class AgentFileNamesTests {
+    [Test]
+    [Arguments("../x")]
+    [Arguments("a/b")]
+    [Arguments("a\\b")]
+    [Arguments("/etc/passwd")]
+    [Arguments("agent-1")]
+    public async Task Every_id_yields_a_fixed_length_lowercase_hex_name(string id) {
+        var name = AgentFileNames.For(id);
+        await Assert.That(name).HasLength().EqualTo(64);
+        await Assert.That(name).Matches("^[0-9a-f]{64}$");
+        await Assert.That(AgentFileNames.For(id)).IsEqualTo(name);
+    }
+
+    [Test]
+    public async Task Name_is_the_sha256_the_pid_record_store_always_used() {
+        var expected = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes("agent-1"))).ToLowerInvariant();
+        await Assert.That(AgentFileNames.For("agent-1")).IsEqualTo(expected);
+        using var tmp = new TempDir();
+        var store = new AgentPidRecordStore(tmp.Path, Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+        store.Write(new AgentPidRecord("agent-1", 1, "", PidIdentityKind.IdentityUnavailable, "agent", "pi", null, null, "d", "e", DateTimeOffset.UnixEpoch));
+        await Assert.That(File.Exists(Path.Combine(tmp.Path, "agents", expected + ".json"))).IsTrue();
+    }
+}
+```
+
+
+
+- [ ] **Step 2: Run to verify failure** — `~/.dotnet/dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj -- --treenode-filter '/*/*/AgentFileNamesTests/*'`; expected: build error.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// The file name every per-agent store uses. The agent id crosses the wire unconstrained, so it is
+/// hashed rather than interpolated: no `..` or separator can leave the directory, and the PID record
+/// and the transcript journal of one agent always share a name.
+internal static class AgentFileNames {
+    public static string For(string agentId) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(agentId ?? ""))).ToLowerInvariant();
+}
+```
+
+`AgentPidRecordStore.PathFor`: `Path.Combine(_agentsDir, AgentFileNames.For(agentId) + ".json")`; delete `SafeName` and the now-unused `using System.Security.Cryptography; using System.Text;` if nothing else uses them.
+
+- [ ] **Step 4: Run tests** — filter `AgentFileNamesTests` and `AgentPidRecordStoreTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services/AgentFileNames.cs src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentFileNamesTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Share the hashed per-agent file name across stores (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 9: `JournalPathLocks`
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/JournalPathLocks.cs`
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/JournalPathLocksTests.cs`
+
+**Interfaces:**
+- Produces:
+
+```csharp
+internal sealed class JournalPathLocks {
+    public static readonly JournalPathLocks Shared = new();
+    /// Null when the wait timed out; throws OperationCanceledException on ct.
+    public Task<IDisposable?> AcquireAsync(string path, TimeSpan timeout, CancellationToken ct);
+    /// Entries with a live owner or waiter (tests).
+    public int LiveEntries { get; }
+}
+```
+
+Keyed by `Path.GetFullPath(path)` under `PlatformPaths.Comparer`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class JournalPathLocksTests {
+    [Test]
+    public async Task Acquire_release_churn_leaves_the_map_empty() {
+        var locks = new JournalPathLocks();
+        for (var i = 0; i < 200; i++) {
+            using var lease = await locks.AcquireAsync($"/j/{i}.jsonl", TimeSpan.FromSeconds(1), CancellationToken.None);
+            await Assert.That(lease).IsNotNull();
+        }
+        await Assert.That(locks.LiveEntries).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task A_waiter_keeps_the_entry_alive_until_it_too_releases() {
+        var locks = new JournalPathLocks();
+        var owner = await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromSeconds(1), CancellationToken.None);
+        var waiter = locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromSeconds(5), CancellationToken.None);
+        await Task.Delay(50);
+        await Assert.That(locks.LiveEntries).IsEqualTo(1);
+        owner!.Dispose();
+        await Assert.That(locks.LiveEntries).IsEqualTo(1);
+        (await waiter)!.Dispose();
+        await Assert.That(locks.LiveEntries).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Timed_out_and_cancelled_waits_release_nothing_and_leave_no_entry() {
+        var locks = new JournalPathLocks();
+        var owner = await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        var timedOut = await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromMilliseconds(20), CancellationToken.None);
+        await Assert.That(timedOut).IsNull();
+
+        using var cts = new CancellationTokenSource(20);
+        await Assert.That(async () => await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromSeconds(5), cts.Token)).Throws<OperationCanceledException>();
+
+        // Still held: a third waiter must not get in.
+        await Assert.That(await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromMilliseconds(20), CancellationToken.None)).IsNull();
+        owner!.Dispose();
+        await Assert.That(locks.LiveEntries).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Two_spellings_of_one_path_share_one_entry() {
+        var locks = new JournalPathLocks();
+        using var tmp = new TempDir();
+        var a = tmp.PathTo("j.jsonl");
+        var b = Path.Combine(tmp.Path, ".", "j.jsonl");
+        using var owner = await locks.AcquireAsync(a, TimeSpan.FromSeconds(1), CancellationToken.None);
+        await Assert.That(await locks.AcquireAsync(b, TimeSpan.FromMilliseconds(20), CancellationToken.None)).IsNull();
+        await Assert.That(locks.LiveEntries).IsEqualTo(1);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — filter `JournalPathLocksTests`; build error.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// One writer per journal path at a time, process-wide. FileStream has no cross-handle append, so two
+/// handles on one file overwrite each other; the lock is what makes "one handle" true. Entries are
+/// reference-counted so a waiter can never be left holding an entry the map has forgotten.
+internal sealed class JournalPathLocks {
+    public static readonly JournalPathLocks Shared = new();
+
+    sealed class Entry { public readonly SemaphoreSlim Gate = new(1, 1); public int Count; }
+
+    readonly Dictionary<string, Entry> _entries = new(PlatformPaths.Comparer);
+    readonly Lock _sync = new();
+
+    public int LiveEntries { get { lock (_sync) return _entries.Count; } }
+
+    public async Task<IDisposable?> AcquireAsync(string path, TimeSpan timeout, CancellationToken ct) {
+        var key = Path.GetFullPath(path);
+        Entry entry;
+        lock (_sync) {
+            if (!_entries.TryGetValue(key, out entry!)) _entries[key] = entry = new Entry();
+            entry.Count++;
+        }
+        var acquired = false;
+        try {
+            acquired = await entry.Gate.WaitAsync(timeout, ct).ConfigureAwait(false);
+        } finally {
+            if (!acquired) Decrement(key, entry);
+        }
+        return acquired ? new Lease(this, key, entry) : null;
+    }
+
+    void Decrement(string key, Entry entry) {
+        lock (_sync) {
+            if (--entry.Count == 0) _entries.Remove(key);
+        }
+    }
+
+    sealed class Lease(JournalPathLocks owner, string key, Entry entry) : IDisposable {
+        int _disposed;
+        public void Dispose() {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            entry.Gate.Release();
+            owner.Decrement(key, entry);
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests** — filter `JournalPathLocksTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services/JournalPathLocks.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/JournalPathLocksTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Add reference-counted per-path journal locks (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 10: `TranscriptJournal` — open, record, drain
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/JournalItem.cs`, `src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs`
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs`
+
+**Interfaces:**
+- Produces:
+
+```csharp
+internal readonly record struct JournalItem(AcpEventEnvelope Envelope, int GapBefore);
+
+internal sealed class TranscriptJournal {
+    public const int Capacity = 4096;
+    public static readonly TimeSpan CompleteGrace = TimeSpan.FromSeconds(2);
+    public static readonly TimeSpan LockBound     = TimeSpan.FromSeconds(2);
+
+    /// append(path, bytes) is the disk seam; the default appends with FileMode.Open/FileAccess.Write/FileShare.ReadWrite|Delete, seek-to-end, write, flush, close.
+    public TranscriptJournal(string path, ILogger logger, TimeProvider? time = null, Action<string, byte[]>? append = null, JournalPathLocks? locks = null, int capacity = Capacity, TimeSpan? completeGrace = null, TimeSpan? lockBound = null);
+    public static TranscriptJournal ForAgent(string stateDir, string agentId, ILogger logger);   // <stateDir>/transcripts/<AgentFileNames.For(agentId)>.jsonl
+
+    public string Path { get; }
+    public bool IsOpen { get; }        // true only after Open wrote and flushed the header
+    public bool CreatedFile { get; }   // the file did not exist before Open
+    public bool Drained { get; }       // set by CompleteAsync: the writer exited within the grace
+    public int  PendingGap { get; }    // tests
+
+    public bool Open(string? cwd, string? model);   // synchronous IO on the caller's thread
+    public void Record(AcpEventEnvelope envelope);  // no IO, never throws, no-op unless IsOpen and not latched
+    public Task<bool> CompleteAsync();              // closes the queue, awaits the writer ≤ grace, returns Drained
+}
+```
+
+The spec calls the lifecycle call `Complete()`; here it is `CompleteAsync()` because it awaits the writer.
+
+Design notes the implementation must honour:
+- Channel: `Channel.CreateBounded<JournalItem>(new BoundedChannelOptions(capacity) { FullMode = BoundedChannelFullMode.Wait, SingleReader = true, SingleWriter = false })`.
+- `Record`: return if `!IsOpen || _latched || envelope.Ephemeral`. Take `gap = Interlocked.Exchange(ref _pendingGap, 0)`; `if (!writer.TryWrite(new JournalItem(envelope, gap))) Interlocked.Add(ref _pendingGap, gap + 1);` (put the gap back and count this drop).
+- Writer task (`Task.Run`): `await foreach (var item in reader.ReadAllAsync(ct))` → build one buffer: if `item.GapBefore > 0` the `system_note` line first (`new AcpEventEnvelope(Kind: AcpEventKind.SystemNote, Text: $"{item.GapBefore} envelopes were not recorded to this journal", TimestampIso: NowIso())`) then the envelope line, each `EnvelopeJournalFormat.Write(e) + "\n"`; then `using var lease = await locks.AcquireAsync(Path, lockBound, CancellationToken.None)` — a null lease is a write failure; `append(Path, bytes)`. On any exception: log one Warning, set `_latched`, `writer.TryComplete()`, drain and count the rest into the abandonment count, exit. Cancellation is observed only between items (the token is checked by `ReadAllAsync`, never inside an append).
+- After the loop ends normally: if `_pendingGap > 0` write one final note line (same path lock).
+- `Open`: `Directory.CreateDirectory(dir)`; `CreatedFile = !File.Exists(Path)`; under the path lock (`AcquireAsync(...).GetAwaiter().GetResult()` is acceptable here — the launch path is synchronous by design; a null lease → `IsOpen` stays false, Warning); `using var fs = new FileStream(Path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete); fs.Seek(0, SeekOrigin.End); fs.Write(header); fs.Flush(true);` where header is `EnvelopeJournalFormat.Write(AcpEventTranslator.BuildSessionStarted(0, NowIso(), cwd, model)) + "\n"`. On success set `IsOpen = true` and start the writer. Any exception: Warning, `IsOpen` false, return false.
+- `CompleteAsync`: idempotent; `writer.TryComplete()`; `await Task.WhenAny(writerTask, Task.Delay(grace, time))`; if the writer finished → `Drained = true`; else `_writerCts.Cancel()`, log Warning "abandoning journal writer: item {Kind} in flight, {Queued} queued, {Gap} unrecorded", `_latched = true`, `Drained = false`. Return `Drained`.
+- `NowIso()` = `time.GetUtcNow().ToString("o")`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class TranscriptJournalTests {
+    static readonly FakeTimeProvider Time = new(new DateTimeOffset(2026, 9, 9, 10, 0, 0, TimeSpan.Zero));
+
+    static string[] Lines(string path) {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(fs);
+        return reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    static AcpEventEnvelope Text(string t) => new(Kind: AcpEventKind.AssistantText, Text: t);
+
+    [Test]
+    public async Task Open_writes_the_header_synchronously_and_reports_created() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+
+        await Assert.That(journal.Open("/w", "m1")).IsTrue();
+
+        await Assert.That(journal.IsOpen).IsTrue();
+        await Assert.That(journal.CreatedFile).IsTrue();
+        await Assert.That(journal.Path).IsEqualTo(Path.Combine(tmp.Path, "transcripts", AgentFileNames.For("agent-1") + ".jsonl"));
+        var lines = Lines(journal.Path);
+        await Assert.That(lines).Count().IsEqualTo(1);
+        await Assert.That(EnvelopeJournalFormat.TryRead(lines[0], out var header)).IsTrue();
+        await Assert.That(header.Kind).IsEqualTo(AcpEventKind.SessionStarted);
+        await Assert.That(header.Cwd).IsEqualTo("/w");
+        await Assert.That(header.Model).IsEqualTo("m1");
+        await Assert.That(header.RawSessionId).IsNull();
+        await journal.CompleteAsync();
+    }
+
+    [Test]
+    public async Task Second_open_of_the_same_agent_appends_a_header_and_keeps_every_byte() {
+        using var tmp = new TempDir();
+        var first = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        first.Open("/w", null);
+        first.Record(Text("a"));
+        await Assert.That(await first.CompleteAsync()).IsTrue();
+        var before = Lines(first.Path);
+
+        var second = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        second.Open("/w", null);
+        await Assert.That(second.CreatedFile).IsFalse();
+        await second.CompleteAsync();
+
+        var after = Lines(second.Path);
+        await Assert.That(after.Take(before.Length)).IsEquivalentTo(before);
+        await Assert.That(after).Count().IsEqualTo(before.Length + 1);
+    }
+
+    [Test]
+    public async Task Record_appends_in_order_skips_ephemerals_and_drains_on_complete() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open(null, null);
+        journal.Record(Text("a"));
+        journal.Record(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "live", Ephemeral: true));
+        journal.Record(Text("b"));
+
+        await Assert.That(await journal.CompleteAsync()).IsTrue();
+
+        var texts = Lines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Text; });
+        await Assert.That(texts).IsEquivalentTo(new[] { "a", "b" });
+    }
+
+    [Test]
+    public async Task No_handle_is_held_between_writes() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open(null, null);
+        journal.Record(Text("a"));
+        await journal.CompleteAsync();
+
+        // Exclusive open and delete both succeed: nothing else holds the file.
+        using (new FileStream(journal.Path, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+        File.Delete(journal.Path);
+        await Assert.That(File.Exists(journal.Path)).IsFalse();
+    }
+
+    [Test]
+    public async Task Header_failure_leaves_the_journal_closed_and_record_a_noop() {
+        using var tmp = new TempDir();
+        var blockedDir = tmp.CreateFile("transcripts"); // a FILE where the directory should be
+        var journal = new TranscriptJournal(Path.Combine(blockedDir, "x.jsonl"), NullLogger.Instance);
+
+        await Assert.That(journal.Open(null, null)).IsFalse();
+
+        await Assert.That(journal.IsOpen).IsFalse();
+        journal.Record(Text("a")); // must not throw
+        await Assert.That(await journal.CompleteAsync()).IsTrue();
+    }
+
+    [Test]
+    public async Task Record_never_blocks_while_the_sink_hangs() {
+        using var tmp = new TempDir();
+        var hang = new ManualResetEventSlim(false);
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time,
+            append: (path, bytes) => { if (Lines(path).Length >= 1) hang.Wait(); File.AppendAllText(path, System.Text.Encoding.UTF8.GetString(bytes)); },
+            capacity: 4);
+        journal.Open(null, null);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        for (var i = 0; i < 100; i++) journal.Record(Text(i.ToString()));
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(500));
+
+        await Assert.That(journal.PendingGap).IsGreaterThan(0);
+        hang.Set();
+        await journal.CompleteAsync();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — filter `TranscriptJournalTests`; build error.
+
+- [ ] **Step 3: Implement** `JournalItem.cs` and `TranscriptJournal.cs` per the design notes above. Skeleton:
+
+```csharp
+using System.Text;
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// The daemon-written envelope record of one hosted session: a bounded queue fed from the runtime's
+/// emit site and one writer task that appends to disk. Record never does IO; a hung disk costs journal
+/// lines, never protocol liveness.
+internal sealed class TranscriptJournal {
+    public const int Capacity = 4096;
+    public static readonly TimeSpan CompleteGrace = TimeSpan.FromSeconds(2);
+    public static readonly TimeSpan LockBound     = TimeSpan.FromSeconds(2);
+
+    readonly ILogger _logger;
+    readonly TimeProvider _time;
+    readonly Action<string, byte[]> _append;
+    readonly JournalPathLocks _locks;
+    readonly TimeSpan _grace, _lockBound;
+    readonly Channel<JournalItem> _queue;
+    readonly CancellationTokenSource _writerCts = new();
+    Task? _writer;
+    int _pendingGap;
+    volatile bool _latched;
+    volatile JournalItem? _inFlight;
+    int _completed;
+
+    public TranscriptJournal(string path, ILogger logger, TimeProvider? time = null, Action<string, byte[]>? append = null,
+            JournalPathLocks? locks = null, int capacity = Capacity, TimeSpan? completeGrace = null, TimeSpan? lockBound = null) {
+        Path = path; _logger = logger; _time = time ?? TimeProvider.System; _append = append ?? AppendToFile;
+        _locks = locks ?? JournalPathLocks.Shared; _grace = completeGrace ?? CompleteGrace; _lockBound = lockBound ?? LockBound;
+        _queue = Channel.CreateBounded<JournalItem>(new BoundedChannelOptions(capacity) {
+            FullMode = BoundedChannelFullMode.Wait, SingleReader = true, SingleWriter = false });
+    }
+
+    public static TranscriptJournal ForAgent(string stateDir, string agentId, ILogger logger) =>
+        new(System.IO.Path.Combine(stateDir, "transcripts", AgentFileNames.For(agentId) + ".jsonl"), logger);
+
+    public string Path { get; }
+    public bool IsOpen { get; private set; }
+    public bool CreatedFile { get; private set; }
+    public bool Drained { get; private set; }
+    public int PendingGap => Volatile.Read(ref _pendingGap);
+
+    public bool Open(string? cwd, string? model) {
+        try {
+            System.IO.Directory.CreateDirectory(System.IO.Path.GetDirectoryName(Path)!);
+            CreatedFile = !File.Exists(Path);
+            using var lease = _locks.AcquireAsync(Path, _lockBound, CancellationToken.None).GetAwaiter().GetResult();
+            if (lease is null) { _logger.LogWarning("Transcript journal {Path}: could not take the path lock to open", Path); return false; }
+            var header = Encode(AcpEventTranslator.BuildSessionStarted(0, NowIso(), cwd, model));
+            using (var fs = new FileStream(Path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete)) {
+                fs.Seek(0, SeekOrigin.End); fs.Write(header); fs.Flush(true);
+            }
+            IsOpen = true;
+            _writer = Task.Run(() => RunWriterAsync(_writerCts.Token));
+            return true;
+        } catch (Exception ex) {
+            _logger.LogWarning(ex, "Transcript journal {Path}: open failed; the session will not be journaled", Path);
+            return false;
+        }
+    }
+
+    public void Record(AcpEventEnvelope envelope) {
+        if (!IsOpen || _latched || envelope.Ephemeral) return;
+        var gap = Interlocked.Exchange(ref _pendingGap, 0);
+        if (!_queue.Writer.TryWrite(new JournalItem(envelope, gap))) Interlocked.Add(ref _pendingGap, gap + 1);
+    }
+
+    public async Task<bool> CompleteAsync() {
+        if (Interlocked.Exchange(ref _completed, 1) != 0) return Drained;
+        _queue.Writer.TryComplete();
+        if (_writer is null) { Drained = true; return true; }
+        var finished = await Task.WhenAny(_writer, Task.Delay(_grace, _time)).ConfigureAwait(false) == _writer;
+        if (finished) { Drained = true; return true; }
+        _writerCts.Cancel();
+        _latched = true;
+        _logger.LogWarning("Transcript journal {Path}: abandoning the writer — item {Kind} in flight, {Queued} queued, {Gap} unrecorded",
+            Path, _inFlight?.Envelope.Kind ?? "(none)", _queue.Reader.Count, PendingGap);
+        return false;
+    }
+
+    async Task RunWriterAsync(CancellationToken ct) {
+        try {
+            await foreach (var item in _queue.Reader.ReadAllAsync(ct).ConfigureAwait(false)) {
+                _inFlight = item;
+                await WriteItemAsync(item).ConfigureAwait(false);
+                _inFlight = null;
+            }
+            var gap = Interlocked.Exchange(ref _pendingGap, 0);
+            if (gap > 0) await WriteBytesAsync(Encode(GapNote(gap))).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+        } catch (Exception ex) {
+            _latched = true;
+            _queue.Writer.TryComplete();
+            var abandoned = 0;
+            while (_queue.Reader.TryRead(out _)) abandoned++;
+            _logger.LogWarning(ex, "Transcript journal {Path}: write failed; {Abandoned} queued and {Gap} unrecorded envelopes are lost", Path, abandoned, PendingGap);
+        }
+    }
+
+    Task WriteItemAsync(JournalItem item) {
+        var bytes = item.GapBefore > 0
+            ? [.. Encode(GapNote(item.GapBefore)), .. Encode(item.Envelope)]
+            : Encode(item.Envelope);
+        return WriteBytesAsync(bytes);
+    }
+
+    async Task WriteBytesAsync(byte[] bytes) {
+        using var lease = await _locks.AcquireAsync(Path, _lockBound, CancellationToken.None).ConfigureAwait(false)
+                       ?? throw new IOException("could not take the journal path lock");
+        _append(Path, bytes);
+    }
+
+    AcpEventEnvelope GapNote(int count) =>
+        new(Kind: AcpEventKind.SystemNote, Text: $"{count} envelopes were not recorded to this journal", TimestampIso: NowIso());
+
+    static byte[] Encode(AcpEventEnvelope e) => Encoding.UTF8.GetBytes(EnvelopeJournalFormat.Write(e) + "\n");
+    string NowIso() => _time.GetUtcNow().ToString("o");
+
+    static void AppendToFile(string path, byte[] bytes) {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
+        fs.Seek(0, SeekOrigin.End); fs.Write(bytes); fs.Flush(true);
+    }
+}
+```
+
+`JournalItem.cs`: `internal readonly record struct JournalItem(AcpEventEnvelope Envelope, int GapBefore);`
+
+- [ ] **Step 4: Run tests** — filter `TranscriptJournalTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services/JournalItem.cs src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Journal envelope transcripts to the daemon state dir (#839)" -m "Record is one TryWrite onto a bounded queue and never touches the disk, so a hung filesystem costs journal lines rather than an ACP read loop." -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 11: `TranscriptJournal` — gaps, abandonment, latching, path locks
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs` (only if a test below exposes a defect)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs` (append)
+
+- [ ] **Step 1: Write the tests** (append to the class; `Lines`, `Text`, `Time` from Task 10)
+
+```csharp
+    /// A sink that blocks every append until released, then writes for real.
+    sealed class GatedSink {
+        public readonly SemaphoreSlim Release = new(0);
+        public int Appends;
+        public void Append(string path, byte[] bytes) {
+            Release.Wait();
+            Interlocked.Increment(ref Appends);
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
+            fs.Seek(0, SeekOrigin.End); fs.Write(bytes); fs.Flush(true);
+        }
+    }
+
+    [Test]
+    public async Task Gap_note_lands_between_the_last_kept_and_the_first_after_the_loss() {
+        using var tmp = new TempDir();
+        var sink = new GatedSink();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 2);
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("b")); // fill the queue (writer is blocked)
+        journal.Record(Text("lost-1")); journal.Record(Text("lost-2"));
+        await Assert.That(journal.PendingGap).IsEqualTo(2);
+        sink.Release.Release(); // the writer takes "a": one slot frees
+        await Task.Delay(100);
+        journal.Record(Text("c")); // exactly one slot free: this item carries the gap
+        await Assert.That(journal.PendingGap).IsEqualTo(0);
+        sink.Release.Release(10);
+        await Assert.That(await journal.CompleteAsync()).IsTrue();
+
+        var texts = Lines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); }).ToList();
+        await Assert.That(texts).IsEquivalentTo(new[] {
+            (AcpEventKind.AssistantText, "a"), (AcpEventKind.AssistantText, "b"),
+            (AcpEventKind.SystemNote, "2 envelopes were not recorded to this journal"), (AcpEventKind.AssistantText, "c") });
+    }
+
+    [Test]
+    public async Task Gap_pending_at_completion_is_written_last() {
+        using var tmp = new TempDir();
+        var sink = new GatedSink();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 1);
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("lost"));
+        sink.Release.Release(10);
+        await Assert.That(await journal.CompleteAsync()).IsTrue();
+        var last = Lines(journal.Path).Last();
+        EnvelopeJournalFormat.TryRead(last, out var e);
+        await Assert.That(e.Text).IsEqualTo("1 envelopes were not recorded to this journal");
+    }
+
+    [Test]
+    public async Task Complete_against_a_hung_sink_returns_within_the_grace_and_reports_not_drained() {
+        using var tmp = new TempDir();
+        var sink = new GatedSink();
+        var log = new CapturingLogger();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), log, Time, sink.Append, capacity: 2, completeGrace: TimeSpan.FromMilliseconds(200));
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("b")); journal.Record(Text("lost"));
+        await Task.Delay(50);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var drained = await journal.CompleteAsync();
+
+        await Assert.That(drained).IsFalse();
+        await Assert.That(journal.Drained).IsFalse();
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+        await Assert.That(log.Warnings.Single()).Contains("assistant_text").And.Contains("1 queued").And.Contains("1 unrecorded");
+        journal.Record(Text("after")); // latched: silently ignored
+        sink.Release.Release(10);
+    }
+
+    [Test]
+    public async Task Cancellation_never_splits_a_gap_bearing_item() {
+        using var tmp = new TempDir();
+        var sink = new GatedSink();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 1, completeGrace: TimeSpan.FromMilliseconds(100));
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("lost"));
+        await Task.Delay(50);
+        journal.Record(Text("c")); // still full: counted
+        var complete = journal.CompleteAsync(); // expires while the sink still blocks on "a"
+        await Assert.That(await complete).IsFalse();
+        sink.Release.Release(10);
+        await Task.Delay(200);
+
+        // The abandoned writer finished "a" (one item, whole) and then observed cancellation: no torn note.
+        var lines = Lines(journal.Path);
+        foreach (var line in lines) await Assert.That(EnvelopeJournalFormat.TryRead(line, out _)).IsTrue();
+        await Assert.That(sink.Appends).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task First_append_failure_latches_after_one_warning_and_counts_the_queue() {
+        using var tmp = new TempDir();
+        var log = new CapturingLogger();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), log, Time, append: (_, _) => throw new IOException("disk gone"));
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("b"));
+        await Assert.That(await journal.CompleteAsync()).IsTrue(); // the writer exited (by faulting), so it drained
+        await Assert.That(log.Warnings).Count().IsEqualTo(1);
+        await Assert.That(log.Warnings[0]).Contains("write failed");
+        await Assert.That(Lines(journal.Path)).Count().IsEqualTo(1); // header only
+    }
+
+    [Test]
+    public async Task Torn_gap_item_renders_the_note_and_drops_the_torn_envelope() {
+        using var tmp = new TempDir();
+        var path = tmp.PathTo("j.jsonl");
+        // The crash model: a buffer cut after its note line.
+        var journal = new TranscriptJournal(path, NullLogger.Instance, Time, append: (p, bytes) => {
+            var text = System.Text.Encoding.UTF8.GetString(bytes);
+            var cut = text.IndexOf('\n') + 1 + 5;
+            File.AppendAllText(p, text[..Math.Min(cut, text.Length)]);
+        }, capacity: 1);
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("lost")); // "a" carries no gap
+        await Task.Delay(50);
+        journal.Record(Text("c")); // carries gap 1: note + torn "c"
+        await journal.CompleteAsync();
+
+        var tail = new JsonlTail(path).ReadAppended();
+        await Assert.That(tail.Lines.Count(l => l.Contains("not recorded"))).IsEqualTo(1);
+        await Assert.That(tail.Lines.Any(l => l.Contains("\"c\""))).IsFalse();
+    }
+
+    [Test]
+    public async Task Same_id_open_waits_out_an_abandoned_writer_and_appends_after_its_line() {
+        if (OperatingSystem.IsWindows()) return;
+        using var tmp = new TempDir();
+        var locks = new JournalPathLocks();
+        var sink = new GatedSink();
+        var first = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, locks, capacity: 1, completeGrace: TimeSpan.FromMilliseconds(100), lockBound: TimeSpan.FromMilliseconds(100));
+        first.Open(null, null);
+        first.Record(Text("late"));
+        await Task.Delay(50);
+        await Assert.That(await first.CompleteAsync()).IsFalse(); // writer abandoned inside the (gated) append, holding the path lock
+
+        var second = new TranscriptJournal(first.Path, NullLogger.Instance, Time, locks: locks, lockBound: TimeSpan.FromMilliseconds(100));
+        await Assert.That(second.Open(null, null)).IsFalse(); // the lock is held by the abandoned call
+        await Assert.That(second.IsOpen).IsFalse();
+
+        sink.Release.Release(10);
+        await Task.Delay(200);
+        var third = new TranscriptJournal(first.Path, NullLogger.Instance, Time, locks: locks, lockBound: TimeSpan.FromMilliseconds(100));
+        await Assert.That(third.Open(null, null)).IsTrue();
+        await third.CompleteAsync();
+
+        var texts = Lines(first.Path).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Kind == AcpEventKind.SessionStarted ? "header" : e.Text; });
+        await Assert.That(texts).IsEquivalentTo(new[] { "header", "late", "header" });
+    }
+
+    [Test]
+    public async Task Same_agent_id_under_two_state_dirs_takes_two_locks() {
+        using var a = new TempDir(); using var b = new TempDir();
+        var locks = new JournalPathLocks();
+        var sink = new GatedSink();
+        var hung = new TranscriptJournal(TranscriptJournal.ForAgent(a.Path, "agent-1", NullLogger.Instance).Path, NullLogger.Instance, Time, sink.Append, locks, capacity: 1, completeGrace: TimeSpan.FromMilliseconds(100));
+        hung.Open(null, null); hung.Record(Text("x"));
+        await Task.Delay(50);
+        await hung.CompleteAsync();
+
+        var other = new TranscriptJournal(TranscriptJournal.ForAgent(b.Path, "agent-1", NullLogger.Instance).Path, NullLogger.Instance, Time, locks: locks, lockBound: TimeSpan.FromMilliseconds(100));
+        await Assert.That(other.Open(null, null)).IsTrue();
+        await other.CompleteAsync();
+        sink.Release.Release(10);
+    }
+
+    [Test]
+    public async Task Abrupt_disposal_leaves_exactly_the_lines_the_writer_reached() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open(null, null);
+        for (var i = 0; i < 50; i++) journal.Record(Text(i.ToString()));
+        await Task.Delay(300); // no CompleteAsync: the process "dies"
+        foreach (var line in Lines(journal.Path)) await Assert.That(EnvelopeJournalFormat.TryRead(line, out _)).IsTrue();
+    }
+```
+
+`CapturingLogger` is an `ILogger` that records `LogLevel.Warning` messages into `List<string> Warnings`; if the daemon test project already has one (grep `class CapturingLogger` / `ListLogger` under `test/`), use it, otherwise add `test/Capacitor.Tests.Helpers/CapturingLogger.cs` (public, `IsEnabled` true, `BeginScope` returns a no-op disposable, `Log` formats with the supplied formatter and appends when `logLevel == LogLevel.Warning`).
+
+- [ ] **Step 2: Run the tests** — filter `TranscriptJournalTests`. Fix any defect they expose in `TranscriptJournal` (the most likely: `CompleteAsync` must not await the writer after cancelling; `Record` must not lose the `gap` when `TryWrite` fails).
+
+- [ ] **Step 3: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs test/Capacitor.Tests.Helpers
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Pin journal gap notes, abandonment and path locking (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 12: `TranscriptJournalSweep`
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs`
+- Modify: `src/Capacitor.Cli.Daemon/DaemonRunner.cs` (register at line ~587 beside `LocalControlServer`; run once after `ReapOrphansOnceAsync()` at line ~742)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs`
+
+**Interfaces:**
+- Produces:
+
+```csharp
+internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time, ILogger<TranscriptJournalSweep> logger, JournalPathLocks? locks = null) : BackgroundService {
+    public static readonly TimeSpan Retention = TimeSpan.FromDays(30);
+    public static readonly TimeSpan Interval  = TimeSpan.FromHours(24);
+    public Task RunOnceAsync(CancellationToken ct);   // single-flight, never throws
+    public int SweepsStarted { get; }                 // tests
+}
+```
+
+Rules: delete `<stateDir>/transcripts/*.jsonl` whose `File.GetLastWriteTimeUtc` is older than `time.GetUtcNow() - Retention` AND for which `<stateDir>/agents/<same stem>.json` does not exist; take the path lock (`LockBound`) first, skip when it cannot be had. Per-file try/catch at Warning; outer try/catch around enumeration. `ExecuteAsync`: `using var timer = new PeriodicTimer(Interval, time); while (await timer.WaitForNextTickAsync(ct)) await RunOnceAsync(ct);`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class TranscriptJournalSweepTests {
+    static readonly DateTimeOffset Now = new(2026, 9, 9, 10, 0, 0, TimeSpan.Zero);
+
+    static string Journal(TempDir tmp, string agentId, TimeSpan age) {
+        var path = Path.Combine(tmp.CreateDir("transcripts"), AgentFileNames.For(agentId) + ".jsonl");
+        File.WriteAllText(path, "{}\n");
+        File.SetLastWriteTimeUtc(path, (Now - age).UtcDateTime);
+        return path;
+    }
+
+    static void PidRecord(TempDir tmp, string agentId) =>
+        File.WriteAllText(Path.Combine(tmp.CreateDir("agents"), AgentFileNames.For(agentId) + ".json"), "{}");
+
+    static TranscriptJournalSweep Sweep(TempDir tmp, FakeTimeProvider time, JournalPathLocks? locks = null) =>
+        new(tmp.Path, time, NullLogger<TranscriptJournalSweep>.Instance, locks);
+
+    [Test]
+    public async Task Deletes_only_old_journals_without_a_pid_record() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var old        = Journal(tmp, "old", TimeSpan.FromDays(31));
+        var fresh      = Journal(tmp, "fresh", TimeSpan.FromDays(1));
+        var oldButLive = Journal(tmp, "live", TimeSpan.FromDays(31)); PidRecord(tmp, "live");
+        var other      = Path.Combine(tmp.Path, "transcripts", "notes.txt"); File.WriteAllText(other, "x"); File.SetLastWriteTimeUtc(other, (Now - TimeSpan.FromDays(40)).UtcDateTime);
+
+        await Sweep(tmp, time).RunOnceAsync(CancellationToken.None);
+
+        await Assert.That(File.Exists(old)).IsFalse();
+        await Assert.That(File.Exists(fresh)).IsTrue();
+        await Assert.That(File.Exists(oldButLive)).IsTrue();
+        await Assert.That(File.Exists(other)).IsTrue();
+    }
+
+    [Test]
+    public async Task Skips_a_journal_whose_lock_is_held() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var locks = new JournalPathLocks();
+        var old = Journal(tmp, "old", TimeSpan.FromDays(31));
+        using var held = await locks.AcquireAsync(old, TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Sweep(tmp, time, locks).RunOnceAsync(CancellationToken.None);
+
+        await Assert.That(File.Exists(old)).IsTrue();
+    }
+
+    [Test]
+    public async Task Missing_directory_and_enumeration_faults_never_escape() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        await Sweep(tmp, time).RunOnceAsync(CancellationToken.None); // no transcripts dir
+        tmp.CreateFile("transcripts"); // a file where the directory belongs: enumeration throws
+        await Sweep(tmp, time).RunOnceAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task Runs_again_after_24_hours_without_a_restart() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var sweep = Sweep(tmp, time);
+        await sweep.StartAsync(CancellationToken.None);
+        await Assert.That(sweep.SweepsStarted).IsEqualTo(0);
+
+        var journal = Journal(tmp, "old", TimeSpan.FromDays(31));
+        time.Advance(TimeSpan.FromHours(24));
+        await WaitUntil(() => sweep.SweepsStarted == 1);
+        await Assert.That(File.Exists(journal)).IsFalse();
+
+        time.Advance(TimeSpan.FromHours(24));
+        await WaitUntil(() => sweep.SweepsStarted == 2);
+        await sweep.StopAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task A_tick_during_a_sweep_is_skipped() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var locks = new JournalPathLocks();
+        var old = Journal(tmp, "old", TimeSpan.FromDays(31));
+        using var held = await locks.AcquireAsync(old, TimeSpan.FromSeconds(1), CancellationToken.None); // the sweep waits ≤ LockBound on this
+        var sweep = Sweep(tmp, time, locks);
+
+        var first = sweep.RunOnceAsync(CancellationToken.None);
+        var second = sweep.RunOnceAsync(CancellationToken.None);
+        await Task.WhenAll(first, second);
+
+        await Assert.That(sweep.SweepsStarted).IsEqualTo(1);
+    }
+
+    static async Task WaitUntil(Func<bool> condition) {
+        for (var i = 0; i < 500 && !condition(); i++) await Task.Delay(10);
+        await Assert.That(condition()).IsTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — filter `TranscriptJournalSweepTests`; build error.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// Reaps envelope journals kcap owns: older than the retention and with no PID record under the
+/// same name. Runs once after the startup orphan reap (which removes a prior epoch's records) and
+/// then every 24 hours. Never throws — a sweep fault must not block the daemon's connect.
+internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time, ILogger<TranscriptJournalSweep> logger, JournalPathLocks? locks = null) : BackgroundService {
+    public static readonly TimeSpan Retention = TimeSpan.FromDays(30);
+    public static readonly TimeSpan Interval  = TimeSpan.FromHours(24);
+
+    readonly JournalPathLocks _locks = locks ?? JournalPathLocks.Shared;
+    int _running;
+    int _started;
+
+    public int SweepsStarted => Volatile.Read(ref _started);
+
+    protected override async Task ExecuteAsync(CancellationToken ct) {
+        using var timer = new PeriodicTimer(Interval, time);
+        try {
+            while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) await RunOnceAsync(ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+    }
+
+    public async Task RunOnceAsync(CancellationToken ct) {
+        if (Interlocked.CompareExchange(ref _running, 1, 0) != 0) return;
+        Interlocked.Increment(ref _started);
+        try {
+            var dir = Path.Combine(stateDir, "transcripts");
+            if (!Directory.Exists(dir)) return;
+            var cutoff = time.GetUtcNow() - Retention;
+            foreach (var path in Directory.EnumerateFiles(dir, "*.jsonl")) {
+                ct.ThrowIfCancellationRequested();
+                await TrySweepAsync(path, cutoff).ConfigureAwait(false);
+            }
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "Transcript journal sweep: enumeration failed");
+        } finally {
+            Interlocked.Exchange(ref _running, 0);
+        }
+    }
+
+    async Task TrySweepAsync(string path, DateTimeOffset cutoff) {
+        try {
+            if (File.GetLastWriteTimeUtc(path) >= cutoff.UtcDateTime) return;
+            var record = Path.Combine(stateDir, "agents", Path.GetFileNameWithoutExtension(path) + ".json");
+            if (File.Exists(record)) return;
+            using var lease = await _locks.AcquireAsync(path, TranscriptJournal.LockBound, CancellationToken.None).ConfigureAwait(false);
+            if (lease is null) return;
+            File.Delete(path);
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "Transcript journal sweep: skipped {Path}", path);
+        }
+    }
+}
+```
+
+`DaemonRunner.cs` — beside the `LocalControlServer` registration:
+
+```csharp
+        builder.Services.AddSingleton(sp => new TranscriptJournalSweep(
+            config.Store.StateDirectory(config.Name), TimeProvider.System, sp.GetRequiredService<ILogger<TranscriptJournalSweep>>()));
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<TranscriptJournalSweep>());
+```
+
+and after `await orchestrator.ReapOrphansOnceAsync();`:
+
+```csharp
+                await host.Services.GetRequiredService<TranscriptJournalSweep>().RunOnceAsync(lifetime.ApplicationStopping);
+```
+
+- [ ] **Step 4: Run tests** — filter `TranscriptJournalSweepTests`; PASS. Build the daemon.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs src/Capacitor.Cli.Daemon/DaemonRunner.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Sweep envelope journals after 30 days (#839)" -m "The startup run follows the orphan reap: the reap is what removes a prior epoch's PID records, and a sweep before it would keep every journal whose agent died with the old daemon." -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 13: Orchestrator — journal on the launch path, snapshot fields, PTY-only gating
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs` (`RuntimeStartContext` gains a trailing `TranscriptJournal? Journal = null`)
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — `AgentInstance` gains `public TranscriptJournal? Journal { get; init; }`; `HandleLaunchAgentCore` constructs the journal before `runtimeCtx`, sets `SessionId`/`TranscriptPath`/`Journal` in the `AgentInstance` initializer (line ~2360), gates `DetectSessionIdAsync` (line ~2481) on `start.Transcript is null`, gates the Codex probe (`isCodex` at line ~3705) on `agent.Runtime.EmitsTerminalOutput`
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs` — `SnapshotAgentsForStatus` emits `TranscriptFormat`
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs` (append), `test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs` (new)
+
+**Interfaces:**
+- Consumes: `TranscriptJournal.ForAgent(stateDir, agentId, logger)`, `.IsOpen`, `.Path`, `SessionIds.Canonical`, `TranscriptFormats`.
+- Produces: `RuntimeStartContext.Journal`; `AgentInstance.Journal`; every status row carries `transcript_format`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `AgentStatusSnapshotTests` (uses its `Build()` fixture and `RegisterAgentForTest`):
+
+```csharp
+    [Test]
+    public async Task Envelope_sourced_agent_reports_envelopes_format_canonical_session_id_and_journal_path() {
+        var f = Build();
+        try {
+            var journal = TranscriptJournal.ForAgent(f.Daemons.Store.StateDirectory("status-snapshot-test"), "acp-1", NullLogger.Instance);
+            journal.Open("/w", "m");
+            var runtime = new FakeAcpRuntime { AcpSessionId = "8BC7255F-2453-4EFD-A733-0AF4B6AE9F20" };
+            f.Orchestrator.RegisterAgentForTest(new AgentInstance("acp-1", "p", "m", null, "/repo", "cursor", runtime, new WorktreeInfo("/repo", "b", "/w"), new CancellationTokenSource()) {
+                SessionId = SessionIds.Canonical(runtime.AcpSessionId), TranscriptPath = journal.Path, Journal = journal });
+
+            var row = f.Orchestrator.SnapshotAgentsForStatus().Single();
+
+            await Assert.That(row.TranscriptFormat).IsEqualTo(TranscriptFormats.Envelopes);
+            await Assert.That(row.SessionId).IsEqualTo("8bc7255f24534efda7330af4b6ae9f20");
+            await Assert.That(row.TranscriptPath).IsEqualTo(journal.Path);
+            await journal.CompleteAsync();
+        } finally { await f.CleanupAsync(); }
+    }
+
+    [Test]
+    public async Task Pty_agent_reports_vendor_format_and_null_path_until_discovery() {
+        var f = Build();
+        try {
+            f.Orchestrator.RegisterAgentForTest(new AgentInstance("pty-1", "p", "m", null, "/repo", "claude",
+                new PtyHostedAgentRuntime("claude", NoopPtyProcess.Instance), new WorktreeInfo("/repo", "b", "/w"), new CancellationTokenSource()));
+
+            var row = f.Orchestrator.SnapshotAgentsForStatus().Single();
+
+            await Assert.That(row.TranscriptFormat).IsEqualTo(TranscriptFormats.Vendor);
+            await Assert.That(row.TranscriptPath).IsNull();
+            await Assert.That(row.SessionId).IsNull();
+        } finally { await f.CleanupAsync(); }
+    }
+
+    [Test]
+    public async Task Opaque_acp_session_id_is_reported_unchanged() {
+        var f = Build();
+        try {
+            var runtime = new FakeAcpRuntime { AcpSessionId = "sess-1" };
+            f.Orchestrator.RegisterAgentForTest(new AgentInstance("acp-2", "p", "m", null, "/repo", "cursor", runtime, new WorktreeInfo("/repo", "b", "/w"), new CancellationTokenSource()) {
+                SessionId = SessionIds.Canonical(runtime.AcpSessionId) });
+            await Assert.That(f.Orchestrator.SnapshotAgentsForStatus().Single().SessionId).IsEqualTo("sess-1");
+        } finally { await f.CleanupAsync(); }
+    }
+```
+
+New `AgentOrchestratorJournalTests.cs` (launch through the real orchestrator with `SpyAcpHostedAgentRuntimeFactory`):
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class AgentOrchestratorJournalTests {
+    [Test]
+    public async Task Launch_hands_the_factory_an_unopened_journal_and_publishes_the_opened_path_before_registration() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var factory = new OpeningAcpFactory();
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-journal", repoPath));
+
+        var ctx = factory.LastContext!;
+        await Assert.That(ctx.Journal).IsNotNull();
+        await Assert.That(ctx.Journal!.Path).IsEqualTo(Path.Combine(orch.PidRecordRootForTest, "transcripts", AgentFileNames.For("agent-journal") + ".jsonl"));
+        var row = orch.SnapshotAgentsForStatus().Single();
+        await Assert.That(row.TranscriptPath).IsEqualTo(ctx.Journal.Path);
+        await Assert.That(row.TranscriptFormat).IsEqualTo(TranscriptFormats.Envelopes);
+        await Assert.That(row.SessionId).IsEqualTo("acp-sess-1");
+        await Assert.That(File.Exists(ctx.Journal.Path)).IsTrue();
+        // The first status the server saw for this agent already carried the canonical id.
+        await Assert.That(server.StatusChangedWithSession.First(c => c.AgentId == "agent-journal").SessionId).IsEqualTo("acp-sess-1");
+        // Discovery never started for an envelope-sourced agent.
+        await Assert.That(orch.DiscoveryStartsForTest).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Envelope_sourced_codex_keeps_the_journal_path_and_arms_no_probe() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var factory = new OpeningAcpFactory("codex");
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-codex-env", repoPath) with { Vendor = "codex" });
+        await orch.HandleSendInputForTest(new SendInputCommand("agent-codex-env", "hello", null));
+
+        await Assert.That(orch.SnapshotAgentsForStatus().Single().TranscriptPath).IsEqualTo(factory.LastContext!.Journal!.Path);
+        await Assert.That(orch.DiscoveryStartsForTest).IsEqualTo(0);
+        await Assert.That(orch.CodexProbesArmedForTest).IsEqualTo(0);
+    }
+
+    /// The real factories call Open before constructing the runtime; this double does the same.
+    sealed class OpeningAcpFactory(string vendor = "cursor") : IHostedAgentRuntimeFactory {
+        readonly SpyAcpHostedAgentRuntimeFactory _inner = new(vendor);
+        public string CliPath => _inner.CliPath;
+        public string Vendor => _inner.Vendor;
+        public bool SupportsUnattended => false;
+        public RuntimeStartContext? LastContext => _inner.LastContext;
+        public FakeAcpRuntime? LastRuntime => _inner.LastRuntime;
+        public bool IsAvailable() => true;
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+            ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
+            return _inner.StartAsync(ctx, ct);
+        }
+    }
+}
+```
+
+`CaptureServerConnection` records `(AgentId, Status)` in `StatusChangedCalls`; add a sibling `public List<(string AgentId, string Status, string? SessionId)> StatusChangedWithSession { get; } = [];` appended in the same `AgentStatusChangedAsync` override (leave the existing list untouched). Add `internal int CodexProbesArmedForTest => Volatile.Read(ref _codexProbesArmed);` to the orchestrator, incremented at the top of `ArmCodexTurnProbe`.
+
+- [ ] **Step 2: Run to verify failure** — filters `AgentStatusSnapshotTests`, `AgentOrchestratorJournalTests`; build errors.
+
+- [ ] **Step 3: Implement**
+
+`IHostedAgentRuntimeFactory.cs` — last parameter of `RuntimeStartContext`:
+
+```csharp
+        // The launch's transcript journal, unopened. An envelope-emitting factory opens it before
+        // constructing its runtime and hands it to the constructor; a PTY factory ignores it.
+        TranscriptJournal? Journal = null
+```
+
+`AgentOrchestrator.cs`:
+
+1. `AgentInstance`: add `public TranscriptJournal? Journal { get; init; }` beside `TranscriptPath`.
+2. In `HandleLaunchAgentCore`, immediately before `var runtimeCtx = new RuntimeStartContext(`:
+
+```csharp
+            var journal = TranscriptJournal.ForAgent(_pidRecordRoot, agentId, _logger);
+```
+
+and add `Journal: journal` to the `RuntimeStartContext` construction. Declare `TranscriptJournal? journal = null;` beside `string? reviewerToken = null;` (line ~2008) and assign it here instead of `var`, so the catch block in Task 14 can reach it.
+
+3. `AgentInstance` initializer (line ~2360): add
+
+```csharp
+                SessionId      = start.Transcript is { } t ? SessionIds.Canonical(t.AcpSessionId) : null,
+                TranscriptPath = start.Transcript is null ? null : journal.IsOpen ? journal.Path : null,
+                Journal        = start.Transcript is null ? null : journal,
+```
+
+4. `_ = DetectSessionIdAsync(agent, cmd.Vendor, spawnedAtUtc);` → `if (start.Transcript is null) _ = DetectSessionIdAsync(agent, cmd.Vendor, spawnedAtUtc);`
+5. In `HandleSendInput`: `var isCodex = agent.Runtime.EmitsTerminalOutput && string.Equals(agent.Runtime.Vendor, "codex", StringComparison.OrdinalIgnoreCase);`
+6. `ArmCodexTurnProbe`: first statement `Interlocked.Increment(ref _codexProbesArmed);` with `int _codexProbesArmed;` and the `ForTest` accessor.
+
+`AgentOrchestrator.LocalIpc.cs` — in `SnapshotAgentsForStatus`, after `AwaitingInput: …`:
+
+```csharp
+                AwaitingInput: a.Status == "Running" && a.ActivityClock.AwaitingInput,
+                TranscriptFormat: a.Runtime is IAcpTranscriptSource ? TranscriptFormats.Envelopes : TranscriptFormats.Vendor))];
+```
+
+Remove the `?? (a.Runtime as IAcpTranscriptSource)?.AcpSessionId` fallback from `SessionId:` only if every test still passes with the initializer supplying it; otherwise keep it (harmless, same value for a GUID-less id) — note: keep it wrapped as `a.SessionId ?? SessionIds.Canonical((a.Runtime as IAcpTranscriptSource)?.AcpSessionId)` so a seeded test agent without the initializer still reports the canonical form.
+
+- [ ] **Step 4: Run tests** — the two filters plus `AgentOrchestratorAcpForwardingTests`, `SendInputQuitCommandTests`, `AgentOrchestratorBorrowLaunchTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Publish journal path, format and canonical id at construction (#839)" -m "PublishAgent precedes RegisterAgentAsync, whose server call can stall for an outage, so these fields must be in the initializer to reach the first snapshot." -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 14: Orchestrator — journal lifecycle (cleanup, launch failure)
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` — `CleanupAgentAsync` (line ~4909) and the `HandleLaunchAgentCore` catch (line ~2504)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs` (append)
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+    [Test]
+    public async Task Cleanup_completes_the_journal_after_disposing_the_runtime() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var factory = new OpeningAcpFactory();
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+        orch.GracefulExitWait = TimeSpan.FromMilliseconds(50);
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-cleanup", repoPath));
+        var journal = factory.LastContext!.Journal!;
+        journal.Record(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "bye"));
+
+        await orch.HandleLocalStopV2Async(force: true, "agent-cleanup", Stream.Null, CancellationToken.None);
+        await WaitUntil(() => journal.Drained);
+
+        await Assert.That(File.Exists(journal.Path)).IsTrue(); // agent exit never deletes a journal
+        await Assert.That(File.ReadAllText(journal.Path)).Contains("\"bye\"");
+    }
+
+    [Test]
+    public async Task Factory_failure_after_open_deletes_only_a_journal_this_launch_created() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var factory = new FailingAfterOpenFactory();
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-fail-fresh", repoPath));
+        await Assert.That(File.Exists(factory.LastJournal!.Path)).IsFalse();
+
+        // A pre-existing file (a rebind whose factory fails) keeps the prior incarnation's bytes.
+        var existing = TranscriptJournal.ForAgent(orch.PidRecordRootForTest, "agent-fail-rebind", Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+        existing.Open("/w", null); await existing.CompleteAsync();
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-fail-rebind", repoPath));
+        await Assert.That(File.Exists(existing.Path)).IsTrue();
+        await Assert.That(File.ReadLines(existing.Path).Count()).IsEqualTo(2); // its header plus the failed launch's header
+    }
+
+    sealed class FailingAfterOpenFactory : IHostedAgentRuntimeFactory {
+        public string CliPath => "x"; public string Vendor => "cursor"; public bool SupportsUnattended => false;
+        public TranscriptJournal? LastJournal { get; private set; }
+        public bool IsAvailable() => true;
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+            LastJournal = ctx.Journal;
+            ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
+            throw new InvalidOperationException("boom");
+        }
+    }
+
+    static async Task WaitUntil(Func<bool> condition) {
+        for (var i = 0; i < 500 && !condition(); i++) await Task.Delay(10);
+        await Assert.That(condition()).IsTrue();
+    }
+```
+
+- [ ] **Step 2: Run to verify failure** — filter `AgentOrchestratorJournalTests`; the two new tests FAIL (file still exists / never drained).
+
+- [ ] **Step 3: Implement**
+
+`CleanupAgentAsync`, directly after the `Runtime.DisposeAsync()` line:
+
+```csharp
+        if (agent.Journal is { } journal) {
+            try { await journal.CompleteAsync(); } catch (Exception ex) { LogCleanupStepFailed(ex, "completing transcript journal", agentId); }
+        }
+```
+
+In the `catch (Exception ex)` of `HandleLaunchAgentCore`, inside the pre-insert branch (after `if (_agents.ContainsKey(agentId)) { … return; }` and before the reviewer-token revoke):
+
+```csharp
+            if (journal is { IsOpen: true }) {
+                var drained = await journal.CompleteAsync();
+                if (journal.CreatedFile && drained) {
+                    using var lease = await JournalPathLocks.Shared.AcquireAsync(journal.Path, TranscriptJournal.LockBound, CancellationToken.None);
+                    if (lease is not null) { try { File.Delete(journal.Path); } catch (Exception deleteEx) { LogCleanupStepFailed(deleteEx, "deleting transcript journal (failed-launch)", agentId); } }
+                }
+            }
+```
+
+- [ ] **Step 4: Run tests** — filter `AgentOrchestratorJournalTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Complete the journal on cleanup and delete only a failed launch's own file (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 15: ACP runtime records to the journal
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs` (ctor line ~608; `EmitEnvelope` line ~1799), `src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs` (line ~201)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs` (append)
+
+**Interfaces:**
+- Produces: `AcpHostedAgentRuntime(..., TranscriptJournal? journal = null)` (last optional parameter). `EmitEnvelope` calls `_journal?.Record(envelope)` inside `lock (_aggregationLock)` right after a successful `TryWrite`.
+
+- [ ] **Step 1: Write the failing tests** (in the existing `Harness`, add a `TranscriptJournal? journal` ctor argument threaded into `new AcpHostedAgentRuntime(Conn, Process, NullLogger.Instance, journal: journal)`, and a `TempDir Tmp` field it owns; then)
+
+```csharp
+    static async Task<List<AcpEventEnvelope>> JournalEnvelopes(string path) {
+        var list = new List<AcpEventEnvelope>();
+        foreach (var line in await File.ReadAllLinesAsync(path)) if (EnvelopeJournalFormat.TryRead(line, out var e)) list.Add(e);
+        return list;
+    }
+
+    [Test]
+    public async Task Journal_receives_every_accepted_envelope_in_channel_order_including_the_initial_user_message() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/abs/worktree", null);
+        await using var h = new Harness(journal);
+        h.StartFakeAgentLoop();
+        await h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard);
+        h.Fake.EmitAgentText("hello");   // whichever FakeAcpAgent helper pushes a session/update agent_message_chunk
+        var fromChannel = new List<AcpEventEnvelope>();
+        while (fromChannel.Count < 2) fromChannel.Add(await h.Runtime.Envelopes.ReadAsync(h.Cts.Token).AsTask().WaitAsync(HangGuard));
+
+        await journal.CompleteAsync();
+        var fromJournal = (await JournalEnvelopes(journal.Path)).Skip(1).ToList(); // header first
+
+        await Assert.That(fromJournal.Select(e => (e.Kind, e.Text))).IsEquivalentTo(fromChannel.Select(e => (e.Kind, e.Text)));
+        await Assert.That(fromJournal[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+    }
+
+    [Test]
+    public async Task Envelope_evicted_by_drop_oldest_is_still_in_the_journal_and_one_after_completion_is_not() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/abs/worktree", null);
+        await using var h = new Harness(journal, transcriptCapacity: 1);
+        h.StartFakeAgentLoop();
+        await h.Runtime.StartAsync("/abs/worktree", "p", h.Cts.Token).WaitAsync(HangGuard);
+        h.Fake.EmitAgentText("a"); h.Fake.EmitAgentText("b"); // capacity 1: "a" (or the user turn) is evicted
+        await Task.Delay(100);
+        await h.Runtime.DisposeAsync();  // completes the channel
+        h.Fake.EmitAgentText("late");
+        await Task.Delay(100);
+        await journal.CompleteAsync();
+
+        var texts = (await JournalEnvelopes(journal.Path)).Select(e => e.Text).ToList();
+        await Assert.That(texts).Contains("a").And.Contains("b");
+        await Assert.That(texts).DoesNotContain("late");
+    }
+```
+
+If `FakeAcpAgent` has no helper that emits an `agent_message_chunk` update on demand, add `EmitAgentText(string text)` to it that writes the corresponding `session/update` notification to the client read stream (copy the JSON shape from an existing test that does this). `Harness` gains optional `transcriptCapacity` forwarded to the runtime's `transcriptCapacity:` parameter.
+
+- [ ] **Step 2: Run to verify failure** — filter `AcpHostedAgentRuntimeTests`; build error.
+
+- [ ] **Step 3: Implement**
+
+Constructor: add `TranscriptJournal? journal = null` as the final parameter and `_journal = journal;` (field `readonly TranscriptJournal? _journal;`).
+
+`EmitEnvelope`:
+
+```csharp
+            if (!_transcript.Writer.TryWrite(envelope))
+                _logger.LogDebug("ACP: dropped an ACP transcript envelope (Kind={Kind}) — transcript channel already completed.", envelope.Kind);
+            else
+                _journal?.Record(envelope);
+```
+
+Factory (`AcpHostedAgentRuntimeFactory.StartAsync`, before `runtime = new AcpHostedAgentRuntime(`): `ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);` and pass `journal: ctx.Journal` in the construction.
+
+- [ ] **Step 4: Run tests** — filter `AcpHostedAgentRuntimeTests`, `AcpHostedAgentRuntimeFactoryTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs test/Capacitor.Cli.Daemon.Tests.Unit/Services/FakeAcpAgent.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Journal ACP envelopes at the emit site (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 16: Pi runtime records to the journal
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntime.cs` (ctor line ~168; `Write` line ~658), `src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntimeFactory.cs` (line ~121)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcRuntimeFakes.cs` (`NewRuntime` gains `TranscriptJournal? journal = null`), `test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs` (append)
+
+**Interfaces:**
+- Produces: `PiRpcHostedAgentRuntime(..., Action? onDisposed = null, TranscriptJournal? journal = null)`. `Write` takes a `readonly Lock _writeLock` around `TryWrite` + `Record`; the activity advance stays before the lock.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+    [Test]
+    public async Task Journal_matches_channel_order_under_concurrent_pump_and_send_time_writers() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/w", null);
+        var (runtime, process) = PiRpcRuntimeFakes.NewRuntime(journal: journal);
+        await using var _ = runtime;
+        await runtime.WaitForSessionReadyForTesting();   // the existing ready seam, or the handshake-observing pattern the file already uses
+
+        var drained = new List<AcpEventEnvelope>();
+        var drain = Task.Run(async () => { await foreach (var e in runtime.Envelopes.ReadAllAsync()) drained.Add(e); });
+        var pump  = Task.Run(() => { for (var i = 0; i < 200; i++) process.Push(PiRpcRuntimeFakes.AssistantText($"a{i}")); });
+        var sends = Task.Run(async () => { for (var i = 0; i < 200; i++) await runtime.SendUserInputAsync($"u{i}"); });
+        await Task.WhenAll(pump, sends);
+        await Task.Delay(200);
+        process.EndOfStream();
+        await drain.WaitAsync(TimeSpan.FromSeconds(10));
+        await journal.CompleteAsync();
+
+        var journaled = File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
+        await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)));
+    }
+
+    [Test]
+    public async Task Envelope_written_after_channel_completion_is_not_journaled() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/w", null);
+        var (runtime, process) = PiRpcRuntimeFakes.NewRuntime(journal: journal);
+        process.EndOfStream();
+        await runtime.WaitForExitAsync(TimeSpan.FromSeconds(5));
+        await runtime.SendUserInputAsync("late"); // the channel is complete: dropped at Debug
+        await runtime.DisposeAsync();
+        await journal.CompleteAsync();
+        await Assert.That(File.ReadAllText(journal.Path)).DoesNotContain("\"late\"");
+    }
+```
+
+(Use the file's existing way of awaiting the handshake instead of `WaitForSessionReadyForTesting` if that seam has a different name; `SendUserInputAsync` may throw once the process has exited — wrap the late send in a try/catch that swallows `InvalidOperationException`/`IOException`.)
+
+- [ ] **Step 2: Run to verify failure** — filter `PiRpcHostedAgentRuntimeTests`; build error.
+
+- [ ] **Step 3: Implement**
+
+Constructor: `TranscriptJournal? journal = null` after `onDisposed`; `_journal = journal;`. Fields: `readonly TranscriptJournal? _journal; readonly Lock _writeLock = new();`
+
+```csharp
+    void Write(AcpEventEnvelope env, bool agentActivity) {
+        if (agentActivity) ActivityClock?.Advance();
+
+        lock (_writeLock) {
+            if (_transcript.Writer.TryWrite(env)) { _journal?.Record(env); return; }
+        }
+
+        _logger.LogDebug("Pi: dropped a transcript envelope — the channel is already completed.");
+    }
+```
+
+Factory: before `runtime = new PiRpcHostedAgentRuntime(`: `ctx.Journal?.Open(ctx.Worktree.Path, ResolveModel(config, ctx));` and pass `journal: ctx.Journal`.
+
+`PiRpcRuntimeFakes.NewRuntime`: add `TranscriptJournal? journal = null` and pass `journal: journal`.
+
+- [ ] **Step 4: Run tests** — filter `PiRpcHostedAgentRuntimeTests`, `PiHostedLaunchTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Harness/Pi test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Journal Pi envelopes under a write lock (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 17: Antigravity — clock, synthesized user turn, journal
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs` (ctor line ~323; `RunTurnWorkerAsync` line ~534; `Write` line ~919), `src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs` (line ~316)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityRuntimeFakes.cs` (`FakeRuntime` gains `TimeProvider? time = null, TranscriptJournal? journal = null`), `test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityUserTurnTests.cs` (new)
+
+**Interfaces:**
+- Produces: `AntigravityHostedAgentRuntime(..., Action? onDisposed = null, TimeProvider? timeProvider = null, TranscriptJournal? journal = null)`; `string NowIso()`; the worker emits `AcpEventTranslator.BuildUserMessage(0, NowIso(), turn.Text)` via `Write(env, agentActivity: false)` after `_turnGate.WaitAsync` and before `ProcessTurnAsync`. `Write` takes `_writeLock` around `TryWrite` + `Record`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
+
+public class AntigravityUserTurnTests {
+    static readonly FakeTimeProvider Time = new(new DateTimeOffset(2026, 9, 9, 10, 0, 0, TimeSpan.Zero));
+
+    static async Task<List<AcpEventEnvelope>> Drain(AntigravityHostedAgentRuntime rt, int count) {
+        var list = new List<AcpEventEnvelope>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (list.Count < count) list.Add(await rt.Envelopes.ReadAsync(cts.Token));
+        return list;
+    }
+
+    [Test]
+    public async Task One_user_message_per_admitted_turn_ordered_before_that_turns_output_with_the_injected_clock() {
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(time: Time);
+        await rt.StartAsync("/w", "first", CancellationToken.None);
+        await rt.SendUserInputAsync("second");
+
+        var envelopes = await Drain(rt, 4); // user, output…, user, output…
+        var users = envelopes.Where(e => e.Kind == AcpEventKind.UserMessage).ToList();
+        await Assert.That(users.Select(u => u.Text)).IsEquivalentTo(new[] { "first", "second" });
+        await Assert.That(users.All(u => u.TimestampIso == "2026-09-09T10:00:00.0000000+00:00")).IsTrue();
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+        var secondIndex = envelopes.FindIndex(e => e.Kind == AcpEventKind.UserMessage && e.Text == "second");
+        await Assert.That(envelopes.Take(secondIndex).Count(e => e.Kind != AcpEventKind.UserMessage)).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task A_refused_turn_emits_only_the_not_delivered_note() {
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1, time: Time);
+        await rt.StartAsync("/w", "first", CancellationToken.None);
+        await rt.SendUserInputAsync("queued");
+        await Assert.That(async () => await rt.SendUserInputAsync("refused")).Throws<Exception>();
+        await Task.Delay(100);
+        var seen = new List<AcpEventEnvelope>();
+        while (rt.Envelopes.TryRead(out var e)) seen.Add(e);
+        await Assert.That(seen.Count(e => e.Kind == AcpEventKind.UserMessage && e.Text == "refused")).IsEqualTo(0);
+        await Assert.That(seen.Any(e => e.Kind == AcpEventKind.SystemNote && e.Text!.Contains("not delivered"))).IsTrue();
+    }
+
+    [Test]
+    public async Task Journal_matches_channel_order_under_worker_and_queue_full_notice_writers() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/w", null);
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1, time: Time, journal: journal);
+        await rt.StartAsync("/w", "first", CancellationToken.None);
+        await rt.SendUserInputAsync("queued");
+        var refusals = Task.Run(async () => { for (var i = 0; i < 50; i++) { try { await rt.SendUserInputAsync($"r{i}"); } catch { } } });
+        await refusals;
+        await Task.Delay(200);
+        var drained = new List<AcpEventEnvelope>();
+        while (rt.Envelopes.TryRead(out var e)) drained.Add(e);
+        await journal.CompleteAsync();
+
+        var journaled = File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
+        await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)));
+    }
+}
+```
+
+The `NeverEnds` fake blocks the worker inside the first turn so later turns queue; the fake `Normal` turn emits `init` and a `result`, which `AntigravityNdjson.ToEnvelopes` maps to at least one envelope — if the first test's `Drain(rt, 4)` needs a different count, read the fake's mapping and adjust (the assertion is on order and the user rows, not the count).
+
+- [ ] **Step 2: Run to verify failure** — filter `AntigravityUserTurnTests`; build error.
+
+- [ ] **Step 3: Implement**
+
+Constructor: add `TimeProvider? timeProvider = null, TranscriptJournal? journal = null` after `onDisposed`; fields `readonly TimeProvider _time; readonly TranscriptJournal? _journal; readonly Lock _writeLock = new();`; `_time = timeProvider ?? TimeProvider.System;`. Add `string NowIso() => _time.GetUtcNow().ToString("o");`.
+
+Worker (`RunTurnWorkerAsync`), after `await _turnGate.WaitAsync(ownerCt)…` and before `ActivityClock?.SetTurnInFlight(true);`:
+
+```csharp
+                    Write(AcpEventTranslator.BuildUserMessage(seq: 0, NowIso(), turn.Text), agentActivity: false);
+```
+
+(`using Capacitor.Cli.Daemon.Acp;` for the translator.) `Write`:
+
+```csharp
+    bool Write(AcpEventEnvelope env, bool agentActivity) {
+        if (agentActivity) ActivityClock?.Advance();
+
+        lock (_writeLock) {
+            if (_transcript.Writer.TryWrite(env)) { _journal?.Record(env); return true; }
+        }
+
+        _logger.LogDebug("Antigravity: dropped a transcript envelope — the transcript channel is already completed.");
+        return false;
+    }
+```
+
+Factory: before `var runtime = new AntigravityHostedAgentRuntime(`: `ctx.Journal?.Open(ctx.Worktree.Path, model);` and pass `journal: ctx.Journal`.
+
+`AntigravityRuntimeFakes.FakeRuntime`: add `TimeProvider? time = null, TranscriptJournal? journal = null` and pass `timeProvider: time, journal: journal`.
+
+- [ ] **Step 4: Run tests** — filters `AntigravityUserTurnTests`, `AntigravityRuntimeLifecycleTests`, `AntigravityActivityClockTests`, `AntigravityReviewerLaunchTests`; PASS. Any lifecycle test that counted envelopes now sees one extra `user_message` per turn: update its expectation and say so in the commit body.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Harness/Antigravity test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Emit Antigravity user turns from the worker and journal them (#839)" -m "The single worker is what orders the user turn ahead of the turn's own output; emitting from EnqueueTurn would race the child's first line." -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 18: Codex forward buffer — journal and explicit acceptance
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Harness/Codex/CodexForwardBuffer.cs`, `src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs` (ctor line ~151; buffer construction line ~180), `src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs` (line ~126)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexForwardBufferTests.cs` (append; `New` gains `TranscriptJournal? journal = null, CancellationToken shutdown = default`)
+
+**Interfaces:**
+- Produces: `CodexForwardBuffer(int capacity, TimeSpan stallTimeout, CancellationToken shutdown, Action<TimeSpan> onStall, TranscriptJournal? journal = null)`; `bool WriteCanonicalBlocking(AcpEventEnvelope env)` (private; true only when the envelope entered the channel; `ChannelClosedException` → Debug log, false). `CodexAppServerHostedAgentRuntime(..., TimeSpan? approvalTimeout = null, TranscriptJournal? journal = null)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+    static (TranscriptJournal Journal, TempDir Tmp) OpenJournal() {
+        var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/w", null);
+        return (journal, tmp);
+    }
+
+    static async Task<List<string?>> JournaledTexts(TranscriptJournal journal) {
+        await journal.CompleteAsync();
+        return File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Text; }).ToList();
+    }
+
+    [Test]
+    public async Task Canonical_envelopes_are_journaled_and_ephemerals_dropped_from_a_full_buffer_are_not() {
+        var (journal, tmp) = OpenJournal(); using var _ = tmp;
+        using var buf = New(1, TimeSpan.FromSeconds(5), journal: journal);
+        buf.Emit(Canonical("a"));
+        buf.Emit(Ephemeral("live"));  // full: dropped
+        await Assert.That(buf.DroppedEphemeralCount).IsEqualTo(1);
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new[] { "a" });
+    }
+
+    [Test]
+    public async Task Blocking_canonical_write_is_journaled_only_after_it_completes() {
+        var (journal, tmp) = OpenJournal(); using var _ = tmp;
+        using var buf = New(1, TimeSpan.FromSeconds(5), journal: journal);
+        buf.Emit(Canonical("a"));
+        var blocked = Task.Run(() => buf.Emit(Canonical("b")));
+        await Task.Delay(100);
+        await Assert.That(blocked.IsCompleted).IsFalse();
+        await Assert.That(File.ReadAllText(journal.Path)).DoesNotContain("\"b\"");
+        await buf.Reader.ReadAsync(); // frees the slot
+        await blocked.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new[] { "a", "b" });
+    }
+
+    [Test]
+    public async Task Stalled_buffer_journals_nothing_further_and_the_watchdog_fires_once() {
+        var (journal, tmp) = OpenJournal(); using var _ = tmp;
+        var stalls = 0;
+        using var buf = New(1, TimeSpan.FromMilliseconds(100), onStall: _ => stalls++, journal: journal);
+        buf.Emit(Canonical("a"));
+        buf.Emit(Canonical("stalled")); // blocks 100 ms, then faults
+        buf.Emit(Canonical("after"));
+        await Assert.That(stalls).IsEqualTo(1);
+        await Assert.That(buf.Stalled).IsTrue();
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new[] { "a" });
+    }
+
+    [Test]
+    public async Task Shutdown_cancelled_wait_and_emit_after_complete_are_not_journaled_and_do_not_throw() {
+        var (journal, tmp) = OpenJournal(); using var _ = tmp;
+        using var shutdown = new CancellationTokenSource();
+        using var buf = New(1, TimeSpan.FromSeconds(30), journal: journal, shutdown: shutdown.Token);
+        buf.Emit(Canonical("a"));
+        var blocked = Task.Run(() => buf.Emit(Canonical("cancelled")));
+        await Task.Delay(50);
+        shutdown.Cancel();
+        await blocked.WaitAsync(TimeSpan.FromSeconds(5)); // returned, no throw
+        buf.Complete();
+        buf.Emit(Canonical("after-complete")); // no throw
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new[] { "a" });
+    }
+```
+
+`Canonical(text)` / `Ephemeral(text)` are the file's existing envelope builders (add `Ephemeral` if absent: `new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: text, Ephemeral: true, ItemId: "i1")`).
+
+- [ ] **Step 2: Run to verify failure** — filter `CodexForwardBufferTests`; build error.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+    public CodexForwardBuffer(int capacity, TimeSpan stallTimeout, CancellationToken shutdown, Action<TimeSpan> onStall, TranscriptJournal? journal = null) {
+        …existing…
+        _journal = journal;
+    }
+
+    public void Emit(AcpEventEnvelope env) {
+        if (Stalled) return;
+
+        if (env.Ephemeral) {
+            if (!_channel.Writer.TryWrite(env)) Interlocked.Increment(ref _droppedEphemeral);
+            return;
+        }
+
+        if (_channel.Writer.TryWrite(env) || WriteCanonicalBlocking(env)) _journal?.Record(env);
+    }
+
+    bool WriteCanonicalBlocking(AcpEventEnvelope env) {
+        using var stall = CancellationTokenSource.CreateLinkedTokenSource(_shutdown);
+        stall.CancelAfter(_stallTimeout);
+        try {
+            _channel.Writer.WriteAsync(env, stall.Token).AsTask().GetAwaiter().GetResult();
+            return true;
+        } catch (ChannelClosedException) {
+            _logger?.LogDebug("Codex: dropped a transcript envelope (Kind={Kind}) — forward buffer already completed.", env.Kind);
+            return false;
+        } catch (OperationCanceledException) {
+            if (_shutdown.IsCancellationRequested) return false;
+            if (Interlocked.Exchange(ref _stalled, 1) == 0) _onStall(_stallTimeout);
+            return false;
+        }
+    }
+```
+
+The buffer has no logger today: add an optional `ILogger? logger = null` parameter after `journal` (the runtime passes its own) or drop the Debug line and keep the silent `return false`. Keep the constructor's existing four parameters in place.
+
+`CodexAppServerHostedAgentRuntime`: add `TranscriptJournal? journal = null` as the last constructor parameter and pass it to `new CodexForwardBuffer(ForwardBufferCapacity, …, _cts.Token, OnForwardStall, journal)`.
+
+Factory (`CodexHostedAgentRuntimeFactory`, before `var runtime = new CodexAppServerHostedAgentRuntime(`): `ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);` and pass `journal: ctx.Journal`.
+
+`CodexForwardBufferTests.New`: `static CodexForwardBuffer New(int capacity, TimeSpan stall, Action<TimeSpan>? onStall = null, TranscriptJournal? journal = null, CancellationToken shutdown = default) => new(capacity, stall, shutdown, onStall ?? (_ => { }), journal);`
+
+- [ ] **Step 4: Run tests** — filters `CodexForwardBufferTests`, `CodexAppServerHostedAgentRuntimeTests`, `CodexHostedAgentRuntimeFactoryTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Harness/Codex test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Journal Codex envelopes only once the forward buffer accepts them (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+## Part C — Daemon: local input
+
+### Task 19: `InputNotAdmittedException` — typed refusal from the runtimes
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/InputNotAdmittedException.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs` (doc contract on `SendUserInputAsync` / `SendUserInputAndWaitForWriteAsync`), `src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs` (`EnqueueTurn` line ~1167), `src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs` (`EnqueueTurn` line ~464), `src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs` (`EnqueueAsync` line ~80), `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`SendInputDropReason.QueueFull`)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/InputAdmissionTests.cs` (new), `test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs` (append)
+
+**Interfaces:**
+- Produces: `internal sealed class InputNotAdmittedException(string message) : InvalidOperationException(message);` `SendInputDropReason.QueueFull = "queue_full"`. Contract: a runtime that will not queue or write the text fails with `InputNotAdmittedException` — thrown synchronously from `SendUserInputAsync`, carried by the task from `SendUserInputAndWaitForWriteAsync`.
+
+- [ ] **Step 1: Write the failing tests**
+
+`InputAdmissionTests.cs`:
+
+```csharp
+using Capacitor.Cli.Daemon.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class InputAdmissionTests {
+    [Test]
+    public async Task Antigravity_full_queue_refuses_with_input_not_admitted_on_both_send_paths() {
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1);
+        await rt.StartAsync("/w", "first", CancellationToken.None);
+        await rt.SendUserInputAsync("queued");
+
+        await Assert.That(() => rt.SendUserInputAsync("refused")).Throws<InputNotAdmittedException>();
+        await Assert.That(async () => await rt.SendUserInputAndWaitForWriteAsync("refused-ack")).Throws<InputNotAdmittedException>();
+    }
+
+    [Test]
+    public async Task Antigravity_terminal_runtime_refuses_the_acknowledging_path_with_input_not_admitted() {
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime();
+        await rt.StartAsync("/w", "first", CancellationToken.None);
+        await rt.TerminateAsync(TimeSpan.FromSeconds(1));
+        await Assert.That(async () => await rt.SendUserInputAndWaitForWriteAsync("late")).Throws<InputNotAdmittedException>();
+    }
+}
+```
+
+Append to `AcpHostedAgentRuntimeTests` (its `Harness` gains an optional `pendingTurnsCapacity` forwarded to the runtime):
+
+```csharp
+    [Test]
+    public async Task Full_pending_turns_queue_refuses_with_input_not_admitted_on_both_send_paths() {
+        await using var h = new Harness(pendingTurnsCapacity: 1);
+        h.StartFakeAgentLoop();
+        h.Fake.HoldPromptResponses = true;   // the worker stays inside the first turn
+        await h.Runtime.StartAsync("/abs/worktree", "first", h.Cts.Token).WaitAsync(HangGuard);
+        await h.Runtime.SendUserInputAsync("queued");
+
+        await Assert.That(() => h.Runtime.SendUserInputAsync("refused")).Throws<InputNotAdmittedException>();
+        await Assert.That(async () => await h.Runtime.SendUserInputAndWaitForWriteAsync("refused-ack")).Throws<InputNotAdmittedException>();
+    }
+```
+
+(If `FakeAcpAgent` has no way to hold a `session/prompt` response open, add a `bool HoldPromptResponses` that makes it skip replying to `session/prompt`; look at how the fake answers that method today.)
+
+Append to `CodexTurnInputDispatcherTests`:
+
+```csharp
+    [Test]
+    public async Task Enqueue_after_fault_all_is_refused_never_left_pending() {
+        var sink = new FakeTurnSink();
+        var d = new CodexTurnInputDispatcher(sink.Start, sink.Steer, NullLogger.Instance, CancellationToken.None);
+        d.FaultAll(new ObjectDisposedException("runtime"));
+
+        await Assert.That(() => d.EnqueueAsync("late")).Throws<InputNotAdmittedException>();
+    }
+
+    [Test]
+    public async Task Enqueue_racing_fault_all_is_either_faulted_or_refused() {
+        for (var round = 0; round < 50; round++) {
+            var sink = new FakeTurnSink();
+            var d = new CodexTurnInputDispatcher(sink.Start, sink.Steer, NullLogger.Instance, CancellationToken.None, sealedAtStart: true);
+            var fault = Task.Run(() => d.FaultAll(new ObjectDisposedException("runtime")));
+            Task ack;
+            try { ack = d.EnqueueAsync("racing"); } catch (InputNotAdmittedException) { await fault; continue; }
+            await fault;
+            await Assert.That(async () => await ack.WaitAsync(TimeSpan.FromSeconds(2))).Throws<Exception>(); // faulted, not pending
+        }
+    }
+```
+
+- [ ] **Step 2: Run to verify failure** — filters `InputAdmissionTests`, `AcpHostedAgentRuntimeTests`, `CodexTurnInputDispatcherTests`; build errors.
+
+- [ ] **Step 3: Implement**
+
+`InputNotAdmittedException.cs`:
+
+```csharp
+namespace Capacitor.Cli.Daemon.Services;
+
+/// A runtime declined to queue or write the text: its pending-turn queue is full or it is terminal.
+/// Both callers of the delivery core map this to the `queue_full` reason.
+internal sealed class InputNotAdmittedException(string message) : InvalidOperationException(message);
+```
+
+`IHostedAgentRuntime.cs` — extend the two doc comments: "Fails with <see cref="InputNotAdmittedException"/> when the runtime will not queue or write the text (a full pending-turn queue, a terminal runtime): thrown synchronously by <see cref="SendUserInputAsync"/>, carried by the task from <see cref="SendUserInputAndWaitForWriteAsync"/>."
+
+`AcpHostedAgentRuntime.EnqueueTurn`:
+
+```csharp
+        if (_pendingTurns.Reader.Count >= _pendingTurnsCapacity) {
+            var dropped = Interlocked.Increment(ref _droppedPendingTurns);
+            _logger.LogWarning(…unchanged…);
+            var full = new InputNotAdmittedException("ACP pending-turns queue is full.");
+            if (written is null) throw full;
+            written.TrySetException(full);
+            return written.Task;
+        }
+
+        if (!_pendingTurns.Writer.TryWrite(new PendingTurn(text, written))) {
+            _logger.LogDebug("ACP: dropped a prompt turn — pending-turns channel already completed.");
+            var closed = new InputNotAdmittedException("ACP runtime is terminal; this input was not queued.");
+            if (written is null) throw closed;
+            written.TrySetException(closed);
+        }
+        return written?.Task ?? Task.CompletedTask;
+```
+
+`AntigravityHostedAgentRuntime.EnqueueTurn`: the terminal branch's `InvalidOperationException` and the queue-full `failure` both become `InputNotAdmittedException`; the non-acknowledging return `Task.FromException(failure)` becomes `throw failure` (synchronous, both branches), the acknowledging path keeps `written.TrySetException(...)`. The "message not delivered" note emission stays before the throw.
+
+`CodexTurnInputDispatcher.EnqueueAsync`:
+
+```csharp
+    public Task EnqueueAsync(string text, CancellationToken ct = default) {
+        var item = new InputItem(text, ct);
+        lock (_gate) {
+            if (_faulted) throw new InputNotAdmittedException("Codex dispatcher is torn down; this input was not queued.");
+            _queue.Enqueue(item);
+        }
+        PumpDispatch();
+        return item.Ack.Task;
+    }
+```
+
+`AgentOrchestrator.SendInputDropReason`: add `public const string QueueFull = "queue_full";`.
+
+- [ ] **Step 4: Run tests** — the three filters plus `AntigravityRuntimeLifecycleTests`; PASS (an existing lifecycle test asserting `InvalidOperationException` still passes: the new type derives from it).
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services/InputNotAdmittedException.cs src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs test/Capacitor.Cli.Daemon.Tests.Unit
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Refuse unadmitted input with a typed exception (#839)" -m "The Codex dispatcher refuses under the lock FaultAll takes, so an enqueue can no longer slip in after the fault and stay pending forever." -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 20: `DeliverInputAsync` — one delivery core for both callers
+
+**Files:**
+- Create: `src/Capacitor.Cli.Daemon/Services/InputDelivery.cs`
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs` (`HandleSendInput` line ~3674 → thin wrapper; new `DeliverInputAsync`)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/SendInputQuitCommandTests.cs` (must keep passing), `test/Capacitor.Cli.Daemon.Tests.Unit/Services/InputDeliveryCoreTests.cs` (new)
+
+**Interfaces:**
+- Produces:
+
+```csharp
+internal enum InputDeliveryKind { Delivered, QuitRequested, Dropped }
+/// Reason is a SendInputDropReason token when Kind is Dropped; Error is the runtime's message for a delivery fault.
+internal readonly record struct InputDeliveryOutcome(InputDeliveryKind Kind, string? Reason = null, string? Error = null) {
+    public static readonly InputDeliveryOutcome Delivered = new(InputDeliveryKind.Delivered);
+    public static readonly InputDeliveryOutcome QuitRequested = new(InputDeliveryKind.QuitRequested);
+    public static InputDeliveryOutcome Drop(string reason, string? error = null) => new(InputDeliveryKind.Dropped, reason, error);
+}
+internal Task<InputDeliveryOutcome> AgentOrchestrator.DeliverInputAsync(AgentInstance agent, string text, string[]? attachmentIds);
+```
+
+`DeliverInputAsync` is `HandleSendInput`'s body from the quit check onward, with these changes only: a quit on a non-PTY runtime returns `QuitRequested` instead of stopping; a failed borrowed refresh returns `Drop(SendInputDropReason.ReaperClaimed)`-style? No — it returns `Drop("delivery_failed", "borrowed snapshot refresh failed")` (today that path silently returns; keep the log line); `InputNotAdmittedException` → `Drop(SendInputDropReason.QueueFull, ex.Message)`; any other exception from the runtime → `Drop(SendTextReasons.DeliveryFailed, ex.Message)` (the constant is in Core's `SendTextReasons`; add `SendInputDropReason.DeliveryFailed = "delivery_failed"` beside `QueueFull` and use that). Reaper tokens stay. Gate, `SendUserInputAndWaitForWriteAsync` for a borrowed round, activity clock and awaiting-input clearing on completion only, the status report, the Codex probe (already PTY-gated) — all unchanged. **No `ReportInputDroppedAsync` inside the core**: the caller reports.
+
+`HandleSendInput` becomes: unknown agent / private agent checks (unchanged, they report) → `LogSendInputReceived` → `var outcome = await DeliverInputAsync(agent, text, attachmentIds);` → `QuitRequested` → `LogSendInputQuitCommand` + `await HandleUnsequencedStopAgent(agentId)`; `Dropped` → `await ReportInputDroppedAsync(cmd, outcome.Reason!)`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class InputDeliveryCoreTests {
+    static AgentOrchestrator Build(CaptureServerConnection server) =>
+        AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+    [Test]
+    public async Task Full_queue_on_the_real_antigravity_runtime_maps_to_queue_full_and_the_server_caller_reports_it() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1);
+        await rt.StartAsync("/w", "first", CancellationToken.None);
+        await rt.SendUserInputAsync("queued");
+        var clock = new AgentActivityClock(new FakeTimeProvider());
+        var agent = AgentOrchestratorHarness.SeedAcpAgent(orch, "agy-full", rt, activityClock: clock);
+        clock.MarkAwaitingInput();   // whichever member sets AwaitingInput true today
+        var before = clock.ActivitySeq;
+
+        var outcome = await orch.DeliverInputAsync(agent, "refused", null);
+        await Assert.That(outcome.Kind).IsEqualTo(InputDeliveryKind.Dropped);
+        await Assert.That(outcome.Reason).IsEqualTo(SendInputDropReason.QueueFull);
+        await Assert.That(clock.ActivitySeq).IsEqualTo(before);       // no advance on a refusal
+        await Assert.That(clock.AwaitingInput).IsTrue();                // the needs-you pip survives
+
+        var dispatch = Guid.NewGuid();
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "refused-again", null, dispatch));
+        await Assert.That(server.InputRejections).Contains((dispatch, agent.Id, SendInputDropReason.QueueFull));
+    }
+
+    [Test]
+    public async Task Borrowed_round_on_a_full_queue_uses_the_wait_for_write_path_and_still_maps_to_queue_full() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1);
+        await rt.StartAsync("/w", "first", CancellationToken.None);
+        await rt.SendUserInputAsync("queued");
+        var agent = AgentOrchestratorHarness.SeedBorrowedAcpAgent(orch, "agy-borrowed", rt);   // a seeded agent with BorrowedSnapshotSource set and Work = BorrowedCwd (no refresh)
+
+        var outcome = await orch.DeliverInputAsync(agent, "refused", null);
+        await Assert.That(outcome.Reason).IsEqualTo(SendInputDropReason.QueueFull);
+    }
+
+    [Test]
+    public async Task Quit_on_a_non_pty_runtime_is_reported_not_delivered_and_the_server_caller_stops_the_agent() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        orch.GracefulExitWait = TimeSpan.FromMilliseconds(50);
+        var rt = new FakeAcpRuntime();
+        var agent = AgentOrchestratorHarness.SeedAcpAgent(orch, "acp-quit", rt);
+
+        var outcome = await orch.DeliverInputAsync(agent, "/quit", null);
+        await Assert.That(outcome.Kind).IsEqualTo(InputDeliveryKind.QuitRequested);
+        await Assert.That(rt.HasExited).IsFalse(); // the core never stops
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "/exit", null));
+        for (var i = 0; i < 300 && !rt.HasExited; i++) await Task.Delay(10);
+        await Assert.That(rt.HasExited).IsTrue();
+    }
+
+    [Test]
+    public async Task Runtime_fault_maps_to_delivery_failed_with_the_message() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        var rt = new FakeAcpRuntime { SendUserInputThrow = new IOException("pipe closed") };
+        var agent = AgentOrchestratorHarness.SeedAcpAgent(orch, "acp-fault", rt);
+
+        var outcome = await orch.DeliverInputAsync(agent, "hi", null);
+        await Assert.That(outcome.Kind).IsEqualTo(InputDeliveryKind.Dropped);
+        await Assert.That(outcome.Reason).IsEqualTo(SendInputDropReason.DeliveryFailed);
+        await Assert.That(outcome.Error).IsEqualTo("pipe closed");
+    }
+
+    [Test]
+    public async Task Delivery_completes_only_when_the_runtime_task_settles() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        var rt = new FakeAcpRuntime { SendUserInputGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously) };
+        var agent = AgentOrchestratorHarness.SeedAcpAgent(orch, "acp-slow", rt);
+
+        var pending = orch.DeliverInputAsync(agent, "hi", null);
+        await Task.Delay(200);
+        await Assert.That(pending.IsCompleted).IsFalse();
+        rt.SendUserInputGate.SetResult();
+        await Assert.That((await pending).Kind).IsEqualTo(InputDeliveryKind.Delivered);
+    }
+}
+```
+
+`FakeAcpRuntime` gains `public Exception? SendUserInputThrow { get; init; }` and `public TaskCompletionSource? SendUserInputGate { get; init; }`, honoured by `SendUserInputAsync`/`SendUserInputAndWaitForWriteAsync` (throw / await the gate before recording the input). `SeedBorrowedAcpAgent` is a new harness helper identical to `SeedAcpAgent` but with `BorrowedSnapshotSource = <a non-null source the harness can construct>` and `Work = WorkLocation.BorrowedCwd` (check `AgentInstance.BorrowedSnapshotSource`'s type and use its simplest constructor or an existing fake). If `AgentActivityClock` has no direct setter for the awaiting flag, drive it through the member the turn-end path uses (grep `AwaitingInput` in `AgentActivityClock.cs`).
+
+- [ ] **Step 2: Run to verify failure** — filter `InputDeliveryCoreTests`; build error.
+
+- [ ] **Step 3: Implement** `InputDelivery.cs` (the enum and the record struct, one file named for the record: `InputDeliveryOutcome.cs` with the enum beside it is acceptable under the "enum plus its owner" exception; otherwise two files) and the `AgentOrchestrator` refactor described above. Add `SendInputDropReason.DeliveryFailed = "delivery_failed"`.
+
+- [ ] **Step 4: Run tests** — filters `InputDeliveryCoreTests`, `SendInputQuitCommandTests`, `AgentOrchestratorBorrowLaunchTests`, and any test class whose name contains `SendInput`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon/Services test/Capacitor.Cli.Daemon.Tests.Unit/Services
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Extract the input delivery core from the server-origin handler (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 21: `HandleLocalSendTextAsync`, routing and `input/1`
+
+**Files:**
+- Modify: `src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs` (new handler), `src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs` (`case FrameType.SendText`; the `default:` error text lists `SendText`), `src/Capacitor.Cli.Daemon/Services/LocalControlCapabilities.cs` (`"input/1"`)
+- Test: `test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalControlHelloTests.cs` (three pins gain `"input/1"`), `test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalControlCapabilitiesTests.cs` (create if absent: pins the list equals `["consent/1","consent/2","consent/3","status/1","permission/1","input/1"]`), `test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalSendTextTests.cs` (new)
+
+**Interfaces:**
+- Produces: `public async Task HandleLocalSendTextAsync(string payload, Stream stream, CancellationToken ct)` on `AgentOrchestrator` (partial, LocalIpc file). Every outcome is one `SendTextAck` frame; never an `Error` frame, never an escaped exception. Check order per the spec table: malformed → text_empty → too_large → no_such_agent → protected_kind → not_running → (core) reaper_claimed / reaper_claimed_late / queue_full / delivery_failed → quit: `StopAgentCoreAsync(agent)` → `Ok, Outcome="stopped"` or `stop_failed`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class LocalSendTextTests {
+    static AgentOrchestrator Build() =>
+        AgentOrchestratorHarness.BuildOrchestrator(new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+    static async Task<SendTextAckDto> Send(AgentOrchestrator orch, string payload) {
+        using var ms = new MemoryStream();
+        await orch.HandleLocalSendTextAsync(payload, ms, CancellationToken.None);
+        ms.Position = 0;
+        var frame = await FrameCodec.ReadAsync(ms, CancellationToken.None);
+        await Assert.That(frame!.Type).IsEqualTo(FrameType.SendTextAck);
+        return JsonSerializer.Deserialize(frame.Text, InputIpcJsonContext.Default.SendTextAckDto)!;
+    }
+
+    static string Payload(string agentId, string text) =>
+        JsonSerializer.Serialize(new SendTextDto(agentId, text), InputIpcJsonContext.Default.SendTextDto);
+
+    [Test]
+    [Arguments("not json")]
+    [Arguments("{}")]
+    [Arguments("""{"agent_id":"a1"}""")]
+    [Arguments("""{"agent_id":null,"text":"x"}""")]
+    [Arguments("""{"agent_id":"a1","text":null}""")]
+    [Arguments("[]")]
+    public async Task Malformed_payloads_ack_malformed(string payload) {
+        await using var orch = Build();
+        var ack = await Send(orch, payload);
+        await Assert.That(ack.Ok).IsFalse();
+        await Assert.That(ack.Reason).IsEqualTo(SendTextReasons.Malformed);
+    }
+
+    [Test]
+    public async Task Empty_and_oversized_text_and_unknown_agent_are_named() {
+        await using var orch = Build();
+        await Assert.That((await Send(orch, Payload("a1", "   "))).Reason).IsEqualTo(SendTextReasons.TextEmpty);
+        await Assert.That((await Send(orch, Payload("a1", new string('x', InputWire.MaxTextBytes + 1)))).Reason).IsEqualTo(SendTextReasons.TooLarge);
+        await Assert.That((await Send(orch, Payload("nope", "hi"))).Reason).IsEqualTo(SendTextReasons.NoSuchAgent);
+    }
+
+    [Test]
+    public async Task Protected_kind_and_not_running_are_refused_before_the_core() {
+        await using var orch = Build();
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "rev", new FakeAcpRuntime(), kind: LaunchKind.Review);
+        var ack = await Send(orch, Payload("rev", "hi"));
+        await Assert.That(ack.Reason).IsEqualTo(SendTextReasons.ProtectedKind);
+        await Assert.That(ack.Error).Contains("review");
+
+        var starting = AgentOrchestratorHarness.SeedAcpAgent(orch, "starting", new FakeAcpRuntime(), status: "Starting");
+        await Assert.That((await Send(orch, Payload("starting", "hi"))).Reason).IsEqualTo(SendTextReasons.NotRunning);
+        var done = AgentOrchestratorHarness.SeedAcpAgent(orch, "done", new FakeAcpRuntime(), status: "Completed");
+        await Assert.That((await Send(orch, Payload("done", "hi"))).Reason).IsEqualTo(SendTextReasons.NotRunning);
+    }
+
+    [Test]
+    public async Task Delivery_acks_ok_delivered_only_when_the_core_settles() {
+        await using var orch = Build();
+        var rt = new FakeAcpRuntime { SendUserInputGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously) };
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "a1", rt);
+
+        var pending = Send(orch, Payload("a1", "hello"));
+        await Task.Delay(200);
+        await Assert.That(pending.IsCompleted).IsFalse();
+        rt.SendUserInputGate.SetResult();
+        var ack = await pending;
+        await Assert.That(ack).IsEqualTo(new SendTextAckDto(true, null, null, SendTextOutcomes.Delivered));
+        await Assert.That(rt.SentInputs).IsEquivalentTo(new[] { "hello" });
+    }
+
+    [Test]
+    public async Task Queue_full_reaper_claim_and_delivery_failure_are_coded() {
+        await using var orch = Build();
+        await using var agy = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1);
+        await agy.StartAsync("/w", "first", CancellationToken.None);
+        await agy.SendUserInputAsync("queued");
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "full", agy);
+        await Assert.That((await Send(orch, Payload("full", "x"))).Reason).IsEqualTo(SendTextReasons.QueueFull);
+
+        var claimed = AgentOrchestratorHarness.SeedAcpAgent(orch, "claimed", new FakeAcpRuntime());
+        orch.ClaimReapForTest(claimed);
+        await Assert.That((await Send(orch, Payload("claimed", "x"))).Reason).IsEqualTo(SendTextReasons.ReaperClaimed);
+
+        var late = AgentOrchestratorHarness.SeedAcpAgent(orch, "late", new FakeAcpRuntime());
+        orch.SendInputBeforeWriteHookForTest = () => { orch.ClaimReapForTest(late); return Task.CompletedTask; };
+        await Assert.That((await Send(orch, Payload("late", "x"))).Reason).IsEqualTo(SendTextReasons.ReaperClaimedLate);
+        orch.SendInputBeforeWriteHookForTest = null;
+
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "faulty", new FakeAcpRuntime { SendUserInputThrow = new IOException("pipe closed") });
+        var ack = await Send(orch, Payload("faulty", "x"));
+        await Assert.That(ack.Reason).IsEqualTo(SendTextReasons.DeliveryFailed);
+        await Assert.That(ack.Error).IsEqualTo("pipe closed");
+    }
+
+    [Test]
+    public async Task Quit_stops_a_private_and_a_public_agent_through_the_owner_stop_and_acks_stopped() {
+        await using var orch = Build();
+        orch.GracefulExitWait = TimeSpan.FromMilliseconds(50);
+        var pub = new FakeAcpRuntime();
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "pub", pub);
+        var prv = new FakeAcpRuntime();
+        var privateAgent = AgentOrchestratorHarness.SeedAcpAgent(orch, "prv", prv);
+        orch.MarkPrivateForTest(privateAgent);
+
+        await Assert.That((await Send(orch, Payload("pub", "/quit"))).Outcome).IsEqualTo(SendTextOutcomes.Stopped);
+        await Assert.That(pub.HasExited).IsTrue();
+        await Assert.That((await Send(orch, Payload("prv", "/exit"))).Outcome).IsEqualTo(SendTextOutcomes.Stopped);
+        await Assert.That(prv.HasExited).IsTrue();
+
+        var stuck = new FakeAcpRuntime { NeverExits = true };
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "stuck", stuck);
+        await Assert.That((await Send(orch, Payload("stuck", "/quit"))).Reason).IsEqualTo(SendTextReasons.StopFailed);
+    }
+
+    [Test]
+    public async Task Two_frames_against_a_pending_write_deliver_two_turns_in_order() {
+        await using var orch = Build();
+        var rt = new FakeAcpRuntime { SendUserInputGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously) };
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "a1", rt);
+        var first = Send(orch, Payload("a1", "one"));
+        var second = Send(orch, Payload("a1", "two"));
+        await Task.Delay(100);
+        rt.SendUserInputGate.SetResult();
+        await Task.WhenAll(first, second);
+        await Assert.That(rt.SentInputs).IsEquivalentTo(new[] { "one", "two" });
+    }
+
+    [Test]
+    public async Task A_cancelled_wait_and_a_failing_ack_write_each_still_deliver_exactly_once() {
+        await using var orch = Build();
+        var rt = new FakeAcpRuntime { SendUserInputGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously) };
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "a1", rt);
+
+        using var cts = new CancellationTokenSource();
+        var cancelled = orch.HandleLocalSendTextAsync(Payload("a1", "one"), new MemoryStream(), cts.Token);
+        await Task.Delay(50);
+        cts.Cancel();
+        rt.SendUserInputGate.SetResult();
+        try { await cancelled; } catch (OperationCanceledException) { }
+
+        var rt2 = new FakeAcpRuntime();
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "a2", rt2);
+        await orch.HandleLocalSendTextAsync(Payload("a2", "two"), new ThrowingStream(), CancellationToken.None); // ack write faults, no throw out
+
+        await Assert.That(rt.SentInputs).IsEquivalentTo(new[] { "one" });
+        await Assert.That(rt2.SentInputs).IsEquivalentTo(new[] { "two" });
+    }
+
+    sealed class ThrowingStream : Stream {
+        public override bool CanRead => false; public override bool CanSeek => false; public override bool CanWrite => true;
+        public override long Length => 0; public override long Position { get => 0; set { } }
+        public override void Flush() { }
+        public override int Read(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) { }
+        public override void Write(byte[] buffer, int offset, int count) => throw new IOException("socket closed");
+    }
+}
+```
+
+Test seams to add: `SeedAcpAgent` gains an optional `LaunchKind kind = LaunchKind.Default` passed into the `AgentInstance` initializer (`Kind` is `init`-only); on the orchestrator (all `internal … ForTest`): `ClaimReapForTest(agent)` sets the agent's reap-claim latch the way `TryClaimReapAsync` does (grep `IsReapClaimed` for the field); `MarkPrivateForTest(agent)` sets whatever backs `IsPrivate`. `FakeAcpRuntime` gains `List<string> SentInputs` (recorded on both send paths after the gate) and `bool NeverExits` (TerminateAsync does not flip `HasExited`).
+
+Socket-level test — append to `LocalControlHelloTests`:
+
+```csharp
+    [Test]
+    public async Task SendText_frame_is_routed_and_answered_with_an_ack() {
+        await RunAsync("hello-sendtext", async (h, ct) => {
+            await using var s = await ConnectAsync(h.SockPath, ct);
+            var json = JsonSerializer.Serialize(new SendTextDto("nope", "hi"), InputIpcJsonContext.Default.SendTextDto);
+            await FrameCodec.WriteAsync(s, LocalFrame.InputJson(FrameType.SendText, json), ct);
+            var resp = await FrameCodec.ReadAsync(s, ct);
+            await Assert.That(resp!.Type).IsEqualTo(FrameType.SendTextAck);
+            var ack = JsonSerializer.Deserialize(resp.Text, InputIpcJsonContext.Default.SendTextAckDto)!;
+            await Assert.That(ack.Reason).IsEqualTo(SendTextReasons.NoSuchAgent);
+        });
+    }
+```
+
+and change the three capability pins to `new[] { "consent/1", "consent/2", "consent/3", "status/1", "permission/1", "input/1" }`.
+
+- [ ] **Step 2: Run to verify failure** — filters `LocalSendTextTests`, `LocalControlHelloTests`; build errors.
+
+- [ ] **Step 3: Implement**
+
+`AgentOrchestrator.LocalIpc.cs`:
+
+```csharp
+    /// Composer input from the owner's socket. Every outcome is an ack the composer can word, never an
+    /// Error frame; the ack is written only once the delivery core has settled.
+    public async Task HandleLocalSendTextAsync(string payload, Stream stream, CancellationToken ct) {
+        var ack = await AnswerSendTextAsync(payload);
+        try {
+            var json = JsonSerializer.Serialize(ack, InputIpcJsonContext.Default.SendTextAckDto);
+            await FrameCodec.WriteAsync(stream, LocalFrame.InputJson(FrameType.SendTextAck, json), ct);
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            _logger.LogDebug(ex, "SendText: the ack could not be written; the delivery already settled ({Reason})", ack.Reason ?? ack.Outcome);
+        }
+    }
+
+    async Task<SendTextAckDto> AnswerSendTextAsync(string payload) {
+        SendTextDto? dto;
+        try { dto = JsonSerializer.Deserialize(payload, InputIpcJsonContext.Default.SendTextDto); }
+        catch (JsonException) { dto = null; }
+        if (!InputWire.IsStructurallyValid(dto)) return Refuse(SendTextReasons.Malformed, "expected {\"agent_id\",\"text\"}");
+        if (string.IsNullOrWhiteSpace(dto!.Text)) return Refuse(SendTextReasons.TextEmpty, "text is empty");
+        if (Encoding.UTF8.GetByteCount(dto.Text) > InputWire.MaxTextBytes) return Refuse(SendTextReasons.TooLarge, $"text exceeds {InputWire.MaxTextBytes} bytes");
+        if (!_agents.TryGetValue(dto.AgentId, out var agent)) return Refuse(SendTextReasons.NoSuchAgent, $"no agent {dto.AgentId}");
+        if (agent.Kind != LaunchKind.Default) return Refuse(SendTextReasons.ProtectedKind, ProtectionReason(agent));
+        if (agent.Status is "Starting" or "Completed" or "Failed") return Refuse(SendTextReasons.NotRunning, $"agent is {agent.Status}");
+
+        InputDeliveryOutcome outcome;
+        try { outcome = await DeliverInputAsync(agent, dto.Text, null); }
+        catch (Exception ex) when (ex is not OperationCanceledException) { return Refuse(SendTextReasons.DeliveryFailed, ex.Message); }
+
+        switch (outcome.Kind) {
+            case InputDeliveryKind.Delivered:
+                return new SendTextAckDto(true, null, null, SendTextOutcomes.Delivered);
+            case InputDeliveryKind.QuitRequested:
+                LogSendInputQuitCommand(agent.Id, agent.Runtime.Vendor);
+                return await StopAgentCoreAsync(agent)
+                    ? new SendTextAckDto(true, null, null, SendTextOutcomes.Stopped)
+                    : Refuse(SendTextReasons.StopFailed, "the agent did not stop");
+            default:
+                return Refuse(outcome.Reason!, outcome.Error);
+        }
+    }
+
+    static SendTextAckDto Refuse(string reason, string? error) => new(false, reason, error, null);
+```
+
+The drop reasons the core returns are the `SendInputDropReason` tokens; they are spelled identically to the `SendTextReasons` tokens (`reaper_claimed`, `reaper_claimed_late`, `queue_full`, `delivery_failed`), so they pass through unchanged. Add `using System.Text;` and `using System.Text.Json;` if absent.
+
+`LocalControlServer.cs`: `case FrameType.SendText: await orchestrator.HandleLocalSendTextAsync(first.Text, stream, ct); break;` and append `/SendText` to the `default:` message. `LocalControlCapabilities.Current`: append `"input/1"`; add one sentence to its doc: `"input/1"` routes `SendText` to `AgentOrchestrator.HandleLocalSendTextAsync`.
+
+- [ ] **Step 4: Run tests** — filters `LocalSendTextTests`, `LocalControlHelloTests`, `LocalControlCapabilitiesTests`; PASS. Then the whole daemon suite: `~/.dotnet/dotnet run --project test/Capacitor.Cli.Daemon.Tests.Unit/Capacitor.Cli.Daemon.Tests.Unit.csproj`; green. AOT publish check prints nothing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.Cli.Daemon test/Capacitor.Cli.Daemon.Tests.Unit
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Route SendText into the delivery core and advertise input/1 (#839)" -m "The capability is added in the same change as the routing case: nothing is advertised without a live handler." -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+---
+
+## Part D — App: workspace and composer
+
+### Task 22: `AgentPresence` in its own file; `SendAvailability.Unsupported`
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/AgentPresence.cs`
+- Modify: `src/Capacitor.App/ViewModels/WorkspaceViewModel.cs` (delete the nested record), `src/Capacitor.App/Services/TerminalAttach.cs` (enum)
+- Test: none new (a pure move plus one enum member); build both projects.
+
+- [ ] **Step 1: Move the record**
+
+`AgentPresence.cs`:
+
+```csharp
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.ViewModels;
+
+/// The workspace's accumulated view of one agent: its latest dto and whether the session has ended,
+/// which stays true once set even if a later dto arrives.
+internal sealed record AgentPresence(AgentStatusDto? Dto, bool SessionEnded);
+```
+
+Delete `sealed record AgentPresence(...)` from `WorkspaceViewModel`.
+
+- [ ] **Step 2: Add the enum member**
+
+`TerminalAttach.cs`: `public enum SendAvailability { Ready, Sending, Transitioning, ReadOnly, Connecting, Reattach, Ended, NoTerminal, Unsupported }`.
+
+- [ ] **Step 3: Build and run the App suites that touch these** — `~/.dotnet/dotnet build src/Capacitor.App/Capacitor.App.csproj`; run filters `WorkspaceViewModelTests`, `TerminalTabViewModelTests`; PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.App/ViewModels/AgentPresence.cs src/Capacitor.App/ViewModels/WorkspaceViewModel.cs src/Capacitor.App/Services/TerminalAttach.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Lift AgentPresence out of the workspace and add Unsupported availability (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 23: `ChatInput` and `TerminalChatInput`
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/ChatInput.cs`, `src/Capacitor.App/ViewModels/TerminalChatInput.cs`
+- Test: `test/Capacitor.App.Tests.Unit/TerminalChatInputTests.cs`
+
+**Interfaces:**
+- Produces:
+
+```csharp
+public abstract class ChatInput : ReactiveObject, IDisposable {
+    public abstract SendAvailability Availability { get; }
+    public abstract bool CanAcceptText { get; }
+    public abstract string Hint { get; }
+    /// Completes when the channel considers the text committed: true to clear the composer.
+    public abstract Task<bool> SendAsync(string text, CancellationToken ct);
+    public abstract void Dispose();
+}
+public sealed class TerminalChatInput(TerminalTabViewModel terminal) : ChatInput { … }
+```
+
+`TerminalChatInput.HintFor(SendAvailability, TerminalSessionState)` is today's `ChatTabViewModel.HintFor` moved verbatim (internal static).
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class TerminalChatInputTests {
+    static async Task<(TerminalTabViewModel Terminal, TerminalChatInput Input, FakeTerminalAttachClient Client, FakeTimeProvider Time)> BuildAttachedAsync() {
+        var daemon = new FakeDaemonClientService();
+        var factory = new FakeTerminalAttachClientFactory();
+        var time = new FakeTimeProvider();
+        var terminal = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), time);
+        var input = new TerminalChatInput(terminal);
+        daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true) with { Status = "Running" });
+        Dispatcher.UIThread.RunJobs();
+        await (terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+        var client = factory.Created.Single();
+        await client.TriggerAttached([]);
+        return (terminal, input, client, time);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Mirrors_the_terminal_availability_and_wording() {
+        await RunOnUiAsync(async () => {
+            var (terminal, input, client, time) = await BuildAttachedAsync();
+            await Assert.That(input.Availability).IsEqualTo(SendAvailability.Ready);
+            await Assert.That(input.Hint).IsEqualTo("Enter sends · Shift+Enter for a new line");
+            await Assert.That(input.CanAcceptText).IsTrue();
+
+            var raised = new List<string>();
+            input.PropertyChanged += (_, e) => raised.Add(e.PropertyName!);
+            await Assert.That(await input.SendAsync("hello", CancellationToken.None)).IsTrue();
+            await Assert.That(input.Availability).IsEqualTo(SendAvailability.Sending);
+            await Assert.That(input.Hint).IsEqualTo("Sending…");
+            await Assert.That(raised).Contains(nameof(ChatInput.Availability));
+
+            time.Advance(TimeSpan.FromMilliseconds(150));
+            await terminal.PendingDeliveryForTesting!;
+            await Assert.That(input.Availability).IsEqualTo(SendAvailability.Ready);
+            await Assert.That(client.SentInput).Count().IsEqualTo(1);
+            input.Dispose();
+            await terminal.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Dispose_detaches_from_the_terminal() {
+        await RunOnUiAsync(async () => {
+            var (terminal, input, client, _) = await BuildAttachedAsync();
+            input.Dispose();
+            var raised = 0;
+            input.PropertyChanged += (_, _) => raised++;
+            await client.TriggerExited(0);
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(raised).IsEqualTo(0);
+            await Assert.That(await input.SendAsync("x", CancellationToken.None)).IsFalse();
+            await terminal.TeardownAsync();
+        });
+    }
+}
+```
+
+(`TriggerExited` — use whatever `FakeTerminalAttachClient` exposes to end the session; if it is named differently, use that member.)
+
+- [ ] **Step 2: Run to verify failure** — `~/.dotnet/dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj -- --treenode-filter '/*/*/TerminalChatInputTests/*'`; build error.
+
+- [ ] **Step 3: Implement**
+
+`ChatInput.cs`:
+
+```csharp
+using Capacitor.App.Services;
+using ReactiveUI.Reactive;
+
+namespace Capacitor.App.ViewModels;
+
+/// The composer's channel to the agent. The terminal channel commits when the paste is accepted; the
+/// frame channel when the daemon's ack arrives — that difference lives in SendAsync alone.
+public abstract class ChatInput : ReactiveObject, IDisposable {
+    public abstract SendAvailability Availability { get; }
+    public abstract bool CanAcceptText { get; }
+    public abstract string Hint { get; }
+    /// Completes when the channel considers the text committed: true to clear the composer.
+    public abstract Task<bool> SendAsync(string text, CancellationToken ct);
+    public abstract void Dispose();
+}
+```
+
+`TerminalChatInput.cs`:
+
+```csharp
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Capacitor.App.Services;
+using ReactiveUI.Reactive;
+
+namespace Capacitor.App.ViewModels;
+
+public sealed class TerminalChatInput : ChatInput {
+    readonly TerminalTabViewModel _terminal;
+    readonly IDisposable _subscription;
+    bool _disposed;
+
+    public TerminalChatInput(TerminalTabViewModel terminal) {
+        _terminal = terminal;
+        _subscription = terminal.WhenAnyValue(t => t.SendAvailability, t => t.State, t => t.CanAcceptText)
+            .Skip(1)
+            .Subscribe(_ => {
+                this.RaisePropertyChanged(nameof(Availability));
+                this.RaisePropertyChanged(nameof(CanAcceptText));
+                this.RaisePropertyChanged(nameof(Hint));
+            });
+    }
+
+    public override SendAvailability Availability => _disposed ? SendAvailability.Ended : _terminal.SendAvailability;
+    public override bool CanAcceptText => !_disposed && _terminal.CanAcceptText;
+    public override string Hint => HintFor(_terminal.SendAvailability, _terminal.State);
+
+    /// The terminal path has nothing to cancel: acceptance is synchronous.
+    public override Task<bool> SendAsync(string text, CancellationToken ct) =>
+        Task.FromResult(!_disposed && _terminal.TrySendText(text));
+
+    public override void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+        _subscription.Dispose();
+    }
+
+    /// The hint is built from the terminal's own availability, so it is true in the windows where
+    /// State alone would lie (a reattach or detach under way while State reads Attached).
+    internal static string HintFor(SendAvailability availability, TerminalSessionState state) => availability switch {
+        SendAvailability.Ready         => "Enter sends · Shift+Enter for a new line",
+        SendAvailability.Sending       => "Sending…",
+        SendAvailability.Transitioning => "Updating the terminal connection…",
+        SendAvailability.ReadOnly      => $"Read-only: {state.Detail}",
+        SendAvailability.Connecting    => "Connecting to the terminal…",
+        SendAvailability.Reattach      => "Reattach the terminal to send",
+        SendAvailability.Ended         => "This session has ended",
+        _                              => "No terminal to send to",
+    };
+}
+```
+
+Leave `ChatTabViewModel.HintFor` in place until Task 25 removes it (or make it delegate now: `internal static string HintFor(...) => TerminalChatInput.HintFor(...)`).
+
+- [ ] **Step 4: Run tests** — filter `TerminalChatInputTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.App/ViewModels/ChatInput.cs src/Capacitor.App/ViewModels/TerminalChatInput.cs src/Capacitor.App/ViewModels/ChatTabViewModel.cs test/Capacitor.App.Tests.Unit/TerminalChatInputTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Abstract the composer channel and wrap the terminal in it (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 24: `LocalFrameChatInput`
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/LocalFrameChatInput.cs`
+- Test: `test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs`
+
+**Interfaces:**
+- Consumes: `ILocalControlOps.SendTextAsync`, `SendTextResult`, `SendTextReasons`, `SendTextOutcomes`, `IDaemonClientService.Status` (`AttachStatus.State`, `.Capabilities`), `IObservable<AgentPresence>`.
+- Produces: `internal sealed class LocalFrameChatInput(string agentId, IDaemonClientService daemon, ILocalControlOps ops, IObservable<AgentPresence> presence) : ChatInput`. State rules, in priority order: `Ended` when `SessionEnded`; `Connecting` while `Status.State != AttachState.Connected`; `Unsupported` when `Capabilities` lacks `"input/1"`; `Sending` while a send is in flight; `Ready` when `Dto.Status == "Running"`; otherwise `Connecting`. `Hint` shows the last refusal notice until the next send starts or the availability changes.
+
+- [ ] **Step 1: Write the failing tests**
+
+```csharp
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class LocalFrameChatInputTests {
+    sealed class Rig {
+        public FakeDaemonClientService Daemon { get; } = new();
+        public ScriptedLocalControlOps Ops { get; } = new();
+        public BehaviorSubject<AgentPresence> Presence { get; } = new(new AgentPresence(null, false));
+        public LocalFrameChatInput Input { get; }
+        public Rig() => Input = new LocalFrameChatInput("a1", Daemon, Ops, Presence);
+        public void Connected(params string[] caps) => Daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, caps));
+        public void Running() => Presence.OnNext(new AgentPresence(Agent("a1", "pi", hasTerminal: false) with { Status = "Running" }, false));
+    }
+
+    [Test]
+    public async Task Availability_matrix() {
+        var rig = new Rig();
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Connecting);
+        rig.Connected("status/1");
+        rig.Running();
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Unsupported);
+        await Assert.That(rig.Input.Hint).IsEqualTo("Update the daemon to send messages from the app");
+        await Assert.That(await rig.Input.SendAsync("x", CancellationToken.None)).IsFalse();
+        await Assert.That(rig.Ops.SendTextCalls).IsEqualTo(0);
+
+        rig.Connected("status/1", "input/1");
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+        await Assert.That(rig.Input.CanAcceptText).IsTrue();
+        await Assert.That(rig.Input.Hint).IsEqualTo("Enter sends · Shift+Enter for a new line");
+
+        rig.Presence.OnNext(new AgentPresence(rig.Presence.Value.Dto, true));
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ended);
+        await Assert.That(rig.Input.Hint).IsEqualTo("This session has ended");
+    }
+
+    [Test]
+    public async Task One_send_in_flight_until_the_ack_and_a_delivered_ack_clears() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        var gate = rig.Ops.ArmSendText();
+        var pending = rig.Input.SendAsync("hello", CancellationToken.None);
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Sending);
+        await Assert.That(rig.Input.CanAcceptText).IsFalse();
+        await Assert.That(await rig.Input.SendAsync("second", CancellationToken.None)).IsFalse();
+        gate.SetResult(new SendTextResult(true, null, null, SendTextOutcomes.Delivered));
+        await Assert.That(await pending).IsTrue();
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+        await Assert.That(rig.Ops.SendTextPayloads).IsEquivalentTo(new[] { ("a1", "hello") });
+    }
+
+    [Test]
+    [Arguments("not_running", null, "agent is no longer running")]
+    [Arguments("protected_kind", null, "read-only participant")]
+    [Arguments("queue_full", null, "the agent's input queue is full, try again shortly")]
+    [Arguments("delivery_failed", "pipe closed", "pipe closed")]
+    [Arguments("transport", "eof", "delivery unconfirmed — check the chat before sending again")]
+    public async Task Refusal_keeps_the_text_and_words_the_hint(string reason, string? error, string hint) {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        rig.Ops.QueueSendText(new SendTextResult(false, reason, error, null));
+        await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
+        await Assert.That(rig.Input.Hint).IsEqualTo(hint);
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+        rig.Ops.ArmSendText();
+        _ = rig.Input.SendAsync("again", CancellationToken.None);
+        await Assert.That(rig.Input.Hint).IsEqualTo("Sending…"); // the notice clears when the next send starts
+    }
+
+    [Test]
+    public async Task Stopped_outcome_clears_and_unknown_ok_outcome_counts_as_delivered() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        rig.Ops.QueueSendText(new SendTextResult(true, null, null, SendTextOutcomes.Stopped));
+        await Assert.That(await rig.Input.SendAsync("/quit", CancellationToken.None)).IsTrue();
+        rig.Ops.QueueSendText(new SendTextResult(true, null, null, "future_outcome"));
+        await Assert.That(await rig.Input.SendAsync("x", CancellationToken.None)).IsTrue();
+    }
+
+    [Test]
+    public async Task Cancelled_wait_keeps_the_text_with_the_unconfirmed_hint() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        rig.Ops.ArmSendText();
+        using var cts = new CancellationTokenSource();
+        var pending = rig.Input.SendAsync("hello", cts.Token);
+        cts.Cancel();
+        await Assert.That(await pending).IsFalse();
+        await Assert.That(rig.Input.Hint).IsEqualTo("delivery unconfirmed — check the chat before sending again");
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+    }
+
+    [Test]
+    public async Task Completion_after_dispose_mutates_nothing_and_dispose_detaches_subscriptions() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        var gate = rig.Ops.ArmSendText();
+        var pending = rig.Input.SendAsync("hello", CancellationToken.None);
+        rig.Input.Dispose();
+        var raised = 0;
+        rig.Input.PropertyChanged += (_, _) => raised++;
+        gate.SetResult(new SendTextResult(false, "queue_full", null, null));
+        await Assert.That(await pending).IsFalse();
+        rig.Connected("input/1"); rig.Running();
+        rig.Presence.OnNext(new AgentPresence(null, true));
+        await Assert.That(raised).IsEqualTo(0);
+    }
+}
+```
+
+- [ ] **Step 2: Run to verify failure** — filter `LocalFrameChatInputTests`; build error.
+
+- [ ] **Step 3: Implement**
+
+```csharp
+using System.Reactive.Disposables;
+using System.Reactive.Linq;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+using ReactiveUI.Reactive;
+
+namespace Capacitor.App.ViewModels;
+
+/// The composer channel for a session with no PTY: one SendText exchange per send, acked when the
+/// daemon's delivery settles. A lost ack is an unknown outcome and the hint says so.
+internal sealed class LocalFrameChatInput : ChatInput {
+    const string InputCapability = "input/1";
+    const string Unconfirmed = "delivery unconfirmed — check the chat before sending again";
+
+    readonly string _agentId;
+    readonly ILocalControlOps _ops;
+    readonly CompositeDisposable _subscriptions = new();
+    AttachStatus _status = new(AttachState.Connecting, null, null);
+    AgentPresence _presence = new(null, false);
+    bool _sending;
+    bool _disposed;
+    string? _notice;
+
+    public LocalFrameChatInput(string agentId, IDaemonClientService daemon, ILocalControlOps ops, IObservable<AgentPresence> presence) {
+        _agentId = agentId;
+        _ops = ops;
+        daemon.Status.Subscribe(s => { _status = s; _notice = null; Raise(); }).DisposeWith(_subscriptions);
+        presence.Subscribe(p => { _presence = p; Raise(); }).DisposeWith(_subscriptions);
+    }
+
+    public override SendAvailability Availability =>
+        _presence.SessionEnded ? SendAvailability.Ended
+        : _status.State != AttachState.Connected ? SendAvailability.Connecting
+        : _status.Capabilities is not { } caps || !caps.Contains(InputCapability) ? SendAvailability.Unsupported
+        : _sending ? SendAvailability.Sending
+        : _presence.Dto?.Status == "Running" ? SendAvailability.Ready
+        : SendAvailability.Connecting;
+
+    public override bool CanAcceptText => Availability == SendAvailability.Ready;
+
+    public override string Hint => _notice ?? Availability switch {
+        SendAvailability.Ready       => "Enter sends · Shift+Enter for a new line",
+        SendAvailability.Sending     => "Sending…",
+        SendAvailability.Unsupported => "Update the daemon to send messages from the app",
+        SendAvailability.Ended       => "This session has ended",
+        _                            => "Connecting to the agent…",
+    };
+
+    public override async Task<bool> SendAsync(string text, CancellationToken ct) {
+        if (!CanAcceptText) return false;
+        _sending = true; _notice = null; Raise();
+        SendTextResult result;
+        try {
+            result = await _ops.SendTextAsync(_agentId, text, ct);
+        } catch (OperationCanceledException) {
+            return Settle(false, Unconfirmed);
+        } catch (Exception ex) {
+            return Settle(false, ex.Message);
+        }
+        if (result.Ok) return Settle(true, null);
+        return Settle(false, result.Reason switch {
+            SendTextReasons.Transport     => Unconfirmed,
+            SendTextReasons.NotRunning    => "agent is no longer running",
+            SendTextReasons.NoSuchAgent   => "agent is no longer running",
+            SendTextReasons.ProtectedKind => "read-only participant",
+            SendTextReasons.QueueFull     => "the agent's input queue is full, try again shortly",
+            SendTextReasons.StopFailed    => "the agent did not stop",
+            SendTextReasons.DeliveryFailed => result.Error ?? "delivery failed",
+            _                             => result.Error ?? result.Reason ?? "delivery failed",
+        });
+    }
+
+    bool Settle(bool committed, string? notice) {
+        if (_disposed) return committed;
+        _sending = false; _notice = notice; Raise();
+        return committed;
+    }
+
+    void Raise() {
+        if (_disposed) return;
+        this.RaisePropertyChanged(nameof(Availability));
+        this.RaisePropertyChanged(nameof(CanAcceptText));
+        this.RaisePropertyChanged(nameof(Hint));
+    }
+
+    public override void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+        _subscriptions.Dispose();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests** — filter `LocalFrameChatInputTests`; PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.App/ViewModels/LocalFrameChatInput.cs test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Send composer text over SendText for sessions without a PTY (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 25: `ChatTabViewModel` over `ChatInput` and `IChatTranscriptProjection`
+
+**Files:**
+- Create: `src/Capacitor.App/ViewModels/ChatTranscriptSource.cs`
+- Modify: `src/Capacitor.App/ViewModels/ChatTabViewModel.cs`
+- Modify (constructions): `test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs:49`, `ChatComposerTests.cs:22,151`, `ChatTabViewSmokeTests.cs:106` — `new ChatTabViewModel("a1", Daemon, new TerminalChatInput(Terminal), projection, Opener, Time, Permissions)`
+- Test: `test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs` (append), `test/Capacitor.App.Tests.Unit/ChatComposerTests.cs` (existing tests keep passing), `test/Capacitor.App.Tests.Unit/ChatTranscriptSourceTests.cs` (new)
+
+**Interfaces:**
+- Produces:
+
+```csharp
+public ChatTabViewModel(string agentId, IDaemonClientService daemon, ChatInput input, IChatTranscriptProjection? projection,
+                        IUrlOpener opener, TimeProvider time, IPermissionService permissions, string? unavailableNote = null);
+internal static class ChatTranscriptSource {
+    public const string OlderDaemonNote = "Update the daemon to view this session";
+    public const string NewerDaemonNote = "Update the app to view this session";
+    public static (IChatTranscriptProjection? Projection, string? UnavailableNote) Resolve(AgentStatusDto dto);
+}
+```
+
+`PhaseNote` for `Unavailable` is `unavailableNote ?? "No chat view for this harness"`. `SendCommand` is `ReactiveCommand.CreateFromTask` over `input.SendAsync(text, _lifetimeToken)`; clears `ComposerText` only when `true` came back and the text still equals the sent snapshot. `TeardownAsync` cancels `_lifetime` **before** `_disposables.Dispose()` (the input is in `_disposables`). `ChatTabViewModel.HintFor` is deleted (moved to `TerminalChatInput` in Task 23).
+
+- [ ] **Step 1: Write the failing tests**
+
+`ChatTranscriptSourceTests.cs`:
+
+```csharp
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ChatTranscriptSourceTests {
+    [Test]
+    public async Task Formats_pick_the_reader() {
+        var (vendorProjection, vendorNote) = ChatTranscriptSource.Resolve(Agent("a", "claude", hasTerminal: true) with { TranscriptFormat = TranscriptFormats.Vendor });
+        await Assert.That(vendorProjection).IsNotNull(); await Assert.That(vendorNote).IsNull();
+
+        var (leafless, leaflessNote) = ChatTranscriptSource.Resolve(Agent("a", "gemini", hasTerminal: true) with { TranscriptFormat = TranscriptFormats.Vendor });
+        await Assert.That(leafless).IsNull(); await Assert.That(leaflessNote).IsNull();
+
+        var (journal, journalNote) = ChatTranscriptSource.Resolve(Agent("a", "pi", hasTerminal: false) with { TranscriptFormat = TranscriptFormats.Envelopes });
+        await Assert.That(journal).IsSameReferenceAs(TranscriptChat.Journal); await Assert.That(journalNote).IsNull();
+    }
+
+    [Test]
+    public async Task Null_format_is_the_older_daemon_for_a_non_pty_dto_and_the_vendor_path_for_a_pty_dto() {
+        var (older, olderNote) = ChatTranscriptSource.Resolve(Agent("a", "pi", hasTerminal: false));
+        await Assert.That(older).IsNull(); await Assert.That(olderNote).IsEqualTo("Update the daemon to view this session");
+
+        var (pty, ptyNote) = ChatTranscriptSource.Resolve(Agent("a", "claude", hasTerminal: true));
+        await Assert.That(pty).IsNotNull(); await Assert.That(ptyNote).IsNull();
+    }
+
+    [Test]
+    public async Task Unknown_format_asks_for_an_app_update() {
+        var (projection, note) = ChatTranscriptSource.Resolve(Agent("a", "pi", hasTerminal: false) with { TranscriptFormat = "v9" });
+        await Assert.That(projection).IsNull(); await Assert.That(note).IsEqualTo("Update the app to view this session");
+    }
+}
+```
+
+Append to `ChatTabViewModelTests` (its `Harness` ctor gains `ChatInput? input = null` → `input ?? new TerminalChatInput(Terminal)`, and `string? unavailableNote = null`):
+
+```csharp
+    /// A scripted ChatInput for composer tests: SendAsync completes when the test says so.
+    sealed class ScriptedInput : ChatInput {
+        public TaskCompletionSource<bool>? Pending;
+        public int Disposals;
+        public List<(string Text, CancellationToken Ct)> Sends { get; } = [];
+        public override SendAvailability Availability => Pending is null ? SendAvailability.Ready : SendAvailability.Sending;
+        public override bool CanAcceptText => Pending is null;
+        public override string Hint => "scripted";
+        public override Task<bool> SendAsync(string text, CancellationToken ct) {
+            Sends.Add((text, ct));
+            Pending = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            this.RaisePropertyChanged(nameof(CanAcceptText));
+            return Pending.Task.ContinueWith(t => { Pending = null; this.RaisePropertyChanged(nameof(CanAcceptText)); return t.Result; }, ct, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+        public override void Dispose() => Disposals++;
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Journal_file_renders_user_assistant_note_and_tool_rows() {
+        await RunOnUiAsync(async () => {
+            using var tmp = new TempDir();
+            var path = tmp.PathTo("j.jsonl");
+            File.WriteAllLines(path, [
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.SessionStarted, Cwd: "/w")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: "hi")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "hello")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.SystemNote, Text: "note")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.ToolCall, ToolCallId: "c1", ToolName: "Read", ToolInputJson: """{"file_path":"/w/a.cs"}""")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.ToolResult, ToolCallId: "c1", ToolResult: "ok")),
+            ]);
+            var h = new Harness(TranscriptChat.Journal);
+            await h.PushAsync(Agent("a1", "pi", hasTerminal: false) with { TranscriptPath = path, TranscriptFormat = TranscriptFormats.Envelopes });
+            await h.TickAsync();
+
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(new[] { "UserTurnItem", "AssistantTextItem", "SystemNoteItem", "ToolGroupItem" });
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Unavailable_note_words_the_older_and_newer_daemon_cases() {
+        await RunOnUiAsync(async () => {
+            var older = new Harness(null, unavailableNote: "Update the daemon to view this session");
+            await Assert.That(older.Chat.Phase).IsEqualTo(ChatTabPhase.Unavailable);
+            await Assert.That(older.Chat.PhaseNote).IsEqualTo("Update the daemon to view this session");
+            await older.TeardownAsync();
+            var plain = new Harness(null);
+            await Assert.That(plain.Chat.PhaseNote).IsEqualTo("No chat view for this harness");
+            await plain.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Send_clears_only_when_committed_and_the_text_is_unchanged() {
+        await RunOnUiAsync(async () => {
+            var input = new ScriptedInput();
+            var h = new Harness(TranscriptChat.Journal, input: input);
+            await h.PushAsync(Agent("a1", "pi", hasTerminal: false) with { Status = "Running" });
+
+            h.Chat.ComposerText = "hello";
+            var send = h.Chat.SendCommand.Execute().ToTask();
+            await Assert.That(input.Sends.Single().Text).IsEqualTo("hello");
+            h.Chat.ComposerText = "hello edited";
+            input.Pending!.SetResult(true);
+            await send;
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("hello edited"); // typed during the round trip: kept
+
+            h.Chat.ComposerText = "two";
+            send = h.Chat.SendCommand.Execute().ToTask();
+            input.Pending!.SetResult(false);
+            await send;
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("two"); // refused: kept
+
+            h.Chat.ComposerText = "three";
+            send = h.Chat.SendCommand.Execute().ToTask();
+            input.Pending!.SetResult(true);
+            await send;
+            await Assert.That(h.Chat.ComposerText).IsEqualTo(""); // committed and unchanged: cleared
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Teardown_cancels_an_in_flight_send_before_disposing_the_input_once() {
+        await RunOnUiAsync(async () => {
+            var input = new ScriptedInput();
+            var h = new Harness(TranscriptChat.Journal, input: input);
+            await h.PushAsync(Agent("a1", "pi", hasTerminal: false) with { Status = "Running" });
+            h.Chat.ComposerText = "hello";
+            var send = h.Chat.SendCommand.Execute().ToTask();
+            var ct = input.Sends.Single().Ct;
+            await Assert.That(ct.IsCancellationRequested).IsFalse();
+
+            await h.TeardownAsync();
+
+            await Assert.That(ct.IsCancellationRequested).IsTrue();
+            await Assert.That(input.Disposals).IsEqualTo(1);
+            input.Pending?.TrySetCanceled(ct);
+            try { await send; } catch (OperationCanceledException) { }
+        });
+    }
+```
+
+(`ScriptedInput` needs `using ReactiveUI.Reactive;` for `RaisePropertyChanged`; `Execute().ToTask()` needs `System.Reactive.Threading.Tasks`.)
+
+- [ ] **Step 2: Run to verify failure** — filters `ChatTranscriptSourceTests`, `ChatTabViewModelTests`; build errors.
+
+- [ ] **Step 3: Implement**
+
+`ChatTranscriptSource.cs`:
+
+```csharp
+using Capacitor.App.Services;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.ViewModels;
+
+/// Which reader a session's transcript_path gets, stated on the wire by transcript_format. Null is an
+/// older daemon: its PTY agents take today's vendor path, anything else cannot be read.
+internal static class ChatTranscriptSource {
+    public const string OlderDaemonNote = "Update the daemon to view this session";
+    public const string NewerDaemonNote = "Update the app to view this session";
+
+    public static (IChatTranscriptProjection? Projection, string? UnavailableNote) Resolve(AgentStatusDto dto) => dto.TranscriptFormat switch {
+        TranscriptFormats.Vendor    => (TranscriptChat.For(dto.Vendor), null),
+        TranscriptFormats.Envelopes => (TranscriptChat.Journal, null),
+        null => HostedHarnessCatalog.ShowsTerminal(dto.HasTerminal, dto.Vendor) ? (TranscriptChat.For(dto.Vendor), null) : (null, OlderDaemonNote),
+        _    => (null, NewerDaemonNote),
+    };
+}
+```
+
+`ChatTabViewModel.cs` changes:
+
+- Fields: replace `readonly TerminalTabViewModel _terminal;` with `readonly ChatInput _input;`; `readonly TranscriptChatProjection? _projection;` → `readonly IChatTranscriptProjection? _projection;`; add `readonly string? _unavailableNote;`.
+- `TailLease.ContextFor(IChatTranscriptProjection projection, string agentId)`; `ReadAndApplyAsync(TailLease lease, IChatTranscriptProjection projection)`.
+- Constructor signature as in Interfaces; `_input = input; _disposables.Add(input); _unavailableNote = unavailableNote;`.
+- `PhaseNote`: `ChatTabPhase.Unavailable => _unavailableNote ?? "No chat view for this harness"`.
+- Delete `HintFor` and the `using` it needed if unused.
+- Composer observables:
+
+```csharp
+        _composerHint = Observable.CombineLatest(
+                _input.WhenAnyValue(i => i.Hint),
+                this.WhenAnyValue(x => x.IsReadOnlyParticipant),
+                (hint, readOnly) => readOnly ? "" : hint)
+            .ToProperty(this, x => x.ComposerHint, initialValue: IsReadOnlyParticipant ? "" : _input.Hint)
+            .DisposeWith(_disposables);
+
+        _showsComposer = Observable.CombineLatest(
+                _input.WhenAnyValue(i => i.Availability),
+                this.WhenAnyValue(x => x.IsReadOnlyParticipant),
+                (availability, readOnly) => !readOnly && availability != SendAvailability.Ended)
+            .ToProperty(this, x => x.ShowsComposer, initialValue: !IsReadOnlyParticipant && _input.Availability != SendAvailability.Ended)
+            .DisposeWith(_disposables);
+
+        var canSend = Observable.CombineLatest(
+            this.WhenAnyValue(x => x.ComposerText),
+            _input.WhenAnyValue(i => i.CanAcceptText),
+            this.WhenAnyValue(x => x.IsReadOnlyParticipant),
+            (text, can, readOnly) => can && !readOnly && !string.IsNullOrWhiteSpace(text));
+        SendCommand = ReactiveCommand.CreateFromTask(async () => {
+            var snapshot = ComposerText;
+            bool committed;
+            try { committed = await _input.SendAsync(snapshot, _lifetimeToken); }
+            catch (OperationCanceledException) { return; }
+            if (committed && ComposerText == snapshot) ComposerText = "";
+        }, canSend);
+        _disposables.Add(SendCommand);
+```
+
+- `TeardownAsync`: move `try { _lifetime.Cancel(); } catch (ObjectDisposedException) { }` to before `_disposables.Dispose();`, keep `_lifetime.Dispose()` last.
+
+Update the four test constructions listed under Files.
+
+- [ ] **Step 4: Run tests** — filters `ChatTranscriptSourceTests`, `ChatTabViewModelTests`, `ChatComposerTests`, `ChatTabViewSmokeTests`; PASS. `Send_clears_the_text_on_acceptance_and_keeps_it_on_refusal` in `ChatComposerTests` still passes: the terminal input completes synchronously and the text is unchanged at that instant.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.App/ViewModels test/Capacitor.App.Tests.Unit
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Drive the chat tab from a ChatInput and a chat projection (#839)" -m "The composer clears only when the channel commits and the text is still what was sent, so typing during a round trip is never erased." -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 26: Chat for every session — workspace, XAML, app wiring
+
+**Files:**
+- Modify: `src/Capacitor.App/ViewModels/WorkspaceViewModel.cs` (constructor gains `ILocalControlOps ops` right after `IWorkContextSource workContext`; Chat built on the first dto of any vendor; `NoTerminalNote` property removed)
+- Modify: `src/Capacitor.App/Views/WorkspaceView.axaml` (lines 65–66 `ChatTabButton` loses `IsVisible`; line 69 `NoTerminalNote` TextBlock deleted; lines 161–167 `ChatHost.IsVisible` becomes `IsVisible="{Binding $parent[views:WorkspaceView].((vm:WorkspaceViewModel)DataContext).IsChatActive}"`; the tab-strip comment rewritten: "Chat for every session; Terminal only when the daemon reports a PTY.")
+- Modify: `src/Capacitor.App/App.axaml.cs:528` (`BuildWorkspace` passes `workContext, ops, requestSignIn: …`)
+- Modify (constructions gain `new ScriptedLocalControlOps()` or the ops already in scope): `test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs:25,260`, `WorkspaceViewSmokeTests.cs:43`, `MainWindowViewModelTests.cs:42`, `PullRequestViewSmokeTests.cs:25`, `WorkspaceNavigationTests.cs:88`, `MainWindowSmokeTests.cs:301,388`
+- Test: `test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs` (invert the pin), `test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs` (names list, visibility test)
+
+- [ ] **Step 1: Rewrite the tests**
+
+`WorkspaceViewModelTests`: `Build` passes `new ScriptedLocalControlOps()` (or take an `ops` parameter defaulting to a fresh one). Replace `Chat_is_built_for_a_pty_dto_only_and_torn_down_with_the_workspace` with:
+
+```csharp
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Chat_is_built_on_the_first_dto_of_any_vendor_with_the_reader_the_format_names() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var vm = Build(daemon, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider());
+            await Assert.That(vm.Chat).IsNull();
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "pi", hasTerminal: false) with { TranscriptFormat = TranscriptFormats.Envelopes });
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(vm.Chat).IsNotNull();
+            await Assert.That(vm.Chat!.Phase).IsEqualTo(ChatTabPhase.Waiting); // journal reader, no path yet
+            await Assert.That(vm.ShowsTerminalTab).IsFalse();
+
+            var chat = vm.Chat;
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+            await Assert.That(vm.Chat).IsSameReferenceAs(chat); // built once
+
+            await vm.TeardownAsync();
+            await Assert.That(chat.PendingReadForTesting!).IsNull();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Null_format_non_pty_dto_is_the_older_daemon_and_a_vendor_pty_dto_takes_the_vendor_reader() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var older = Build(daemon, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider());
+            daemon.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: false));
+            await (older.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(older.Chat!.Phase).IsEqualTo(ChatTabPhase.Unavailable);
+            await Assert.That(older.Chat.PhaseNote).IsEqualTo("Update the daemon to view this session");
+            await older.TeardownAsync();
+
+            var daemon2 = new FakeDaemonClientService();
+            var pty = Build(daemon2, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider(), agentId: "a2");
+            daemon2.Agents.AddOrUpdate(Agent("a2", "claude", hasTerminal: true) with { TranscriptFormat = TranscriptFormats.Vendor });
+            await (pty.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(pty.Chat!.Phase).IsEqualTo(ChatTabPhase.Waiting);
+            await Assert.That(pty.ShowsTerminalTab).IsTrue();
+            await pty.TeardownAsync();
+        });
+    }
+```
+
+`WorkspaceViewSmokeTests`: remove `"NoTerminalNote"` from the names list; rewrite `Tab_and_note_visibility_flip_with_ShowsTerminalTab` as `Chat_is_always_offered_and_the_terminal_pair_follows_ShowsTerminalTab`: after the `hasTerminal: false` dto assert `ChatTabButton.IsEffectivelyVisible` true, `ChatHost.IsVisible` true (Chat is the default tab), `TerminalTabButton.IsEffectivelyVisible` false, `TerminalHost.IsVisible` false, and that `Find<Control>(window, "NoTerminalNote")` is null; after the `hasTerminal: true` dto assert the terminal pair is visible and the Chat button still is.
+
+- [ ] **Step 2: Run to verify failure** — filters `WorkspaceViewModelTests`, `WorkspaceViewSmokeTests`; build errors / failures.
+
+- [ ] **Step 3: Implement**
+
+`WorkspaceViewModel.cs`:
+
+- Constructor: `…, IPermissionService permissions, IWorkContextSource workContext, ILocalControlOps ops, Action? requestSignIn = null, …`.
+- Delete `_noTerminalNote` / `NoTerminalNote` and their construction.
+- Replace the Chat construction:
+
+```csharp
+        presence
+            .Where(p => p.Dto is not null)
+            .Take(1)
+            .Subscribe(p => {
+                var dto = p.Dto!;
+                var (projection, note) = ChatTranscriptSource.Resolve(dto);
+                ChatInput input = HostedHarnessCatalog.ShowsTerminal(dto.HasTerminal, dto.Vendor)
+                    ? new TerminalChatInput(Terminal)
+                    : new LocalFrameChatInput(agentId, daemon, ops, presence);
+                Chat = new ChatTabViewModel(agentId, daemon, input, projection, opener, time, permissions, note);
+            })
+            .DisposeWith(_disposables);
+```
+
+- Update the `Chat` property doc: "Built once, on the first dto; the reader comes from transcript_format and the input channel from has_terminal."
+
+`WorkspaceView.axaml`: edits as listed under Files. `App.axaml.cs`: `workContext, ops, requestSignIn: requestSignIn, …` in `BuildWorkspace`. Update every test construction listed.
+
+- [ ] **Step 4: Run tests** — the whole App suite: `~/.dotnet/dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj`; green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 add src/Capacitor.App test/Capacitor.App.Tests.Unit
+/usr/bin/git -C /Users/tony/dev/kcap-cli/.claude/worktrees/pi-agents-desktop-display-9cfa56 commit -q -m "Show the Chat tab for every hosted session (#839)" -m "Co-Authored-By: Claude Fable 5.1 <noreply@anthropic.com>"
+```
+
+### Task 27: Full verification and the live reproduction
+
+**Files:** none new (fixes only, if anything surfaces).
+
+- [ ] **Step 1: Full suites**
+
+```bash
+~/.dotnet/dotnet test --solution Capacitor.slnx
+```
+
+Expected: green apart from the known environmental install/config failures that also fail on pristine `main` (compare before trusting a red).
+
+- [ ] **Step 2: AOT and hygiene**
+
+```bash
+~/.dotnet/dotnet publish src/Capacitor.Cli/Capacitor.Cli.csproj -c Release 2>&1 | grep -E 'IL[23][01][0-9]{2}'
+```
+
+Expected: no output.
+
+```bash
+bash scripts/check-linear-ids.sh
+```
+
+Expected: clean.
+
+- [ ] **Step 3: Live reproduction** (the investigation's repro): build and run the daemon and the app from this worktree with `DOTNET_ROOT=~/.dotnet`; launch a Pi agent and a Cursor agent from the app. Verify in the app: both workspaces show a Chat tab with the initial prompt as the first user row and the agent's output following; no Terminal tab; the composer's hint reads "Enter sends · Shift+Enter for a new line"; a follow-up sent from the composer appears as a user row and gets a reply; typing `/quit` stops the agent and the composer reads "This session has ended". Verify on disk: `~/.config/kcap/daemons/<state>/<name>/transcripts/*.jsonl` exists per agent with a `session_started` first line. Verify in the web UI: the Pi session's status changes carry a session id (no "Agent failed to start" on a clean stop is out of scope — AI-2644).
+
+- [ ] **Step 4: Spec ride-along**
+
+The spec (`docs/superpowers/specs/2026-09-09-ai2197-non-pty-chat-and-composer-design.md`) and this plan are already committed on the branch; they ride the implementation PR. Re-read the spec's "Decisions" and §6 once more against the code and fix any drift found in a final commit `Align the non-PTY chat implementation with its spec (#839)`; if nothing drifted, no commit.
+
+- [ ] **Step 5: Open the PR** per `.github/PULL_REQUEST_TEMPLATE.md` (title without a reference: `Show chat and composer for hosted sessions without a PTY`; description reference line `Closes #839` and `AI-2197`, `AI-2625`). Report the PR to Tony by its Linear ids, not the GitHub number.
+
+---
+
+## Self-review notes
+
+- Spec coverage: §1 → Tasks 8–18 (journal, names, locks, sweep, orchestrator fields and gating, four runtimes, Antigravity user turn); §2 → Tasks 6, 7, 19, 20, 21; §3 → Tasks 3, 4, 5; §4 → Tasks 22–26; §5 compatibility matrix → `ChatTranscriptSource` (Task 25) and `LocalFrameChatInput.Unsupported` (Task 24); §6 parity items are asserted by the tests named in Tasks 13, 20, 21, 25; §7 test list mapped task by task; Task 1–2 are the two Core prerequisites the spec calls out (`PlatformPaths`, `SessionIds`).
+- Naming: the spec's `Complete()` is `CompleteAsync()` here (it awaits the writer); the spec's delivery outcome is `InputDeliveryOutcome`; the spec's `AgentPresence` observable is `IObservable<AgentPresence>` fed by the workspace's existing replayed `presence`.
+- Every `SendTextReasons` token equals the `SendInputDropReason` token of the same name, so the core's drop reasons pass through the local ack unchanged.

--- a/docs/superpowers/specs/2026-09-09-ai2197-non-pty-chat-and-composer-design.md
+++ b/docs/superpowers/specs/2026-09-09-ai2197-non-pty-chat-and-composer-design.md
@@ -1,0 +1,1051 @@
+# Chat and composer for non-PTY hosted sessions (AI-2197, AI-2625)
+
+Slice of the desktop shell (parent AI-2171). Today the workspace renders a Chat
+tab only for the two PTY-hosted vendors, Claude and interactive Codex, by
+tailing the transcript file the vendor writes. Every other harness the app
+offers — Cursor, Copilot, Gemini, Kiro, OpenCode (ACP), Antigravity (NDJSON per
+turn), Pi (JSONL-RPC) and Codex on app-server — produces its transcript as a
+live `AcpEventEnvelope` stream that the daemon forwards to the server and
+nothing else consumes. The daemon reports those agents, the rail and Home list
+them, but their workspace has no Chat tab, no Terminal tab, and no way to send
+a follow-up. AI-2625 is the user-facing report of that; AI-2197 is the slice
+that was always meant to close it.
+
+The design goal, settled with the owner: **a non-PTY session should work as
+identically to a PTY session as the transport allows.** This spec is the first
+of two slices toward that. It delivers the transcript and the composer for all
+eight non-PTY vendors. The second slice (permission and question cards for
+these vendors) is scoped at the end and is not designed here.
+
+## Decisions
+
+Settled with the owner during brainstorming, 2026-09-09:
+
+1. **The transcript reaches the app as a daemon-written envelope journal on
+   disk, read through the existing tail.** The chat is already envelope-based:
+   the PTY path projects vendor records to canonical events and maps those to
+   `AcpEventEnvelope`s before rendering. Non-PTY runtimes emit that very type
+   natively. So the daemon appends each envelope as one JSON line to a
+   per-agent file and reports it as the agent's `transcript_path`; the app's
+   `JsonlTail`, `SwitchPath` and renderer work unchanged. The complete persisted
+   history on open, survival across app restarts, a file that outlives the
+   agent, and a file `kcap` and tests can read. Rejected: an in-memory journal replayed over a
+   new long-lived `TranscriptSubscribe` frame (a bounded buffer with a
+   truncation story, a replay/live splice, a second app-side source, and
+   history that dies with the daemon — more code for a worse parity result);
+   server history plus live frames (two sources to align, and the app's chat
+   is deliberately local-daemon-only).
+2. **The journal is fed at each runtime's emit site, not by a second consumer
+   of its channel, and it never does file IO on the runtime's thread.** Every
+   envelope-emitting runtime funnels its writes through one method; the journal
+   is handed the envelope there, after the channel accepts it and under the
+   same serialization the channel write uses, so the journal's own queue
+   receives the envelopes the runtime wrote, in the order it wrote them — less
+   only what the journal's own counted overflow sheds, and what a crash leaves
+   unpersisted (§1). The hand-off is a non-blocking enqueue onto the journal's
+   bounded queue; a single writer task drains it to disk. So the forwarder's channel and its
+   backpressure and loss policy are untouched, and a slow or hung disk can
+   never stall an ACP read loop, Pi's pump, Antigravity's worker or Codex's
+   read loop — it costs journal lines, never protocol liveness. The journal is
+   a constructor dependency, because the runtimes' pumps start in their
+   constructors and the initial prompt's envelopes are emitted before the
+   factory returns. Rejected: a tee channel between runtime and forwarder (it
+   cannot reproduce `CodexForwardBuffer`'s split policy — canonical waits with
+   a watchdog, ephemeral drops — and it doubles the queued capacity before the
+   watchdog can fire); synchronous appends at the emit site (a hung
+   filesystem would hold the ACP read loop under `_aggregationLock`, exactly
+   what that runtime's non-blocking transcript design exists to prevent).
+3. **Input rides one new one-shot frame, `SendText`, routed to the same delivery
+   core the server-origin `SendInput` uses.** The raw `Stdin` attach path is
+   unsupported for these runtimes by design (`SendRawInputAsync` throws); every
+   runtime implements `SendUserInputAsync`. PTY keeps its `Stdin` path
+   untouched in this slice; the app chooses by `has_terminal`.
+4. **Which reader a session gets is stated on the wire, not inferred.**
+   `AgentStatusDto` gains a trailing `transcript_format` that a current daemon
+   always emits — `"vendor"` for a PTY runtime, `"envelopes"` for an
+   envelope-emitting one — so null means an older daemon and nothing else.
+   Same wire rule AI-2196 set: trailing nullable members, no new frame family
+   for reading, every member always emitted.
+5. **Parity amendments the PTY comparison surfaced.** Discovery sets
+   `agent.SessionId` for PTY agents, so an envelope-sourced agent gets it at
+   construction, in the canonical form the server uses; PTY transcript
+   discovery and the Codex turn probe are gated to PTY runtimes so neither can
+   replace or watch a journal.
+6. **Retention is 30 days**, mirroring Claude's own default transcript cleanup,
+   because these files are kcap-owned where the PTY files are the vendor's.
+7. **No vendor display rules on the journal path.** `ClaudeChatRules` and
+   `CodexChatRules` exist to drop or rewrite noisy vendor records; the ACP
+   translators already emit the clean vocabulary the web renders verbatim. The
+   per-vendor `IChatDisplayRules` hook under `Harness/<Vendor>/` stays available
+   if one ever needs it.
+8. **The tab-strip "no terminal" note goes away.** It explained an empty pane;
+   the pane is no longer empty, and the work-context header already names the
+   transport.
+
+## 1. Daemon: the envelope journal
+
+### What is journaled
+
+Every envelope an envelope-emitting runtime's transcript channel **accepts**,
+except ephemerals (`Ephemeral == true`: Codex app-server live chunks, which the
+server never persists either). Kinds the chat does not render (`usage`,
+`token_usage`, `plan`, `session_title`, `assistant_thinking`) are still
+written: the file is the session's envelope record, and the renderer already
+ignores kinds it does not handle, exactly as thinking is projected and dropped
+on the PTY path. An envelope the runtime itself declines — written after its
+channel completed at teardown, or after `CodexForwardBuffer` has stalled — is
+not in the journal, because it was never in the transcript. The journal's own
+queue can also overflow when the disk has hung (§ `TranscriptJournal`); that
+loss is counted and marked in the file with a gap note whenever the writer
+survives to persist it.
+
+Line order is the order; the `seq` a line carries is the runtime's placeholder
+`0`, because the forwarder assigns the real sequence on its own dequeue and the
+chat never reads it.
+
+### Where
+
+`<daemon state dir>/transcripts/<sha256(agentId)>.jsonl`, where the state dir
+is `DaemonStore.StateDirectory(config.Name)` — so two daemons never collide,
+and the directory is already 0700. The filename is the same lowercase SHA-256
+hex `AgentPidRecordStore` uses for its records, and for the same reason it
+documents: the agent id crosses the SignalR wire unconstrained, so
+interpolating it into a path would let `..` or a separator escape the
+directory. The derivation moves out of `AgentPidRecordStore` into a shared
+`AgentFileNames.For(agentId)` so the two stores can never disagree; the sweep
+below joins them by that name. One envelope per line, encoded by
+`EnvelopeJournalFormat` (§3) over `CapacitorJsonContext`: snake_case, the same
+bytes the server receives.
+
+### `TranscriptJournal`
+
+One per launch, constructed by the orchestrator from the agent id **before the
+runtime factory runs** and carried to the factory on a new
+`RuntimeStartContext.Journal` member.
+
+It is a bounded queue plus one writer task. `Record(envelope)` is what the
+runtimes call: it skips ephemerals and otherwise does one non-blocking
+`TryWrite` onto a bounded channel — no IO, no await, never throws. The channel
+is `BoundedChannelOptions(4096) { FullMode = Wait, SingleReader = true,
+SingleWriter = false }`: `Wait` is what makes `TryWrite` return false on a
+full channel so the drop can be counted (`DropWrite` would return true while
+discarding, the trap `AntigravityHostedAgentRuntime` documents and avoids the
+same way), and `SingleWriter = false` because Pi and Antigravity record from
+two threads. The writer task drains the channel in order and appends each
+**item** — its gap-note line, when it carries one, and its envelope line,
+encoded into one buffer — as one open-seek-to-end-write-flush-close with
+`FileMode.Open`, `FileAccess.Write` and `FileShare.ReadWrite | FileShare.Delete`,
+so an orderly writer never stops between a note and its envelope, no handle is
+held between items, the app's `JsonlTail` never contends with one on Windows,
+and the sweep can delete a file the daemon last wrote a moment ago. A regular
+file write is not transactional: a crash or an IO fault mid-write can leave a
+prefix of the buffer, which for a gap-bearing item can be its complete note
+line followed by a torn envelope; `JsonlTail` then renders the note and drops
+the torn tail. That is the crash model below, and the guarantee here is only
+that *cancellation* never splits an item.
+Envelopes arrive at conversational rates with tool-call bursts in the tens per
+second; the queue absorbs any burst a healthy disk will see.
+
+**One writer per path at a time, enforced, not assumed.** .NET's `FileStream`
+has no cross-handle append primitive — `FileMode.Append` snapshots the length
+at open and writes at that cached offset — so two handles on one journal could
+overwrite each other, and the one way two can exist is an abandoned writer
+(below) alongside a same-id relaunch's journal. Every file operation on a
+journal therefore runs under a process-wide per-path `SemaphoreSlim`
+(`JournalPathLocks`, keyed by the normalized absolute path under
+`PlatformPaths.Comparer` — which moves from the app's `TrayModels.cs` to its own
+file in Core (`Capacitor.Cli.Core.PlatformPaths`, one type per file) so the
+daemon and the app share one platform path rule; the app's five call sites
+re-point — so two state directories that hash the same agent id to the same
+file name never share a lock, and one path never has two): each
+writer item, `Open`'s header write, the failure path's delete and the sweep's
+delete. Entries are reference-counted leases: `Acquire(path, timeout, ct)`
+creates or finds the entry and increments its count before waiting; a wait that
+succeeds returns a lease whose `Dispose` releases the semaphore and then
+decrements; a wait that times out, is cancelled or throws decrements on the
+same path **without** releasing a semaphore it never held; and the entry leaves
+the map only when the count reaches zero — every increment, decrement and
+removal under the map's own lock, so a waiter can never be left holding an
+entry the map no longer knows (how one path would end up with two locks) and a
+failed wait can never leave a phantom count behind. The map therefore holds
+exactly the paths with a live owner or waiter, never one per historical
+session or per timed-out attempt. A writer stuck inside
+a filesystem call holds its path's lock for as long as the call lasts, which is
+exactly the property wanted: nothing else can write the file until that call
+has returned and the handle is closed. `Open` and the two deletes take the
+lock with a 2 s bound and treat a miss as their failure case (`IsOpen` false
+for `Open`; skipped for a delete) — a path whose lock cannot be had is one
+whose disk is hung, and the same hang would have taken them down anyway.
+
+**Loss is explicit, local and placed where it happened.** If the queue is full
+— the disk has hung or is far behind — `Record` drops the envelope and counts
+it in a `pendingGap` counter. The count is not flushed as the writer's next
+line, which would put the note ahead of everything already queued before the
+loss. Instead the channel's item type is `JournalItem(AcpEventEnvelope
+Envelope, int GapBefore)`: the next `Record` that finds room takes the counter
+into the item it enqueues (one `TryWrite`, one slot, no two-slot reservation),
+and the writer emits the `system_note` "N envelopes were not recorded to this
+journal" line and then the envelope's line, so the note sits exactly between
+the last envelope that made it and the first one after the gap. A gap still
+pending when the channel completes is written by the writer as the final line
+once the queue has drained; a gap pending when the writer is abandoned is
+part of the abandonment Warning. The server is unaffected: it reads the
+forwarder's channel, not this one. A write failure (including the file having
+been deleted underneath the writer) latches the journal off after one Warning;
+anything still queued is counted and logged with it.
+
+**A crash loses the backlog.** Lines are durable once the writer has appended
+them; what is still queued when the daemon process dies — up to the channel's
+4096 envelopes plus any pending gap count — is lost with no marker, because no
+writer remains to write one. That is the price of keeping file IO off the
+runtime threads, and it bounds "full history" to "every envelope the writer
+reached"; a healthy disk keeps that backlog at zero.
+
+`Open(cwd, model)` is **synchronous and does its IO on the calling thread** —
+the launch path, before the runtime factory runs, where IO is already routine.
+It creates the directory, opens or creates the file (recording `CreatedFile`),
+writes the header line and flushes it, closes the handle, and only then sets
+`IsOpen` and starts the writer. So when the orchestrator publishes
+`TranscriptPath` the file exists with its first line, `JsonlTail` never sees
+`Missing` for a journal that opened, and a failure to create or write the
+header is an open failure: `IsOpen` stays false, no writer starts, `Record` is
+a no-op. The header is a `session_started` envelope built with
+`AcpEventTranslator.BuildSessionStarted` from what is known at that moment (the
+worktree path as `cwd`, the requested model, no raw session id; the file's
+identity is the agent id in its name).
+
+`Complete()` is the one lifecycle call, and its owner is the orchestrator:
+`CleanupAgentAsync` calls it after `Runtime.DisposeAsync()` (the runtime can
+emit nothing further by then), the pre-publish failure path calls it before
+deciding whether to delete the file, and daemon shutdown reaches it through the
+same cleanup. It closes the channel's writer side and awaits the writer task
+for at most 2 s. A healthy writer drains what is queued and exits. A writer
+stuck inside a filesystem call cannot be interrupted, so on expiry `Complete`
+cancels the writer's token (observed only between items, never inside one),
+logs one Warning naming the in-flight item, how many queued items and how
+large a pending gap count are being abandoned, latches the journal, and
+returns without awaiting further; the abandoned task holds at most the one
+handle of the item it is on, finishes that item's write when the call returns,
+observes cancellation and exits. `Complete` reports whether
+the writer exited (`Drained`) or was abandoned, and the pre-publish failure
+path deletes a `CreatedFile` journal only when `Drained` — an abandoned writer
+still holds the path lock inside its call, so the delete would not get the lock
+anyway, and left alone the sweep reaps the file in 30 days. A same-id
+relaunch's `Open` takes the same path lock: while the abandoned call lasts,
+`Open` misses its 2 s bound and the new incarnation runs with `IsOpen` false
+(Waiting in the app), which is the truthful state of a journal whose disk is
+hung; once the call returns and the lock is free, the late line has already
+been written at the true end of the file under the lock, and any later `Open`
+appends after it. No two handles are ever open on one journal. A journal never
+completed (the process died) simply stops with the process. `Path`, `IsOpen`
+and `CreatedFile` are readable by the orchestrator.
+
+The header is written at **every** open, so a relaunch that reuses an agent id
+which already has a journal (an envelope-sourced rebind through the source
+claim) appends a second header that marks the new incarnation, and the
+transcript spans incarnations the way the server's canonical stream does. A
+relaunch under a new agent id starts a new file. The header is deliberately
+independent of the forwarder's own `session_started`, which is still built and
+sent to the server exactly as today; whether a bind is fresh or a rebind is
+only learned from the source-claim response, and the journal must not wait for
+it.
+
+That is the file's story. **The app's story for a same-id relaunch is
+unchanged by this slice**: `WorkspaceViewModel.Accumulate` carries
+`SessionEnded` forward once set, and `OpenSession` keeps an already-open
+workspace for the same id, so a workspace that watched an incarnation end stays
+ended until the user closes it; a workspace opened after the relaunch tails the
+same file from byte zero and sees both incarnations. Whether an ended
+workspace should come back to life on a same-id relaunch is a session-model
+question the PTY path has not answered either, and it is out of scope here.
+
+### Constructor injection at the emit site
+
+Each envelope-emitting runtime has exactly one place its transcript channel is
+written: `AcpHostedAgentRuntime.EmitEnvelope`, `PiRpcHostedAgentRuntime.Write`,
+`AntigravityHostedAgentRuntime`'s transcript write, and
+`CodexForwardBuffer.Emit`. Each gains an optional `TranscriptJournal?`
+constructor parameter (null in every existing direct-construction test site).
+The factory calls `journal.Open(...)` before constructing the runtime and
+passes it in.
+
+Why the constructor and not a later assignment: `PiRpcHostedAgentRuntimeFactory`
+sends the initial prompt and awaits the handshake before returning, the ACP and
+Antigravity factories enqueue the initial prompt in `StartAsync`, and every
+pump starts inside its constructor — envelopes are in the channel before the
+orchestrator ever sees the runtime. The `ActivityClock` post-construction
+assignment carries exactly the race the Pi factory documents; the journal
+cannot accept it, because the first `user_message` is the line that matters
+most.
+
+**Order and admission.** The channel accepting an envelope and the journal
+recording it are one serialized operation per runtime, and the record happens
+only on acceptance:
+
+- `AcpHostedAgentRuntime.EmitEnvelope` already writes under `_aggregationLock`;
+  `Record` joins it after a successful `TryWrite`.
+- `PiRpcHostedAgentRuntime.Write` and Antigravity's transcript write are
+  reached from two threads (the pump and the send-time `user_message`; the turn
+  worker and the queue-full notice from `EnqueueTurn`), which is why their
+  channels are `SingleWriter = false`. Each gains a small write lock around
+  `TryWrite` plus `Record`. The activity-clock advance stays where it is,
+  before the lock. `TryWrite` never blocks on these `DropOldest` channels, so
+  the lock only ever covers the channel write and the journal queue's own
+  `TryWrite` — never any IO.
+- `CodexForwardBuffer.Emit` has a single writer (the read loop) and needs no
+  lock. `WriteCanonicalBlocking` changes from `void` to `bool accepted`: true
+  only when the envelope entered the channel; false when the stall watchdog
+  fired, when shutdown cancelled the wait (today it swallows that cancellation
+  and returns as if nothing happened), and when the channel was already
+  completed (`ChannelClosedException`, caught and logged at Debug as the
+  ordinary teardown race the other runtimes already treat it as, instead of
+  escaping the read loop). `Record` follows a successful `TryWrite` or an
+  accepted blocking write. A stalled buffer, a completed channel, a cancelled
+  wait and a dropped ephemeral are all "not written" and are not journaled.
+  Antigravity's queue-full system note is journaled exactly when
+  `EmitDaemonNotice` returns true, so the file and the transcript agree.
+
+Recording after acceptance means a `DropOldest` eviction costs the journal
+nothing: when the runtime channel is full, `TryWrite` still succeeds and evicts
+the oldest envelope, which the journal already received when it was accepted —
+the journal's own overflow and the crash backlog are the only losses, and both
+are the journal's, not the runtime's. `CodexForwardBuffer`'s canonical
+wait, ephemeral drop and 30-second stall watchdog are untouched because nothing
+sits between the buffer and the forwarder. `Record` is one channel `TryWrite`
+on the emitting thread; the disk is only ever touched by the journal's writer
+task, so no runtime thread can block on it.
+
+### Antigravity's user turn
+
+Three of the four envelope-emitting runtimes already put the user's prompt in
+the transcript: Pi emits a `user_message` in `SendUserInputAsync`, the ACP
+runtime's turn worker emits `AcpEventTranslator.BuildUserMessage` when it
+dequeues a turn, and the Codex mapper translates the app-server's own user
+item. Antigravity does not: `EnqueueTurn` queues the text, the worker hands it
+to the child as an argument, and `AntigravityNdjson.ToEnvelopes` maps only
+what the child prints. The web shows Antigravity user turns from the server's
+own dispatch record, which a local send never reaches.
+
+Antigravity therefore adopts the ACP worker's pattern: `RunTurnWorkerAsync`
+emits `AcpEventTranslator.BuildUserMessage(seq: 0, NowIso(), turn.Text)`
+through the transcript write after it dequeues a turn and takes `_turnGate`,
+before it spawns the turn child. The helper takes a timestamp and Antigravity
+has no clock today, so its constructor gains an optional `TimeProvider`
+(default `TimeProvider.System`, the same shape `AcpHostedAgentRuntime` and
+`CodexAppServerHostedAgentRuntime` already take) and a `NowIso()` over it;
+tests inject a fixed provider so the journal and server bytes are pinned. The
+single worker is what orders it ahead of that turn's output — emitting from
+`EnqueueTurn` would not, since the worker can dequeue and the child can print
+before the enqueuing thread runs again. The initial prompt and every follow-up
+take the same path; a turn the queue refuses emits nothing but the existing
+"message not delivered" note. The server maps a `user_message` envelope to
+`UserMessageReceived` through its attribution service for the other three
+vendors already, so Antigravity joins an existing server path rather than
+adding one.
+
+### Status snapshot
+
+`HostedRuntimeStart` is in hand before the `AgentInstance` is constructed, so
+the envelope-sourced fields are set in the initializer, **before
+`PublishAgent`** and therefore before the first snapshot that can carry this
+agent (today `PublishAgent` precedes `RegisterAgentAsync`, whose server call
+can stall for the length of an outage):
+
+- `SessionId = start.Transcript is { } t ? SessionIds.Canonical(t.AcpSessionId) : null`.
+  `SessionIds.Canonical` is a new Core helper mirroring the server's
+  `CanonicalSessionId.Normalize` exactly: a value that parses as a GUID becomes
+  its 32-hex `N` form, anything else is returned unchanged. It is not
+  `PermissionWire.Canonical`, which returns null for a non-GUID and exists to
+  match permission requests, not to name sessions. ACP session ids are opaque
+  strings on the wire (existing tests use `sess-1` and
+  `fixed-conversation-id`), so the GUID-only form would leave those agents with
+  no session id at all.
+- `TranscriptPath = start.Transcript is null ? null : journal.IsOpen ? journal.Path : null`.
+- `Journal = journal` (a new `AgentInstance` member, null for PTY), so cleanup
+  and the failure path below can reach it.
+
+`SnapshotAgentsForStatus` emits `transcript_format` derived from the runtime,
+not stored: `a.Runtime is IAcpTranscriptSource ? "envelopes" : "vendor"`. It is
+therefore present and correct in the first snapshot, whether or not the journal
+opened. PTY agents keep null `SessionId`/`TranscriptPath` until discovery, as
+today.
+
+Every later `AgentStatusChanged` for an envelope-sourced agent now carries the
+canonical session id instead of null — which is what makes the web UI render a
+stopped Pi agent as "Agent failed to start" today. The rest of that report (the
+SIGKILL exit and stop-as-failure mapping) stays with AI-2644.
+
+**The same rule on the app's server reads.** `WorkContextIds.CanonicalSessionId`
+today trims and strips every dash, which would turn an opaque `sess-1` into
+`sess1` and miss the server; it delegates to `SessionIds.Canonical` (GUID →
+`N` form, anything else trimmed and unchanged) before its existing dot-segment
+validation. The PR pane passes the dto's `session_id` through untouched and
+needs no change.
+
+### PTY-only paths
+
+- `DetectSessionIdAsync` runs unconditionally after launch and, for
+  `vendor == "codex"`, would locate app-server Codex's rollout and overwrite
+  `TranscriptPath` with a file the journal projection cannot read. It is
+  gated on `start.Transcript is null`.
+- `ArmCodexTurnProbe` samples `TranscriptPath`'s length as a rollout baseline;
+  it is gated on `agent.Runtime.EmitsTerminalOutput`.
+
+### Lifecycle
+
+- **Daemon restart.** The daemon does not re-adopt a prior epoch's children:
+  `OrphanReaper` reaps them at boot. Their journals stay on disk and readable
+  in the app (the rows are gone, so the workspace shows the session as ended)
+  until the sweep.
+- **Agent exit.** The file stays; the chat keeps rendering; `SessionEnded`
+  comes from the snapshot; the composer reads `Ended`.
+- **Launch failure before `PublishAgent`** (the factory threw after
+  `journal.Open` ran): the orchestrator deletes the file **only if
+  `CreatedFile` is true and `Complete` drained** — this launch made it,
+  everything in it is this launch's, and no abandoned writer can recreate it. A
+  rebind whose factory fails leaves the prior incarnation's bytes untouched; an
+  abandoned writer leaves the file to the sweep. Nothing else deletes a journal: not agent exit, not worktree
+  teardown (the file is outside the worktree), not a failure after publish.
+- **Sweep.** `TranscriptJournalSweep` deletes `transcripts/*.jsonl` whose last
+  write is older than 30 days and for which no PID record `agents/<same
+  name>.json` exists, taking each file's path lock first (a file whose lock it
+  cannot take is skipped this run). It is its own hosted singleton, a
+  `BackgroundService` registered in `DaemonRunner` beside the other hosted
+  services and built over a `TimeProvider`, with two entry points. `RunOnceAsync`
+  is awaited by `DaemonRunner` **after** the awaited startup orphan reap and
+  before the server connect — the reap is what removes a prior epoch's PID
+  records, so a sweep before it would keep every journal whose agent died with
+  the old daemon. `ExecuteAsync` then runs `RunOnceAsync` every 24 hours on a
+  `PeriodicTimer` over the same `TimeProvider`, anchored at the first tick 24 h
+  after start, until host shutdown cancels it. `RunOnceAsync` is single-flight
+  (an `Interlocked` guard, the shape `ReapOrphansOnceAsync` uses, so a slow
+  sweep and the next tick never overlap) and **never throws**: each file's
+  metadata read, lock attempt and delete is its own try/catch logged at
+  Warning, and an outer catch guards enumeration itself — a sweep fault can
+  neither block the daemon's connect nor end the periodic loop. So 30 days is
+  a retention policy rather than a restart-only cleanup. A record the reap left
+  in place (a still-live or quarantined child) keeps its journal.
+
+### Faults
+
+- Open failure: `IsOpen` stays false, `Record` no-ops, one Warning;
+  `TranscriptPath` is null while `transcript_format` is still `"envelopes"`, so
+  the app shows Waiting — the same phase a failed PTY discovery produces, and
+  distinguishable from an older daemon by the format.
+- Write failure later: one Warning, the journal latches off, the path stays set
+  so the app keeps what it has. Forwarding is unaffected: the journal never
+  touches the channel.
+- Crash: the queued backlog is lost without a marker (above); the line being
+  appended may be torn, and `JsonlTail` yields complete lines only, re-reading
+  an unterminated tail once its newline lands, so the file stays readable.
+
+## 2. Local input frame
+
+### Frames (append-only)
+
+`FrameType.SendText = 22` (one-shot request) and `FrameType.SendTextAck = 80`
+(reply). Both carry JSON text like the permission frames, encoded and decoded
+in `FrameCodec` beside them:
+
+- `SendTextDto(string AgentId, string Text)` — `{"agent_id","text"}`.
+- `SendTextAckDto(bool Ok, string? Reason, string? Error, string? Outcome = null)`
+  — `Reason` is one of the coded refusals below (null when `Ok`), `Error` is
+  human-readable detail, and `Outcome` says what an `Ok` did: `"delivered"`
+  (the runtime admitted the text) or `"stopped"` (the text was a quit command
+  and the agent was stopped instead). Null when not `Ok`.
+
+Both in a new `InputIpcJsonContext` (snake_case). Advertised as `input/1` in
+`LocalControlCapabilities.Current`, added in the same change as the new `case`
+in `LocalControlServer` — the capability list is assembled beside the routing
+switch and nothing is advertised without a live handler.
+
+**Compatibility contract: a client never sends `SendText` to a daemon that
+does not advertise `input/1`.** An older daemon cannot answer it: its
+`FrameCodec.Decode` throws `InvalidDataException` on the unknown type before
+routing, `HandleConnectionAsync` logs and closes, and the client sees EOF.
+`SendTextAsync` maps EOF and any transport fault to `Ok = false, Reason =
+"transport"`; that mapping, not an `Error` frame, is what the client tests pin.
+
+### Handler
+
+`AgentOrchestrator.HandleLocalSendTextAsync(string payload, Stream stream,
+CancellationToken ct)` in `AgentOrchestrator.LocalIpc.cs`. Every outcome is an
+ack, never an `Error` frame and never an escaped exception, so the composer can
+word it. Checks run in this order, each answered before the next runs:
+
+| `reason`              | when                                                                          |
+|-----------------------|-------------------------------------------------------------------------------|
+| `malformed`           | payload is not JSON, is not an object, or lacks `agent_id` or `text` (missing or null). Source-generated STJ leaves a missing member null, so this is an explicit structural check, the way `PermissionWire.IsPendingStructurallyValid` guards the permission frames |
+| `text_empty`          | `text` is present but empty or whitespace                                     |
+| `too_large`           | `text` over 256 KiB of UTF-8                                                  |
+| `no_such_agent`       | id not in `_agents`                                                           |
+| `protected_kind`      | a review or flow participant; `Error` carries the `ProtectionReason` text the read-only attach uses |
+| `not_running`         | status is Starting, Completed or Failed                                       |
+| `reaper_claimed`      | the delivery core refused because the reaper claimed the agent (the existing `SendInputDropReason` token) |
+| `reaper_claimed_late` | the reaper's claim landed inside the delivery section (likewise the existing token) |
+| `queue_full`          | the runtime refused to admit the text (its pending-turn queue is full or it is terminal) |
+| `stop_failed`         | the text was a quit command and the owner's stop did not succeed             |
+| `delivery_failed`     | the runtime threw anything else; `Error` carries the message                  |
+
+The reason vocabulary is the server-origin `SendInputDropReason` set plus the
+local-only refusals; no existing token is renamed. Private (locally spawned)
+agents are accepted: a request on the owner's 0600 socket is the owner's, the
+rule `kcap agent stop` already follows. The size cap exists because a single
+JSON frame is one buffer where PTY input streams through the PTY's own flow
+control; no prompt approaches it.
+
+### Admission is explicit
+
+`Ok = true` means **the runtime's own delivery task completed without a
+fault** — or, for a quit command, that the agent was stopped (`Outcome` says
+which). What that task's completion means is the runtime's existing contract,
+unchanged by this slice:
+
+| runtime               | `SendUserInputAsync` completes when                                        |
+|-----------------------|----------------------------------------------------------------------------|
+| ACP vendors           | the turn is queued for the single turn worker (immediately)                |
+| Antigravity           | the turn is queued for the turn worker (immediately)                       |
+| Codex app-server      | the dispatcher has started or steered a turn with the text                 |
+| Pi                    | the prompt command has been written to Pi's stdin                          |
+| PTY (Claude, Codex)   | the bracketed paste has been written; the delayed Enter is best-effort (skipped when the process has exited or the pipe closed) — the runtime's existing contract, and PTY is not on this frame in this slice |
+
+Today the ACP and Antigravity runtimes refuse a full pending-turn queue
+silently for a non-acknowledging caller (`EnqueueTurn` logs and returns a
+completed task), so the server-origin path cannot tell a delivery from a drop —
+a residual the code already notes as accepted. This slice makes refusal
+explicit and typed:
+
+- `IHostedAgentRuntime.SendUserInputAsync` and `SendUserInputAndWaitForWriteAsync`
+  gain a documented contract: a runtime that will not queue or write the text
+  fails with `InputNotAdmittedException` (new, `Services/`) — thrown
+  synchronously by the non-acknowledging path, and carried by the acknowledging
+  path's task in place of today's `InvalidOperationException`, so the borrowed
+  server-origin round (which keeps using the wait-for-write variant) maps to
+  the same reason. `AcpHostedAgentRuntime.EnqueueTurn` and
+  `AntigravityHostedAgentRuntime.EnqueueTurn` do this on a full queue and on a
+  completed channel; Antigravity keeps emitting its "message not delivered"
+  system note first.
+- `CodexTurnInputDispatcher.EnqueueAsync` has the same gap in a different
+  shape: it enqueues unconditionally even after `FaultAll` has set `_faulted`,
+  and the dispatch paths then refuse to settle the item, so a send that races
+  teardown stays pending forever. It refuses under its `_gate` — the lock
+  `FaultAll` takes — by throwing `InputNotAdmittedException` once `_faulted`
+  is set, so an enqueue and a fault cannot interleave; the runtime's
+  `SendUserInputAsync` lets it propagate. An item enqueued before the fault is
+  faulted by `FaultAll` as today.
+- Pi and PTY admit by writing and need no change.
+
+The shared core (below) maps `InputNotAdmittedException` to `queue_full` for
+both callers. The server-origin caller reports it through
+`ReportInputDroppedAsync` with a new `SendInputDropReason.QueueFull =
+"queue_full"`: the server's `SendInputRejected` treats the reason as opaque
+text — it logs it and records it against the dispatch — so the new token needs
+no server change.
+
+**The delivery core's own behaviour does not change**, for either caller. It
+holds `BorrowedSnapshotGate` for the whole delivery, uses
+`SendUserInputAndWaitForWriteAsync` for a borrowed round exactly as today (the
+server-origin path's review and flow participants are protected kinds, and they
+keep entering the core), awaits the runtime's task to completion, and runs the
+activity-clock, awaiting-input and status-report side effects after that
+completion, as it does now. Nothing in this slice bounds, times out or cancels
+a delivery, and the gate is never released while a write is in flight — that
+gate is what keeps a retry or a reap claim from racing the same write.
+
+**The local handler answers when the core settles, and not before.** There is
+no early acknowledgement, no admission signal and no timeout: a fault answers
+`queue_full`, a reaper token or `delivery_failed`; completion answers `Ok`. The
+handler holds the connection open for as long as that takes, and the client's
+only bound is its own cancellation.
+
+**A lost ack is an unknown outcome — as it is for a PTY paste today.** A
+one-shot exchange can lose its answer: the client cancels while the core is
+still delivering, or the delivery completes and the `SendTextAck` write fails
+on a closing socket. The daemon delivers each frame it received exactly once,
+under the gate, whatever became of the connection; the client that lost the
+answer simply does not know which way it went. This slice does not add an
+idempotency key or a result ledger to close that window: the PTY composer has
+had the same window since it shipped (a paste is written and never
+acknowledged), the transport is a local Unix socket where the window is
+vanishingly small, and the machinery to close it — client-minted keys, a
+per-agent replayable ledger, a store that outlives the workspace so a
+torn-down tab can still replay — is a second protocol's worth of state for a
+guarantee the PTY path does not make. The composer instead tells the truth:
+after a transport failure or a cancelled wait it keeps the text and says
+"delivery unconfirmed — check the chat before sending again", and the user
+decides. Two clients sending different texts serialize on the gate and deliver
+one turn each.
+
+Two further consequences are deliberate:
+
+- **A slow runtime looks slow.** ACP and Antigravity answer at once; Codex
+  answers when its dispatcher has started or steered the turn (input during an
+  active turn is steered, so this is usually prompt, and it can wait when a
+  `turn/start` is pending); Pi answers when its stdin write completes, which is
+  microseconds unless the child is wedged. A wedged child keeps the composer in
+  `Sending` until the reaper or a stop faults the write, at which point the ack
+  is `delivery_failed` and the composer says so from the ack's own text — it
+  never depends on the runtime's best-effort transcript note.
+- **Cancelling the wait abandons the observation, not the delivery.** If the
+  client cancels (the tab is torn down) the connection closes; the core still
+  runs to settlement under the gate, delivering once, and logs the outcome;
+  the client is left with the unknown outcome above.
+
+The borrowed-snapshot refresh (up to 30 s) never reaches the local handler: it
+applies only to borrowed reviewers, which `protected_kind` refuses before the
+core runs.
+
+### Delivery core, shared not copied
+
+`HandleSendInput`'s body from the quit-command check onward becomes
+`DeliverInputAsync(AgentInstance agent, string text, string[]? attachmentIds)`
+returning a delivery outcome — delivered, quit requested, or a drop reason —
+and both callers use it. A local send therefore gets identical behaviour to a
+web send:
+
+- a `/quit`-style command on a non-PTY runtime is recognised by the core and
+  reported as *quit requested* rather than sent as a prompt (PTY runtimes still
+  receive the text verbatim). **Each caller then performs the stop on its own
+  lane**: the server-origin caller routes it through
+  `HandleUnsequencedStopAgent` exactly as today, keeping the invariant that
+  server-origin launch and stop share one serial lane, and that path's
+  `HandleStopAgent` refusal of private agents stays; the local caller calls
+  `StopAgentCoreAsync(agent)` directly — the owner's stop, the one `kcap agent
+  stop` uses, which private agents are eligible for — and acks `Ok` with
+  `Outcome = "stopped"`, or `stop_failed` when the core reports failure;
+- the borrowed-snapshot gate serialises local and server inputs per agent;
+- a reap-claimed agent refuses, early or late, with the existing tokens;
+- a refused admission is `queue_full` for both callers;
+- the activity clock advances and the awaiting-input wait clears **only on
+  completion**, so a refused or failed text never drops the rail's needs-you
+  pip;
+- the post-send status report fires on completion;
+- the Codex probe arms only for PTY Codex (§1).
+
+The server-origin caller keeps reporting drops to the server through
+`ReportInputDroppedAsync`; the local caller puts the same reason in the ack.
+
+### Core client
+
+`ILocalControlOps.SendTextAsync(string agentId, string text, CancellationToken
+ct)` beside `StopAgentAsync`, one frame exchange per call, returning
+`SendTextResult(bool Ok, string? Reason, string? Error, string? Outcome)` —
+the ack's four members passed through verbatim; EOF and transport faults map to
+`Ok = false, Reason = "transport", Outcome = null`. Unlike the other one-shot
+exchanges it has **no reply timeout**: the ack arrives when the delivery
+settles, and the caller's token is the only bound. The app reads `Outcome`
+exactly once: `"stopped"` is the quit case; any other value on an `Ok`,
+including one this build has never seen, is treated as delivered.
+
+The frame is vendor-agnostic on purpose (`PtyHostedAgentRuntime.SendUserInputAsync`
+is the bracketed-paste path the web already uses), but the app keeps PTY on the
+attach's `Stdin` path in this slice so nothing changes for Claude and Codex.
+
+## 3. Core: reading journal lines as chat
+
+### One reader interface
+
+`IChatTranscriptProjection` (Core, public) with the two members the tab already
+calls on `TranscriptChatProjection`:
+
+```csharp
+public interface IChatTranscriptProjection {
+    TranscriptContext CreateContext(string sessionId, string? agentId);
+    IReadOnlyList<AcpEventEnvelope> Project(string line, int lineNumber, DateTimeOffset receivedAt, TranscriptContext context);
+}
+```
+
+`TranscriptChatProjection` implements it unchanged. `ChatTabViewModel` and its
+`TailLease` take the interface. No behaviour change for Claude or Codex.
+
+### `EnvelopeJournalProjection`
+
+Core, vendor-neutral, so outside `Harness/`. `Project` decodes the line as one
+`AcpEventEnvelope` through `EnvelopeJournalFormat.TryRead` and returns it; a
+line that does not decode throws, which the tab already catches per line and
+logs once, the same as a malformed vendor record. Its context is a stateless
+`TranscriptContext`: journal lines carry no ids to dedupe. Passthrough is the
+whole rule (decision 7).
+
+### `EnvelopeJournalFormat`
+
+Core owns the line encoding both sides use: `string Write(AcpEventEnvelope)`
+and `bool TryRead(string line, out AcpEventEnvelope)`, over
+`CapacitorJsonContext.Default.AcpEventEnvelope`. The daemon writes with it, the
+app reads with it, and one round-trip test pins the bytes.
+
+`TryRead` decides structural validity itself rather than trusting the
+deserializer: `AcpEventEnvelope` is a record struct whose `Kind` defaults to
+`""`, so source-generated STJ happily produces a value from `{}` or from a
+null `kind`. A line is valid only if it is a JSON object with a non-null,
+non-empty `kind` and a `contract_version` this build supports; `{}`, a scalar,
+an array, a missing, null or empty `kind`, an unsupported version, and
+unparseable text all fail and take the per-line fault path. The supported set
+mirrors the server's `AcpContractVersion` gate (today exactly `1`), for the
+reason the server states: a future version may reuse a known `kind` with
+changed field semantics, so a v2 line with a v1 kind must not render as v1. A
+syntactically valid v1 envelope whose `kind` this build does not know is valid
+— that is the additive-within-a-version rule the renderer already relies on.
+
+### `TranscriptChat`
+
+Gains `public static readonly IChatTranscriptProjection Journal` (an
+`EnvelopeJournalProjection`). `For(vendor)` stays the PTY registry and keeps
+returning null for vendors without a leaf.
+
+### Wire: `transcript_format`
+
+`AgentStatusDto` gains one trailing member after `AwaitingInput`:
+
+- `string? TranscriptFormat = null`, serialized `transcript_format`, always
+  emitted. A current daemon sends `TranscriptFormats.Vendor` (`"vendor"`) for a
+  PTY runtime and `TranscriptFormats.Envelopes` (`"envelopes"`) for an
+  envelope-emitting one, from the first snapshot the agent appears in; null can
+  only come from an older daemon. The constants live beside `WorkLocationText`
+  in `StatusIpc.cs`.
+
+Serialization acceptance (extends `StatusIpcJsonTests`): old JSON without the
+member deserializes to null; a value and null both serialize with the member
+present, last, in the declared trailing order.
+
+The workspace resolves the projection from the format: `"vendor"` →
+`TranscriptChat.For(vendor)` (null for a vendor without a leaf, today's
+`Unavailable`), `"envelopes"` → `TranscriptChat.Journal`, null → the
+older-daemon phase (§4), any other value → `Unavailable` worded "Update the app
+to view this session", so a future format never renders as garbage.
+
+## 4. App: workspace and composer
+
+### Chat for every session
+
+`WorkspaceViewModel` builds `ChatTabViewModel` on the first dto for any vendor
+(`presence.Where(p => p.Dto is not null).Take(1)`), no longer only the first
+dto that passes `ShowsTerminal`. The projection is resolved from that dto's
+`transcript_format` as §3 describes; because a current daemon carries the
+format from the first snapshot, no later re-resolution is needed, and a null
+format is the older-daemon case, not a race. The composer's input channel comes
+from `has_terminal`. `ShowsTerminalTab` and the Terminal tab stay PTY-only.
+
+`WorkspaceView.axaml` today gates three things on `ShowsTerminalTab`: the
+`ChatTabButton`, the `ChatHost` (through a `MultiBinding` with `IsChatActive`)
+and the `TerminalTabButton`/`TerminalHost`. The first two lose the gate
+(`ChatTabButton` always visible, `ChatHost` visible on `IsChatActive` alone);
+the terminal pair keeps it. The tab-strip `NoTerminalNote` binding is removed
+(decision 8); `HostedHarnessCatalog.NoTerminalNote` itself stays, because
+`TerminalTabViewModel` still publishes it as the hidden terminal pane's state.
+
+`AgentPresence`, today a private nested record of `WorkspaceViewModel`, moves to
+its own file as an internal record so the input channel below can observe it.
+
+### One composer, two channels
+
+`ChatTabViewModel` stops reading `TerminalTabViewModel` directly and takes a
+`ChatInput`:
+
+```csharp
+public abstract class ChatInput : ReactiveObject, IDisposable {
+    public abstract SendAvailability Availability { get; }
+    public abstract bool CanAcceptText { get; }
+    public abstract string Hint { get; }
+    /// Completes when the channel considers the text committed: true to clear the composer.
+    public abstract Task<bool> SendAsync(string text, CancellationToken ct);
+    public abstract void Dispose();
+}
+```
+
+`SendAsync` is where the two channels legitimately differ (see "Clear on ack"):
+the terminal channel completes as soon as the paste is accepted, the frame
+channel when the ack arrives.
+
+Both implementations own long-lived subscriptions — the terminal one to the
+terminal tab's availability and state, the frame one to the daemon client's
+status and capabilities and to the agent's presence — so the input is
+disposable and **`ChatTabViewModel` owns it**: it goes into the tab's
+`_disposables`, and `TeardownAsync` cancels the lifetime token (ending any
+in-flight send) before disposing it, in that order. After `Dispose` an input
+raises nothing and sends nothing.
+
+- `TerminalChatInput(TerminalTabViewModel)` wraps the terminal tab and
+  reproduces today's PTY behaviour and wording exactly (`HintFor` moves here
+  with its terminal-state inputs). Its `SendAsync` returns the accepted flag as
+  an already-completed task and ignores the token, since the terminal path has
+  nothing to cancel.
+- `LocalFrameChatInput(agentId, IDaemonClientService, ILocalControlOps,
+  IObservable<AgentPresence>)` sends `SendText` and derives its state from the
+  daemon client: `Connecting` while not attached; `Unsupported` (one new
+  `SendAvailability` member) when the attached daemon does not advertise
+  `input/1`, hinted "Update the daemon to send messages from the app" — and it
+  never sends in that state; `Ready` while the dto is Running; `Sending` from
+  the send until its ack arrives, however long that takes, one at a time like
+  the PTY gate; `Ended` once the session ends. A refused ack keeps the typed
+  text and puts the coded reason in the hint ("agent is no longer running",
+  "read-only participant", "the agent's input queue is full, try again
+  shortly", and for `delivery_failed` the ack's own `Error` text); a transport
+  failure or a cancelled wait keeps the text with the hint "delivery
+  unconfirmed — check the chat before sending again" (§2). An `Ok` with
+  `Outcome = "stopped"` clears the text
+  and lets the session's ending, which the snapshot delivers moments later,
+  speak for itself.
+
+The composer's `ComposerHint`, `ShowsComposer` and `canSend` bindings read the
+`ChatInput`. The read-only participant banner (derived from the dto's kind) is
+unchanged and already vendor-neutral.
+
+### Clear on ack
+
+PTY clears the composer when the paste is accepted, because it never learns
+more. The frame learns the outcome, so the text clears on `Ok` and stays
+otherwise. `SendCommand` becomes `CreateFromTask` over `ChatInput.SendAsync`,
+passing the tab's lifetime token, and on `true` clears `ComposerText` **only if
+it still equals the snapshot that was sent** — the box stays editable while
+`Sending`, and text typed or pasted during the round trip must not be erased.
+`TeardownAsync` cancels the lifetime token, which cancels an in-flight send;
+`LocalFrameChatInput` checks disposal before touching any state on completion,
+so a late ack can never mutate a torn-down tab. `TerminalChatInput.SendAsync`
+completes synchronously, so the PTY composer behaves exactly as today.
+
+### The user's message comes from the transcript
+
+No local echo, same as PTY: every non-PTY runtime emits the prompt as a
+`user_message` envelope — Pi, ACP and Codex app-server today, Antigravity
+through the worker change in §1 — so it appears through the journal.
+
+### Older daemon
+
+A dto with `transcript_format: null` can only come from a daemon that predates
+the field. For a non-PTY dto (`has_terminal: false`) the chat's phase note
+reads "Update the daemon to view this session" instead of Waiting forever; a
+PTY dto with a null format takes today's vendor path unchanged, because an
+older daemon's PTY agents are exactly what the app renders now. `input/1`
+covers the composer independently.
+
+### Unchanged
+
+Rail and Home rows (they already flow), Chat as the default tab, the launch
+auto-open, the PR pane (which starts working for these sessions because
+`session_id` is now canonical; the work-context pane needs the
+`WorkContextIds` change in §1 as well), vendor tiles (the monogram fallback for
+kiro, pi and antigravity stays; brand marks are cosmetic and out of scope).
+
+## 5. Compatibility matrix
+
+| app     | daemon  | non-PTY session                                                                                     |
+|---------|---------|-----------------------------------------------------------------------------------------------------|
+| new     | new     | Chat renders from the journal; composer sends through `input/1`.                                    |
+| new     | old     | `transcript_format` null with `has_terminal` false → "Update the daemon to view this session"; composer `Unsupported` with the same advice, and nothing is sent. |
+| old     | new     | Unknown trailing member ignored; Chat is never built for these vendors, as today.                    |
+| new     | newer   | Unknown `transcript_format` → `Unavailable`, "Update the app to view this session".                  |
+
+PTY sessions are unaffected in every cell: a current daemon marks them
+`"vendor"` and an older one null, and both take the path the app runs today;
+the Terminal and Chat tabs, `Stdin` input and discovery are untouched.
+
+## 6. Parity with the PTY path
+
+What matches: a file on disk tailed from byte 0 by the same `JsonlTail`, so the
+complete persisted history on open and after an app restart; the same
+Waiting/Missing/Reading phases and per-line fault handling; shared-open for
+Windows; when `Open` succeeds, path and session id present in the first
+snapshot the agent appears in; the file outliving the agent; a relaunch under
+the same agent id appending to the same file when its `Open` succeeds (the
+app's view of that relaunch is the existing one, §1); no
+redaction on either path (PTY files are vendor-written, envelopes are not
+redacted before the server either); Chat as the default tab with the composer
+on it only; one user turn per send, in the transcript, for every vendor
+(Antigravity gains the synthesized turn the other three already emit); the
+needs-you pip clearing when a send is admitted; the read-only participant rule; no attachments on either local path
+yet; reviewers and flow participants on non-PTY vendors getting a read-only
+chat as PTY reviewers do.
+
+What differs, deliberately: kcap owns and sweeps the file (30 days) where the
+vendor owns the PTY file; the path and session id are known at construction
+rather than discovered by a poll; no vendor display rules; the composer answers
+with coded acks instead of guessing, has no `Reattach` state (one exchange per
+send) and adds `Unsupported`; the text clears on ack rather than on accept; two
+web-path side effects (the post-send status report and the PTY-gated Codex
+probe) ride the shared core where the PTY-local `Stdin` path does neither; a
+refused admission is reported where the PTY path cannot observe one; an older
+daemon gets an explicit message instead of PTY's indefinite Waiting. A lost
+acknowledgement is an unknown outcome on both paths — the PTY paste has never
+had one — and the composer says so rather than guessing.
+
+What remains after this slice: permission and question cards render for PTY and
+not yet for these vendors (§8).
+
+## 7. Testing
+
+Core (`test/Capacitor.Cli.Core.Tests.Unit/`):
+
+- `EnvelopeJournalFormatTests`: round-trip pins exact bytes (snake_case, member
+  order); `TryRead` rejects unparseable text, `{}`, a scalar, an array, a
+  missing, null or empty `kind`, and `contract_version: 2` carrying a known
+  display kind; it accepts a well-formed v1 envelope with an unknown future
+  `kind`.
+- `EnvelopeJournalProjectionTests`: passthrough of every kind, throw on a
+  malformed line, stateless context.
+- `SessionIdsTests`: a dashed GUID canonicalizes to its `N` form; an opaque id
+  such as `sess-1` is returned unchanged; agreement with the server's
+  `CanonicalSessionId.Normalize` on both shapes.
+- `WorkContextIdsTests`: an opaque dashed id reaches the request path
+  unchanged; a GUID reaches it in `N` form; dot-segment validation unchanged.
+- `StatusIpcJsonTests`: `transcript_format` trailing, `"vendor"`,
+  `"envelopes"`, null, and old JSON without it.
+- `FrameCodecTests`: `SendText` / `SendTextAck` encode and decode.
+- `LocalControlOpsTests`: `SendTextAsync` passes all four ack members through
+  (`Outcome` included), maps EOF on the request to `Reason = "transport"`,
+  waits past the other exchanges' reply timeout for a late ack, and closes the
+  connection on the caller's cancellation.
+
+Daemon (`test/Capacitor.Cli.Daemon.Tests.Unit/`):
+
+- `AgentFileNamesTests`: `../x`, both separators, an absolute-looking id and a
+  plain id all yield a fixed-length hex name; stable across calls; identical to
+  the name `AgentPidRecordStore` used before the extraction.
+- `TranscriptJournalTests`: header first line on open; `CreatedFile` true only
+  when the file did not exist; a second open of the same agent id appends a
+  second header and preserves every prior byte; ephemeral skipped; no handle
+  held between writes (the file can be exclusively opened and deleted between
+  two lines); `Open` returns with the file created and the header flushed
+  before the writer has run, so a status snapshot taken immediately after
+  publish points at an existing file with one line; a header write that fails
+  leaves `IsOpen` false, starts no writer and makes `Record` a no-op; `Record`
+  returns without blocking while the writer is stalled on a hung sink (a fake
+  sink that never completes) and the caller's thread is never blocked;
+  `TryWrite` on the full channel returns false (pinning `FullMode.Wait`), and
+  with distinguishable preloaded lines the gap note lands between the last line
+  before the loss and the first after it, with the right count, including when
+  exactly one slot is free at the first post-gap `Record` (one item carries
+  both); an item whose write hangs and is abandoned is named in the Warning
+  together with the queued-item and pending-gap counts, and cancellation never
+  stops the writer between a note and its envelope (a torn write is the crash
+  model, pinned separately: a buffer cut after its note line renders the note
+  and drops the torn envelope); `Complete`
+  with a pending gap and a drained queue writes the note last, and with a full
+  channel and a hung writer reports the pending gap in the abandonment
+  Warning; `Complete` drains what is queued within the grace and reports
+  `Drained`; `Complete` against a hung sink returns within the grace, reports
+  not drained and logs the abandoned item, queued-item and gap counts; with a REAL
+  `FileStream` on the host OS, a same-id `Open` while an abandoned writer holds
+  the path lock misses its bound and stays `IsOpen` false, and once the writer
+  is released its line is at the true end and a subsequent `Open` appends after
+  it with every byte intact; the sweep and the failure-path delete skip a path
+  whose lock they cannot take; the same agent id under two state directories
+  takes two locks under the Core `PlatformPaths.Comparer`, so a hung writer in
+  one never blocks the other's `Open`, and two spellings of one path under
+  that comparer take one lock; abrupt disposal without `Complete` leaves a
+  readable file containing exactly the lines the writer reached; a first append
+  that fails after a good open latches after one Warning and counts what was
+  queued.
+- Per runtime (`AcpHostedAgentRuntimeTests`, `PiRpcHostedAgentRuntimeTests`,
+  `AntigravityHostedAgentRuntimeTests`, `CodexForwardBufferTests`): a journal
+  passed to the constructor records every accepted envelope in channel order —
+  including under **forced concurrent writers** for Pi (pump vs send-time
+  `user_message`) and Antigravity (worker vs queue-full notice), asserted by
+  comparing the journal to the channel's dequeue order; an envelope evicted by
+  `DropOldest` is still in the journal; an envelope written after channel
+  completion is not; Codex ephemerals dropped from a full buffer are not
+  journaled and canonical envelopes are journaled only after their write
+  completes; a stalled buffer journals nothing further and the watchdog fires
+  at the same threshold; a blocking write cancelled by shutdown and an emit
+  after `Complete` are both not journaled and neither throws out of `Emit`; the
+  initial prompt's `user_message` is journaled even though it is emitted before
+  the factory returns; Antigravity emits exactly one `user_message` per
+  admitted turn (initial and follow-up), ordered before that turn's first
+  output under a forced race with the child's first line, none for a refused
+  turn, and with the injected clock's timestamp so its bytes are pinned.
+- `AgentStatusSnapshotTests`: `"envelopes"` format, journal path and canonical
+  `session_id` for an envelope-sourced agent in the snapshot taken immediately
+  after `PublishAgent`, before registration; `"vendor"` and null path for a PTY
+  agent; an opaque ACP id reported unchanged.
+- Orchestrator: `AgentStatusChanged` carries the canonical id for an
+  envelope-sourced agent; `DetectSessionIdAsync` not started for an
+  envelope-sourced Codex agent, so its `TranscriptPath` stays the journal;
+  Codex probe not armed for it; a factory failure after `Open` deletes the
+  journal only when `CreatedFile` is true and `Complete` drained, and leaves a
+  pre-existing or abandoned-writer one intact;
+  `LocalControlCapabilitiesTests` pins `input/1` beside its handler;
+  `HandleLocalSendTextAsync` answers an ack for `{}`, a missing member, an
+  explicit null member and invalid JSON, and for each remaining reason in the
+  table, including both reaper tokens; delivery through a fake runtime;
+  `InputNotAdmittedException` maps to `queue_full` on both callers, the
+  server-origin caller reports it, and the awaiting-input wait is untouched —
+  exercised through the REAL ACP and Antigravity runtimes with a full queue on
+  both the plain send and, for a borrowed server-origin round, the
+  wait-for-write path; a server-origin borrowed round still uses
+  `SendUserInputAndWaitForWriteAsync` and its core does not complete before the
+  write, unbounded, exactly as today; the local handler answers only when the
+  core settles (a fake runtime whose task completes after a delay gets no ack
+  before it, and a runtime whose task faults after returning gets
+  `delivery_failed`, never `Ok`); two frames against a fake runtime whose first
+  write stays pending deliver two turns in order, one each, once the write
+  settles; a client that cancels its wait, and a client whose ack write faults,
+  each still produce exactly one delivery;
+  `CodexTurnInputDispatcher.EnqueueAsync` after
+  `FaultAll` throws `InputNotAdmittedException`, and an enqueue racing
+  `FaultAll` either faults its item or is refused, never left pending; a quit
+  from the local frame stops a private agent through `StopAgentCoreAsync` and
+  acks `Outcome = "stopped"`, a public one likewise, and a failed stop acks
+  `stop_failed`; the server-origin quit still rides
+  `HandleUnsequencedStopAgent`.
+- `TranscriptJournalSweepTests`: age and PID-record rules joined by the shared
+  name, nothing else deleted; the daemon-start sequence with an old journal and
+  a prior-epoch PID record deletes the journal once the orphan reap has
+  removed the record and keeps it while a still-live or quarantined record
+  remains; a `FakeTimeProvider` advanced 24 h runs the sweep again without a
+  restart; a directory enumeration fault and a per-file delete fault are each
+  logged, neither escapes `RunOnceAsync`, and the next 24 h tick still runs; a
+  tick arriving while a sweep is in progress is skipped.
+- `JournalPathLocksTests`: acquire/release churn over many distinct paths
+  leaves the map empty; a waiter blocked on a path keeps its entry alive until
+  it too releases; a wait that times out and a wait that is cancelled each
+  leave the map empty once the owner releases, and release nothing themselves;
+  two spellings of one path share one entry.
+
+App (`test/Capacitor.App.Tests.Unit/`):
+
+- `WorkspaceViewModelTests`: Chat built for `has_terminal: false` with the
+  journal projection; Terminal tab hidden; the existing "Chat is null for
+  gemini/pi" pins inverted; a null-format non-PTY dto yields the older-daemon
+  phase and a `"vendor"` PTY dto the vendor projection.
+- `ChatTabViewModelTests`: a journal file renders user, assistant, system-note
+  and tool rows; unknown format → `Unavailable` wording; older-daemon wording.
+- `LocalFrameChatInputTests`: availability matrix including `Unsupported`
+  (and that nothing is sent in it), `Sending` one-in-flight, `Ended`;
+  clear-on-ack only when the text is unchanged, text edited during the round
+  trip survives; a refusal keeps the text and sets the hint; an
+  `Outcome = "stopped"` ack clears the text; a transport failure and a cancelled
+  wait each keep the text and set the unconfirmed hint; cancellation via the
+  lifetime token; a completion after teardown mutates nothing; `Dispose`
+  detaches the daemon-status and presence subscriptions (no further property
+  changes after a later emission).
+- `TerminalChatInputTests`: today's `SendAvailability` states reproduced
+  (existing terminal-tab composer tests re-pointed); `Dispose` detaches the
+  terminal-tab subscription.
+- `ChatTabViewModelTests` (teardown): `TeardownAsync` cancels an in-flight
+  send before disposing the input, and the input is disposed exactly once.
+- `WorkspaceViewSmokeTests`: the non-PTY layout renders the Chat tab button and
+  the Chat host, no Terminal button, no tab-strip note.
+- `WorkContextViewModelTests`: an opaque ACP session id is requested from the
+  source unchanged.
+
+Live: the reproduction from the investigation — a Pi and a Cursor agent on the
+local daemon, instrumented app instance — before and after.
+
+## 8. Out of scope
+
+- **Permission and question cards for non-PTY vendors** — the second slice.
+  Today `AcpInteractionBridge` and `CodexApprovalBridge` go server-only, the
+  server has no hub method for a daemon to report a locally answered ACP
+  interaction (PTY has `RespondToPermission`), and the app's card DTOs are
+  Claude-shaped (no ACP `Options`, multi-select or free text). That slice
+  routes these interactions through the `PermissionPromptBroker` first-wins
+  race, extends the permission DTOs (`permission/2`), adds the server method
+  and web clearing in kcap-server, and generalizes the cards. It closes
+  AI-2197.
+- Attachments in the composer (AI-2318; the frame's DTO takes a trailing
+  field when it lands).
+- Streaming partial text (ephemeral envelopes) — PTY has none either.
+- Moving PTY input onto `SendText`.
+- Brand marks for kiro, pi and antigravity.
+- A `kcap agent send` CLI verb over the new frame.
+- The SIGKILL exit and stop-as-failure mapping for Pi (AI-2644).

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -527,7 +527,7 @@ public partial class App : Application {
         Action requestSignIn = () => OpenSignInDialog(profiles, notifier);
         WorkspaceViewModel BuildWorkspace(string agentId) => new(
             agentId, service, actions, attachFactory, () => new XtermTerminalSurface(80, 24, PtyDumpPath), TimeProvider.System, opener, permissions,
-            workContext, requestSignIn: requestSignIn, signInCompleted: serverClients.SignInCompleted, pullRequests: readers,
+            workContext, ops, requestSignIn: requestSignIn, signInCompleted: serverClients.SignInCompleted, pullRequests: readers,
             linkGitHub: () => {
                 if (profiles?.Resolution.ServerUrl is { Length: > 0 } url) LinkPolicy.Open(opener, url.TrimEnd('/') + "/auth/github-link/start");
             });

--- a/src/Capacitor.App/Services/AgentDirectory.cs
+++ b/src/Capacitor.App/Services/AgentDirectory.cs
@@ -1,7 +1,7 @@
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
-using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Remote.Models;
 using DynamicData;

--- a/src/Capacitor.App/Services/HostedHarnessCatalog.cs
+++ b/src/Capacitor.App/Services/HostedHarnessCatalog.cs
@@ -179,7 +179,7 @@ public static class HostedHarnessCatalog {
         return hasTerminal == false && family == "pty" ? "rpc" : family;
     }
 
-    /// The one source of the no-terminal wording (terminal tab and workspace tab strip alike).
+    /// The one source of the no-terminal wording, which the terminal pane carries as its state.
     /// Suffixed only when the family is reliably known: ACP is; the rpc/"chat" bucket also covers
     /// claude/codex/any unmapped vendor whose has_terminal came back false for a reason this build
     /// can't classify further, so it gets no family token at all rather than leaking "RPC" (an

--- a/src/Capacitor.App/Services/Onboarding/WizardLateBinding.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardLateBinding.cs
@@ -26,6 +26,9 @@ public sealed class LateBoundLocalControlOps(Func<ILocalControlOps> bind) : ILoc
 
     public Task<PermissionAckDto> ResolvePermissionAsync(PermissionResolveDto resolve, CancellationToken ct) =>
         bind().ResolvePermissionAsync(resolve, ct);
+
+    public Task<SendTextResult> SendTextAsync(string agentId, string text, CancellationToken ct) =>
+        bind().SendTextAsync(agentId, text, ct);
 }
 
 /// <summary>

--- a/src/Capacitor.App/Services/TerminalAttach.cs
+++ b/src/Capacitor.App/Services/TerminalAttach.cs
@@ -37,7 +37,7 @@ public enum TerminalSessionPhase { Resolving, NoTerminal, NotFound, Connecting, 
 /// What the composer can do right now, folding the send gate into the terminal state so a hint
 /// built from it is true in every window — including the ones where State still reads Attached
 /// while a reattach or detach is under way.
-public enum SendAvailability { Ready, Sending, Transitioning, ReadOnly, Connecting, Reattach, Ended, NoTerminal }
+public enum SendAvailability { Ready, Sending, Transitioning, ReadOnly, Connecting, Reattach, Ended, NoTerminal, Unsupported }
 
 public sealed record TerminalSessionState(TerminalSessionPhase Phase, string? Detail = null, bool ReadOnly = false, int? ExitCode = null) {
     public static readonly TerminalSessionState Resolving = new(TerminalSessionPhase.Resolving);

--- a/src/Capacitor.App/ViewModels/AgentPresence.cs
+++ b/src/Capacitor.App/ViewModels/AgentPresence.cs
@@ -1,0 +1,7 @@
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.ViewModels;
+
+/// The workspace's accumulated view of one agent: its latest dto and whether the session has ended,
+/// which stays true once set even if a later dto arrives.
+internal sealed record AgentPresence(AgentStatusDto? Dto, bool SessionEnded);

--- a/src/Capacitor.App/ViewModels/ChatInput.cs
+++ b/src/Capacitor.App/ViewModels/ChatInput.cs
@@ -1,0 +1,15 @@
+using Capacitor.App.Services;
+using ReactiveUI.Reactive;
+
+namespace Capacitor.App.ViewModels;
+
+/// The composer's channel to the agent. The terminal channel commits when the paste is accepted; the
+/// frame channel when the daemon's ack arrives — that difference lives in SendAsync alone.
+public abstract class ChatInput : ReactiveObject, IDisposable {
+    public abstract SendAvailability Availability { get; }
+    public abstract bool CanAcceptText { get; }
+    public abstract string Hint { get; }
+    /// Completes when the channel considers the text committed: true to clear the composer.
+    public abstract Task<bool> SendAsync(string text, CancellationToken ct);
+    public abstract void Dispose();
+}

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -20,7 +20,7 @@ namespace Capacitor.App.ViewModels;
 public enum ChatTabPhase { Waiting, Reading, Missing, Unavailable }
 
 /// The Chat tab: the session's transcript, tailed and projected into chat rows, plus the composer
-/// that sends through the sibling terminal. Ctor-scoped; TeardownAsync is the one exit.
+/// that sends through whatever channel the session offers. Ctor-scoped; TeardownAsync is the one exit.
 ///
 /// Path identity is part of the read generation: a distinct transcript_path clears the rows and
 /// installs a fresh tail in one UI-thread step, and any read still in flight for the old file
@@ -32,8 +32,9 @@ public sealed class ChatTabViewModel : ReactiveObject {
     internal const int MaxWithdrawRetries = 3;
 
     readonly string _agentId;
-    readonly TerminalTabViewModel _terminal;
-    readonly TranscriptChatProjection? _projection;
+    readonly ChatInput _input;
+    readonly IChatTranscriptProjection? _projection;
+    readonly string? _unavailableNote;
     readonly IUrlOpener _opener;
     readonly TimeProvider _time;
     readonly IPermissionService _permissions;
@@ -65,7 +66,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
         int _linesRead;
 
         // The app has no session id and persists nothing, so the agent id stands in; only attachment ids would read it.
-        public TranscriptContext ContextFor(TranscriptChatProjection projection, string agentId) =>
+        public TranscriptContext ContextFor(IChatTranscriptProjection projection, string agentId) =>
             _context ??= projection.CreateContext(agentId, null);
 
         public void Reset() { _context = null; _linesRead = 0; }
@@ -104,7 +105,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
     public string PhaseNote => Phase switch {
         ChatTabPhase.Waiting     => "Waiting for the transcript…",
         ChatTabPhase.Missing     => "The transcript file is missing",
-        ChatTabPhase.Unavailable => "No chat view for this harness",
+        ChatTabPhase.Unavailable => _unavailableNote ?? "No chat view for this harness",
         _                        => "",
     };
 
@@ -163,9 +164,6 @@ public sealed class ChatTabViewModel : ReactiveObject {
     IBrush _statusDot = SessionStatusDots.For("");
     public IBrush StatusDot { get => _statusDot; private set => this.RaiseAndSetIfChanged(ref _statusDot, value); }
 
-    internal static string HintFor(SendAvailability availability, TerminalSessionState state) =>
-        TerminalChatInput.HintFor(availability, state);
-
     /// Test-only seam: the read in flight, or the last one started. A switch that loses the
     /// in-flight CAS starts no read of its own, so this still points at the previous file's read —
     /// await that, advance one tick, then await again to see the new path's first rows.
@@ -175,11 +173,14 @@ public sealed class ChatTabViewModel : ReactiveObject {
     internal int WithdrawsInFlightForTesting => _withdrawing.Count;
 
     public ChatTabViewModel(
-            string agentId, IDaemonClientService daemon, TerminalTabViewModel terminal,
-            TranscriptChatProjection? projection, IUrlOpener opener, TimeProvider time, IPermissionService permissions) {
+            string agentId, IDaemonClientService daemon, ChatInput input,
+            IChatTranscriptProjection? projection, IUrlOpener opener, TimeProvider time, IPermissionService permissions,
+            string? unavailableNote = null) {
         _agentId = agentId;
-        _terminal = terminal;
+        _input = input;
+        _disposables.Add(input);
         _projection = projection;
+        _unavailableNote = unavailableNote;
         _opener = opener;
         _time = time;
         _permissions = permissions;
@@ -253,27 +254,33 @@ public sealed class ChatTabViewModel : ReactiveObject {
         // The banner carries the read-only explanation for a flow participant, so the hint
         // goes blank there instead of offering a reply that can never be sent.
         _composerHint = Observable.CombineLatest(
-                terminal.WhenAnyValue(t => t.SendAvailability, t => t.State, (availability, state) => (availability, state)),
+                _input.WhenAnyValue(i => i.Hint),
                 this.WhenAnyValue(x => x.IsReadOnlyParticipant),
-                (t, readOnly) => readOnly ? "" : HintFor(t.availability, t.state))
-            .ToProperty(this, x => x.ComposerHint, HintFor(terminal.SendAvailability, terminal.State))
+                (hint, readOnly) => readOnly ? "" : hint)
+            .ToProperty(this, x => x.ComposerHint, initialValue: IsReadOnlyParticipant ? "" : _input.Hint)
             .DisposeWith(_disposables);
 
         _showsComposer = Observable.CombineLatest(
-                terminal.WhenAnyValue(t => t.SendAvailability),
+                _input.WhenAnyValue(i => i.Availability),
                 this.WhenAnyValue(x => x.IsReadOnlyParticipant),
                 (availability, readOnly) => !readOnly && availability != SendAvailability.Ended)
             .ToProperty(this, x => x.ShowsComposer,
-                initialValue: !IsReadOnlyParticipant && terminal.SendAvailability != SendAvailability.Ended)
+                initialValue: !IsReadOnlyParticipant && _input.Availability != SendAvailability.Ended)
             .DisposeWith(_disposables);
 
         var canSend = Observable.CombineLatest(
             this.WhenAnyValue(x => x.ComposerText),
-            terminal.WhenAnyValue(t => t.CanAcceptText),
+            _input.WhenAnyValue(i => i.CanAcceptText),
             this.WhenAnyValue(x => x.IsReadOnlyParticipant),
             (text, can, readOnly) => can && !readOnly && !string.IsNullOrWhiteSpace(text));
-        SendCommand = ReactiveCommand.Create(() => {
-            if (_terminal.TrySendText(ComposerText)) ComposerText = "";
+        // The composer keeps whatever the user typed while the channel was deciding: only the
+        // snapshot that was actually sent is cleared, and only once the channel commits it.
+        SendCommand = ReactiveCommand.CreateFromTask(async () => {
+            var snapshot = ComposerText;
+            bool committed;
+            try { committed = await _input.SendAsync(snapshot, _lifetimeToken); }
+            catch (OperationCanceledException) { return; }
+            if (committed && ComposerText == snapshot) ComposerText = "";
         }, canSend);
         _disposables.Add(SendCommand);
 
@@ -328,7 +335,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
         _pendingRead = ReadAndApplyAsync(lease, projection);
     }
 
-    async Task ReadAndApplyAsync(TailLease lease, TranscriptChatProjection projection) {
+    async Task ReadAndApplyAsync(TailLease lease, IChatTranscriptProjection projection) {
         try {
             var (read, envelopes) = await Task.Run(() => {
                 var result = lease.Tail.ReadAppended();
@@ -479,9 +486,11 @@ public sealed class ChatTabViewModel : ReactiveObject {
         _lease = null;
         _timer?.Dispose();
         _timer = null;
+        // Ahead of the disposables: the input is one of them, and an in-flight send has to see
+        // the cancellation before the channel it is sending through goes away.
+        try { _lifetime.Cancel(); } catch (ObjectDisposedException) { }
         _disposables.Dispose();
         _rootSubject.Dispose();
-        try { _lifetime.Cancel(); } catch (ObjectDisposedException) { }
         _lifetime.Dispose();
         return Task.CompletedTask;
     }

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -163,19 +163,8 @@ public sealed class ChatTabViewModel : ReactiveObject {
     IBrush _statusDot = SessionStatusDots.For("");
     public IBrush StatusDot { get => _statusDot; private set => this.RaiseAndSetIfChanged(ref _statusDot, value); }
 
-    /// The hint is built from the terminal's own availability, so it is true in the windows
-    /// where State alone would lie (a reattach or detach under way while State reads Attached).
-    /// Ready omits the harness name — the workspace chip already names it.
-    internal static string HintFor(SendAvailability availability, TerminalSessionState state) => availability switch {
-        SendAvailability.Ready         => "Enter sends · Shift+Enter for a new line",
-        SendAvailability.Sending       => "Sending…",
-        SendAvailability.Transitioning => "Updating the terminal connection…",
-        SendAvailability.ReadOnly      => $"Read-only: {state.Detail}",
-        SendAvailability.Connecting    => "Connecting to the terminal…",
-        SendAvailability.Reattach      => "Reattach the terminal to send",
-        SendAvailability.Ended         => "This session has ended",
-        _                              => "No terminal to send to",
-    };
+    internal static string HintFor(SendAvailability availability, TerminalSessionState state) =>
+        TerminalChatInput.HintFor(availability, state);
 
     /// Test-only seam: the read in flight, or the last one started. A switch that loses the
     /// in-flight CAS starts no read of its own, so this still points at the previous file's read —

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -110,9 +110,14 @@ public sealed class ChatTabViewModel : ReactiveObject {
     };
 
     string _composerText = "";
+    int _composerEdits;
     public string ComposerText {
         get => _composerText;
-        set => this.RaiseAndSetIfChanged(ref _composerText, value);
+        set {
+            if (string.Equals(_composerText, value, StringComparison.Ordinal)) return;
+            _composerEdits++;
+            this.RaiseAndSetIfChanged(ref _composerText, value);
+        }
     }
 
     public ReactiveCommand<Unit, Unit> SendCommand { get; }
@@ -274,13 +279,16 @@ public sealed class ChatTabViewModel : ReactiveObject {
             this.WhenAnyValue(x => x.IsReadOnlyParticipant),
             (text, can, readOnly) => can && !readOnly && !string.IsNullOrWhiteSpace(text));
         // The composer keeps whatever the user typed while the channel was deciding: only the
-        // snapshot that was actually sent is cleared, and only once the channel commits it.
+        // snapshot that was actually sent is cleared, and only once the channel commits it. The
+        // edit count is what the text alone cannot say — an edit that lands back on the sent text
+        // is still the user's own draft, not the snapshot.
         SendCommand = ReactiveCommand.CreateFromTask(async () => {
             var snapshot = ComposerText;
+            var edits = _composerEdits;
             bool committed;
             try { committed = await _input.SendAsync(snapshot, _lifetimeToken); }
             catch (OperationCanceledException) { return; }
-            if (committed && ComposerText == snapshot) ComposerText = "";
+            if (committed && _composerEdits == edits && ComposerText == snapshot) ComposerText = "";
         }, canSend);
         _disposables.Add(SendCommand);
 

--- a/src/Capacitor.App/ViewModels/ChatTranscriptSource.cs
+++ b/src/Capacitor.App/ViewModels/ChatTranscriptSource.cs
@@ -1,0 +1,19 @@
+using Capacitor.App.Services;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.App.ViewModels;
+
+/// Which reader a session's transcript_path gets, stated on the wire by transcript_format. Null is an
+/// older daemon: its PTY agents take today's vendor path, anything else cannot be read.
+internal static class ChatTranscriptSource {
+    public const string OlderDaemonNote = "Update the daemon to view this session";
+    public const string NewerDaemonNote = "Update the app to view this session";
+
+    public static (IChatTranscriptProjection? Projection, string? UnavailableNote) Resolve(AgentStatusDto dto) => dto.TranscriptFormat switch {
+        TranscriptFormats.Vendor    => (TranscriptChat.For(dto.Vendor), null),
+        TranscriptFormats.Envelopes => (TranscriptChat.Journal, null),
+        null => HostedHarnessCatalog.ShowsTerminal(dto.HasTerminal, dto.Vendor) ? (TranscriptChat.For(dto.Vendor), null) : (null, OlderDaemonNote),
+        _    => (null, NewerDaemonNote),
+    };
+}

--- a/src/Capacitor.App/ViewModels/LocalFrameChatInput.cs
+++ b/src/Capacitor.App/ViewModels/LocalFrameChatInput.cs
@@ -1,0 +1,90 @@
+using System.Reactive.Disposables;
+using Capacitor.App.Services;
+using Capacitor.Cli.Core.LocalIpc;
+using ReactiveUI.Reactive;
+
+namespace Capacitor.App.ViewModels;
+
+/// The composer channel for a session with no PTY: one SendText exchange per send, acked when the
+/// daemon's delivery settles. A lost ack is an unknown outcome and the hint says so.
+internal sealed class LocalFrameChatInput : ChatInput {
+    const string InputCapability = "input/1";
+    const string Unconfirmed = "delivery unconfirmed — check the chat before sending again";
+
+    readonly string _agentId;
+    readonly ILocalControlOps _ops;
+    readonly CompositeDisposable _subscriptions = new();
+    AttachStatus _status = new(AttachState.Connecting, null, null);
+    AgentPresence _presence = new(null, false);
+    bool _sending;
+    bool _disposed;
+    string? _notice;
+
+    public LocalFrameChatInput(string agentId, IDaemonClientService daemon, ILocalControlOps ops, IObservable<AgentPresence> presence) {
+        _agentId = agentId;
+        _ops = ops;
+        _subscriptions.Add(daemon.Status.Subscribe(s => { _status = s; _notice = null; Raise(); }));
+        _subscriptions.Add(presence.Subscribe(p => { _presence = p; Raise(); }));
+    }
+
+    public override SendAvailability Availability =>
+        _presence.SessionEnded ? SendAvailability.Ended
+        : _status.State != AttachState.Connected ? SendAvailability.Connecting
+        : _status.Capabilities is not { } caps || !caps.Contains(InputCapability) ? SendAvailability.Unsupported
+        : _sending ? SendAvailability.Sending
+        : _presence.Dto?.Status == "Running" ? SendAvailability.Ready
+        : SendAvailability.Connecting;
+
+    public override bool CanAcceptText => Availability == SendAvailability.Ready;
+
+    public override string Hint => _notice ?? Availability switch {
+        SendAvailability.Ready       => "Enter sends · Shift+Enter for a new line",
+        SendAvailability.Sending     => "Sending…",
+        SendAvailability.Unsupported => "Update the daemon to send messages from the app",
+        SendAvailability.Ended       => "This session has ended",
+        _                            => "Connecting to the agent…",
+    };
+
+    public override async Task<bool> SendAsync(string text, CancellationToken ct) {
+        if (!CanAcceptText) return false;
+        _sending = true; _notice = null; Raise();
+        SendTextResult result;
+        try {
+            result = await _ops.SendTextAsync(_agentId, text, ct);
+        } catch (OperationCanceledException) {
+            return Settle(false, Unconfirmed);
+        } catch (Exception ex) {
+            return Settle(false, ex.Message);
+        }
+        if (result.Ok) return Settle(true, null);
+        return Settle(false, result.Reason switch {
+            SendTextReasons.Transport      => Unconfirmed,
+            SendTextReasons.NotRunning     => "agent is no longer running",
+            SendTextReasons.NoSuchAgent    => "agent is no longer running",
+            SendTextReasons.ProtectedKind  => "read-only participant",
+            SendTextReasons.QueueFull      => "the agent's input queue is full, try again shortly",
+            SendTextReasons.StopFailed     => "the agent did not stop",
+            SendTextReasons.DeliveryFailed => result.Error ?? "delivery failed",
+            _                              => result.Error ?? result.Reason ?? "delivery failed",
+        });
+    }
+
+    bool Settle(bool committed, string? notice) {
+        if (_disposed) return committed;
+        _sending = false; _notice = notice; Raise();
+        return committed;
+    }
+
+    void Raise() {
+        if (_disposed) return;
+        this.RaisePropertyChanged(nameof(Availability));
+        this.RaisePropertyChanged(nameof(CanAcceptText));
+        this.RaisePropertyChanged(nameof(Hint));
+    }
+
+    public override void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+        _subscriptions.Dispose();
+    }
+}

--- a/src/Capacitor.App/ViewModels/LocalFrameChatInput.cs
+++ b/src/Capacitor.App/ViewModels/LocalFrameChatInput.cs
@@ -23,8 +23,22 @@ internal sealed class LocalFrameChatInput : ChatInput {
     public LocalFrameChatInput(string agentId, IDaemonClientService daemon, ILocalControlOps ops, IObservable<AgentPresence> presence) {
         _agentId = agentId;
         _ops = ops;
-        _subscriptions.Add(daemon.Status.Subscribe(s => { _status = s; _notice = null; Raise(); }));
-        _subscriptions.Add(presence.Subscribe(p => { _presence = p; Raise(); }));
+        _subscriptions.Add(daemon.Status.Subscribe(ApplyStatus));
+        _subscriptions.Add(presence.Subscribe(ApplyPresence));
+    }
+
+    void ApplyStatus(AttachStatus s) {
+        var before = Availability;
+        _status = s;
+        if (Availability != before) _notice = null;
+        Raise();
+    }
+
+    void ApplyPresence(AgentPresence p) {
+        var before = Availability;
+        _presence = p;
+        if (Availability != before) _notice = null;
+        Raise();
     }
 
     public override SendAvailability Availability =>

--- a/src/Capacitor.App/ViewModels/LocalFrameChatInput.cs
+++ b/src/Capacitor.App/ViewModels/LocalFrameChatInput.cs
@@ -82,6 +82,7 @@ internal sealed class LocalFrameChatInput : ChatInput {
             SendTextReasons.QueueFull      => "the agent's input queue is full, try again shortly",
             SendTextReasons.StopFailed     => "the agent did not stop",
             SendTextReasons.ReaperClaimed or SendTextReasons.ReaperClaimedLate => "the agent is being stopped",
+            SendTextReasons.TooLarge       => result.Error ?? "message is too large",
             SendTextReasons.DeliveryFailed => result.Error ?? "delivery failed",
             // A reason this build has no wording for is still not composer text: the raw wire token
             // would read as a bug report to the user.

--- a/src/Capacitor.App/ViewModels/LocalFrameChatInput.cs
+++ b/src/Capacitor.App/ViewModels/LocalFrameChatInput.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Disposables;
+using System.Reactive.Linq;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.LocalIpc;
 using ReactiveUI.Reactive;
@@ -23,7 +24,9 @@ internal sealed class LocalFrameChatInput : ChatInput {
     public LocalFrameChatInput(string agentId, IDaemonClientService daemon, ILocalControlOps ops, IObservable<AgentPresence> presence) {
         _agentId = agentId;
         _ops = ops;
-        _subscriptions.Add(daemon.Status.Subscribe(ApplyStatus));
+        // Status comes off the daemon client's worker thread; presence is already marshalled by the
+        // workspace that publishes it.
+        _subscriptions.Add(daemon.Status.ObserveOn(RxSchedulers.MainThreadScheduler).Subscribe(ApplyStatus));
         _subscriptions.Add(presence.Subscribe(ApplyPresence));
     }
 
@@ -60,7 +63,7 @@ internal sealed class LocalFrameChatInput : ChatInput {
     };
 
     public override async Task<bool> SendAsync(string text, CancellationToken ct) {
-        if (!CanAcceptText) return false;
+        if (_disposed || !CanAcceptText) return false;
         _sending = true; _notice = null; Raise();
         SendTextResult result;
         try {
@@ -78,8 +81,11 @@ internal sealed class LocalFrameChatInput : ChatInput {
             SendTextReasons.ProtectedKind  => "read-only participant",
             SendTextReasons.QueueFull      => "the agent's input queue is full, try again shortly",
             SendTextReasons.StopFailed     => "the agent did not stop",
+            SendTextReasons.ReaperClaimed or SendTextReasons.ReaperClaimedLate => "the agent is being stopped",
             SendTextReasons.DeliveryFailed => result.Error ?? "delivery failed",
-            _                              => result.Error ?? result.Reason ?? "delivery failed",
+            // A reason this build has no wording for is still not composer text: the raw wire token
+            // would read as a bug report to the user.
+            _                              => "delivery failed",
         });
     }
 

--- a/src/Capacitor.App/ViewModels/RailWorktreeViewModel.cs
+++ b/src/Capacitor.App/ViewModels/RailWorktreeViewModel.cs
@@ -5,6 +5,7 @@ using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using Capacitor.App.Services;
+using Capacitor.Cli.Core;
 using DynamicData;
 using DynamicData.Binding;
 using ReactiveUI.Reactive;

--- a/src/Capacitor.App/ViewModels/TerminalChatInput.cs
+++ b/src/Capacitor.App/ViewModels/TerminalChatInput.cs
@@ -1,0 +1,49 @@
+using System.Reactive.Linq;
+using Capacitor.App.Services;
+using ReactiveUI.Reactive;
+
+namespace Capacitor.App.ViewModels;
+
+public sealed class TerminalChatInput : ChatInput {
+    readonly TerminalTabViewModel _terminal;
+    readonly IDisposable _subscription;
+    bool _disposed;
+
+    public TerminalChatInput(TerminalTabViewModel terminal) {
+        _terminal = terminal;
+        _subscription = terminal.WhenAnyValue(t => t.SendAvailability, t => t.State, t => t.CanAcceptText)
+            .Skip(1)
+            .Subscribe(_ => {
+                this.RaisePropertyChanged(nameof(Availability));
+                this.RaisePropertyChanged(nameof(CanAcceptText));
+                this.RaisePropertyChanged(nameof(Hint));
+            });
+    }
+
+    public override SendAvailability Availability => _disposed ? SendAvailability.Ended : _terminal.SendAvailability;
+    public override bool CanAcceptText => !_disposed && _terminal.CanAcceptText;
+    public override string Hint => HintFor(_terminal.SendAvailability, _terminal.State);
+
+    /// The terminal path has nothing to cancel: acceptance is synchronous.
+    public override Task<bool> SendAsync(string text, CancellationToken ct) =>
+        Task.FromResult(!_disposed && _terminal.TrySendText(text));
+
+    public override void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+        _subscription.Dispose();
+    }
+
+    /// The hint is built from the terminal's own availability, so it is true in the windows where
+    /// State alone would lie (a reattach or detach under way while State reads Attached).
+    internal static string HintFor(SendAvailability availability, TerminalSessionState state) => availability switch {
+        SendAvailability.Ready         => "Enter sends · Shift+Enter for a new line",
+        SendAvailability.Sending       => "Sending…",
+        SendAvailability.Transitioning => "Updating the terminal connection…",
+        SendAvailability.ReadOnly      => $"Read-only: {state.Detail}",
+        SendAvailability.Connecting    => "Connecting to the terminal…",
+        SendAvailability.Reattach      => "Reattach the terminal to send",
+        SendAvailability.Ended         => "This session has ended",
+        _                              => "No terminal to send to",
+    };
+}

--- a/src/Capacitor.App/ViewModels/TrayModels.cs
+++ b/src/Capacitor.App/ViewModels/TrayModels.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 
 namespace Capacitor.App.ViewModels;
@@ -22,42 +23,6 @@ public static class CheckoutLabel {
 
     public static string Format(string checkout, string repoRoot) =>
         IsMain(checkout, repoRoot) ? "main checkout" : PlatformPaths.Leaf(checkout);
-}
-
-/// The path primitives every surface shares: one platform comparison rule and one leaf
-/// expression, never a per-view copy.
-public static class PlatformPaths {
-    /// Repo paths compare the way the filesystem underneath them does: case-insensitively on
-    /// Windows and macOS, case-sensitively on Linux where two checkouts differing only in case
-    /// are genuinely different repositories. Trailing directory separators are ignored — `/a`
-    /// and `/a/` are one repository.
-    public static readonly StringComparer Comparer = new TrailingSeparatorComparer(
-        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
-
-    /// Drops a trailing directory separator so list/group keys share one spelling.
-    public static string Normalize(string path) =>
-        string.IsNullOrEmpty(path) ? path : Path.TrimEndingDirectorySeparator(path);
-
-    /// The path's own last segment, verbatim.
-    public static string Leaf(string path) => Path.GetFileName(Normalize(path));
-
-    sealed class TrailingSeparatorComparer(StringComparer inner) : StringComparer {
-        public override int Compare(string? x, string? y) {
-            if (ReferenceEquals(x, y)) return 0;
-            if (x is null) return -1;
-            if (y is null) return 1;
-            return inner.Compare(Normalize(x), Normalize(y));
-        }
-
-        public override bool Equals(string? x, string? y) {
-            if (ReferenceEquals(x, y)) return true;
-            if (x is null || y is null) return false;
-            return inner.Equals(Normalize(x), Normalize(y));
-        }
-
-        public override int GetHashCode(string obj) =>
-            inner.GetHashCode(Normalize(obj));
-    }
 }
 
 // StopEnabled: false while AgentActionService.StopsInFlight contains Id. Kind is the wire

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -64,7 +64,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     public bool IsChatActive => ActiveTab == WorkspaceTab.Chat;
     public bool IsTerminalActive => ActiveTab == WorkspaceTab.Terminal;
     public bool IsPullRequestActive => ActiveTab == WorkspaceTab.PullRequest;
-    public bool ShowsTerminalBanners => !IsPullRequestActive && (IsTerminalActive || !ShowsTerminalTab);
+    public bool ShowsTerminalBanners => !IsPullRequestActive && IsTerminalActive;
 
     public ReactiveCommand<Unit, Unit> ShowChatCommand { get; }
     public ReactiveCommand<Unit, Unit> ShowTerminalCommand { get; }

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -133,7 +133,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
             .Where(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
             .Take(1)
             .Subscribe(p => Chat = new ChatTabViewModel(
-                agentId, daemon, Terminal, TranscriptChat.For(p.Dto!.Vendor), opener, time, permissions))
+                agentId, daemon, new TerminalChatInput(Terminal), TranscriptChat.For(p.Dto!.Vendor), opener, time, permissions))
             .DisposeWith(_disposables);
 
         ShowChatCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Chat; });

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -3,7 +3,6 @@ using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
 using Capacitor.App.Services;
-using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Core.PullRequests;
 using DynamicData;
@@ -31,17 +30,14 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     readonly ObservableAsPropertyHelper<bool> _showsTerminalTab;
     public bool ShowsTerminalTab => _showsTerminalTab.Value;
 
-    readonly ObservableAsPropertyHelper<string> _noTerminalNote;
-    public string NoTerminalNote => _noTerminalNote.Value;
-
     readonly ObservableAsPropertyHelper<bool> _sessionEnded;
     public bool SessionEnded => _sessionEnded.Value;
 
     public TerminalTabViewModel Terminal { get; }
 
     ChatTabViewModel? _chat;
-    /// Built once, on the first dto that passes the PTY gate -- the projection is chosen by the
-    /// dto's vendor. Null for a non-PTY session.
+    /// Built once, on the first dto; the reader comes from transcript_format and the input channel
+    /// from has_terminal.
     public ChatTabViewModel? Chat {
         get => _chat;
         private set => this.RaiseAndSetIfChanged(ref _chat, value);
@@ -87,7 +83,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     public WorkspaceViewModel(
             string agentId, IDaemonClientService daemon, AgentActionService actions,
             TerminalAttachClientFactory factory, Func<ITerminalSurface> surfaceFactory, TimeProvider time,
-            IUrlOpener opener, IPermissionService permissions, IWorkContextSource workContext,
+            IUrlOpener opener, IPermissionService permissions, IWorkContextSource workContext, ILocalControlOps ops,
             Action? requestSignIn = null, IObservable<Unit>? signInCompleted = null, IPullRequestSource? pullRequests = null, Action? linkGitHub = null) {
         AgentId = agentId;
         Terminal = new TerminalTabViewModel(agentId, daemon, factory, surfaceFactory, time);
@@ -119,21 +115,21 @@ public sealed class WorkspaceViewModel : ReactiveObject {
             .ToProperty(this, x => x.ShowsTerminalTab, initialValue: false)
             .DisposeWith(_disposables);
         presence.Subscribe(_ => this.RaisePropertyChanged(nameof(ShowsTerminalBanners))).DisposeWith(_disposables);
-        // Blank whenever ShowsTerminalTab is true (or the dto isn't resolved yet): the note
-        // replaces the Terminal tab button in the tab strip, so it must never render alongside it.
-        _noTerminalNote = presence
-            .Select(p => p.Dto is null || HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor) ? "" : HostedHarnessCatalog.NoTerminalNote(p.Dto.HasTerminal, p.Dto.Vendor))
-            .ToProperty(this, x => x.NoTerminalNote, "")
-            .DisposeWith(_disposables);
         _sessionEnded = presence.Select(p => p.SessionEnded)
             .ToProperty(this, x => x.SessionEnded, initialValue: false)
             .DisposeWith(_disposables);
 
         presence
-            .Where(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
+            .Where(p => p.Dto is not null)
             .Take(1)
-            .Subscribe(p => Chat = new ChatTabViewModel(
-                agentId, daemon, new TerminalChatInput(Terminal), TranscriptChat.For(p.Dto!.Vendor), opener, time, permissions))
+            .Subscribe(p => {
+                var dto = p.Dto!;
+                var (projection, note) = ChatTranscriptSource.Resolve(dto);
+                ChatInput input = HostedHarnessCatalog.ShowsTerminal(dto.HasTerminal, dto.Vendor)
+                    ? new TerminalChatInput(Terminal)
+                    : new LocalFrameChatInput(agentId, daemon, ops, presence);
+                Chat = new ChatTabViewModel(agentId, daemon, input, projection, opener, time, permissions, note);
+            })
             .DisposeWith(_disposables);
 
         ShowChatCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Chat; });

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -19,8 +19,6 @@ public enum WorkspaceTab { Chat, Terminal, PullRequest }
 public sealed class WorkspaceViewModel : ReactiveObject {
     const string UnresolvedKind = "unresolved";
 
-    sealed record AgentPresence(AgentStatusDto? Dto, bool SessionEnded);
-
     public string AgentId { get; }
 
     readonly ObservableAsPropertyHelper<string> _title;

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -114,7 +114,6 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         _showsTerminalTab = presence.Select(p => p.Dto is not null && HostedHarnessCatalog.ShowsTerminal(p.Dto.HasTerminal, p.Dto.Vendor))
             .ToProperty(this, x => x.ShowsTerminalTab, initialValue: false)
             .DisposeWith(_disposables);
-        presence.Subscribe(_ => this.RaisePropertyChanged(nameof(ShowsTerminalBanners))).DisposeWith(_disposables);
         _sessionEnded = presence.Select(p => p.SessionEnded)
             .ToProperty(this, x => x.SessionEnded, initialValue: false)
             .DisposeWith(_disposables);

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -56,18 +56,15 @@
                     Foreground="{StaticResource KcapDangerBrush}" Padding="10,5" FontSize="12.5" />
         </Grid>
 
-        <!-- Tab strip: Chat and Terminal when the daemon reports this session has a PTY; the muted
-             family-aware note in their place otherwise (it never names a vendor). -->
+        <!-- Chat for every session; Terminal only when the daemon reports a PTY. -->
         <Border Grid.Row="1" BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="0,1,0,1">
             <Grid Margin="20,0">
                 <StackPanel Orientation="Horizontal" Spacing="6"
                             HorizontalAlignment="Left" VerticalAlignment="Center">
                     <Button x:Name="ChatTabButton" Content="Chat" Classes="tab" Classes.active="{Binding IsChatActive}"
-                            Command="{Binding ShowChatCommand}" IsVisible="{Binding ShowsTerminalTab}" />
+                            Command="{Binding ShowChatCommand}" />
                     <Button x:Name="TerminalTabButton" Content="Terminal" Classes="tab" Classes.active="{Binding IsTerminalActive}"
                             Command="{Binding ShowTerminalCommand}" IsVisible="{Binding ShowsTerminalTab}" />
-                <TextBlock x:Name="NoTerminalNote" Text="{Binding NoTerminalNote}" IsVisible="{Binding !ShowsTerminalTab}"
-                           Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5" VerticalAlignment="Center" />
                     <Button x:Name="PullRequestTabButton" Content="Pull request" Classes="tab" Classes.active="{Binding IsPullRequestActive}"
                             Command="{Binding ShowPullRequestCommand}" IsVisible="{Binding ShowsPullRequestTab}" />
                 </StackPanel>
@@ -93,9 +90,9 @@
                                        CaretBrush="{StaticResource KcapTextBrush}"
                                        Model="{Binding Terminal.Surface, Converter={x:Static views:TerminalSurfaceModelConverter.Instance}}" />
 
-            <!-- A session with no tabs at all has no Terminal tab to activate, and these banners
-                 are the only content its cell ever gets — so they stay up whenever the strip is
-                 showing the muted note instead of the tabs. -->
+            <!-- A session with no PTY has no Terminal tab to activate, so these banners are the
+                 only place its terminal state — the end of the session included — is announced;
+                 they stay up whenever the strip offers no Terminal tab. -->
             <Panel x:Name="TerminalBanners" IsVisible="{Binding ShowsTerminalBanners}">
 
                 <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Connecting}"
@@ -153,19 +150,12 @@
                 </Border>
             </Panel>
 
-            <!-- The chat surface exists only where the tab strip does, so a session with no PTY
-                 renders none of it. The automation peer reports offscreen from the control's OWN
-                 IsVisible, so hiding an ancestor instead would leave the inactive chat announced
-                 as onscreen — and both flags live on the workspace VM, which is not this
-                 control's DataContext. -->
-            <views:ChatTabView x:Name="ChatHost" DataContext="{Binding Chat}">
-                <views:ChatTabView.IsVisible>
-                    <MultiBinding Converter="{x:Static BoolConverters.And}">
-                        <Binding Path="$parent[views:WorkspaceView].((vm:WorkspaceViewModel)DataContext).ShowsTerminalTab" />
-                        <Binding Path="$parent[views:WorkspaceView].((vm:WorkspaceViewModel)DataContext).IsChatActive" />
-                    </MultiBinding>
-                </views:ChatTabView.IsVisible>
-            </views:ChatTabView>
+            <!-- The automation peer reports offscreen from the control's OWN IsVisible, so hiding
+                 an ancestor instead would leave the inactive chat announced as onscreen — and the
+                 active-tab flag lives on the workspace VM, which is not this control's
+                 DataContext. -->
+            <views:ChatTabView x:Name="ChatHost" DataContext="{Binding Chat}"
+                               IsVisible="{Binding $parent[views:WorkspaceView].((vm:WorkspaceViewModel)DataContext).IsChatActive}" />
             <ContentControl x:Name="PullRequestHost" IsVisible="{Binding IsPullRequestActive}" />
         </Grid>
     </Grid>

--- a/src/Capacitor.App/Views/WorkspaceView.axaml
+++ b/src/Capacitor.App/Views/WorkspaceView.axaml
@@ -90,9 +90,8 @@
                                        CaretBrush="{StaticResource KcapTextBrush}"
                                        Model="{Binding Terminal.Surface, Converter={x:Static views:TerminalSurfaceModelConverter.Instance}}" />
 
-            <!-- A session with no PTY has no Terminal tab to activate, so these banners are the
-                 only place its terminal state — the end of the session included — is announced;
-                 they stay up whenever the strip offers no Terminal tab. -->
+            <!-- Terminal-tab-only: a session with no PTY reports its own end through the chat
+                 composer's hint instead, so this layer never overlaps the live ChatHost. -->
             <Panel x:Name="TerminalBanners" IsVisible="{Binding ShowsTerminalBanners}">
 
                 <Border IsVisible="{Binding Terminal.State, Converter={x:Static views:TerminalPhaseIsConverter.Instance}, ConverterParameter=Connecting}"

--- a/src/Capacitor.Cli.Core/EnvelopeJournalFormat.cs
+++ b/src/Capacitor.Cli.Core/EnvelopeJournalFormat.cs
@@ -1,0 +1,29 @@
+using System.Text.Json;
+
+namespace Capacitor.Cli.Core;
+
+/// One envelope per JSONL line, the same bytes the server receives. Validity is decided here, not by
+/// the deserializer: a record struct decodes from `{}` or a null `kind` without complaint, and a
+/// later contract version may reuse a known kind with different fields.
+public static class EnvelopeJournalFormat {
+    public const int SupportedContractVersion = 1;
+
+    public static string Write(AcpEventEnvelope envelope) =>
+        JsonSerializer.Serialize(envelope, CapacitorJsonContext.Default.AcpEventEnvelope);
+
+    public static bool TryRead(string line, out AcpEventEnvelope envelope) {
+        envelope = default;
+        try {
+            using var doc = JsonDocument.Parse(line);
+            var root = doc.RootElement;
+            if (root.ValueKind != JsonValueKind.Object) return false;
+            if (!root.TryGetProperty("kind", out var kind) || kind.ValueKind != JsonValueKind.String || string.IsNullOrEmpty(kind.GetString())) return false;
+            if (root.TryGetProperty("contract_version", out var version)
+             && (version.ValueKind != JsonValueKind.Number || !version.TryGetInt32(out var v) || v != SupportedContractVersion)) return false;
+            envelope = JsonSerializer.Deserialize(line, CapacitorJsonContext.Default.AcpEventEnvelope);
+            return true;
+        } catch (JsonException) {
+            return false;
+        }
+    }
+}

--- a/src/Capacitor.Cli.Core/EnvelopeJournalFormat.cs
+++ b/src/Capacitor.Cli.Core/EnvelopeJournalFormat.cs
@@ -16,10 +16,11 @@ public static class EnvelopeJournalFormat {
         try {
             using var doc = JsonDocument.Parse(line);
             var root = doc.RootElement;
-            if (root.ValueKind != JsonValueKind.Object) return false;
-            if (!root.TryGetProperty("kind", out var kind) || kind.ValueKind != JsonValueKind.String || string.IsNullOrEmpty(kind.GetString())) return false;
-            if (root.TryGetProperty("contract_version", out var version)
-             && (version.ValueKind != JsonValueKind.Number || !version.TryGetInt32(out var v) || v != SupportedContractVersion)) return false;
+            if (!root.IsObject) return false;
+            if (string.IsNullOrEmpty(root.Str("kind"))) return false;
+            // Absent reads as v1; present must be the supported number, so a null or a string fails
+            // rather than reading as the default the deserializer would hand back.
+            if (root.Prop("contract_version") is not null && root.Num("contract_version") != SupportedContractVersion) return false;
             envelope = JsonSerializer.Deserialize(line, CapacitorJsonContext.Default.AcpEventEnvelope);
             return true;
         } catch (JsonException) {

--- a/src/Capacitor.Cli.Core/EnvelopeJournalProjection.cs
+++ b/src/Capacitor.Cli.Core/EnvelopeJournalProjection.cs
@@ -1,0 +1,13 @@
+namespace Capacitor.Cli.Core;
+
+/// Journal lines are already envelopes: no vendor rules, no dedupe, one envelope per valid line.
+public sealed class EnvelopeJournalProjection : IChatTranscriptProjection {
+    sealed class StatelessContext : TranscriptContext;
+
+    public TranscriptContext CreateContext(string sessionId, string? agentId) => new StatelessContext();
+
+    public IReadOnlyList<AcpEventEnvelope> Project(string line, int lineNumber, DateTimeOffset receivedAt, TranscriptContext context) =>
+        EnvelopeJournalFormat.TryRead(line, out var envelope)
+            ? [envelope]
+            : throw new FormatException($"line {lineNumber} is not a v{EnvelopeJournalFormat.SupportedContractVersion} envelope");
+}

--- a/src/Capacitor.Cli.Core/EnvelopeJournalProjection.cs
+++ b/src/Capacitor.Cli.Core/EnvelopeJournalProjection.cs
@@ -9,5 +9,7 @@ public sealed class EnvelopeJournalProjection : IChatTranscriptProjection {
     public IReadOnlyList<AcpEventEnvelope> Project(string line, int lineNumber, DateTimeOffset receivedAt, TranscriptContext context) =>
         EnvelopeJournalFormat.TryRead(line, out var envelope)
             ? [envelope]
-            : throw new FormatException($"line {lineNumber} is not a v{EnvelopeJournalFormat.SupportedContractVersion} envelope");
+            // No line number in the message: the reader logs one failure per distinct message, so a
+            // per-line message would log a corrupt journal once per line.
+            : throw new FormatException($"not a v{EnvelopeJournalFormat.SupportedContractVersion} envelope");
 }

--- a/src/Capacitor.Cli.Core/IChatTranscriptProjection.cs
+++ b/src/Capacitor.Cli.Core/IChatTranscriptProjection.cs
@@ -1,0 +1,7 @@
+namespace Capacitor.Cli.Core;
+
+/// What the chat tab needs from any transcript reader: a per-file context and a line-to-envelopes step.
+public interface IChatTranscriptProjection {
+    TranscriptContext CreateContext(string sessionId, string? agentId);
+    IReadOnlyList<AcpEventEnvelope> Project(string line, int lineNumber, DateTimeOffset receivedAt, TranscriptContext context);
+}

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameCodec.cs
@@ -57,7 +57,8 @@ public static class FrameCodec {
             or FrameType.ConsentPending or FrameType.ConsentRules
             or FrameType.ConsentAck or FrameType.DaemonStatus
             or FrameType.PermissionSubscribe or FrameType.PermissionResolve
-            or FrameType.PermissionPending or FrameType.PermissionResolved or FrameType.PermissionAck => Encoding.UTF8.GetBytes(f.Text),
+            or FrameType.PermissionPending or FrameType.PermissionResolved or FrameType.PermissionAck
+            or FrameType.SendText or FrameType.SendTextAck => Encoding.UTF8.GetBytes(f.Text),
         FrameType.Attached or FrameType.Spawn
             or FrameType.StopV2 or FrameType.AttachedReadOnly => f.Bytes, // pre-encoded by the helpers below
         _ => throw new InvalidDataException($"unencodable frame {f.Type}"),
@@ -78,7 +79,8 @@ public static class FrameCodec {
             or FrameType.ConsentPending or FrameType.ConsentRules
             or FrameType.ConsentAck or FrameType.DaemonStatus
             or FrameType.PermissionSubscribe or FrameType.PermissionResolve
-            or FrameType.PermissionPending or FrameType.PermissionResolved or FrameType.PermissionAck => new(t) { Text = Encoding.UTF8.GetString(p) },
+            or FrameType.PermissionPending or FrameType.PermissionResolved or FrameType.PermissionAck
+            or FrameType.SendText or FrameType.SendTextAck => new(t) { Text = Encoding.UTF8.GetString(p) },
         FrameType.Attached or FrameType.Spawn
             or FrameType.StopV2 or FrameType.AttachedReadOnly => new(t) { Bytes = p },
         _ => throw new InvalidDataException($"undecodable frame {t}"),

--- a/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/FrameType.cs
@@ -28,6 +28,8 @@ public enum FrameType : byte {
     // Permission control frames — values append-only
     PermissionSubscribe = 20, // long-lived: replay pending + push PermissionPending/PermissionResolved
     PermissionResolve   = 21, // one-shot: settle a pending request (Text = PermissionResolveDto JSON)
+    // Composer input for a hosted agent — one-shot; the ack lands when the daemon's delivery settles.
+    SendText = 22, // Text = SendTextDto JSON
     // daemon → client
     Attached  = 64,
     Stdout    = 65,
@@ -46,4 +48,5 @@ public enum FrameType : byte {
     PermissionPending  = 77, // Text = PermissionPendingDto JSON, pushed on PermissionSubscribe
     PermissionResolved = 78, // Text = PermissionResolvedDto JSON, pushed on every settlement
     PermissionAck      = 79, // Text = PermissionAckDto JSON, reply to PermissionResolve
+    SendTextAck = 80, // Text = SendTextAckDto JSON, reply to SendText
 }

--- a/src/Capacitor.Cli.Core/LocalIpc/InputIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/InputIpc.cs
@@ -1,0 +1,44 @@
+using System.Text.Json.Serialization;
+
+namespace Capacitor.Cli.Core.LocalIpc;
+
+/// JSON payloads for the composer input frames. snake_case on the wire; every member always emitted.
+public sealed record SendTextDto(string AgentId, string Text);
+
+/// Reason is one of SendTextReasons when Ok is false; Outcome is one of SendTextOutcomes when Ok is true.
+public sealed record SendTextAckDto(bool Ok, string? Reason, string? Error, string? Outcome = null);
+
+public static class SendTextReasons {
+    public const string Malformed         = "malformed";
+    public const string TextEmpty         = "text_empty";
+    public const string TooLarge          = "too_large";
+    public const string NoSuchAgent       = "no_such_agent";
+    public const string ProtectedKind     = "protected_kind";
+    public const string NotRunning        = "not_running";
+    public const string ReaperClaimed     = "reaper_claimed";
+    public const string ReaperClaimedLate = "reaper_claimed_late";
+    public const string QueueFull         = "queue_full";
+    public const string StopFailed        = "stop_failed";
+    public const string DeliveryFailed    = "delivery_failed";
+    /// Client-side only: the request or the reply never crossed the socket.
+    public const string Transport         = "transport";
+}
+
+public static class SendTextOutcomes {
+    public const string Delivered = "delivered";
+    public const string Stopped   = "stopped";
+}
+
+public static class InputWire {
+    /// One frame is one buffer, where PTY input streams under the PTY's own flow control.
+    public const int MaxTextBytes = 256 * 1024;
+
+    /// STJ source-gen leaves a missing member null and `{}` decodes fine; emptiness is the handler's call.
+    public static bool IsStructurallyValid(SendTextDto? dto) =>
+        dto is not null && dto.AgentId is not null && dto.Text is not null;
+}
+
+[JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]
+[JsonSerializable(typeof(SendTextDto))]
+[JsonSerializable(typeof(SendTextAckDto))]
+public partial class InputIpcJsonContext : JsonSerializerContext;

--- a/src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/LocalControlOps.cs
@@ -8,6 +8,9 @@ namespace Capacitor.Cli.Core.LocalIpc;
 /// frame; Error carries its display text). Ok is true only for "stopped".
 public sealed record StopAgentResult(bool Ok, string Status, string? Error);
 
+/// The SendTextAck's four members verbatim; Reason is "transport" when the exchange itself failed.
+public sealed record SendTextResult(bool Ok, string? Reason, string? Error, string? Outcome);
+
 /// Reason ∈ daemon_unreachable | daemon_rejected | unexpected_reply | timed_out (stable
 /// identifiers, not user copy — spec §10).
 public sealed class LocalControlOpsException(string reason, string message) : Exception(message) {
@@ -21,6 +24,7 @@ public interface ILocalControlOps {
     Task<ConsentAckDto>    PutConsentPolicyV2Async(ConsentPolicyPutV2Dto put, CancellationToken ct);
     Task<ConsentAckDto>    ResolveConsentAsync(ConsentResolveDto resolve, CancellationToken ct);
     Task<PermissionAckDto> ResolvePermissionAsync(PermissionResolveDto resolve, CancellationToken ct);
+    Task<SendTextResult>   SendTextAsync(string agentId, string text, CancellationToken ct);
 }
 
 /// One-shot Core IPC operations behind a fresh socket per call — no Hello negotiation (callers
@@ -129,6 +133,32 @@ public sealed class LocalControlOps(DaemonStore store, string daemonName, TimePr
                 throw new LocalControlOpsException(DaemonRejected, reply.Text);
             default:
                 throw new LocalControlOpsException(UnexpectedReply, $"unexpected daemon response to permission resolve ({reply.Type})");
+        }
+    }
+
+    /// The ack lands only when the daemon's delivery settles, so this exchange has no reply
+    /// timeout — the caller's own token is the only bound.
+    public async Task<SendTextResult> SendTextAsync(string agentId, string text, CancellationToken ct) {
+        var json = JsonSerializer.Serialize(new SendTextDto(agentId, text), InputIpcJsonContext.Default.SendTextDto);
+        LocalFrame reply;
+        try {
+            reply = await ExchangeAsync(LocalFrame.InputJson(FrameType.SendText, json), Timeout.InfiniteTimeSpan, ct);
+        } catch (LocalControlOpsException ex) {
+            return new SendTextResult(false, SendTextReasons.Transport, ex.Message, null);
+        }
+        switch (reply.Type) {
+            case FrameType.SendTextAck:
+                try {
+                    var ack = DeserializeOrThrow(reply.Text, InputIpcJsonContext.Default.SendTextAckDto, "malformed send text ack reply");
+                    if (ack is null) return new SendTextResult(false, SendTextReasons.Transport, "malformed send text ack reply", null);
+                    return new SendTextResult(ack.Ok, ack.Reason, ack.Error, ack.Outcome);
+                } catch (LocalControlOpsException ex) {
+                    return new SendTextResult(false, SendTextReasons.Transport, ex.Message, null);
+                }
+            case FrameType.Error:
+                return new SendTextResult(false, SendTextReasons.Transport, reply.Text, null);
+            default:
+                return new SendTextResult(false, SendTextReasons.Transport, $"unexpected daemon response to send text ({reply.Type})", null);
         }
     }
 

--- a/src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/LocalFrame.cs
@@ -39,4 +39,8 @@ public sealed record LocalFrame(FrameType Type) {
     /// Constructs any of the permission control frames, whose payload is UTF-8 JSON
     /// (snake_case via PermissionIpcJsonContext) carried in Text — see PermissionIpc.cs.
     public static LocalFrame PermissionJson(FrameType type, string json) => new(type) { Text = json };
+
+    /// Constructs a SendText or SendTextAck frame, whose payload is UTF-8 JSON (snake_case via
+    /// InputIpcJsonContext) carried in Text — see InputIpc.cs.
+    public static LocalFrame InputJson(FrameType type, string json) => new(type) { Text = json };
 }

--- a/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
+++ b/src/Capacitor.Cli.Core/LocalIpc/StatusIpc.cs
@@ -75,13 +75,23 @@ public sealed record AgentStatusDto(
     // The daemon's verdict that the agent finished a turn and waits on the user: true only while
     // Running, from a runtime-attested turn end or a PTY vendor's relayed Stop hook. Trailing +
     // nullable: null is an older daemon, which a client must read as unknown, never as working.
-    bool? AwaitingInput = null);
+    bool? AwaitingInput = null,
+    // Which reader a client uses for TranscriptPath: TranscriptFormats.Vendor for a PTY runtime's own
+    // file, TranscriptFormats.Envelopes for the daemon-written envelope journal. Always emitted by a
+    // current daemon, so null means an older daemon and nothing else.
+    string? TranscriptFormat = null);
 
 /// Wire tokens for <see cref="AgentStatusDto.WorkLocation"/>, compared literally by every
 /// client, so they never change.
 public static class WorkLocationText {
     public const string Owned    = "owned";
     public const string Borrowed = "borrowed";
+}
+
+/// Wire tokens for <see cref="AgentStatusDto.TranscriptFormat"/>, compared literally by every client.
+public static class TranscriptFormats {
+    public const string Vendor    = "vendor";
+    public const string Envelopes = "envelopes";
 }
 
 [JsonSourceGenerationOptions(PropertyNamingPolicy = JsonKnownNamingPolicy.SnakeCaseLower)]

--- a/src/Capacitor.Cli.Core/PlatformPaths.cs
+++ b/src/Capacitor.Cli.Core/PlatformPaths.cs
@@ -1,0 +1,30 @@
+namespace Capacitor.Cli.Core;
+
+/// One platform path rule for every surface: case-insensitive on Windows and macOS, case-sensitive
+/// on Linux, and a trailing directory separator never distinguishes two paths.
+public static class PlatformPaths {
+    public static readonly StringComparer Comparer = new TrailingSeparatorComparer(
+        OperatingSystem.IsLinux() ? StringComparer.Ordinal : StringComparer.OrdinalIgnoreCase);
+
+    public static string Normalize(string path) =>
+        string.IsNullOrEmpty(path) ? path : Path.TrimEndingDirectorySeparator(path);
+
+    public static string Leaf(string path) => Path.GetFileName(Normalize(path));
+
+    sealed class TrailingSeparatorComparer(StringComparer inner) : StringComparer {
+        public override int Compare(string? x, string? y) {
+            if (ReferenceEquals(x, y)) return 0;
+            if (x is null) return -1;
+            if (y is null) return 1;
+            return inner.Compare(Normalize(x), Normalize(y));
+        }
+
+        public override bool Equals(string? x, string? y) {
+            if (ReferenceEquals(x, y)) return true;
+            if (x is null || y is null) return false;
+            return inner.Equals(Normalize(x), Normalize(y));
+        }
+
+        public override int GetHashCode(string obj) => inner.GetHashCode(Normalize(obj));
+    }
+}

--- a/src/Capacitor.Cli.Core/SessionIds.cs
+++ b/src/Capacitor.Cli.Core/SessionIds.cs
@@ -1,0 +1,12 @@
+namespace Capacitor.Cli.Core;
+
+/// The session id the server files a session under: a GUID in any spelling collapses to its 32-hex
+/// form, and an opaque vendor id (an ACP `sess-1`) is kept as written — stripping its dashes would
+/// name a session the server has never seen.
+public static class SessionIds {
+    public static string? Canonical(string? id) {
+        if (string.IsNullOrWhiteSpace(id)) return null;
+        var trimmed = id.Trim();
+        return Guid.TryParse(trimmed, out var g) ? g.ToString("N") : trimmed;
+    }
+}

--- a/src/Capacitor.Cli.Core/TranscriptChat.cs
+++ b/src/Capacitor.Cli.Core/TranscriptChat.cs
@@ -9,7 +9,7 @@ public interface IChatDisplayRules {
 }
 
 /// The chat's view of a transcript: the leaf projection, the envelope mapping, one vendor's rules.
-public sealed class TranscriptChatProjection(ITranscriptProjection projection, IChatDisplayRules rules) {
+public sealed class TranscriptChatProjection(ITranscriptProjection projection, IChatDisplayRules rules) : IChatTranscriptProjection {
     public TranscriptContext CreateContext(string sessionId, string? agentId) => projection.CreateContext(sessionId, agentId);
 
     public IReadOnlyList<AcpEventEnvelope> Project(string line, int lineNumber, DateTimeOffset receivedAt, TranscriptContext context) {
@@ -26,6 +26,8 @@ public sealed class TranscriptChatProjection(ITranscriptProjection projection, I
 /// The one registration site in Core: a vendor's chat rules live under Harness/&lt;Vendor&gt;/ and
 /// are paired with the leaf's projection here, nowhere else.
 public static class TranscriptChat {
+    public static readonly IChatTranscriptProjection Journal = new EnvelopeJournalProjection();
+
     public static TranscriptChatProjection? For(string vendor) =>
         TranscriptProjection.For(vendor) is not { } projection ? null
         : vendor.ToLowerInvariant() switch {

--- a/src/Capacitor.Cli.Core/WorkItems/WorkContextIds.cs
+++ b/src/Capacitor.Cli.Core/WorkItems/WorkContextIds.cs
@@ -4,8 +4,8 @@ namespace Capacitor.Cli.Core.WorkItems;
 /// escape: `.` is unreserved, so escaping leaves a dot segment intact and URI normalization would
 /// walk it out of the route.
 public static class WorkContextIds {
-    /// Trimmed, dashes stripped — the key the server files a session under; null when nothing usable survives.
-    public static string? CanonicalSessionId(string? raw) => Validate(raw?.Trim().Replace("-", ""));
+    /// The key the server files a session under; null when nothing usable survives.
+    public static string? CanonicalSessionId(string? raw) => Validate(SessionIds.Canonical(raw));
 
     public static string? ValidWorkItemId(string? raw) => Validate(raw?.Trim());
 

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -586,6 +586,10 @@ public static partial class DaemonRunner {
         builder.Services.AddSingleton<LocalControlServer>();
         builder.Services.AddHostedService(sp => sp.GetRequiredService<LocalControlServer>());
 
+        builder.Services.AddSingleton(sp => new TranscriptJournalSweep(
+            config.Store.StateDirectory(config.Name), TimeProvider.System, sp.GetRequiredService<ILogger<TranscriptJournalSweep>>()));
+        builder.Services.AddHostedService(sp => sp.GetRequiredService<TranscriptJournalSweep>());
+
         var host   = builder.Build();
         var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("kcap.Daemon");
 
@@ -740,6 +744,8 @@ public static partial class DaemonRunner {
                 // handler. Under the daemon lock; best-effort (swallows its own faults).
                 orchestrator = host.Services.GetRequiredService<AgentOrchestrator>();
                 await orchestrator.ReapOrphansOnceAsync();
+
+                await host.Services.GetRequiredService<TranscriptJournalSweep>().RunOnceAsync(lifetime.ApplicationStopping);
 
                 try {
                     await connection.ConnectAsync(lifetime.ApplicationStopping);

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs
@@ -465,21 +465,21 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// two alternatives are each wrong in their own way. Blocking until space frees would stall the
     /// daemon's serial command lane behind a reviewer whose turn is stuck — and a stuck turn is the
     /// only way this queue ever fills — so one wedged agent would stop launches and stops for every
-    /// other one. Dropping silently (what this used to do for a caller that asked for no write ack,
-    /// i.e. every server-driven <c>SendInput</c>) loses a message the user has already sent, with
-    /// nothing anywhere to say so. So the send task faults, AND a <c>system_note</c> goes onto the
-    /// transcript: the fault reaches the daemon log through the orchestrator's handler, and the note
-    /// is the only surface the person who typed the message actually sees. One note per rejected
-    /// message — each is a separately lost message, and summarising them is the silent drop again in
-    /// miniature. That note goes out through <see cref="EmitDaemonNotice"/>, NOT
+    /// other one. Dropping silently loses a message the user has already sent, with nothing anywhere
+    /// to say so. So this throws <see cref="InputNotAdmittedException"/> — synchronously for a plain
+    /// send, via the returned task for an acknowledging one — AND a <c>system_note</c> goes onto the
+    /// transcript: the exception reaches only the daemon log through the orchestrator's handler, and
+    /// the note is the only surface the person who typed the message actually sees. One note per
+    /// rejected message — each is a separately lost message, and summarising them is the silent drop
+    /// again in miniature. That note goes out through <see cref="EmitDaemonNotice"/>, NOT
     /// <see cref="EmitEnvelope"/>: a refusal must not refresh the liveness attestation of the very
     /// agent whose wedged turn caused it.</para>
     ///
-    /// <para>A TERMINAL runtime is deliberately NOT symmetric: it still only logs (and faults an
-    /// acknowledging caller, as before). The transcript channel is completed on entry to
-    /// <see cref="RuntimePhase.Terminal"/>, so no note could be delivered anyway, and the agent's
-    /// session ending is itself the user-visible signal — a thrown error for input that raced a
-    /// normal end-of-session would be noise, not news.</para>
+    /// <para>A TERMINAL runtime is deliberately NOT symmetric: it still only logs, throwing the same
+    /// <see cref="InputNotAdmittedException"/> for both callers. The transcript channel is completed
+    /// on entry to <see cref="RuntimePhase.Terminal"/>, so no note could be delivered anyway, and the
+    /// agent's session ending is itself the user-visible signal — a thrown error for input that raced
+    /// a normal end-of-session would be noise, not news.</para>
     /// </summary>
     Task EnqueueTurn(string text, bool acknowledgeWrite) {
         var written = acknowledgeWrite
@@ -491,10 +491,12 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
         if (Phase == RuntimePhase.Terminal) {
             _logger.LogDebug("Antigravity: dropped a prompt turn — the runtime is terminal.");
-            written?.TrySetException(new InvalidOperationException(
-                "Antigravity runtime is terminal; this input was dropped."));
+            var terminal = new InputNotAdmittedException(
+                "Antigravity runtime is terminal; this input was dropped.");
+            if (written is null) throw terminal;
+            written.TrySetException(terminal);
 
-            return written?.Task ?? Task.CompletedTask;
+            return written.Task;
         }
 
         // The only other reason TryWrite can fail on this bounded, not-yet-completed channel.
@@ -529,15 +531,15 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 "Antigravity: the queue-full notice for this input never reached the transcript (the "
               + "channel had already completed), so the sender received no feedback at all.");
 
-        var failure = new InvalidOperationException(
+        var failure = new InputNotAdmittedException(
             $"Antigravity pending-turns queue is full (capacity {_pendingTurnsCapacity}); this input "
           + "was not queued.");
 
-        written?.TrySetException(failure);
+        if (written is null) throw failure;
 
-        // The acknowledging caller awaits `written`; everyone else awaits this. Never both — an
-        // unawaited faulted Task is what TaskScheduler.UnobservedTaskException is for.
-        return written?.Task ?? Task.FromException(failure);
+        // The acknowledging caller awaits `written`; the throw above is how everyone else learns.
+        written.TrySetException(failure);
+        return written.Task;
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs
@@ -1,6 +1,7 @@
 using System.Runtime.CompilerServices;
 using System.Threading.Channels;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging;
 
@@ -242,6 +243,17 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// </summary>
     readonly Action? _onDisposed;
 
+    readonly TimeProvider _time;
+
+    readonly TranscriptJournal? _journal;
+
+    /// <summary>Guards <see cref="Write"/>'s TryWrite + journal Record as one unit — the same shape
+    /// <c>PiRpcHostedAgentRuntime.Write</c> uses, for the same reason: this channel has two writers
+    /// (the turn worker's synthesized <c>user_message</c> and its own forwarded output), so without
+    /// this a Record could interleave in an order that disagrees with the channel's own FIFO write
+    /// order.</summary>
+    readonly Lock _writeLock = new();
+
     /// <summary>
     /// Whether the LAST turn's child was OBSERVED exited while it was still observable — read inside
     /// <see cref="ProcessTurnAsync"/>'s outer <c>finally</c>, immediately before this runtime lets go
@@ -330,7 +342,9 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             TimeSpan?                                                      turnDeadline = null,
             int?                                                           transcriptCapacity = null,
             int?                                                           pendingTurnsCapacity = null,
-            Action?                                                        onDisposed = null
+            Action?                                                        onDisposed = null,
+            TimeProvider?                                                  timeProvider = null,
+            TranscriptJournal?                                             journal = null
         ) {
         _spawnTurn            = spawnTurn;
         _logger               = logger;
@@ -341,6 +355,8 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         _turnDeadline         = turnDeadline;
         _pendingTurnsCapacity = pendingTurnsCapacity ?? DefaultPendingTurnsCapacity;
         _onDisposed           = onDisposed;
+        _time                 = timeProvider ?? TimeProvider.System;
+        _journal              = journal;
 
         // DropOldest: the turn worker is the only writer that matters for ordering, but
         // SingleWriter=false — EnterTerminal's TryComplete() can run concurrently with an in-flight
@@ -396,6 +412,10 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     public string  Cwd           => _cwd ?? "";
     public string? ResolvedModel => _model;
     public ChannelReader<AcpEventEnvelope> Envelopes => _transcript.Reader;
+
+    /// <summary>Defaults to <see cref="TimeProvider.System"/>, overridable in tests for a deterministic
+    /// <c>user_message</c> timestamp.</summary>
+    string NowIso() => _time.GetUtcNow().ToString("o");
 
     /// <summary>Rule (c): parks on the single constructor-owned <see cref="_terminalTcs"/> and nothing
     /// else. Yields no bytes ever — agy's stdout is NDJSON protocol traffic, never terminal output
@@ -553,6 +573,12 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                     }
 
                     await _turnGate.WaitAsync(ownerCt).ConfigureAwait(false);
+
+                    // Synthesized here, not in EnqueueTurn: ACP's session/prompt never round-trips
+                    // through session/update, so there is no natural agent-sourced envelope for the
+                    // prompt itself, and only the single worker (holding the gate) can order it ahead
+                    // of this turn's own output without racing the child's first line.
+                    Write(AcpEventTranslator.BuildUserMessage(seq: 0, NowIso(), turn.Text), agentActivity: false);
 
                     // The turn is in flight from here — set BEFORE the spawn, because a turn whose
                     // process is still being created is legitimately not idle. The finally is what
@@ -925,12 +951,17 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // path below: the content was genuinely produced.
         if (agentActivity) ActivityClock?.Advance();
 
+        // _writeLock covers TryWrite + Record as one unit: this channel has two writers (the
+        // synthesized user_message and the agent's own forwarded output), so without it a Record could
+        // interleave in an order that disagrees with the channel's own FIFO write order.
+        lock (_writeLock) {
+            if (_transcript.Writer.TryWrite(env)) { _journal?.Record(env); return true; }
+        }
+
         // Debug, not Warning, and deliberately: an envelope arriving after the channel closed is the
         // ORDINARY shape of teardown — the turn worker is still draining agy's last lines while
         // TerminateAsync completes the writer — so warning here would fire on every clean stop. A
         // caller for whom the drop is actually meaningful escalates it itself, off this return value.
-        if (_transcript.Writer.TryWrite(env)) return true;
-
         _logger.LogDebug("Antigravity: dropped a transcript envelope — the transcript channel is already completed.");
         return false;
     }

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntime.cs
@@ -248,10 +248,10 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     readonly TranscriptJournal? _journal;
 
     /// <summary>Guards <see cref="Write"/>'s TryWrite + journal Record as one unit — the same shape
-    /// <c>PiRpcHostedAgentRuntime.Write</c> uses, for the same reason: this channel has two writers
-    /// (the turn worker's synthesized <c>user_message</c> and its own forwarded output), so without
-    /// this a Record could interleave in an order that disagrees with the channel's own FIFO write
-    /// order.</summary>
+    /// <c>PiRpcHostedAgentRuntime.Write</c> uses: the turn worker and a caller thread whose
+    /// <see cref="EnqueueTurn"/> hit a full queue (via <see cref="EmitDaemonNotice"/>) can call
+    /// <see cref="Write"/> concurrently, so without this a Record could interleave out of the
+    /// channel's own FIFO write order.</summary>
     readonly Lock _writeLock = new();
 
     /// <summary>
@@ -953,9 +953,9 @@ internal sealed class AntigravityHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // path below: the content was genuinely produced.
         if (agentActivity) ActivityClock?.Advance();
 
-        // _writeLock covers TryWrite + Record as one unit: this channel has two writers (the
-        // synthesized user_message and the agent's own forwarded output), so without it a Record could
-        // interleave in an order that disagrees with the channel's own FIFO write order.
+        // _writeLock covers TryWrite + Record as one unit: the turn worker and a caller thread whose
+        // EnqueueTurn hit a full queue (EmitDaemonNotice) can call this concurrently, so without it a
+        // Record could interleave out of the channel's own FIFO write order.
         lock (_writeLock) {
             if (_transcript.Writer.TryWrite(env)) { _journal?.Record(env); return true; }
         }

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
@@ -300,6 +300,8 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
 
         var model = ResolveModel(config, ctx);
 
+        ctx.Journal?.Open(ctx.Worktree.Path, model);
+
         // Recorded so a failed launch can explain ITSELF — an unauthenticated agy produces no `init`,
         // and "the conversation id never arrived" is not a reason anyone can act on.
         IAgyTurnProcess? firstTurnProcess = null;
@@ -324,7 +326,8 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
             // Disposal, not disk hygiene: the home holds the reviewer's own conversation JSONL — the
             // caller's diff, source excerpts and findings. The daemon-epoch sweep is the crash
             // backstop, not the disposal path.
-            onDisposed: () => AntigravityReviewerHome.Delete(home, stateDir, _logger));
+            onDisposed: () => AntigravityReviewerHome.Delete(home, stateDir, _logger),
+            journal: ctx.Journal);
 
         // MUST precede the first turn: a clock assigned later makes every stamp inside the launch a
         // silent no-op, and the reaper then judges this reviewer from an empty record.

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
@@ -341,7 +341,10 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         launchDeadline.CancelAfter(TimeSpan.FromSeconds(Math.Max(1, config.AntigravityReviewerLaunchTimeoutSeconds)));
 
         try {
-            await runtime.SendUserInputAsync(ctx.Prompt ?? "").ConfigureAwait(false);
+            // A dispose racing this launch can already have closed the turn queue; the launch still
+            // proceeds to the barrier below, which is where that shows up as a real failure.
+            try { await runtime.SendUserInputAsync(ctx.Prompt ?? "").ConfigureAwait(false); }
+            catch (InputNotAdmittedException ex) { _logger.LogDebug(ex, "Antigravity: initial prompt not queued — the runtime is already being torn down."); }
 
             // The ordering guarantee. SendUserInputAsync returns as soon as the turn is enqueued, and
             // WaitForTurnIdleAsync is not a substitute (its enqueue→gate hand-off is itself async), so

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexAppServerHostedAgentRuntime.cs
@@ -154,7 +154,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
             bool emitEnvelopeTranscript = false, bool deferFirstTurn = false,
             string? agentId = null,
             Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>>? requestInteraction = null,
-            TimeSpan? approvalTimeout = null) {
+            TimeSpan? approvalTimeout = null, TranscriptJournal? journal = null) {
         _spawn   = spawn;
         _launch  = launch;
         _clock   = clock;
@@ -180,7 +180,7 @@ internal sealed partial class CodexAppServerHostedAgentRuntime : IHostedAgentRun
         _forwardBuffer = new CodexForwardBuffer(
             ForwardBufferCapacity,
             forwardStallTimeout ?? TimeSpan.FromSeconds(DefaultForwardStallSeconds),
-            _cts.Token, OnForwardStall);
+            _cts.Token, OnForwardStall, journal, logger);
     }
 
     // ── IHostedAgentRuntime: identity / lifecycle observables ──────────────────────────────────

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexForwardBuffer.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexForwardBuffer.cs
@@ -1,5 +1,7 @@
 using System.Threading.Channels;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Harness.Codex;
 
@@ -31,15 +33,21 @@ internal sealed class CodexForwardBuffer : IDisposable {
     readonly TimeSpan          _stallTimeout;
     readonly CancellationToken _shutdown;
     readonly Action<TimeSpan>  _onStall;
+    readonly TranscriptJournal? _journal;
+    readonly ILogger?           _logger;
     int _droppedEphemeral;
     int _stalled;
 
-    public CodexForwardBuffer(int capacity, TimeSpan stallTimeout, CancellationToken shutdown, Action<TimeSpan> onStall) {
+    public CodexForwardBuffer(
+            int capacity, TimeSpan stallTimeout, CancellationToken shutdown, Action<TimeSpan> onStall,
+            TranscriptJournal? journal = null, ILogger? logger = null) {
         _channel = Channel.CreateBounded<AcpEventEnvelope>(new BoundedChannelOptions(capacity) {
             SingleReader = true, SingleWriter = true, FullMode = BoundedChannelFullMode.Wait });
         _stallTimeout = stallTimeout;
         _shutdown     = shutdown;
         _onStall      = onStall;
+        _journal      = journal;
+        _logger       = logger;
     }
 
     /// <summary>The forwarder's drain side — FIFO, real seq assigned downstream (envelopes carry the
@@ -55,7 +63,8 @@ internal sealed class CodexForwardBuffer : IDisposable {
     public bool Stalled => Volatile.Read(ref _stalled) == 1;
 
     /// <summary>Emit one envelope from the read loop. Canonical blocks when full (backpressure);
-    /// ephemeral drops when full. A no-op once stalled.</summary>
+    /// ephemeral drops when full. A no-op once stalled. A canonical envelope is journaled only once it
+    /// is confirmed IN the channel — never on a drop, a stall, or a completed/shutdown buffer.</summary>
     public void Emit(AcpEventEnvelope env) {
         if (Stalled) return;
 
@@ -65,23 +74,32 @@ internal sealed class CodexForwardBuffer : IDisposable {
         }
 
         // Canonical: never dropped. TryWrite is the fast path when there is room.
-        if (_channel.Writer.TryWrite(env)) return;
-        WriteCanonicalBlocking(env);
+        if (_channel.Writer.TryWrite(env) || WriteCanonicalBlocking(env)) _journal?.Record(env);
     }
 
-    void WriteCanonicalBlocking(AcpEventEnvelope env) {
+    /// <summary>True only when <paramref name="env"/> actually entered the channel.</summary>
+    bool WriteCanonicalBlocking(AcpEventEnvelope env) {
         using var stall = CancellationTokenSource.CreateLinkedTokenSource(_shutdown);
         stall.CancelAfter(_stallTimeout);
         try {
             // Blocks the read-loop thread until space frees — the app-server blocks on stdout (lossless).
             _channel.Writer.WriteAsync(env, stall.Token).AsTask().GetAwaiter().GetResult();
+            return true;
+        } catch (ChannelClosedException) {
+            // The ordinary teardown race: Complete() ran while this write was blocked (or arrived
+            // after). Debug, not Warning — every clean stop can hit this.
+            _logger?.LogDebug(
+                "Codex: dropped a transcript envelope (Kind={Kind}) — forward buffer already completed.",
+                env.Kind);
+            return false;
         } catch (OperationCanceledException) {
             // Shutdown fired mid-wait: we are tearing down, so drop this envelope silently (the session
             // is ending anyway) rather than propagating out of the read-loop notification handler.
-            if (_shutdown.IsCancellationRequested) return;
+            if (_shutdown.IsCancellationRequested) return false;
             // Otherwise the buffer stayed full past the stall timeout → deterministic terminal fault. The
             // undrained canonical tail is lost by design and reported loudly by onStall (never silently).
             if (Interlocked.Exchange(ref _stalled, 1) == 0) _onStall(_stallTimeout);
+            return false;
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -123,6 +123,8 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
         CodexAppServerSpawn spawn = (seed, spawnCt) =>
             _spawnFactory(_launcher.CliPath, appServerArgs, seed, ctx.Worktree.Path, env, _config, _loggerFactory);
 
+        ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
+
         var runtime = new CodexAppServerHostedAgentRuntime(
             spawn, launch, ctx.ActivityClock,
             _loggerFactory.CreateLogger<CodexAppServerHostedAgentRuntime>(),
@@ -130,7 +132,8 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
             deferFirstTurn: envelopeSourced,
             agentId: ctx.AgentId,
             requestInteraction: _connection is { } c ? c.RequestAcpInteractionAsync : null,
-            approvalTimeout: TimeSpan.FromSeconds(Math.Max(1, _config.CodexAppServerApprovalTimeoutSeconds)));
+            approvalTimeout: TimeSpan.FromSeconds(Math.Max(1, _config.CodexAppServerApprovalTimeoutSeconds)),
+            journal: ctx.Journal);
 
         // StartAsync may spawn a child before it throws (a failed hooks/list, thread/start, or initial
         // turn on the fail-closed paths). The orchestrator never receives a runtime it did not get a

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexTurnInputDispatcher.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Harness.Codex;
@@ -74,12 +75,17 @@ internal sealed class CodexTurnInputDispatcher {
 
     /// <summary>Enqueues one input and returns a task that completes when the dispatch carrying it
     /// (a <c>turn/start</c> or an accepted <c>turn/steer</c>) succeeds — the "wait for write" contract.
-    /// Faults if that dispatch errors or the runtime is torn down. An optional per-input token (the
-    /// launch's linked token for the initial prompt) is linked into that input's dispatch so cancelling
-    /// it aborts the send.</summary>
+    /// Faults if that dispatch errors. Throws <see cref="InputNotAdmittedException"/> synchronously
+    /// once <see cref="FaultAll"/> has torn the dispatcher down, refused under the same <see cref="_gate"/>
+    /// FaultAll takes so a late enqueue can never slip in and stay pending forever. An optional
+    /// per-input token (the launch's linked token for the initial prompt) is linked into that input's
+    /// dispatch so cancelling it aborts the send.</summary>
     public Task EnqueueAsync(string text, CancellationToken ct = default) {
         var item = new InputItem(text, ct);
-        lock (_gate) _queue.Enqueue(item);
+        lock (_gate) {
+            if (_faulted) throw new InputNotAdmittedException("Codex dispatcher is torn down; this input was not queued.");
+            _queue.Enqueue(item);
+        }
         PumpDispatch();
         return item.Ack.Task;
     }

--- a/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntime.cs
@@ -97,8 +97,14 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
     readonly TimeSpan      _readyDeadline;
     readonly TimeSpan      _stopGrace;
     readonly Action?       _onDisposed;
+    readonly TranscriptJournal? _journal;
 
     readonly Channel<AcpEventEnvelope> _transcript;
+
+    /// <summary>Guards <see cref="Write"/>'s TryWrite + journal Record as one unit — Pi's channel has
+    /// two writers (the pump, and a send-time <c>user_message</c>), so without this a Record could
+    /// interleave in an order that disagrees with the channel's own FIFO write order.</summary>
+    readonly Lock _writeLock = new();
 
     /// <summary>Cancelled by <see cref="TerminateAsync"/>/<see cref="DisposeAsync"/>; the pump's
     /// read token and every command write rides it.
@@ -173,7 +179,8 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
             string        cwd,
             TimeSpan?     readyDeadline = null,
             TimeSpan?     stopGrace     = null,
-            Action?       onDisposed    = null) {
+            Action?       onDisposed    = null,
+            TranscriptJournal? journal  = null) {
         _process        = process;
         _logger         = logger;
         _agentId        = agentId;
@@ -182,6 +189,7 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
         _readyDeadline  = readyDeadline ?? DefaultReadyDeadline;   // never absent — rule (a)
         _stopGrace      = stopGrace ?? DefaultStopGrace;
         _onDisposed     = onDisposed;
+        _journal        = journal;
         _ownerToken     = _ownerCts.Token;
 
         // DropOldest with SingleWriter=false: the pump is the only writer that matters for
@@ -660,7 +668,9 @@ internal sealed class PiRpcHostedAgentRuntime : IHostedAgentRuntime, IAcpTranscr
         // visible, on another thread, so the reverse order is a race a fast reader wins.
         if (agentActivity) ActivityClock?.Advance();
 
-        if (_transcript.Writer.TryWrite(env)) return;
+        lock (_writeLock) {
+            if (_transcript.Writer.TryWrite(env)) { _journal?.Record(env); return; }
+        }
 
         // Debug, not Warning: an envelope arriving after the channel closed is the ORDINARY shape
         // of teardown (the pump is draining Pi's last lines while terminal is entered).

--- a/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntimeFactory.cs
@@ -118,13 +118,18 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
         PiRpcHostedAgentRuntime runtime;
 
         try {
+            // Unopened until now — the orchestrator hands the factory an unopened journal so the
+            // header's cwd/model are this launch's own.
+            ctx.Journal?.Open(ctx.Worktree.Path, ResolveModel(config, ctx));
+
             runtime = new PiRpcHostedAgentRuntime(
                 process,
                 loggerFactory.CreateLogger<PiRpcHostedAgentRuntime>(),
                 ctx.AgentId,
                 ResolveModel(config, ctx),
                 ctx.Worktree.Path,
-                readyDeadline: readyDeadline);
+                readyDeadline: readyDeadline,
+                journal: ctx.Journal);
         } catch {
             // Construction itself failing (it should not, in practice) still leaves a spawned child —
             // no orphan pi processes.

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -511,6 +511,12 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// by production code.</summary>
     internal Task TurnWorkerTaskForTest => _turnWorkerTask;
 
+    /// <summary>Test-only: completes <see cref="_pendingTurns"/> the same way <see cref="DisposeAsync"/>
+    /// does, so a test can force <see cref="EnqueueTurn"/>'s channel-closed branch deterministically —
+    /// simulating a dispose that raced the tail of <see cref="StartAsync"/>'s handshake without
+    /// actually racing a concurrent dispose. Never touched by production code.</summary>
+    internal void CompletePendingTurnsForTest() => _pendingTurns.Writer.TryComplete();
+
     /// <summary>Test-only: installs a throwing owner CTS so <see cref="DisposeAsync"/>'s owner-cancel
     /// (the EARLY cancellation callback) faults. Never touched by production code.</summary>
     internal void SetOwnerCtsForTest(CancellationTokenSource cts) { lock (_reconnectLock) _ownerCts = cts; }
@@ -1079,7 +1085,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // delay agent registration/stoppability for the whole turn. Completion is
         // observed via the Updates/Envelopes channels, not this method's return.
         if (!string.IsNullOrEmpty(initialPrompt)) {
-            _ = EnqueueTurn(initialPrompt, acknowledgeWrite: false);
+            // A dispose racing the tail of this handshake can already have completed
+            // _pendingTurns by the time this runs — the only reachable refusal here, since a
+            // fresh queue can't be full, so it is Debug rather than Warning.
+            try { _ = EnqueueTurn(initialPrompt, acknowledgeWrite: false); }
+            catch (InputNotAdmittedException ex) { _logger.LogDebug(ex, "ACP: initial prompt not queued — the runtime is already being torn down."); }
             ArmFirstOutputWatchdog();
         } else {
             // Deterministic backstop (design spec §3.3): no turn will ever run to settle the marker

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -290,6 +290,10 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// successful review's home would otherwise sit on disk until a later daemon epoch swept it.</summary>
     readonly Action? _onDisposed;
 
+    /// <summary>Recorded from <see cref="EmitEnvelope"/>, opened by the factory before construction. Null
+    /// for every launch/test that carries no journal.</summary>
+    readonly TranscriptJournal? _journal;
+
     /// <summary>
     /// The in-flight out-of-band reap, if one was started. Awaited by disposal so cleanup never runs
     /// ahead of the termination it depends on.
@@ -628,8 +632,10 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             Action<AcpAutoApprovalNotice>?                                                  notifyAutoApproval = null,
             PolicySnapshot?                                                                 policySnapshot = null,
             Action<PolicyDecisionEventV1>?                                                  notifyPolicyDecision = null,
-            string?                                                                         policyCwd = null
+            string?                                                                         policyCwd = null,
+            TranscriptJournal?                                                              journal = null
         ) {
+        _journal = journal;
         _admittedToolIds = admittedToolIds;
         _policySnapshot  = policySnapshot;
         _firstOutputDeadline = firstOutputDeadline;
@@ -1829,6 +1835,8 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
             if (!_transcript.Writer.TryWrite(envelope))
                 _logger.LogDebug("ACP: dropped an ACP transcript envelope (Kind={Kind}) — transcript channel already completed.", envelope.Kind);
+            else
+                _journal?.Record(envelope);
         }
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -1180,13 +1180,17 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 "ACP: pending-turns queue full (capacity={Capacity}) — dropping this input; {DroppedCount} dropped this session so far (the turn worker is likely stuck on a stalled turn).",
                 _pendingTurnsCapacity, dropped);
 
-            written?.TrySetException(new InvalidOperationException("ACP pending-turns queue is full."));
-            return written?.Task ?? Task.CompletedTask;
+            var full = new InputNotAdmittedException("ACP pending-turns queue is full.");
+            if (written is null) throw full;
+            written.TrySetException(full);
+            return written.Task;
         }
 
         if (!_pendingTurns.Writer.TryWrite(new PendingTurn(text, written))) {
             _logger.LogDebug("ACP: dropped a prompt turn — pending-turns channel already completed.");
-            written?.TrySetException(new ObjectDisposedException(nameof(AcpHostedAgentRuntime)));
+            var closed = new InputNotAdmittedException("ACP runtime is terminal; this input was not queued.");
+            if (written is null) throw closed;
+            written.TrySetException(closed);
         }
         return written?.Task ?? Task.CompletedTask;
     }

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -1448,9 +1448,9 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// <summary>
     /// Sends a follow-up <c>session/prompt</c> for hosted-UI text input (server <c>SendInput</c>).
     /// Returns as soon as the text is enqueued (see <see cref="EnqueueTurn"/>) — it does NOT await the
-    /// turn's <c>stopReason</c> response: a real turn can run arbitrarily long, and the
-    /// pre-fix behavior (awaiting the full round trip) blocked this call — and therefore the
-    /// orchestrator's <c>HandleSendInput</c> — for the whole turn. If a prior turn is still in
+    /// turn's <c>stopReason</c> response: a real turn can run arbitrarily long, and awaiting the
+    /// full round trip would block this call — and therefore the orchestrator's
+    /// <c>DeliverInputAsync</c> — for the whole turn. If a prior turn is still in
     /// flight, this text is queued FIFO and the worker sends it only once that turn's own
     /// <c>stopReason</c> has been received and its buffer flushed — turn completion is
     /// observed via <see cref="Updates"/>/<see cref="Envelopes"/>, not this method's return.

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -196,6 +196,10 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             // and the orchestrator replaces recorder+clearer in ONE atomic reference assignment so no
             // partially-wired state is ever observable.
 
+            // Unopened until now — the orchestrator hands the factory an unopened journal
+            // (RuntimeStartContext's remarks) so the header's cwd/model are this launch's own.
+            ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
+
             // Spec-review Finding 4: real production wiring — every launch now gets the
             // permission/elicitation bridge, not the default MethodNotFound/decline.
             runtime = new AcpHostedAgentRuntime(
@@ -260,7 +264,8 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
                 // The same directory the child is spawned in, so a relative tool-call path resolves to
                 // the file the agent will actually touch — an unresolvable one evaluates as Other and
                 // slips past every path rule.
-                policyCwd: ctx.Worktree.Path
+                policyCwd: ctx.Worktree.Path,
+                journal: ctx.Journal
             );
 
             // MUST precede StartAsync below: the handshake's SetLaunchStage stamps are no-ops against

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -190,18 +190,17 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             var reconnect = descriptor.SupportsReconnectResume && !ctx.IsReviewFlow && config.AcpReconnectEnabled
                 ? new AcpReconnectSupport { Spawn = () => _connectionSource(ctx) }
                 : null;
-            // PidCallbacks defaults to AcpPidRecordCallbacks.Unwired — FAIL-CLOSED (code-review r1/r2):
-            // a crash landing in the orchestrator's wiring window fails its attempts (§6.2's
-            // record-before-any-handshake MUST) rather than proceeding with an unrecorded candidate,
-            // and the orchestrator replaces recorder+clearer in ONE atomic reference assignment so no
-            // partially-wired state is ever observable.
+            // PidCallbacks defaults to AcpPidRecordCallbacks.Unwired — fail-closed: a crash during the
+            // orchestrator's wiring window fails its attempts rather than proceeding with an unrecorded
+            // candidate. The orchestrator replaces recorder+clearer in one atomic reference assignment,
+            // so no partially-wired state is ever observable.
 
             // Unopened until now — the orchestrator hands the factory an unopened journal
-            // (RuntimeStartContext's remarks) so the header's cwd/model are this launch's own.
+            // (<see cref="RuntimeStartContext"/>) so the header's cwd/model are this launch's own.
             ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
 
-            // Spec-review Finding 4: real production wiring — every launch now gets the
-            // permission/elicitation bridge, not the default MethodNotFound/decline.
+            // requestInteraction wires the real permission/elicitation bridge — omitting it
+            // silently reverts every launch to the default MethodNotFound/decline.
             runtime = new AcpHostedAgentRuntime(
                 acpConnection,
                 acpProcess,

--- a/src/Capacitor.Cli.Daemon/Services/AgentActivityClock.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentActivityClock.cs
@@ -5,7 +5,7 @@ namespace Capacitor.Cli.Daemon.Services;
 /// relaunch gets a fresh one — fed by PTY output chunks, ACP transcript envelopes, ACP turn
 /// start/end, Antigravity's and Pi's own <c>agentActivity</c>-flagged advances, two independent
 /// <c>LocalPermissionBridge</c> reviewer tool-call-hit sites, and (round-dispatch grace) a
-/// successfully delivered <c>SendInput</c> — see <see cref="AgentOrchestrator.HandleSendInput"/>.
+/// successfully delivered <c>SendInput</c> — see <see cref="AgentOrchestrator.DeliverInputAsync"/>.
 ///
 /// <para>READS are lock-guarded, not just writes: the sources above run on independent threads (a PTY
 /// read loop, an ACP connection's read thread, an HTTP listener), and an unguarded property read can

--- a/src/Capacitor.Cli.Daemon/Services/AgentFileNames.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentFileNames.cs
@@ -1,0 +1,12 @@
+using System.Security.Cryptography;
+using System.Text;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// The file name every per-agent store uses. The agent id crosses the wire unconstrained, so it is
+/// hashed rather than interpolated: no `..` or separator can leave the directory, and the PID record
+/// and the transcript journal of one agent always share a name.
+internal static class AgentFileNames {
+    public static string For(string agentId) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(agentId ?? ""))).ToLowerInvariant();
+}

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -1,5 +1,8 @@
+using System.Text;
+using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
+using Microsoft.Extensions.Logging;
 
 namespace Capacitor.Cli.Daemon.Services;
 
@@ -146,6 +149,65 @@ internal partial class AgentOrchestrator {
     }
 
     static string StatusText(bool confirmedStopped) => confirmedStopped ? "stopped" : "failed";
+
+    /// <summary>Composer input from the owner's socket. Every outcome is one ack the composer can
+    /// word — never an Error frame, never an escaped exception — and it is written only once the
+    /// delivery core has settled, so an ack can never describe a write still in flight.</summary>
+    public async Task HandleLocalSendTextAsync(string payload, Stream stream, CancellationToken ct) {
+        var ack = await AnswerSendTextAsync(payload);
+
+        try {
+            var json = JsonSerializer.Serialize(ack, InputIpcJsonContext.Default.SendTextAckDto);
+            await FrameCodec.WriteAsync(stream, LocalFrame.InputJson(FrameType.SendTextAck, json), ct);
+        } catch (Exception ex) when (ex is not OperationCanceledException) {
+            _logger.LogDebug(
+                ex, "SendText: the ack could not be written; the delivery already settled ({Reason})",
+                ack.Reason ?? ack.Outcome);
+        }
+    }
+
+    /// <summary>A protected kind and a non-running agent are refused BEFORE the delivery core: one is
+    /// addressed through the flow protocol rather than typed at, the other has nothing to accept the
+    /// text. A quit rides <see cref="StopAgentCoreAsync"/> rather than the server-origin stop handler,
+    /// which refuses a private agent — a composer typing at its own local agent would otherwise be
+    /// acked for a stop that never happened.</summary>
+    async Task<SendTextAckDto> AnswerSendTextAsync(string payload) {
+        SendTextDto? dto;
+        try { dto = JsonSerializer.Deserialize(payload, InputIpcJsonContext.Default.SendTextDto); }
+        catch (JsonException) { dto = null; }
+
+        if (!InputWire.IsStructurallyValid(dto)) return Refuse(SendTextReasons.Malformed, "expected {\"agent_id\",\"text\"}");
+        if (string.IsNullOrWhiteSpace(dto!.Text)) return Refuse(SendTextReasons.TextEmpty, "text is empty");
+        if (Encoding.UTF8.GetByteCount(dto.Text) > InputWire.MaxTextBytes)
+            return Refuse(SendTextReasons.TooLarge, $"text exceeds {InputWire.MaxTextBytes} bytes");
+        if (!_agents.TryGetValue(dto.AgentId, out var agent)) return Refuse(SendTextReasons.NoSuchAgent, $"no agent {dto.AgentId}");
+        if (agent.Kind != LaunchKind.Default) return Refuse(SendTextReasons.ProtectedKind, ProtectionReason(agent));
+        if (agent.Status is "Starting" or "Completed" or "Failed") return Refuse(SendTextReasons.NotRunning, $"agent is {agent.Status}");
+
+        InputDeliveryOutcome outcome;
+
+        try { outcome = await DeliverInputAsync(agent, dto.Text, null); }
+        catch (Exception ex) when (ex is not OperationCanceledException) { return Refuse(SendTextReasons.DeliveryFailed, ex.Message); }
+
+        switch (outcome.Kind) {
+            case InputDeliveryKind.Delivered:
+                return new SendTextAckDto(true, null, null, SendTextOutcomes.Delivered);
+
+            case InputDeliveryKind.QuitRequested:
+                LogSendInputQuitCommand(agent.Id, agent.Runtime.Vendor);
+
+                return await StopAgentCoreAsync(agent)
+                    ? new SendTextAckDto(true, null, null, SendTextOutcomes.Stopped)
+                    : Refuse(SendTextReasons.StopFailed, "the agent did not stop");
+
+            // The core's drop reasons are spelled identically to the wire's, so they pass through
+            // unchanged rather than through a mapping that could drift out of step with either set.
+            default:
+                return Refuse(outcome.Reason!, outcome.Error);
+        }
+    }
+
+    static SendTextAckDto Refuse(string reason, string? error) => new(false, reason, error, null);
 
     /// <summary>
     /// Spawn a new agent from a local <c>agent start</c> request, then attach the requesting

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -58,11 +58,12 @@ internal partial class AgentOrchestrator {
                 WorktreePath: a.Checkout.Worktree,
                 WorkLocation: a.Checkout.BorrowedFrom is null ? WorkLocationText.Owned : WorkLocationText.Borrowed,
                 BorrowedFrom: a.Checkout.BorrowedFrom,
-                SessionId: a.SessionId ?? (a.Runtime as IAcpTranscriptSource)?.AcpSessionId,
+                SessionId: a.SessionId ?? SessionIds.Canonical((a.Runtime as IAcpTranscriptSource)?.AcpSessionId),
                 Branch: string.IsNullOrWhiteSpace(a.Worktree.Branch) ? null : a.Worktree.Branch,
                 // Only a live agent can wait on the user; a terminal one keeps whatever its clock
                 // last recorded, which must not read as a pending ask.
-                AwaitingInput: a.Status == "Running" && a.ActivityClock.AwaitingInput))];
+                AwaitingInput: a.Status == "Running" && a.ActivityClock.AwaitingInput,
+                TranscriptFormat: a.Runtime is IAcpTranscriptSource ? TranscriptFormats.Envelopes : TranscriptFormats.Vendor))];
 
     /// <summary>
     /// Serves the legacy <c>Stop</c> frame from older clients that predate --force. That frame

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2535,6 +2535,19 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 return new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, agentId);
             }
 
+            // No AgentInstance owns the journal, so complete it here. Only a file THIS launch
+            // created is removed, and only once the writer is proven gone: a rebind's failed launch
+            // must leave the prior incarnation's records where the app is already reading them.
+            if (journal is { IsOpen: true }) {
+                var drained = await journal.CompleteAsync();
+                if (journal.CreatedFile && drained) {
+                    using var lease = await JournalPathLocks.Shared.AcquireAsync(journal.Path, TranscriptJournal.LockBound, CancellationToken.None);
+                    if (lease is not null) {
+                        try { File.Delete(journal.Path); } catch (Exception deleteEx) { LogCleanupStepFailed(deleteEx, "deleting transcript journal (failed-launch)", agentId); }
+                    }
+                }
+            }
+
             // If a reviewer token was minted before the failure and no AgentInstance was created to
             // own it, revoke it here so it can't linger in the bridge's live-token set.
             if (reviewerToken != null) _permissionBridge.RevokeReviewerToken(reviewerToken);
@@ -4932,6 +4945,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         // Each cleanup step is best-effort so later steps still run
         try { await agent.Runtime.DisposeAsync(); } catch (Exception ex) { LogCleanupStepFailed(ex, "disposing process", agentId); }
+
+        // After the dispose, never before it: the runtime's last envelopes are recorded on its way
+        // out, and completing the journal first would drop them.
+        if (agent.Journal is { } journal) {
+            try { await journal.CompleteAsync(); } catch (Exception ex) { LogCleanupStepFailed(ex, "completing transcript journal", agentId); }
+        }
 
         if (_launchers.TryGetValue(agent.Vendor, out var launcher)) {
             try { launcher.Cleanup(agent); } catch (Exception ex) { LogCleanupStepFailed(ex, "launcher.Cleanup", agentId); }

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -72,6 +72,10 @@ internal record AgentInstance(
     /// runtime that writes nothing the daemon locates.
     public string? TranscriptPath { get; set; }
 
+    /// The daemon-written envelope journal for this launch, for the runtimes that emit envelopes.
+    /// Null for a PTY runtime, which writes its own transcript and needs none.
+    public TranscriptJournal? Journal { get; init; }
+
     bool _titleComputed;
     string? _title;
     /// <summary>The status payload's display title, computed ONCE from the immutable Prompt
@@ -439,6 +443,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     int _discoveryStarts;
     internal int DiscoveryStartsForTest => Volatile.Read(ref _discoveryStarts);
+
+    int _codexProbesArmed;
+    internal int CodexProbesArmedForTest => Volatile.Read(ref _codexProbesArmed);
 
     // Phase B (D4): durable PID records + this daemon's logical identity/epoch for
     // crash-survivor reaping. Initialized in the ctor from config.
@@ -2007,6 +2014,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // method scope so the failure catch can revoke it when no AgentInstance was created to carry it.
         string? reviewerToken = null;
 
+        // Hoisted for the same reason: a launch that fails after the factory opened the journal must
+        // be able to complete it, and remove a file no other incarnation has written to.
+        TranscriptJournal? journal = null;
+
         // Created here, ahead of the reviewer-token mint and the AgentInstance that will own it, so the
         // SAME instance reaches the permission-bridge grant, the ACP runtime and the AgentInstance —
         // one clock per launch, never three.
@@ -2224,6 +2235,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 if (brokeredResultDelivery) flowResultCapabilityUrl = reviewerUrl;
             }
 
+            journal = TranscriptJournal.ForAgent(_pidRecordRoot, agentId, _logger);
+
             var runtimeCtx = new RuntimeStartContext(
                 AgentId: agentId,
                 Vendor: cmd.Vendor,
@@ -2269,7 +2282,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 PermissionMode: cmd.PermissionMode,
                 // The same instance the AgentInstance below carries, so a factory that judges an
                 // action during its own startup uses the documents this launch was reported with.
-                PolicySnapshot: policySnapshot
+                PolicySnapshot: policySnapshot,
+                Journal: journal
             );
 
             HostedRuntimeStart start;
@@ -2364,6 +2378,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             var registeredModel = start.Transcript is { } confirmed ? confirmed.ResolvedModel : effectiveModel;
 
             var agent = new AgentInstance(agentId, prompt, registeredModel, effort, repoPath, cmd.Vendor, runtime, worktree, cts) {
+                // Set in the initializer, not after: PublishAgent below is the first snapshot anyone
+                // reads, and RegisterAgentAsync after it can stall on a server outage.
+                SessionId           = start.Transcript is { } t ? SessionIds.Canonical(t.AcpSessionId) : null,
+                TranscriptPath      = start.Transcript is null ? null : journal.IsOpen ? journal.Path : null,
+                Journal             = start.Transcript is null ? null : journal,
                 ActivityClock       = activityClock,
                 McpConfigPath       = mcpConfigPath,
                 CurrentCols         = HostedPtyCols,
@@ -2478,7 +2497,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // daemon-side locator no-op (the hook stays their only source). Best-effort
             // background task, cancelled with the agent — the server converges incarnations on
             // daemon liveness, so a missing id never blocks a launch.
-            _ = DetectSessionIdAsync(agent, cmd.Vendor, spawnedAtUtc);
+            // Only a runtime that writes its own transcript has anything to discover: an
+            // envelope-sourced one already carries its session id and the journal it is written to.
+            if (start.Transcript is null) _ = DetectSessionIdAsync(agent, cmd.Vendor, spawnedAtUtc);
 
             // Report the resolved model so the server can display / validate the real model the agent
             // is running. Best-effort: never let a report failure break the launch.
@@ -3703,7 +3724,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // Codex turn diagnostic: whether to run the post-send rollout probe, plus this round's
         // generation and the rollout length sampled just BEFORE delivery. Declared out here so both
         // survive the try/finally to reach ArmCodexTurnProbe below.
-        var   isCodex       = string.Equals(agent.Runtime.Vendor, "codex", StringComparison.OrdinalIgnoreCase);
+        // The probe reads a rollout Codex's own CLI writes; an envelope-sourced Codex has none, and
+        // its TranscriptPath names the daemon's journal instead.
+        var   isCodex       = agent.Runtime.EmitsTerminalOutput
+                           && string.Equals(agent.Runtime.Vendor, "codex", StringComparison.OrdinalIgnoreCase);
         long? codexBaseline = null;
         long  codexGen      = 0;
 
@@ -3824,6 +3848,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// already invalidated.</para>
     /// </summary>
     void ArmCodexTurnProbe(AgentInstance agent, long? baseline, long gen) {
+        Interlocked.Increment(ref _codexProbesArmed);
         if (agent.TranscriptPath is not { } rolloutPath || baseline is not { } b) {
             LogCodexTurnRolloutUnresolved(agent.Id);
             return;

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3701,6 +3701,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         public const string PrivateAgent      = "private_agent";
         public const string ReaperClaimed     = "reaper_claimed";
         public const string ReaperClaimedLate = "reaper_claimed_late";
+        public const string QueueFull         = "queue_full";
     }
 
     /// <summary>Reports a drop to the server, when the dispatch carried an id to name. Never throws:
@@ -3823,9 +3824,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 await agent.Runtime.SendUserInputAsync(message);
 
             // Input delivery counts as activity (AgentActivityClock.Advance(), shared with PTY
-            // output/ACP envelopes/turn transitions); a throw from either await above skips it. Known
-            // residual: a full ACP _pendingTurns queue drops input silently without throwing, so this
-            // can advance on a delivery that was actually dropped — kill-delaying only, accepted.
+            // output/ACP envelopes/turn transitions); an InputNotAdmittedException (or any other
+            // throw) from either await above skips it.
             agent.ActivityClock.Advance();
             agent.ActivityClock.ClearAwaitingInputSince(waitGeneration);
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3546,7 +3546,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // Claude CLI requires the slash-command text and the Enter key to arrive
             // as separate PTY writes (with a small delay between them) — sending them
             // in a single write makes Claude treat the carriage return as part of the
-            // command buffer instead of a submit. HandleSendInput uses the same split
+            // command buffer instead of a submit. DeliverInputAsync uses the same split
             // pattern; matching it here makes the graceful path actually fire.
             // BOTH steps are bounded, and bounding the SEND is the load-bearing half. Asking for the
             // graceful stop is not free work: for a PTY runtime it writes "/exit" to the same master fd

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -268,10 +268,10 @@ internal record AgentInstance(
     /// .git entries, and neither the worktree nor the work location changes after launch.</summary>
     public AgentCheckout Checkout => _checkout ??= AgentCheckout.Resolve(Worktree, Work, BorrowedSnapshotSource);
 
-    /// <summary>The per-agent critical section. Named for its original duty (serializing the borrowed-
-    /// checkout refresh against a concurrent send) but it has always wrapped the ENTIRE
-    /// <see cref="AgentOrchestrator.HandleSendInput"/> body for EVERY vendor, borrowed or not — so it
-    /// is simply "the delivery section", and that is its second, load-bearing purpose:
+    /// <summary>The per-agent delivery section: held across the whole of
+    /// <see cref="AgentOrchestrator.DeliverInputAsync"/> for EVERY vendor, borrowed or not. It
+    /// serializes the borrowed-checkout refresh against a concurrent send, and it has a second,
+    /// load-bearing purpose:
     ///
     /// <para><b>The delivery/reap fence (round-dispatch grace §3).</b> The reaper's
     /// validate-and-claim (<see cref="AgentOrchestrator.TryClaimReapAsync"/>) runs inside this same
@@ -289,7 +289,7 @@ internal record AgentInstance(
     /// its stdin. The graceful-stop wait in <see cref="AgentOrchestrator.StopAgentCoreAsync"/> is exactly this case: it
     /// is waiting on the very process that only its OWN next action (terminate) can unblock, so that
     /// wait is bounded. The delivery's own ENTRY wait onto this gate (<see
-    /// cref="AgentOrchestrator.HandleSendInput"/>) is exempt from this rule — it is the holder class,
+    /// cref="AgentOrchestrator.DeliverInputAsync"/>) is exempt from this rule — it is the holder class,
     /// not the bounded class: it is unblocked by whatever the current holder is itself waiting on (the
     /// child exiting, or a stop completing), never by an action the entry waiter must take. See <see
     /// cref="AgentOrchestrator.TryClaimReapAsync"/>.</para>
@@ -314,7 +314,7 @@ internal record AgentInstance(
     /// delivery is holding it (see <see cref="AgentOrchestrator.TryClaimReapAsync"/>), so the two claim
     /// paths cannot share a lock and must share a CAS instead.
     ///
-    /// <para>Read via <see cref="IsReapClaimed"/> by <see cref="AgentOrchestrator.HandleSendInput"/>,
+    /// <para>Read via <see cref="IsReapClaimed"/> by <see cref="AgentOrchestrator.DeliverInputAsync"/>,
     /// which refuses to deliver to a condemned agent. Effectively write-once: a claimed agent is on its
     /// way down, and <see cref="AgentOrchestrator.StopAgentCoreAsync"/> flipping the status to
     /// "Completed" already takes it out of the reap candidate set permanently, so the latch adds no new
@@ -1526,7 +1526,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     ///
     /// <para><b>Lock order.</b> ordering → clock (via <see cref="BuildStatusReport"/>). MUST NEVER be
     /// acquired while a per-agent <see cref="AgentInstance.BorrowedSnapshotGate"/> is held —
-    /// <see cref="HandleSendInput"/> offloads its emission for exactly this reason.</para>
+    /// <see cref="DeliverInputAsync"/> offloads its emission for exactly this reason.</para>
     ///
     /// <para>Never disposed: emissions are fire-and-forget, so a waiter parked here during teardown
     /// must not fault on an <see cref="ObjectDisposedException"/> nobody observes.</para>
@@ -3128,7 +3128,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     ///
     /// <para>Note it is SHORTER than a delivery's own worst-case in-section time (the borrowed-snapshot
     /// refresh is budgeted 30s), so the unfenced timeout arm fires against healthy deliveries too — by
-    /// design, and handled by <see cref="HandleSendInput"/>'s pre-write re-read of the claim latch
+    /// design, and handled by <see cref="DeliverInputAsync"/>'s pre-write re-read of the claim latch
     /// rather than by inflating this wait, which would only restore the deadlock it exists to
     /// prevent.</para></summary>
     internal TimeSpan ReapClaimGateWait { get; set; } = TimeSpan.FromSeconds(20);
@@ -3259,7 +3259,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     /// <summary>The atomic reap claim (round-dispatch grace §3). Runs inside
     /// <see cref="AgentInstance.BorrowedSnapshotGate"/> — the same per-agent section every
-    /// <see cref="HandleSendInput"/> delivery holds across its clock advance — so the claim and a
+    /// <see cref="DeliverInputAsync"/> delivery holds across its clock advance — so the claim and a
     /// delivery are mutually exclusive and exactly one of them wins.
     ///
     /// <para>Rechecking "immediately before" the stop would NOT do: selection is a snapshot, and any
@@ -3376,7 +3376,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// <para>It races a delivery by construction, and the delivery it races is NOT necessarily a
     /// wedged one. The section is legitimately held past this wait by healthy work — the borrowed-
     /// snapshot refresh alone is budgeted 30s — so this claim can fire against an in-flight, entirely
-    /// well-behaved delivery. That is why <see cref="HandleSendInput"/> re-reads the latch immediately
+    /// well-behaved delivery. That is why <see cref="DeliverInputAsync"/> re-reads the latch immediately
     /// before its write instead of only on entry: a healthy delivery must ABORT there rather than
     /// complete into a condemned agent. The genuinely parked case resolves differently — the write is
     /// released by the terminate this claim leads to (which is reachable only because
@@ -3455,7 +3455,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         await StopAgentCoreAsync(agent);
     }
 
-    /// <summary>Test-only: awaited inside <see cref="HandleSendInput"/>'s section in the window between
+    /// <summary>Test-only: awaited inside <see cref="DeliverInputAsync"/>'s section in the window between
     /// its slow pre-write steps (the borrowed-snapshot refresh, attachment downloads) and its
     /// pre-write re-read of the reap-claim latch — i.e. exactly where a reaper's un-sectioned claim
     /// lands in production, since that refresh is budgeted LONGER than the claim's gate wait. A test
@@ -3702,6 +3702,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         public const string ReaperClaimed     = "reaper_claimed";
         public const string ReaperClaimedLate = "reaper_claimed_late";
         public const string QueueFull         = "queue_full";
+        public const string DeliveryFailed    = "delivery_failed";
     }
 
     /// <summary>Reports a drop to the server, when the dispatch carried an id to name. Never throws:
@@ -3737,44 +3738,77 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
         LogSendInputReceived(agentId, agent.Runtime.Vendor, text.Length, attachmentIds?.Length ?? 0);
 
+        var outcome = await DeliverInputAsync(agent, text, attachmentIds);
+
+        switch (outcome.Kind) {
+            case InputDeliveryKind.QuitRequested:
+                LogSendInputQuitCommand(agentId, agent.Runtime.Vendor);
+                // Translated onto the same serial lane a server-origin stop rides.
+                await HandleUnsequencedStopAgent(agentId);
+
+                break;
+
+            // Reported here rather than from inside the delivery section: the report is an unbounded
+            // server round trip, and awaiting one while the per-agent gate is held would hold every
+            // later input for that agent behind a stalled connection — and stretch the section the
+            // reaper's own claim races against.
+            case InputDeliveryKind.Dropped:
+                await ReportInputDroppedAsync(cmd, outcome.Reason!);
+
+                break;
+        }
+    }
+
+    /// <summary>Delivers one message to an agent's runtime and says what happened. It reports
+    /// nothing and stops nothing: answering whoever typed the message belongs to the caller, so a
+    /// caller with a different sender to answer can reuse this write path unchanged. Everything the
+    /// write depends on — the borrowed-snapshot refresh, attachment downloads, and the reap-claim
+    /// checks that decide whether a condemned agent may still be written to — happens inside the
+    /// agent's own delivery section.</summary>
+    internal async Task<InputDeliveryOutcome> DeliverInputAsync(AgentInstance agent, string text, string[]? attachmentIds) {
         // A quit command typed into chat: a runtime with no TUI has nothing that interprets it, so
         // forwarding would hand the text to the model as an ordinary prompt — at best role-played
-        // ("Quitting"), never a stop. Translate it onto the same serial lane a server stop rides.
-        // PTY runtimes keep receiving the text verbatim: their TUI owns the command's meaning.
-        if (!agent.Runtime.EmitsTerminalOutput && IsQuitCommand(text)) {
-            LogSendInputQuitCommand(agentId, agent.Runtime.Vendor);
-            await HandleUnsequencedStopAgent(agentId);
-            return;
-        }
+        // ("Quitting"), never a stop. PTY runtimes keep receiving the text verbatim: their TUI owns
+        // the command's meaning.
+        if (!agent.Runtime.EmitsTerminalOutput && IsQuitCommand(text)) return InputDeliveryOutcome.QuitRequested;
 
         // Codex turn diagnostic: whether to run the post-send rollout probe, plus this round's
-        // generation and the rollout length sampled just BEFORE delivery. Declared out here so both
-        // survive the try/finally to reach ArmCodexTurnProbe below.
-        // The probe reads a rollout Codex's own CLI writes; an envelope-sourced Codex has none, and
-        // its TranscriptPath names the daemon's journal instead.
+        // generation and the rollout length sampled just BEFORE delivery. The probe reads a rollout
+        // Codex's own CLI writes; an envelope-sourced Codex has none, and its TranscriptPath names
+        // the daemon's journal instead.
         var   isCodex       = agent.Runtime.EmitsTerminalOutput
                            && string.Equals(agent.Runtime.Vendor, "codex", StringComparison.OrdinalIgnoreCase);
         long? codexBaseline = null;
         long  codexGen      = 0;
 
-        // Set inside the section, reported outside it: the report is an unbounded server round trip,
-        // and awaiting one while holding this gate would hold every later input for that agent behind
-        // a stalled connection — and stretch the section the reaper's own claim races against.
-        string? dropReason = null;
+        InputDeliveryOutcome outcome;
 
         await agent.BorrowedSnapshotGate.WaitAsync(_shutdownCts.Token);
         try {
-            // Losing side of the reap claim (round-dispatch grace §3): a reap-claimed agent gets
-            // nothing — no write, no clock advance, no report. Failing the dispatch here (not writing
-            // into a dying runtime) is deliberate; the server heals it on resubmit.
-            if (agent.IsReapClaimed) {
-                LogSendInputReapClaimed(agentId);
-                dropReason = SendInputDropReason.ReaperClaimed;
+            outcome = await DeliverInSectionAsync();
+        } finally {
+            agent.BorrowedSnapshotGate.Release();
+        }
 
-                return;
+        // Armed outside the section, and only for a write that actually landed.
+        if (isCodex && outcome.Kind is InputDeliveryKind.Delivered) ArmCodexTurnProbe(agent, codexBaseline, codexGen);
+
+        return outcome;
+
+        async Task<InputDeliveryOutcome> DeliverInSectionAsync() {
+            // Losing side of the reap claim: a reap-claimed agent gets nothing — no write, no clock
+            // advance. Failing the dispatch here rather than writing into a dying runtime is
+            // deliberate; the server heals it on resubmit.
+            if (agent.IsReapClaimed) {
+                LogSendInputReapClaimed(agent.Id);
+
+                return InputDeliveryOutcome.Drop(SendInputDropReason.ReaperClaimed);
             }
 
-            if (!await TryRefreshBorrowedSnapshotAsync(agent)) return;
+            // Fails closed: a refresh that failed has already terminated the reviewer rather than
+            // leave it on a possibly-partial snapshot, so this round is over.
+            if (!await TryRefreshBorrowedSnapshotAsync(agent))
+                return InputDeliveryOutcome.Drop(SendInputDropReason.DeliveryFailed, "borrowed snapshot refresh failed");
 
             var message = text;
 
@@ -3786,28 +3820,25 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 }
             }
 
-            // Re-checked HERE, not only at the top of the section: the borrowed-snapshot refresh
-            // budget (30s, BorrowedSnapshotRefreshTimeout) plus any downloads routinely exceeds the
-            // reap claim's own gate wait (20s, ReapClaimGateWait), so an unfenced claim
-            // (TryClaimUnfencedReapWithoutSection) can land mid-section. The latch is monotonic 0→1
-            // via Volatile.Read, so this re-read can never false-positive.
             if (SendInputBeforeWriteHookForTest is { } beforeWrite) await beforeWrite();
 
+            // Re-read HERE, not only on entry: the borrowed-snapshot refresh budget
+            // (BorrowedSnapshotRefreshTimeout) plus any downloads routinely exceed the reap claim's
+            // own gate wait (ReapClaimGateWait), so an unfenced claim can land mid-section. The latch
+            // is monotonic 0→1 via Volatile.Read, so this re-read can never false-positive.
             if (agent.IsReapClaimed) {
-                LogSendInputReapClaimedLate(agentId);
-                dropReason = SendInputDropReason.ReaperClaimedLate;
+                LogSendInputReapClaimedLate(agent.Id);
 
-                return;
+                return InputDeliveryOutcome.Drop(SendInputDropReason.ReaperClaimedLate);
             }
 
-            // Codex turn diagnostic: BEFORE delivering this round's input — and while the send gate
-            // is held, so it is ordered per agent — bump the round generation and sample the rollout
-            // length from the cached path. Bumping first instantly invalidates any prior round's
-            // still-running probe (it emits a verdict only while its generation is the latest), so a
-            // fast Codex append caused by THIS input can never be credited to the previous round.
-            // Sampling the length after the bump but before the send keeps the baseline honest (the
-            // append lands strictly after it). A null here (path not cached yet, or the stat failed)
-            // is handled in ArmCodexTurnProbe.
+            // Codex turn diagnostic: bump the round generation and sample the rollout length BEFORE
+            // delivering, while the gate is held so it is ordered per agent. Bumping first instantly
+            // invalidates any prior round's still-running probe (it emits a verdict only while its
+            // generation is the latest), so a fast Codex append caused by THIS input can never be
+            // credited to the previous round. Sampling after the bump but before the send keeps the
+            // baseline honest — the append lands strictly after it. A null here (path not cached yet,
+            // or the stat failed) is handled in ArmCodexTurnProbe.
             if (isCodex) {
                 codexGen = Interlocked.Increment(ref agent.CodexTurnProbeGen);
                 if (agent.TranscriptPath is { } rolloutPath) codexBaseline = TryFileLength(rolloutPath);
@@ -3817,15 +3848,24 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // that wait is newer than the one this input answers.
             var waitGeneration = agent.ActivityClock.WaitGeneration;
 
-            // PTY runtimes use bracketed paste; ACP runtimes send a structured prompt.
-            if (agent.BorrowedSnapshotSource is not null)
-                await agent.Runtime.SendUserInputAndWaitForWriteAsync(message);
-            else
-                await agent.Runtime.SendUserInputAsync(message);
+            try {
+                // PTY runtimes use bracketed paste; ACP runtimes send a structured prompt.
+                if (agent.BorrowedSnapshotSource is not null)
+                    await agent.Runtime.SendUserInputAndWaitForWriteAsync(message);
+                else
+                    await agent.Runtime.SendUserInputAsync(message);
+            } catch (InputNotAdmittedException ex) {
+                LogSendInputDeliveryFailed(ex, agent.Id, agent.Runtime.Vendor, SendInputDropReason.QueueFull);
+
+                return InputDeliveryOutcome.Drop(SendInputDropReason.QueueFull, ex.Message);
+            } catch (Exception ex) {
+                LogSendInputDeliveryFailed(ex, agent.Id, agent.Runtime.Vendor, SendInputDropReason.DeliveryFailed);
+
+                return InputDeliveryOutcome.Drop(SendInputDropReason.DeliveryFailed, ex.Message);
+            }
 
             // Input delivery counts as activity (AgentActivityClock.Advance(), shared with PTY
-            // output/ACP envelopes/turn transitions); an InputNotAdmittedException (or any other
-            // throw) from either await above skips it.
+            // output/ACP envelopes/turn transitions); a refused or failed write above skips it.
             agent.ActivityClock.Advance();
             agent.ActivityClock.ClearAwaitingInputSince(waitGeneration);
 
@@ -3842,18 +3882,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // loop while still holding BorrowedSnapshotGate.
             _ = Task.Run(() => SendDaemonStatusReportOnceAsync());
 
-            LogSendInputDelivered(agentId, agent.Runtime.Vendor, message.Length);
-        } finally {
-            agent.BorrowedSnapshotGate.Release();
+            LogSendInputDelivered(agent.Id, agent.Runtime.Vendor, message.Length);
 
-            // After the release, never before it — see dropReason's own note.
-            if (dropReason is { } reason) await ReportInputDroppedAsync(cmd, reason);
+            return InputDeliveryOutcome.Delivered;
         }
-
-        // Codex turn diagnostic: arm the post-send rollout-growth probe. Only reached on the
-        // successful-delivery path (the guards and the borrowed-snapshot failure above all return
-        // before here).
-        if (isCodex) ArmCodexTurnProbe(agent, codexBaseline, codexGen);
     }
 
     /// <summary>
@@ -3862,7 +3894,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     /// round's input was delivered) and logs whether a turn began — the only clean turn-start signal
     /// a PTY runtime gives the daemon (see <see cref="CodexTurnObserver"/>).
     ///
-    /// <para>Single-flight is by GENERATION, established in <see cref="HandleSendInput"/> before
+    /// <para>Single-flight is by GENERATION, established in <see cref="DeliverInputAsync"/> before
     /// delivery: <paramref name="gen"/> is this round's generation, and the probe emits a verdict
     /// only while it is still the agent's latest — so a later round's growth is never credited to an
     /// earlier round even during that earlier probe's own poll. This method itself does no I/O and
@@ -5259,6 +5291,9 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     [LoggerMessage(Level = LogLevel.Information, Message = "SendInput delivered to agent {AgentId}'s {Vendor} runtime ({Chars} chars)")]
     partial void LogSendInputDelivered(string agentId, string vendor, int chars);
+
+    [LoggerMessage(Level = LogLevel.Warning, Message = "SendInput dropped: agent {AgentId}'s {Vendor} runtime did not take the write ({Reason})")]
+    partial void LogSendInputDeliveryFailed(Exception ex, string agentId, string vendor, string reason);
 
     [LoggerMessage(Level = LogLevel.Debug, Message = "Could not report the dropped input for agent {AgentId} ({Reason})")]
     partial void LogSendInputRejectReportFailed(Exception ex, string agentId, string reason);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2329,6 +2329,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                     }
                 }
 
+                // No AgentInstance was created here either, so the journal is otherwise never
+                // completed or deleted — this arm returns before the outer catch below.
+                await DiscardFailedLaunchJournalAsync(journal, agentId);
+
                 return new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, agentId);
             }
 
@@ -2535,18 +2539,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 return new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, agentId);
             }
 
-            // No AgentInstance owns the journal, so complete it here. Only a file THIS launch
-            // created is removed, and only once the writer is proven gone: a rebind's failed launch
-            // must leave the prior incarnation's records where the app is already reading them.
-            if (journal is { IsOpen: true }) {
-                var drained = await journal.CompleteAsync();
-                if (journal.CreatedFile && drained) {
-                    using var lease = await JournalPathLocks.Shared.AcquireAsync(journal.Path, TranscriptJournal.LockBound, CancellationToken.None);
-                    if (lease is not null) {
-                        try { File.Delete(journal.Path); } catch (Exception deleteEx) { LogCleanupStepFailed(deleteEx, "deleting transcript journal (failed-launch)", agentId); }
-                    }
-                }
-            }
+            // No AgentInstance owns the journal, so complete it here.
+            await DiscardFailedLaunchJournalAsync(journal, agentId);
 
             // If a reviewer token was minted before the failure and no AgentInstance was created to
             // own it, revoke it here so it can't linger in the bridge's live-token set.
@@ -2596,6 +2590,24 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
             // was torn down and no agent was ever registered; terminal for the sequenced lane.
             return new CommandOutcome(CommandOutcomeKind.LaunchFailedCleaned, agentId);
         }
+    }
+
+    /// <summary>
+    /// Completes and, only when safe, deletes a journal from a launch that never produced an
+    /// <see cref="AgentInstance"/> to own it — every pre-insert failure arm of
+    /// <see cref="HandleLaunchAgentCore"/> routes here so none can drift from another. Only a
+    /// file THIS launch created is removed, and only once the writer is proven gone: a rebind's
+    /// failed launch must leave the prior incarnation's records where the app is already reading
+    /// them.
+    /// </summary>
+    async Task DiscardFailedLaunchJournalAsync(TranscriptJournal? journal, string agentId) {
+        if (journal is not { IsOpen: true }) return;
+        var drained = await journal.CompleteAsync();
+        if (!journal.CreatedFile || !drained) return;
+
+        using var lease = await JournalPathLocks.Shared.AcquireAsync(journal.Path, TranscriptJournal.LockBound, CancellationToken.None);
+        if (lease is null) return;
+        try { File.Delete(journal.Path); } catch (Exception deleteEx) { LogCleanupStepFailed(deleteEx, "deleting transcript journal (failed-launch)", agentId); }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentPidRecordStore.cs
@@ -1,5 +1,3 @@
-using System.Security.Cryptography;
-using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core;
 using Microsoft.Extensions.Logging;
@@ -136,10 +134,7 @@ internal sealed class AgentPidRecordStore(string stateDir, ILogger logger) {
     }
 
     // Hash the (untrusted) agent id into the filename so no id can escape _agentsDir via path separators.
-    string PathFor(string agentId) => Path.Combine(_agentsDir, SafeName(agentId) + ".json");
-
-    static string SafeName(string agentId) =>
-        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(agentId ?? ""))).ToLowerInvariant();
+    string PathFor(string agentId) => Path.Combine(_agentsDir, AgentFileNames.For(agentId) + ".json");
 
     void TryQuarantine(string path) {
         try { File.Move(path, path + ".corrupt", overwrite: true); }

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntime.cs
@@ -61,13 +61,19 @@ internal interface IHostedAgentRuntime : IAsyncDisposable {
 
     /// <summary>
     /// Hosted-UI text input (server <c>SendInput</c>). PTY runtimes perform the CLI-specific
-    /// text-then-Enter split write; the ACP runtime sends a <c>session/prompt</c>.
+    /// text-then-Enter split write; the ACP runtime sends a <c>session/prompt</c>. Fails with
+    /// <see cref="InputNotAdmittedException"/> when the runtime will not queue or write the text (a
+    /// full pending-turn queue, a terminal runtime): thrown synchronously by this method, carried by
+    /// the task from <see cref="SendUserInputAndWaitForWriteAsync"/>.
     /// </summary>
     Task SendUserInputAsync(string text);
 
     /// <summary>Queue input and complete only after the runtime has written the prompt to its
     /// protocol transport. Borrowed snapshot rounds use this acknowledgement to close the race
-    /// between prompt delivery and a subsequent refresh. PTY runtimes use the normal send.</summary>
+    /// between prompt delivery and a subsequent refresh. PTY runtimes use the normal send. Fails with
+    /// <see cref="InputNotAdmittedException"/> when the runtime will not queue or write the text (a
+    /// full pending-turn queue, a terminal runtime): thrown synchronously by
+    /// <see cref="SendUserInputAsync"/>, carried by the task from this method.</summary>
     Task SendUserInputAndWaitForWriteAsync(string text) => SendUserInputAsync(text);
 
     /// <summary>Wait until any prior structured prompt turn has received its terminal response.

--- a/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/IHostedAgentRuntimeFactory.cs
@@ -252,5 +252,8 @@ internal sealed record RuntimeStartContext(
         // own file — the same instance the AgentInstance carries, so a factory and the permission
         // seam judge against one set of documents. Null when no provider is wired, when the build
         // failed, and for constructions predating this field.
-        PolicySnapshot?     PolicySnapshot = null
+        PolicySnapshot?     PolicySnapshot = null,
+        // The launch's transcript journal, unopened. An envelope-emitting factory opens it before
+        // constructing its runtime and hands it to the constructor; a PTY factory ignores it.
+        TranscriptJournal?  Journal = null
     );

--- a/src/Capacitor.Cli.Daemon/Services/InputDeliveryOutcome.cs
+++ b/src/Capacitor.Cli.Daemon/Services/InputDeliveryOutcome.cs
@@ -1,0 +1,18 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>How <see cref="AgentOrchestrator.DeliverInputAsync"/> ended. <c>QuitRequested</c> is not
+/// a failure: the text was a quit command a TUI-less runtime cannot interpret, and stopping the
+/// agent belongs to the caller, which owns the lane the stop must ride.</summary>
+internal enum InputDeliveryKind { Delivered, QuitRequested, Dropped }
+
+/// <summary>One delivery attempt's result. <see cref="Reason"/> carries an
+/// <see cref="AgentOrchestrator.SendInputDropReason"/> token when the input was dropped — it is what
+/// a caller reports to whoever typed the message; <see cref="Error"/> is the runtime's own message
+/// for the fault behind it, for a log rather than a wire token.</summary>
+internal readonly record struct InputDeliveryOutcome(InputDeliveryKind Kind, string? Reason = null, string? Error = null) {
+    public static readonly InputDeliveryOutcome Delivered     = new(InputDeliveryKind.Delivered);
+    public static readonly InputDeliveryOutcome QuitRequested = new(InputDeliveryKind.QuitRequested);
+
+    public static InputDeliveryOutcome Drop(string reason, string? error = null) =>
+        new(InputDeliveryKind.Dropped, reason, error);
+}

--- a/src/Capacitor.Cli.Daemon/Services/InputNotAdmittedException.cs
+++ b/src/Capacitor.Cli.Daemon/Services/InputNotAdmittedException.cs
@@ -1,5 +1,4 @@
 namespace Capacitor.Cli.Daemon.Services;
 
 /// A runtime declined to queue or write the text: its pending-turn queue is full or it is terminal.
-/// Both callers of the delivery core map this to the `queue_full` reason.
 internal sealed class InputNotAdmittedException(string message) : InvalidOperationException(message);

--- a/src/Capacitor.Cli.Daemon/Services/InputNotAdmittedException.cs
+++ b/src/Capacitor.Cli.Daemon/Services/InputNotAdmittedException.cs
@@ -1,0 +1,5 @@
+namespace Capacitor.Cli.Daemon.Services;
+
+/// A runtime declined to queue or write the text: its pending-turn queue is full or it is terminal.
+/// Both callers of the delivery core map this to the `queue_full` reason.
+internal sealed class InputNotAdmittedException(string message) : InvalidOperationException(message);

--- a/src/Capacitor.Cli.Daemon/Services/JournalItem.cs
+++ b/src/Capacitor.Cli.Daemon/Services/JournalItem.cs
@@ -1,0 +1,8 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// One queued journal append: the envelope, plus how many envelopes were dropped immediately before
+/// it. The count rides the item so the note lands between the last kept line and the first line
+/// after the loss, wherever the writer happens to be.
+internal readonly record struct JournalItem(AcpEventEnvelope Envelope, int GapBefore);

--- a/src/Capacitor.Cli.Daemon/Services/JournalPathLocks.cs
+++ b/src/Capacitor.Cli.Daemon/Services/JournalPathLocks.cs
@@ -1,0 +1,54 @@
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// One writer per journal path at a time, process-wide. FileStream has no cross-handle append, so two
+/// handles on one file overwrite each other; the lock is what makes "one handle" true. Entries are
+/// reference-counted so a waiter can never be left holding an entry the map has forgotten.
+internal sealed class JournalPathLocks {
+    public static readonly JournalPathLocks Shared = new();
+
+    sealed class Entry : IDisposable {
+        public readonly SemaphoreSlim Gate = new(1, 1);
+        public int Count;
+        public void Dispose() => Gate.Dispose();
+    }
+
+    readonly Dictionary<string, Entry> _entries = new(PlatformPaths.Comparer);
+    readonly Lock _sync = new();
+
+    public int LiveEntries { get { lock (_sync) return _entries.Count; } }
+
+    public async Task<IDisposable?> AcquireAsync(string path, TimeSpan timeout, CancellationToken ct) {
+        var key = Path.GetFullPath(path);
+        Entry entry;
+        lock (_sync) {
+            if (!_entries.TryGetValue(key, out entry!)) _entries[key] = entry = new Entry();
+            entry.Count++;
+        }
+        var acquired = false;
+        try {
+            acquired = await entry.Gate.WaitAsync(timeout, ct).ConfigureAwait(false);
+        } finally {
+            if (!acquired) Decrement(key, entry);
+        }
+        return acquired ? new Lease(this, key, entry) : null;
+    }
+
+    void Decrement(string key, Entry entry) {
+        lock (_sync) {
+            if (--entry.Count > 0) return;
+            _entries.Remove(key);
+        }
+        entry.Dispose();
+    }
+
+    sealed class Lease(JournalPathLocks owner, string key, Entry entry) : IDisposable {
+        int _disposed;
+        public void Dispose() {
+            if (Interlocked.Exchange(ref _disposed, 1) != 0) return;
+            entry.Gate.Release();
+            owner.Decrement(key, entry);
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/LocalControlCapabilities.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalControlCapabilities.cs
@@ -5,19 +5,19 @@ namespace Capacitor.Cli.Daemon.Services;
 /// INVARIANT: an entry may exist here ONLY if <see cref="LocalControlServer"/> actually
 /// routes the corresponding frame(s) to a real handler — this list is assembled right next
 /// to that routing switch so a capability can never be advertised without behavior behind
-/// it. All five entries' handlers are live in this build: <c>"consent/1"</c> routes
+/// it. Every entry's handler is live in this build: <c>"consent/1"</c> routes
 /// ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut to <see cref="LaunchConsentIpc"/>;
 /// <c>"consent/2"</c> routes ConsentSubscribeV2/ConsentResolveV2 to the same handler with
 /// identity-checked resolution (mandatory <c>prompt_id</c> echo), <c>rule_saved</c> acks, and
-/// <c>prompt_id</c>/<c>requester_display</c>-stamped pendings — this list entry is discovery
-/// only, enforcement lives in the v2 frames themselves; <c>"consent/3"</c> routes
+/// <c>prompt_id</c>/<c>requester_display</c>-stamped pendings; <c>"consent/3"</c> routes
 /// ConsentRulesPutV2 to the same handler, gating the policy replacement on an
-/// ExpectedName/ExpectedServerUrl identity echo (ack is the existing ConsentAck, with the
-/// coded <c>identity_mismatch</c> error on mismatch and nothing mutated) — again discovery
-/// only, enforcement lives in the v2 frame itself; <c>"status/1"</c> routes
-/// StatusSubscribe to <see cref="DaemonStatusIpc"/>; and <c>"permission/1"</c> routes
-/// PermissionSubscribe/PermissionResolve to <see cref="PermissionIpc"/>.
+/// ExpectedName/ExpectedServerUrl identity echo (ack is the existing ConsentAck, with the coded
+/// <c>identity_mismatch</c> error on mismatch and nothing mutated). Both v2 entries are discovery
+/// only — enforcement lives in the v2 frames themselves. <c>"status/1"</c> routes StatusSubscribe
+/// to <see cref="DaemonStatusIpc"/>; <c>"permission/1"</c> routes
+/// PermissionSubscribe/PermissionResolve to <see cref="PermissionIpc"/>; and <c>"input/1"</c>
+/// routes SendText to <see cref="AgentOrchestrator.HandleLocalSendTextAsync"/>.
 /// </summary>
 internal static class LocalControlCapabilities {
-    public static readonly IReadOnlyList<string> Current = ["consent/1", "consent/2", "consent/3", "status/1", "permission/1"];
+    public static readonly IReadOnlyList<string> Current = ["consent/1", "consent/2", "consent/3", "status/1", "permission/1", "input/1"];
 }

--- a/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
+++ b/src/Capacitor.Cli.Daemon/Services/LocalControlServer.cs
@@ -64,7 +64,8 @@ internal sealed partial class LocalControlServer(
                 case FrameType.PermissionResolve:   await permissionIpc.HandleResolveAsync(first.Text, stream, ct); break;
                 case FrameType.Hello: await HandleHelloAsync(first.Text, stream, ct); break;
                 case FrameType.StatusSubscribe: await statusIpc.HandleSubscribeAsync(stream, ct); break;
-                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List/Stop/StopV2/Restart/ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut/ConsentSubscribeV2/ConsentResolveV2/ConsentRulesPutV2/PermissionSubscribe/PermissionResolve/Hello/StatusSubscribe, got {first.Type}"), ct); break;
+                case FrameType.SendText: await orchestrator.HandleLocalSendTextAsync(first.Text, stream, ct); break;
+                default: await FrameCodec.WriteAsync(stream, LocalFrame.Error($"expected Spawn/Attach/List/Stop/StopV2/Restart/ConsentSubscribe/ConsentResolve/ConsentRulesGet/ConsentRulesPut/ConsentSubscribeV2/ConsentResolveV2/ConsentRulesPutV2/PermissionSubscribe/PermissionResolve/Hello/StatusSubscribe/SendText, got {first.Type}"), ct); break;
             }
         } catch (Exception ex) when (ex is not OperationCanceledException) {
             LogConnectionError(ex);

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -260,7 +260,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         // mutation, so it invokes inline and returns a completed task.
         _hub.On<StopAgentV2>("StopAgentV2", cmd => SafeInvoke("StopAgentV2", () => OnStopAgentV2?.Invoke(cmd)));
         _hub.On<AckProcessedPrefix>("AckProcessedPrefix", ack => { OnAckProcessedPrefix?.Invoke(ack); return Task.CompletedTask; });
-        // Offloaded via Task.Run, same as the delivery site's report in AgentOrchestrator.HandleSendInput:
+        // Offloaded via Task.Run, same as the delivery site's report in AgentOrchestrator.DeliverInputAsync:
         // OnRequestStatusReport ends in the same gated SendDaemonStatusReportOnceAsync, and awaiting it
         // inline here would park this receive loop behind another emission's whole hub send.
         _hub.On("RequestStatusReport", () => { _ = Task.Run(() => SafeInvoke("RequestStatusReport", () => OnRequestStatusReport?.Invoke())); return Task.CompletedTask; });

--- a/src/Capacitor.Cli.Daemon/Services/TitleServerPort.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TitleServerPort.cs
@@ -44,9 +44,9 @@ internal sealed class TitleServerPort(ICapacitorHttpClient http, string baseUrl)
     }
 
     public async Task<bool> PushTitleAsync(string sessionId, string title, CancellationToken ct) {
-        // The server files sessions under the canonical (trimmed, dashless) key — the raw id
-        // must not ride the payload or a dashed runtime id would update a different key than
-        // the one the summary read used.
+        // The server files sessions under the canonical key (a GUID as its 32-hex form, an opaque
+        // vendor id unchanged) — the raw id must not ride the payload or it would update a
+        // different key than the one the summary read used.
         if (WorkContextIds.CanonicalSessionId(sessionId) is not { } canonical) return true; // nothing to converge with
 
         var (client, status) = await http.ForHookAsync(ct);

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
@@ -24,11 +24,11 @@ internal sealed class TranscriptJournal : IDisposable {
     readonly Channel<JournalItem>    _queue;
     readonly CancellationTokenSource _writerCts = new();
 
-    Task?           _writer;
-    int             _pendingGap;
-    volatile bool   _latched;
+    Task?            _writer;
+    int              _pendingGap;
+    int              _completed;
+    volatile bool    _latched;
     volatile string? _inFlightKind;
-    int             _completed;
 
     public TranscriptJournal(
             string                   path,
@@ -126,6 +126,9 @@ internal sealed class TranscriptJournal : IDisposable {
     async Task RunWriterAsync(CancellationToken ct) {
         try {
             await foreach (var item in _queue.Reader.ReadAllAsync(ct).ConfigureAwait(false)) {
+                // ReadAllAsync drains what is already buffered without consulting the token again,
+                // so an abandoned writer would keep appending past the grace it was given.
+                ct.ThrowIfCancellationRequested();
                 _inFlightKind = item.Envelope.Kind;
                 await WriteItemAsync(item).ConfigureAwait(false);
                 _inFlightKind = null;

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
@@ -72,8 +72,15 @@ internal sealed class TranscriptJournal : IDisposable {
 
     public bool Open(string? cwd, string? model) {
         try {
-            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(Path)!);
-            CreatedFile = !File.Exists(Path);
+            var dir = System.IO.Path.GetDirectoryName(Path)!;
+            Directory.CreateDirectory(dir);
+
+            // A journal is the whole conversation: owner-only, and 0700 on the directory stops
+            // another local user traversing in to the files.
+            if (!OperatingSystem.IsWindows()) {
+                try { File.SetUnixFileMode(dir, DirMode); } catch { /* best-effort */ }
+            }
+
             // The launch path is synchronous by design, and the bound is what keeps a journal held
             // by an abandoned writer from stalling it.
             using var lease = _locks.AcquireAsync(Path, _lockBound, CancellationToken.None).GetAwaiter().GetResult();
@@ -82,11 +89,19 @@ internal sealed class TranscriptJournal : IDisposable {
                 return false;
             }
 
+            // Under the lock, immediately before the open: sampled earlier, two same-id opens can
+            // both claim authorship and a failed launch then deletes the other's file.
+            CreatedFile = !File.Exists(Path);
+
             var header = Encode(AcpEventTranslator.BuildSessionStarted(0, NowIso(), cwd, model));
             using (var fs = new FileStream(Path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete)) {
                 fs.Seek(0, SeekOrigin.End);
                 fs.Write(header);
                 fs.Flush(true);
+            }
+
+            if (!OperatingSystem.IsWindows()) {
+                try { File.SetUnixFileMode(Path, FileMode0600); } catch { /* best-effort */ }
             }
 
             IsOpen  = true;
@@ -132,8 +147,13 @@ internal sealed class TranscriptJournal : IDisposable {
     }
 
     /// CompleteAsync is the lifecycle call and disposes the source itself; this covers a journal
-    /// dropped without one.
-    public void Dispose() => _writerCts.Dispose();
+    /// dropped without one, where the writer would otherwise keep draining a queue nobody closed.
+    public void Dispose() {
+        if (Interlocked.Exchange(ref _completed, 1) != 0) return;
+        _queue.Writer.TryComplete();
+        _writerCts.Cancel();
+        _writerCts.Dispose();
+    }
 
     async Task RunWriterAsync(CancellationToken ct) {
         try {
@@ -181,6 +201,9 @@ internal sealed class TranscriptJournal : IDisposable {
     static byte[] Encode(AcpEventEnvelope e) => Encoding.UTF8.GetBytes(EnvelopeJournalFormat.Write(e) + "\n");
 
     string NowIso() => _time.GetUtcNow().ToString("o");
+
+    const UnixFileMode FileMode0600 = UnixFileMode.UserRead | UnixFileMode.UserWrite;
+    const UnixFileMode DirMode      = UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute;
 
     static void AppendToFile(string path, byte[] bytes) {
         using var fs = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
@@ -1,0 +1,175 @@
+using System.Text;
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Acp;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// The daemon-written envelope record of one hosted session: a bounded queue fed from the runtime's
+/// emit site and one writer task that appends to disk. Record never does IO, so a hung filesystem
+/// costs journal lines rather than protocol liveness; what it costs is counted and rendered as a
+/// note in the file itself.
+internal sealed class TranscriptJournal : IDisposable {
+    public const int Capacity = 4096;
+    public static readonly TimeSpan CompleteGrace = TimeSpan.FromSeconds(2);
+    public static readonly TimeSpan LockBound     = TimeSpan.FromSeconds(2);
+
+    readonly ILogger                 _logger;
+    readonly TimeProvider            _time;
+    readonly Action<string, byte[]>  _append;
+    readonly JournalPathLocks        _locks;
+    readonly TimeSpan                _grace;
+    readonly TimeSpan                _lockBound;
+    readonly Channel<JournalItem>    _queue;
+    readonly CancellationTokenSource _writerCts = new();
+
+    Task?           _writer;
+    int             _pendingGap;
+    volatile bool   _latched;
+    volatile string? _inFlightKind;
+    int             _completed;
+
+    public TranscriptJournal(
+            string                   path,
+            ILogger                  logger,
+            TimeProvider?            time          = null,
+            Action<string, byte[]>?  append        = null,
+            JournalPathLocks?        locks         = null,
+            int                      capacity      = Capacity,
+            TimeSpan?                completeGrace = null,
+            TimeSpan?                lockBound     = null) {
+        Path       = path;
+        _logger    = logger;
+        _time      = time ?? TimeProvider.System;
+        _append    = append ?? AppendToFile;
+        _locks     = locks ?? JournalPathLocks.Shared;
+        _grace     = completeGrace ?? CompleteGrace;
+        _lockBound = lockBound ?? LockBound;
+        _queue     = Channel.CreateBounded<JournalItem>(new BoundedChannelOptions(capacity) {
+            FullMode = BoundedChannelFullMode.Wait, SingleReader = true, SingleWriter = false });
+    }
+
+    public static TranscriptJournal ForAgent(string stateDir, string agentId, ILogger logger) =>
+        new(System.IO.Path.Combine(stateDir, "transcripts", AgentFileNames.For(agentId) + ".jsonl"), logger);
+
+    public string Path { get; }
+
+    /// True only once the header is on disk: until then Record has nothing to append to.
+    public bool IsOpen { get; private set; }
+
+    public bool CreatedFile { get; private set; }
+
+    /// Set by <see cref="CompleteAsync"/>: the writer exited within the grace.
+    public bool Drained { get; private set; }
+
+    public int PendingGap => Volatile.Read(ref _pendingGap);
+
+    public bool Open(string? cwd, string? model) {
+        try {
+            Directory.CreateDirectory(System.IO.Path.GetDirectoryName(Path)!);
+            CreatedFile = !File.Exists(Path);
+            // The launch path is synchronous by design, and the bound is what keeps a journal held
+            // by an abandoned writer from stalling it.
+            using var lease = _locks.AcquireAsync(Path, _lockBound, CancellationToken.None).GetAwaiter().GetResult();
+            if (lease is null) {
+                _logger.LogWarning("Transcript journal {Path}: could not take the path lock to open", Path);
+                return false;
+            }
+
+            var header = Encode(AcpEventTranslator.BuildSessionStarted(0, NowIso(), cwd, model));
+            using (var fs = new FileStream(Path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete)) {
+                fs.Seek(0, SeekOrigin.End);
+                fs.Write(header);
+                fs.Flush(true);
+            }
+
+            IsOpen  = true;
+            _writer = Task.Run(() => RunWriterAsync(_writerCts.Token));
+            return true;
+        } catch (Exception ex) {
+            _logger.LogWarning(ex, "Transcript journal {Path}: open failed; the session will not be journaled", Path);
+            return false;
+        }
+    }
+
+    public void Record(AcpEventEnvelope envelope) {
+        if (!IsOpen || _latched || envelope.Ephemeral) return;
+        var gap = Interlocked.Exchange(ref _pendingGap, 0);
+        if (!_queue.Writer.TryWrite(new JournalItem(envelope, gap))) Interlocked.Add(ref _pendingGap, gap + 1);
+    }
+
+    public async Task<bool> CompleteAsync() {
+        if (Interlocked.Exchange(ref _completed, 1) != 0) return Drained;
+        _queue.Writer.TryComplete();
+        if (_writer is null) { Drained = true; return true; }
+
+        // Wall-clock, not the injected TimeProvider: the grace bounds a shutdown against a hung
+        // disk, and a caller's test clock advancing is not evidence the disk came back.
+        if (await Task.WhenAny(_writer, Task.Delay(_grace)).ConfigureAwait(false) == _writer) {
+            Drained = true;
+            return true;
+        }
+
+        // Not awaited: the writer is by definition stuck inside an append the cancellation cannot
+        // reach, so waiting on it here would spend the grace twice.
+        _writerCts.Cancel();
+        _latched = true;
+        _logger.LogWarning(
+            "Transcript journal {Path}: abandoning the writer — item {Kind} in flight, {Queued} queued, {Gap} unrecorded",
+            Path, _inFlightKind ?? "(none)", _queue.Reader.Count, PendingGap);
+        return false;
+    }
+
+    public void Dispose() => _writerCts.Dispose();
+
+    async Task RunWriterAsync(CancellationToken ct) {
+        try {
+            await foreach (var item in _queue.Reader.ReadAllAsync(ct).ConfigureAwait(false)) {
+                _inFlightKind = item.Envelope.Kind;
+                await WriteItemAsync(item).ConfigureAwait(false);
+                _inFlightKind = null;
+            }
+
+            var gap = Interlocked.Exchange(ref _pendingGap, 0);
+            if (gap > 0) await WriteBytesAsync(Encode(GapNote(gap))).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+        } catch (Exception ex) {
+            // One warning for the whole session: a failing disk fails every subsequent append too.
+            _latched = true;
+            _queue.Writer.TryComplete();
+            var abandoned = 0;
+            while (_queue.Reader.TryRead(out _)) abandoned++;
+            _logger.LogWarning(ex, "Transcript journal {Path}: write failed; {Abandoned} queued and {Gap} unrecorded envelopes are lost",
+                Path, abandoned, PendingGap);
+        }
+    }
+
+    /// One buffer per item, so a note and the envelope it precedes reach the file in one append.
+    Task WriteItemAsync(JournalItem item) {
+        byte[] bytes = item.GapBefore > 0
+            ? [.. Encode(GapNote(item.GapBefore)), .. Encode(item.Envelope)]
+            : Encode(item.Envelope);
+        return WriteBytesAsync(bytes);
+    }
+
+    async Task WriteBytesAsync(byte[] bytes) {
+        using var lease = await _locks.AcquireAsync(Path, _lockBound, CancellationToken.None).ConfigureAwait(false)
+                       ?? throw new IOException("could not take the journal path lock");
+        _append(Path, bytes);
+    }
+
+    AcpEventEnvelope GapNote(int count) =>
+        new(Kind: AcpEventKind.SystemNote, Text: $"{count} envelopes were not recorded to this journal", TimestampIso: NowIso());
+
+    static byte[] Encode(AcpEventEnvelope e) => Encoding.UTF8.GetBytes(EnvelopeJournalFormat.Write(e) + "\n");
+
+    string NowIso() => _time.GetUtcNow().ToString("o");
+
+    static void AppendToFile(string path, byte[] bytes) {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
+        fs.Seek(0, SeekOrigin.End);
+        fs.Write(bytes);
+        fs.Flush(true);
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
@@ -24,6 +24,9 @@ internal sealed class TranscriptJournal : IDisposable {
     readonly Channel<JournalItem>    _queue;
     readonly CancellationTokenSource _writerCts = new();
 
+    /// Test-only: the writer waits on it before its first read, pinning what is queued when it starts.
+    readonly Task? _writerStartGate;
+
     Task?            _writer;
     int              _pendingGap;
     int              _completed;
@@ -33,20 +36,22 @@ internal sealed class TranscriptJournal : IDisposable {
     public TranscriptJournal(
             string                   path,
             ILogger                  logger,
-            TimeProvider?            time          = null,
-            Action<string, byte[]>?  append        = null,
-            JournalPathLocks?        locks         = null,
-            int                      capacity      = Capacity,
-            TimeSpan?                completeGrace = null,
-            TimeSpan?                lockBound     = null) {
-        Path       = path;
-        _logger    = logger;
-        _time      = time ?? TimeProvider.System;
-        _append    = append ?? AppendToFile;
-        _locks     = locks ?? JournalPathLocks.Shared;
-        _grace     = completeGrace ?? CompleteGrace;
-        _lockBound = lockBound ?? LockBound;
-        _queue     = Channel.CreateBounded<JournalItem>(new BoundedChannelOptions(capacity) {
+            TimeProvider?            time            = null,
+            Action<string, byte[]>?  append          = null,
+            JournalPathLocks?        locks           = null,
+            int                      capacity        = Capacity,
+            TimeSpan?                completeGrace   = null,
+            TimeSpan?                lockBound       = null,
+            Task?                    writerStartGate = null) {
+        Path             = path;
+        _logger          = logger;
+        _time            = time ?? TimeProvider.System;
+        _append          = append ?? AppendToFile;
+        _locks           = locks ?? JournalPathLocks.Shared;
+        _grace           = completeGrace ?? CompleteGrace;
+        _lockBound       = lockBound ?? LockBound;
+        _writerStartGate = writerStartGate;
+        _queue           = Channel.CreateBounded<JournalItem>(new BoundedChannelOptions(capacity) {
             FullMode = BoundedChannelFullMode.Wait, SingleReader = true, SingleWriter = false });
     }
 
@@ -101,30 +106,38 @@ internal sealed class TranscriptJournal : IDisposable {
 
     public async Task<bool> CompleteAsync() {
         if (Interlocked.Exchange(ref _completed, 1) != 0) return Drained;
-        _queue.Writer.TryComplete();
-        if (_writer is null) { Drained = true; return true; }
+        try {
+            _queue.Writer.TryComplete();
+            if (_writer is null) { Drained = true; return true; }
 
-        // Wall-clock, not the injected TimeProvider: the grace bounds a shutdown against a hung
-        // disk, and a caller's test clock advancing is not evidence the disk came back.
-        if (await Task.WhenAny(_writer, Task.Delay(_grace)).ConfigureAwait(false) == _writer) {
-            Drained = true;
-            return true;
+            // Wall-clock, not the injected TimeProvider: the grace bounds a shutdown against a hung
+            // disk, and a caller's test clock advancing is not evidence the disk came back.
+            if (await Task.WhenAny(_writer, Task.Delay(_grace)).ConfigureAwait(false) == _writer) {
+                Drained = true;
+                return true;
+            }
+
+            // Not awaited: the writer is by definition stuck inside an append the cancellation cannot
+            // reach, so waiting on it here would spend the grace twice.
+            _writerCts.Cancel();
+            _latched = true;
+            _logger.LogWarning(
+                "Transcript journal {Path}: abandoning the writer — item {Kind} in flight, {Queued} queued, {Gap} unrecorded",
+                Path, _inFlightKind ?? "(none)", _queue.Reader.Count, PendingGap);
+            return false;
+        } finally {
+            // Safe under an abandoned writer: it holds its token, and a cancelled token needs no source.
+            _writerCts.Dispose();
         }
-
-        // Not awaited: the writer is by definition stuck inside an append the cancellation cannot
-        // reach, so waiting on it here would spend the grace twice.
-        _writerCts.Cancel();
-        _latched = true;
-        _logger.LogWarning(
-            "Transcript journal {Path}: abandoning the writer — item {Kind} in flight, {Queued} queued, {Gap} unrecorded",
-            Path, _inFlightKind ?? "(none)", _queue.Reader.Count, PendingGap);
-        return false;
     }
 
+    /// CompleteAsync is the lifecycle call and disposes the source itself; this covers a journal
+    /// dropped without one.
     public void Dispose() => _writerCts.Dispose();
 
     async Task RunWriterAsync(CancellationToken ct) {
         try {
+            if (_writerStartGate is not null) await _writerStartGate.WaitAsync(ct).ConfigureAwait(false);
             await foreach (var item in _queue.Reader.ReadAllAsync(ct).ConfigureAwait(false)) {
                 // ReadAllAsync drains what is already buffered without consulting the token again,
                 // so an abandoned writer would keep appending past the grace it was given.

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptJournal.cs
@@ -93,8 +93,14 @@ internal sealed class TranscriptJournal : IDisposable {
             // both claim authorship and a failed launch then deletes the other's file.
             CreatedFile = !File.Exists(Path);
 
+            // A new file is born 0600 (UnixCreateMode), closing the umask-default window a
+            // post-write chmod would otherwise leave; the chmod below still re-asserts it onto a
+            // pre-existing file, which UnixCreateMode never touches.
+            var options = new FileStreamOptions { Mode = FileMode.OpenOrCreate, Access = FileAccess.Write, Share = FileShare.ReadWrite | FileShare.Delete };
+            if (!OperatingSystem.IsWindows()) options.UnixCreateMode = FileMode0600;
+
             var header = Encode(AcpEventTranslator.BuildSessionStarted(0, NowIso(), cwd, model));
-            using (var fs = new FileStream(Path, FileMode.OpenOrCreate, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete)) {
+            using (var fs = new FileStream(Path, options)) {
                 fs.Seek(0, SeekOrigin.End);
                 fs.Write(header);
                 fs.Flush(true);

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs
@@ -37,7 +37,7 @@ internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time,
             var cutoff = time.GetUtcNow() - Retention;
             foreach (var path in Directory.EnumerateFiles(dir, "*.jsonl")) {
                 ct.ThrowIfCancellationRequested();
-                await TrySweepAsync(path, cutoff).ConfigureAwait(false);
+                await TrySweepAsync(path, cutoff, ct).ConfigureAwait(false);
             }
         } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
         } catch (Exception ex) {
@@ -48,9 +48,9 @@ internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time,
         }
     }
 
-    async Task TrySweepAsync(string path, DateTimeOffset cutoff) {
+    async Task TrySweepAsync(string path, DateTimeOffset cutoff, CancellationToken ct) {
         try {
-            using var lease = await _locks.AcquireAsync(path, TranscriptJournal.LockBound, CancellationToken.None).ConfigureAwait(false);
+            using var lease = await _locks.AcquireAsync(path, TranscriptJournal.LockBound, ct).ConfigureAwait(false);
             if (lease is null) return;
 
             // A same-id relaunch reopens the journal under this lock, so everything the delete turns
@@ -60,6 +60,9 @@ internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time,
             var record = Path.Combine(stateDir, "agents", Path.GetFileNameWithoutExtension(path) + ".json");
             if (File.Exists(record)) return;
             File.Delete(path);
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+            // Shutdown ends the sweep quietly; the caller swallows it rather than logging a skip.
+            throw;
         } catch (Exception ex) {
             logger.LogWarning(ex, "Transcript journal sweep: skipped {Path}", path);
         }

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs
@@ -1,0 +1,57 @@
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// Reaps envelope journals kcap owns: older than the retention and with no PID record under the
+/// same name. Runs once after the startup orphan reap (which removes a prior epoch's records) and
+/// then every 24 hours. Never throws — a sweep fault must not block the daemon's connect.
+internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time, ILogger<TranscriptJournalSweep> logger, JournalPathLocks? locks = null) : BackgroundService {
+    public static readonly TimeSpan Retention = TimeSpan.FromDays(30);
+    public static readonly TimeSpan Interval  = TimeSpan.FromHours(24);
+
+    readonly JournalPathLocks _locks = locks ?? JournalPathLocks.Shared;
+    int _running;
+    int _started;
+
+    public int SweepsStarted => Volatile.Read(ref _started);
+
+    protected override async Task ExecuteAsync(CancellationToken ct) {
+        using var timer = new PeriodicTimer(Interval, time);
+        try {
+            while (await timer.WaitForNextTickAsync(ct).ConfigureAwait(false)) await RunOnceAsync(ct).ConfigureAwait(false);
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) { }
+    }
+
+    public async Task RunOnceAsync(CancellationToken ct) {
+        if (Interlocked.CompareExchange(ref _running, 1, 0) != 0) return;
+        Interlocked.Increment(ref _started);
+        try {
+            var dir = Path.Combine(stateDir, "transcripts");
+            if (!Directory.Exists(dir)) return;
+            var cutoff = time.GetUtcNow() - Retention;
+            foreach (var path in Directory.EnumerateFiles(dir, "*.jsonl")) {
+                ct.ThrowIfCancellationRequested();
+                await TrySweepAsync(path, cutoff).ConfigureAwait(false);
+            }
+        } catch (OperationCanceledException) when (ct.IsCancellationRequested) {
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "Transcript journal sweep: enumeration failed");
+        } finally {
+            Interlocked.Exchange(ref _running, 0);
+        }
+    }
+
+    async Task TrySweepAsync(string path, DateTimeOffset cutoff) {
+        try {
+            if (File.GetLastWriteTimeUtc(path) >= cutoff.UtcDateTime) return;
+            var record = Path.Combine(stateDir, "agents", Path.GetFileNameWithoutExtension(path) + ".json");
+            if (File.Exists(record)) return;
+            using var lease = await _locks.AcquireAsync(path, TranscriptJournal.LockBound, CancellationToken.None).ConfigureAwait(false);
+            if (lease is null) return;
+            File.Delete(path);
+        } catch (Exception ex) {
+            logger.LogWarning(ex, "Transcript journal sweep: skipped {Path}", path);
+        }
+    }
+}

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs
@@ -13,8 +13,13 @@ internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time,
     readonly JournalPathLocks _locks = locks ?? JournalPathLocks.Shared;
     int _running;
     int _started;
+    int _finished;
 
     public int SweepsStarted => Volatile.Read(ref _started);
+
+    /// Rises only after the single-flight flag is released, so a caller that waits on it can drive
+    /// the next tick without it being skipped.
+    public int SweepsCompleted => Volatile.Read(ref _finished);
 
     protected override async Task ExecuteAsync(CancellationToken ct) {
         using var timer = new PeriodicTimer(Interval, time);
@@ -39,16 +44,21 @@ internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time,
             logger.LogWarning(ex, "Transcript journal sweep: enumeration failed");
         } finally {
             Interlocked.Exchange(ref _running, 0);
+            Interlocked.Increment(ref _finished);
         }
     }
 
     async Task TrySweepAsync(string path, DateTimeOffset cutoff) {
         try {
+            using var lease = await _locks.AcquireAsync(path, TranscriptJournal.LockBound, CancellationToken.None).ConfigureAwait(false);
+            if (lease is null) return;
+
+            // A same-id relaunch reopens the journal under this lock, so everything the delete turns
+            // on is read after it is held: a check made while waiting would be about a stale file.
+            if (!File.Exists(path)) return;
             if (File.GetLastWriteTimeUtc(path) >= cutoff.UtcDateTime) return;
             var record = Path.Combine(stateDir, "agents", Path.GetFileNameWithoutExtension(path) + ".json");
             if (File.Exists(record)) return;
-            using var lease = await _locks.AcquireAsync(path, TranscriptJournal.LockBound, CancellationToken.None).ConfigureAwait(false);
-            if (lease is null) return;
             File.Delete(path);
         } catch (Exception ex) {
             logger.LogWarning(ex, "Transcript journal sweep: skipped {Path}", path);

--- a/src/Capacitor.Cli/ArgParsing.cs
+++ b/src/Capacitor.Cli/ArgParsing.cs
@@ -1,3 +1,5 @@
+using Capacitor.Cli.Core;
+
 namespace Capacitor.Cli;
 
 static class ArgParsing {
@@ -32,7 +34,9 @@ static class ArgParsing {
     /// <summary>
     /// Resolves a sessionId purely from environment variables. Prefers
     /// <c>KCAP_SESSION_ID</c> and falls back to <c>CODEX_THREAD_ID</c>.
-    /// Dashes are stripped from the returned value so callers don't have to.
+    /// The value is canonicalized as the server files sessions
+    /// (<see cref="SessionIds.Canonical"/>): a GUID collapses to its 32-hex form and an opaque
+    /// vendor id keeps its dashes, so an ambient id resolves exactly as an explicit one does.
     /// </summary>
     internal static string? ResolveSessionIdFromEnv() =>
         ResolveSessionIdFromEnv(Environment.GetEnvironmentVariable);
@@ -45,10 +49,9 @@ static class ArgParsing {
     internal static string? ResolveSessionIdFromEnv(Func<string, string?> getEnv) {
         var kcapId = getEnv("KCAP_SESSION_ID");
         if (!string.IsNullOrWhiteSpace(kcapId))
-            return kcapId.Replace("-", "");
+            return SessionIds.Canonical(kcapId);
 
-        var codex = getEnv("CODEX_THREAD_ID");
-        return !string.IsNullOrWhiteSpace(codex) ? codex.Replace("-", "") : null;
+        return SessionIds.Canonical(getEnv("CODEX_THREAD_ID"));
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -223,10 +223,10 @@ sealed class McpWorkItemsServer(ConfigRoot config, ProfileContext profiles, Toke
     /// else the ambient <c>KCAP_SESSION_ID</c> (or <c>CODEX_THREAD_ID</c>) env var via
     /// <see cref="ArgParsing.ResolveSessionIdFromEnv()"/>. Throws when neither is available, so
     /// the caller (via <see cref="HandleToolCallAsync"/>) surfaces a clean tool error instead
-    /// of sending a request with a missing/blank session id. Dashes are stripped from the
-    /// explicit argument too — matching <see cref="ArgParsing.ResolveSessionIdFromEnv()"/> — so a
-    /// caller passing a dashed GUID (e.g. copy-pasted from a UI) still resolves to the same
-    /// dashless key the server expects, instead of silently missing the intended session.
+    /// of sending a request with a missing/blank session id. Either source is canonicalized the
+    /// same way — a GUID to its 32-hex form, an opaque vendor id unchanged — so a caller passing a
+    /// dashed GUID (e.g. copy-pasted from a UI) resolves to the key the server expects instead of
+    /// silently missing the intended session.
     /// </summary>
     internal static string ResolveSessionId(JsonObject? args) {
         if (args?["session_id"] is { } node) {

--- a/src/Capacitor.Cli/HarnessRequesterContext.cs
+++ b/src/Capacitor.Cli/HarnessRequesterContext.cs
@@ -1,3 +1,5 @@
+using Capacitor.Cli.Core;
+
 namespace Capacitor.Cli;
 
 /// <summary>
@@ -51,8 +53,8 @@ static class HarnessRequesterContext {
     internal const string CodexThreadIdVar = "CODEX_THREAD_ID";
 
     /// <param name="SessionId">
-    /// The requesting session, dash-stripped to the canonical form the server expects (matching
-    /// the session-start hook's own normalization). Null when no harness signal is available.
+    /// The requesting session in the canonical form the server files it under (a GUID as its
+    /// 32-hex form, an opaque vendor id unchanged). Null when no harness signal is available.
     /// </param>
     /// <param name="ProjectDir">
     /// The running harness's project directory, or null when the harness did not report one (or
@@ -85,6 +87,6 @@ static class HarnessRequesterContext {
             ? projectDir
             : null;
 
-        return new(harnessSessionId.Trim().Replace("-", ""), usableProjectDir);
+        return new(SessionIds.Canonical(harnessSessionId), usableProjectDir);
     }
 }

--- a/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatComposerTests.cs
@@ -19,7 +19,8 @@ public class ChatComposerTests {
         var time = new FakeTimeProvider();
         var opener = new RecordingOpener();
         var terminal = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), time);
-        var chat = new ChatTabViewModel("a1", daemon, terminal, TranscriptChat.For("claude"), opener, time, new FakePermissionService());
+        var chat = new ChatTabViewModel(
+            "a1", daemon, new TerminalChatInput(terminal), TranscriptChat.For("claude"), opener, time, new FakePermissionService());
         daemon.SnapshotsSubject.OnNext(FakeDaemonClientService.Snap(supportedVendors: ["claude", "codex"]));
         daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo", model: "claude-opus-5") with { Status = "Running" });
         // The Avalonia scheduler always posts, even when the caller is already on the UI thread,
@@ -74,11 +75,11 @@ public class ChatComposerTests {
             await Assert.That(chat.ShowsComposer).IsFalse();
 
             var attached = TerminalSessionState.Attached(null);
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Transitioning, attached)).IsEqualTo("Updating the terminal connection…");
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.ReadOnly, TerminalSessionState.Attached("review"))).IsEqualTo("Read-only: review");
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Connecting, TerminalSessionState.Connecting)).IsEqualTo("Connecting to the terminal…");
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.Ended, TerminalSessionState.SessionEnded)).IsEqualTo("This session has ended");
-            await Assert.That(ChatTabViewModel.HintFor(SendAvailability.NoTerminal, TerminalSessionState.NotFound)).IsEqualTo("No terminal to send to");
+            await Assert.That(TerminalChatInput.HintFor(SendAvailability.Transitioning, attached)).IsEqualTo("Updating the terminal connection…");
+            await Assert.That(TerminalChatInput.HintFor(SendAvailability.ReadOnly, TerminalSessionState.Attached("review"))).IsEqualTo("Read-only: review");
+            await Assert.That(TerminalChatInput.HintFor(SendAvailability.Connecting, TerminalSessionState.Connecting)).IsEqualTo("Connecting to the terminal…");
+            await Assert.That(TerminalChatInput.HintFor(SendAvailability.Ended, TerminalSessionState.SessionEnded)).IsEqualTo("This session has ended");
+            await Assert.That(TerminalChatInput.HintFor(SendAvailability.NoTerminal, TerminalSessionState.NotFound)).IsEqualTo("No terminal to send to");
             await chat.TeardownAsync();
         });
     }
@@ -149,7 +150,8 @@ public class ChatComposerTests {
             var time = new FakeTimeProvider();
             var terminal = new TerminalTabViewModel("r1", daemon, factory.Factory, () => new FakeTerminalSurface(), time);
             var chat = new ChatTabViewModel(
-                "r1", daemon, terminal, TranscriptChat.For("claude"), new RecordingOpener(), time, new FakePermissionService());
+                "r1", daemon, new TerminalChatInput(terminal), TranscriptChat.For("claude"), new RecordingOpener(), time,
+                new FakePermissionService());
             daemon.Agents.AddOrUpdate(
                 Agent("r1", "claude", hasTerminal: true, kind: "review-flow") with { FlowRunId = "f1", FlowRole = "reviewer" });
             await (terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -1,4 +1,5 @@
 using System.Reactive.Linq;
+using System.Reactive.Threading.Tasks;
 using Avalonia.Threading;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
@@ -8,6 +9,7 @@ using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Models.Transcripts.Harness.Claude;
 using DynamicData;
 using Microsoft.Extensions.Time.Testing;
+using ReactiveUI.Reactive;
 using TUnit.Assertions.Enums;
 using static Capacitor.App.Tests.Unit.AvaloniaSession;
 using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
@@ -43,10 +45,12 @@ public class ChatTabViewModelTests {
         public TerminalTabViewModel Terminal { get; }
         public ChatTabViewModel Chat { get; }
 
-        public Harness(TranscriptChatProjection? projection, Action<FakePermissionService>? seed = null) {
+        public Harness(IChatTranscriptProjection? projection, Action<FakePermissionService>? seed = null,
+                       ChatInput? input = null, string? unavailableNote = null) {
             seed?.Invoke(Permissions);
             Terminal = new TerminalTabViewModel("a1", Daemon, Factory.Factory, () => new FakeTerminalSurface(), Time);
-            Chat = new ChatTabViewModel("a1", Daemon, Terminal, projection, Opener, Time, Permissions);
+            Chat = new ChatTabViewModel(
+                "a1", Daemon, input ?? new TerminalChatInput(Terminal), projection, Opener, Time, Permissions, unavailableNote);
         }
 
         public async Task PushAsync(AgentStatusDto dto) {
@@ -664,6 +668,113 @@ public class ChatTabViewModelTests {
             await Assert.That(counting.LineNumbers).IsEquivalentTo(new[] { 1, 2, 1 });
             await Assert.That(counting.ContextsCreated).IsEqualTo(2);
             await h.TeardownAsync();
+        });
+    }
+
+    /// A scripted ChatInput for composer tests: SendAsync completes when the test says so.
+    sealed class ScriptedInput : ChatInput {
+        public TaskCompletionSource<bool>? Pending;
+        public int Disposals;
+        public List<(string Text, CancellationToken Ct)> Sends { get; } = [];
+        public override SendAvailability Availability => Pending is null ? SendAvailability.Ready : SendAvailability.Sending;
+        public override bool CanAcceptText => Pending is null;
+        public override string Hint => "scripted";
+        public override Task<bool> SendAsync(string text, CancellationToken ct) {
+            Sends.Add((text, ct));
+            Pending = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
+            this.RaisePropertyChanged(nameof(CanAcceptText));
+            return Pending.Task.ContinueWith(t => { Pending = null; this.RaisePropertyChanged(nameof(CanAcceptText)); return t.Result; }, ct, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+        public override void Dispose() => Disposals++;
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Journal_file_renders_user_assistant_note_and_tool_rows() {
+        await RunOnUiAsync(async () => {
+            var path = Tmp.CreateFile("j.jsonl", [
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.SessionStarted, Cwd: "/w")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: "hi")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "hello")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.SystemNote, Text: "note")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.ToolCall, ToolCallId: "c1", ToolName: "Read", ToolInputJson: """{"file_path":"/w/a.cs"}""")),
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.ToolResult, ToolCallId: "c1", ToolResult: "ok")),
+            ]);
+            var h = new Harness(TranscriptChat.Journal);
+            await h.PushAsync(Agent("a1", "pi", hasTerminal: false) with { TranscriptPath = path, TranscriptFormat = TranscriptFormats.Envelopes });
+            await h.TickAsync();
+
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.Items.Select(i => i.GetType().Name)).IsEquivalentTo(
+                new[] { nameof(UserTurnItem), nameof(AssistantTextItem), nameof(SystemNoteItem), nameof(ToolGroupItem) },
+                CollectionOrdering.Matching);
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Unavailable_note_words_the_older_and_newer_daemon_cases() {
+        await RunOnUiAsync(async () => {
+            var older = new Harness(null, unavailableNote: "Update the daemon to view this session");
+            await Assert.That(older.Chat.Phase).IsEqualTo(ChatTabPhase.Unavailable);
+            await Assert.That(older.Chat.PhaseNote).IsEqualTo("Update the daemon to view this session");
+            await older.TeardownAsync();
+            var plain = new Harness(null);
+            await Assert.That(plain.Chat.PhaseNote).IsEqualTo("No chat view for this harness");
+            await plain.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Send_clears_only_when_committed_and_the_text_is_unchanged() {
+        await RunOnUiAsync(async () => {
+            var input = new ScriptedInput();
+            var h = new Harness(TranscriptChat.Journal, input: input);
+            await h.PushAsync(Agent("a1", "pi", hasTerminal: false) with { Status = "Running" });
+
+            h.Chat.ComposerText = "hello";
+            var send = h.Chat.SendCommand.Execute().ToTask();
+            await Assert.That(input.Sends.Single().Text).IsEqualTo("hello");
+            h.Chat.ComposerText = "hello edited";
+            input.Pending!.SetResult(true);
+            await send;
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("hello edited");
+
+            h.Chat.ComposerText = "two";
+            send = h.Chat.SendCommand.Execute().ToTask();
+            input.Pending!.SetResult(false);
+            await send;
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("two");
+
+            h.Chat.ComposerText = "three";
+            send = h.Chat.SendCommand.Execute().ToTask();
+            input.Pending!.SetResult(true);
+            await send;
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("");
+            await h.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Teardown_cancels_an_in_flight_send_before_disposing_the_input_once() {
+        await RunOnUiAsync(async () => {
+            var input = new ScriptedInput();
+            var h = new Harness(TranscriptChat.Journal, input: input);
+            await h.PushAsync(Agent("a1", "pi", hasTerminal: false) with { Status = "Running" });
+            h.Chat.ComposerText = "hello";
+            var send = h.Chat.SendCommand.Execute().ToTask();
+            var ct = input.Sends.Single().Ct;
+            await Assert.That(ct.IsCancellationRequested).IsFalse();
+
+            await h.TeardownAsync();
+
+            await Assert.That(ct.IsCancellationRequested).IsTrue();
+            await Assert.That(input.Disposals).IsEqualTo(1);
+            input.Pending?.TrySetCanceled(ct);
+            try { await send; } catch (OperationCanceledException) { }
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -757,6 +757,28 @@ public class ChatTabViewModelTests {
         });
     }
 
+    /// Text alone cannot decide this: an edit during the round trip that ends on the sent text is
+    /// still the user's own draft, and clearing it would erase what they typed.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Text_edited_back_to_the_sent_value_during_the_round_trip_survives() {
+        await RunOnUiAsync(async () => {
+            var input = new ScriptedInput();
+            var h = new Harness(TranscriptChat.Journal, input: input);
+            await h.PushAsync(Agent("a1", "pi", hasTerminal: false) with { Status = "Running" });
+
+            h.Chat.ComposerText = "hello";
+            var send = h.Chat.SendCommand.Execute().ToTask();
+            h.Chat.ComposerText = "hello!";
+            h.Chat.ComposerText = "hello";
+            input.Pending!.SetResult(true);
+            await send;
+
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("hello");
+            await h.TeardownAsync();
+        });
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Teardown_cancels_an_in_flight_send_before_disposing_the_input_once() {

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -103,7 +103,8 @@ public class ChatTabViewSmokeTests {
         /// first read starts before the workspace view exists.
         public Host(bool show = true) {
             Terminal = new TerminalTabViewModel("a1", Daemon, Attach.Factory, () => new FakeTerminalSurface(), Time);
-            Chat = new ChatTabViewModel("a1", Daemon, Terminal, TranscriptChat.For("claude"), Opener, Time, Permissions);
+            Chat = new ChatTabViewModel(
+                "a1", Daemon, new TerminalChatInput(Terminal), TranscriptChat.For("claude"), Opener, Time, Permissions);
             View = new ChatTabView { DataContext = Chat };
             Window = new Window { Content = View, Width = 800, Height = 600 };
             if (!show) return;

--- a/test/Capacitor.App.Tests.Unit/ChatTranscriptSourceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTranscriptSourceTests.cs
@@ -1,0 +1,41 @@
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ChatTranscriptSourceTests {
+    [Test]
+    public async Task Formats_pick_the_reader() {
+        var (vendorProjection, vendorNote) = ChatTranscriptSource.Resolve(Agent("a", "claude", hasTerminal: true) with { TranscriptFormat = TranscriptFormats.Vendor });
+        await Assert.That(vendorProjection).IsNotNull();
+        await Assert.That(vendorNote).IsNull();
+
+        var (leafless, leaflessNote) = ChatTranscriptSource.Resolve(Agent("a", "gemini", hasTerminal: true) with { TranscriptFormat = TranscriptFormats.Vendor });
+        await Assert.That(leafless).IsNull();
+        await Assert.That(leaflessNote).IsNull();
+
+        var (journal, journalNote) = ChatTranscriptSource.Resolve(Agent("a", "pi", hasTerminal: false) with { TranscriptFormat = TranscriptFormats.Envelopes });
+        await Assert.That(journal).IsSameReferenceAs(TranscriptChat.Journal);
+        await Assert.That(journalNote).IsNull();
+    }
+
+    [Test]
+    public async Task Null_format_is_the_older_daemon_for_a_non_pty_dto_and_the_vendor_path_for_a_pty_dto() {
+        var (older, olderNote) = ChatTranscriptSource.Resolve(Agent("a", "pi", hasTerminal: false));
+        await Assert.That(older).IsNull();
+        await Assert.That(olderNote).IsEqualTo("Update the daemon to view this session");
+
+        var (pty, ptyNote) = ChatTranscriptSource.Resolve(Agent("a", "claude", hasTerminal: true));
+        await Assert.That(pty).IsNotNull();
+        await Assert.That(ptyNote).IsNull();
+    }
+
+    [Test]
+    public async Task Unknown_format_asks_for_an_app_update() {
+        var (projection, note) = ChatTranscriptSource.Resolve(Agent("a", "pi", hasTerminal: false) with { TranscriptFormat = "v9" });
+        await Assert.That(projection).IsNull();
+        await Assert.That(note).IsEqualTo("Update the app to view this session");
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs
@@ -1,0 +1,107 @@
+using System.Reactive.Subjects;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class LocalFrameChatInputTests {
+    sealed class Rig {
+        public FakeDaemonClientService Daemon { get; } = new();
+        public ScriptedLocalControlOps Ops { get; } = new();
+        public BehaviorSubject<AgentPresence> Presence { get; } = new(new AgentPresence(null, false));
+        public LocalFrameChatInput Input { get; }
+        public Rig() => Input = new LocalFrameChatInput("a1", Daemon, Ops, Presence);
+        public void Connected(params string[] caps) => Daemon.StatusSubject.OnNext(new AttachStatus(AttachState.Connected, null, caps));
+        public void Running() => Presence.OnNext(new AgentPresence(Agent("a1", "pi", hasTerminal: false) with { Status = "Running" }, false));
+    }
+
+    [Test]
+    public async Task Availability_matrix() {
+        var rig = new Rig();
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Connecting);
+        rig.Connected("status/1");
+        rig.Running();
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Unsupported);
+        await Assert.That(rig.Input.Hint).IsEqualTo("Update the daemon to send messages from the app");
+        await Assert.That(await rig.Input.SendAsync("x", CancellationToken.None)).IsFalse();
+        await Assert.That(rig.Ops.SendTextCalls).IsEqualTo(0);
+
+        rig.Connected("status/1", "input/1");
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+        await Assert.That(rig.Input.CanAcceptText).IsTrue();
+        await Assert.That(rig.Input.Hint).IsEqualTo("Enter sends · Shift+Enter for a new line");
+
+        rig.Presence.OnNext(new AgentPresence(rig.Presence.Value.Dto, true));
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ended);
+        await Assert.That(rig.Input.Hint).IsEqualTo("This session has ended");
+    }
+
+    [Test]
+    public async Task One_send_in_flight_until_the_ack_and_a_delivered_ack_clears() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        var gate = rig.Ops.ArmSendText();
+        var pending = rig.Input.SendAsync("hello", CancellationToken.None);
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Sending);
+        await Assert.That(rig.Input.CanAcceptText).IsFalse();
+        await Assert.That(await rig.Input.SendAsync("second", CancellationToken.None)).IsFalse();
+        gate.SetResult(new SendTextResult(true, null, null, SendTextOutcomes.Delivered));
+        await Assert.That(await pending).IsTrue();
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+        await Assert.That(rig.Ops.SendTextPayloads).IsEquivalentTo(new[] { ("a1", "hello") });
+    }
+
+    [Test]
+    [Arguments("not_running", null, "agent is no longer running")]
+    [Arguments("protected_kind", null, "read-only participant")]
+    [Arguments("queue_full", null, "the agent's input queue is full, try again shortly")]
+    [Arguments("delivery_failed", "pipe closed", "pipe closed")]
+    [Arguments("transport", "eof", "delivery unconfirmed — check the chat before sending again")]
+    public async Task Refusal_keeps_the_text_and_words_the_hint(string reason, string? error, string hint) {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        rig.Ops.QueueSendText(new SendTextResult(false, reason, error, null));
+        await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
+        await Assert.That(rig.Input.Hint).IsEqualTo(hint);
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+        rig.Ops.ArmSendText();
+        _ = rig.Input.SendAsync("again", CancellationToken.None);
+        await Assert.That(rig.Input.Hint).IsEqualTo("Sending…"); // the notice clears when the next send starts
+    }
+
+    [Test]
+    public async Task Stopped_outcome_clears_and_unknown_ok_outcome_counts_as_delivered() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        rig.Ops.QueueSendText(new SendTextResult(true, null, null, SendTextOutcomes.Stopped));
+        await Assert.That(await rig.Input.SendAsync("/quit", CancellationToken.None)).IsTrue();
+        rig.Ops.QueueSendText(new SendTextResult(true, null, null, "future_outcome"));
+        await Assert.That(await rig.Input.SendAsync("x", CancellationToken.None)).IsTrue();
+    }
+
+    [Test]
+    public async Task Cancelled_wait_keeps_the_text_with_the_unconfirmed_hint() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        rig.Ops.ArmSendText();
+        using var cts = new CancellationTokenSource();
+        var pending = rig.Input.SendAsync("hello", cts.Token);
+        cts.Cancel();
+        await Assert.That(await pending).IsFalse();
+        await Assert.That(rig.Input.Hint).IsEqualTo("delivery unconfirmed — check the chat before sending again");
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+    }
+
+    [Test]
+    public async Task Completion_after_dispose_mutates_nothing_and_dispose_detaches_subscriptions() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        var gate = rig.Ops.ArmSendText();
+        var pending = rig.Input.SendAsync("hello", CancellationToken.None);
+        rig.Input.Dispose();
+        var raised = 0;
+        rig.Input.PropertyChanged += (_, _) => raised++;
+        gate.SetResult(new SendTextResult(false, "queue_full", null, null));
+        await Assert.That(await pending).IsFalse();
+        rig.Connected("input/1"); rig.Running();
+        rig.Presence.OnNext(new AgentPresence(null, true));
+        await Assert.That(raised).IsEqualTo(0);
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs
@@ -91,6 +91,30 @@ public class LocalFrameChatInputTests {
     }
 
     [Test]
+    public async Task Session_ending_after_a_refusal_clears_the_notice() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        rig.Ops.QueueSendText(new SendTextResult(false, "queue_full", null, null));
+        await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
+        await Assert.That(rig.Input.Hint).IsEqualTo("the agent's input queue is full, try again shortly");
+
+        rig.Presence.OnNext(new AgentPresence(rig.Presence.Value.Dto, true));
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ended);
+        await Assert.That(rig.Input.Hint).IsEqualTo("This session has ended");
+    }
+
+    [Test]
+    public async Task A_status_reemission_that_does_not_change_availability_keeps_the_notice() {
+        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+        rig.Ops.QueueSendText(new SendTextResult(false, "queue_full", null, null));
+        await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
+        await Assert.That(rig.Input.Hint).IsEqualTo("the agent's input queue is full, try again shortly");
+
+        rig.Connected("input/1");
+        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+        await Assert.That(rig.Input.Hint).IsEqualTo("the agent's input queue is full, try again shortly");
+    }
+
+    [Test]
     public async Task Completion_after_dispose_mutates_nothing_and_dispose_detaches_subscriptions() {
         var rig = new Rig(); rig.Connected("input/1"); rig.Running();
         var gate = rig.Ops.ArmSendText();

--- a/test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs
@@ -72,6 +72,7 @@ public class LocalFrameChatInputTests {
     [Arguments("reaper_claimed", null, "the agent is being stopped")]
     [Arguments("reaper_claimed_late", null, "the agent is being stopped")]
     [Arguments("delivery_failed", "pipe closed", "pipe closed")]
+    [Arguments("too_large", "text exceeds 262144 bytes", "text exceeds 262144 bytes")]
     [Arguments("transport", "eof", "delivery unconfirmed — check the chat before sending again")]
     // A reason this build has no wording for still never shows the caller the wire token.
     [Arguments("some_future_reason", "raw detail", "delivery failed")]

--- a/test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs
+++ b/test/Capacitor.App.Tests.Unit/LocalFrameChatInputTests.cs
@@ -2,10 +2,16 @@ using System.Reactive.Subjects;
 using Capacitor.App.Services;
 using Capacitor.App.ViewModels;
 using Capacitor.Cli.Core.LocalIpc;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
 using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 
 namespace Capacitor.App.Tests.Unit;
 
+/// <summary>
+/// The daemon-status stream is marshalled onto the main thread, so every test runs under the
+/// session's immediate main-thread scheduler: an emission then applies before the next line, and
+/// the process-global scheduler is what the class constraint protects.
+/// </summary>
 public class LocalFrameChatInputTests {
     sealed class Rig {
         public FakeDaemonClientService Daemon { get; } = new();
@@ -18,114 +24,157 @@ public class LocalFrameChatInputTests {
     }
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Availability_matrix() {
-        var rig = new Rig();
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Connecting);
-        rig.Connected("status/1");
-        rig.Running();
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Unsupported);
-        await Assert.That(rig.Input.Hint).IsEqualTo("Update the daemon to send messages from the app");
-        await Assert.That(await rig.Input.SendAsync("x", CancellationToken.None)).IsFalse();
-        await Assert.That(rig.Ops.SendTextCalls).IsEqualTo(0);
+        await RunOnUiAsync(async () => {
+            var rig = new Rig();
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Connecting);
+            rig.Connected("status/1");
+            rig.Running();
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Unsupported);
+            await Assert.That(rig.Input.Hint).IsEqualTo("Update the daemon to send messages from the app");
+            await Assert.That(await rig.Input.SendAsync("x", CancellationToken.None)).IsFalse();
+            await Assert.That(rig.Ops.SendTextCalls).IsEqualTo(0);
 
-        rig.Connected("status/1", "input/1");
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
-        await Assert.That(rig.Input.CanAcceptText).IsTrue();
-        await Assert.That(rig.Input.Hint).IsEqualTo("Enter sends · Shift+Enter for a new line");
+            rig.Connected("status/1", "input/1");
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+            await Assert.That(rig.Input.CanAcceptText).IsTrue();
+            await Assert.That(rig.Input.Hint).IsEqualTo("Enter sends · Shift+Enter for a new line");
 
-        rig.Presence.OnNext(new AgentPresence(rig.Presence.Value.Dto, true));
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ended);
-        await Assert.That(rig.Input.Hint).IsEqualTo("This session has ended");
+            rig.Presence.OnNext(new AgentPresence(rig.Presence.Value.Dto, true));
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ended);
+            await Assert.That(rig.Input.Hint).IsEqualTo("This session has ended");
+        });
     }
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task One_send_in_flight_until_the_ack_and_a_delivered_ack_clears() {
-        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
-        var gate = rig.Ops.ArmSendText();
-        var pending = rig.Input.SendAsync("hello", CancellationToken.None);
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Sending);
-        await Assert.That(rig.Input.CanAcceptText).IsFalse();
-        await Assert.That(await rig.Input.SendAsync("second", CancellationToken.None)).IsFalse();
-        gate.SetResult(new SendTextResult(true, null, null, SendTextOutcomes.Delivered));
-        await Assert.That(await pending).IsTrue();
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
-        await Assert.That(rig.Ops.SendTextPayloads).IsEquivalentTo(new[] { ("a1", "hello") });
+        await RunOnUiAsync(async () => {
+            var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+            var gate = rig.Ops.ArmSendText();
+            var pending = rig.Input.SendAsync("hello", CancellationToken.None);
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Sending);
+            await Assert.That(rig.Input.CanAcceptText).IsFalse();
+            await Assert.That(await rig.Input.SendAsync("second", CancellationToken.None)).IsFalse();
+            gate.SetResult(new SendTextResult(true, null, null, SendTextOutcomes.Delivered));
+            await Assert.That(await pending).IsTrue();
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+            await Assert.That(rig.Ops.SendTextPayloads).IsEquivalentTo(new[] { ("a1", "hello") });
+        });
     }
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     [Arguments("not_running", null, "agent is no longer running")]
     [Arguments("protected_kind", null, "read-only participant")]
     [Arguments("queue_full", null, "the agent's input queue is full, try again shortly")]
+    [Arguments("reaper_claimed", null, "the agent is being stopped")]
+    [Arguments("reaper_claimed_late", null, "the agent is being stopped")]
     [Arguments("delivery_failed", "pipe closed", "pipe closed")]
     [Arguments("transport", "eof", "delivery unconfirmed — check the chat before sending again")]
+    // A reason this build has no wording for still never shows the caller the wire token.
+    [Arguments("some_future_reason", "raw detail", "delivery failed")]
     public async Task Refusal_keeps_the_text_and_words_the_hint(string reason, string? error, string hint) {
-        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
-        rig.Ops.QueueSendText(new SendTextResult(false, reason, error, null));
-        await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
-        await Assert.That(rig.Input.Hint).IsEqualTo(hint);
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
-        rig.Ops.ArmSendText();
-        _ = rig.Input.SendAsync("again", CancellationToken.None);
-        await Assert.That(rig.Input.Hint).IsEqualTo("Sending…"); // the notice clears when the next send starts
+        await RunOnUiAsync(async () => {
+            var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+            rig.Ops.QueueSendText(new SendTextResult(false, reason, error, null));
+            await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
+            await Assert.That(rig.Input.Hint).IsEqualTo(hint);
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+            rig.Ops.ArmSendText();
+            _ = rig.Input.SendAsync("again", CancellationToken.None);
+            await Assert.That(rig.Input.Hint).IsEqualTo("Sending…"); // the notice clears when the next send starts
+        });
     }
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Stopped_outcome_clears_and_unknown_ok_outcome_counts_as_delivered() {
-        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
-        rig.Ops.QueueSendText(new SendTextResult(true, null, null, SendTextOutcomes.Stopped));
-        await Assert.That(await rig.Input.SendAsync("/quit", CancellationToken.None)).IsTrue();
-        rig.Ops.QueueSendText(new SendTextResult(true, null, null, "future_outcome"));
-        await Assert.That(await rig.Input.SendAsync("x", CancellationToken.None)).IsTrue();
+        await RunOnUiAsync(async () => {
+            var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+            rig.Ops.QueueSendText(new SendTextResult(true, null, null, SendTextOutcomes.Stopped));
+            await Assert.That(await rig.Input.SendAsync("/quit", CancellationToken.None)).IsTrue();
+            rig.Ops.QueueSendText(new SendTextResult(true, null, null, "future_outcome"));
+            await Assert.That(await rig.Input.SendAsync("x", CancellationToken.None)).IsTrue();
+        });
     }
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Cancelled_wait_keeps_the_text_with_the_unconfirmed_hint() {
-        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
-        rig.Ops.ArmSendText();
-        using var cts = new CancellationTokenSource();
-        var pending = rig.Input.SendAsync("hello", cts.Token);
-        cts.Cancel();
-        await Assert.That(await pending).IsFalse();
-        await Assert.That(rig.Input.Hint).IsEqualTo("delivery unconfirmed — check the chat before sending again");
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+        await RunOnUiAsync(async () => {
+            var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+            rig.Ops.ArmSendText();
+            using var cts = new CancellationTokenSource();
+            var pending = rig.Input.SendAsync("hello", cts.Token);
+            await cts.CancelAsync();
+            await Assert.That(await pending).IsFalse();
+            await Assert.That(rig.Input.Hint).IsEqualTo("delivery unconfirmed — check the chat before sending again");
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+        });
     }
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Session_ending_after_a_refusal_clears_the_notice() {
-        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
-        rig.Ops.QueueSendText(new SendTextResult(false, "queue_full", null, null));
-        await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
-        await Assert.That(rig.Input.Hint).IsEqualTo("the agent's input queue is full, try again shortly");
+        await RunOnUiAsync(async () => {
+            var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+            rig.Ops.QueueSendText(new SendTextResult(false, "queue_full", null, null));
+            await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
+            await Assert.That(rig.Input.Hint).IsEqualTo("the agent's input queue is full, try again shortly");
 
-        rig.Presence.OnNext(new AgentPresence(rig.Presence.Value.Dto, true));
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ended);
-        await Assert.That(rig.Input.Hint).IsEqualTo("This session has ended");
+            rig.Presence.OnNext(new AgentPresence(rig.Presence.Value.Dto, true));
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ended);
+            await Assert.That(rig.Input.Hint).IsEqualTo("This session has ended");
+        });
     }
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task A_status_reemission_that_does_not_change_availability_keeps_the_notice() {
-        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
-        rig.Ops.QueueSendText(new SendTextResult(false, "queue_full", null, null));
-        await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
-        await Assert.That(rig.Input.Hint).IsEqualTo("the agent's input queue is full, try again shortly");
+        await RunOnUiAsync(async () => {
+            var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+            rig.Ops.QueueSendText(new SendTextResult(false, "queue_full", null, null));
+            await Assert.That(await rig.Input.SendAsync("hello", CancellationToken.None)).IsFalse();
+            await Assert.That(rig.Input.Hint).IsEqualTo("the agent's input queue is full, try again shortly");
 
-        rig.Connected("input/1");
-        await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
-        await Assert.That(rig.Input.Hint).IsEqualTo("the agent's input queue is full, try again shortly");
+            rig.Connected("input/1");
+            await Assert.That(rig.Input.Availability).IsEqualTo(SendAvailability.Ready);
+            await Assert.That(rig.Input.Hint).IsEqualTo("the agent's input queue is full, try again shortly");
+        });
     }
 
     [Test]
+    [NotInParallel("AvaloniaSession")]
     public async Task Completion_after_dispose_mutates_nothing_and_dispose_detaches_subscriptions() {
-        var rig = new Rig(); rig.Connected("input/1"); rig.Running();
-        var gate = rig.Ops.ArmSendText();
-        var pending = rig.Input.SendAsync("hello", CancellationToken.None);
-        rig.Input.Dispose();
-        var raised = 0;
-        rig.Input.PropertyChanged += (_, _) => raised++;
-        gate.SetResult(new SendTextResult(false, "queue_full", null, null));
-        await Assert.That(await pending).IsFalse();
-        rig.Connected("input/1"); rig.Running();
-        rig.Presence.OnNext(new AgentPresence(null, true));
-        await Assert.That(raised).IsEqualTo(0);
+        await RunOnUiAsync(async () => {
+            var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+            var gate = rig.Ops.ArmSendText();
+            var pending = rig.Input.SendAsync("hello", CancellationToken.None);
+            rig.Input.Dispose();
+            var raised = 0;
+            rig.Input.PropertyChanged += (_, _) => raised++;
+            gate.SetResult(new SendTextResult(false, "queue_full", null, null));
+            await Assert.That(await pending).IsFalse();
+            rig.Connected("input/1"); rig.Running();
+            rig.Presence.OnNext(new AgentPresence(null, true));
+            await Assert.That(raised).IsEqualTo(0);
+        });
+    }
+
+    /// Availability still reads Ready after a dispose (it is derived from the last status and dto),
+    /// so the entry guard is the only thing keeping a torn-down tab from sending.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_disposed_channel_sends_nothing_even_while_it_reads_ready() {
+        await RunOnUiAsync(async () => {
+            var rig = new Rig(); rig.Connected("input/1"); rig.Running();
+            rig.Input.Dispose();
+
+            await Assert.That(rig.Input.CanAcceptText).IsTrue();
+            await Assert.That(await rig.Input.SendAsync("after", CancellationToken.None)).IsFalse();
+            await Assert.That(rig.Ops.SendTextCalls).IsEqualTo(0);
+        });
     }
 }

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -37,7 +37,8 @@ public class MainWindowSmokeTests {
     /// pieces MainWindowViewModelTests wires, over the actions this file's NewActions built.
     static WorkspaceViewModel NewWorkspace(FakeDaemonClientService service, AgentActionService actions, string agentId) =>
         new(agentId, service, actions, new FakeTerminalAttachClientFactory().Factory,
-            () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource());
+            () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(), new FakePermissionService(),
+            new FakeWorkContextSource(), new ScriptedLocalControlOps());
 
     [Test]
     [NotInParallel("AvaloniaSession")]
@@ -299,7 +300,8 @@ public class MainWindowSmokeTests {
             var vm = new MainWindowViewModel(
                 service, CancellationToken.None, activity,
                 workspaceFactory: agentId => new WorkspaceViewModel(
-                    agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource()));
+                    agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(),
+                    new FakePermissionService(), new FakeWorkContextSource(), new ScriptedLocalControlOps()));
             var window = new MainWindow { DataContext = vm };
             window.Show();
             Dispatcher.UIThread.RunJobs();
@@ -386,7 +388,8 @@ public class MainWindowSmokeTests {
                 var vm = new MainWindowViewModel(
                     service, CancellationToken.None, TestActivity.New(),
                     workspaceFactory: agentId => new WorkspaceViewModel(
-                        agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource()));
+                        agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(),
+                        new FakePermissionService(), new FakeWorkContextSource(), new ScriptedLocalControlOps()));
                 var window = new MainWindow { DataContext = vm };
                 window.Show();
                 Dispatcher.UIThread.RunJobs();

--- a/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowViewModelTests.cs
@@ -40,7 +40,8 @@ public class MainWindowViewModelTests {
         var (actions, _) = NewActions(service);
         var attach = new FakeTerminalAttachClientFactory();
         return new WorkspaceViewModel(
-            agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource());
+            agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(),
+            new FakePermissionService(), new FakeWorkContextSource(), new ScriptedLocalControlOps());
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/PullRequestViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PullRequestViewSmokeTests.cs
@@ -23,7 +23,7 @@ public class PullRequestViewSmokeTests {
         var time = new FakeTimeProvider();
         var source = new FakePullRequestSource(time);
         var vm = new WorkspaceViewModel("agent", daemon, NewActions(), attach.Factory, () => new FakeTerminalSurface(), time,
-            new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource(), pullRequests: source);
+            new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource(), new ScriptedLocalControlOps(), pullRequests: source);
         var view = new WorkspaceView { DataContext = vm };
         var window = new Window { Content = view, Width = 1200, Height = 800 };
         window.Show();

--- a/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
+++ b/test/Capacitor.App.Tests.Unit/ScriptedLocalControlOps.cs
@@ -17,6 +17,7 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
     readonly Queue<TaskCompletionSource<StopAgentResult>> _stops = new();
     readonly Queue<TaskCompletionSource<ConsentAckDto>> _resolves = new();
     readonly Queue<TaskCompletionSource<PermissionAckDto>> _permissionResolves = new();
+    readonly Queue<TaskCompletionSource<SendTextResult>> _sendTexts = new();
 
     public int GetCalls;
     public int PutCalls;
@@ -24,11 +25,13 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
     public int StopCalls;
     public int ResolveCalls;
     public int PermissionResolveCalls;
+    public int SendTextCalls;
     public readonly List<ConsentPolicyDto> PutPayloads = [];
     public readonly List<ConsentPolicyPutV2Dto> PutV2Payloads = [];
     public readonly List<(string AgentId, bool Force)> StopPayloads = [];
     public readonly List<ConsentResolveDto> ResolvePayloads = [];
     public readonly List<PermissionResolveDto> PermissionResolvePayloads = [];
+    public readonly List<(string AgentId, string Text)> SendTextPayloads = [];
 
     public TaskCompletionSource<ConsentPolicyDto> ArmGet() {
         var tcs = new TaskCompletionSource<ConsentPolicyDto>(TaskCreationOptions.RunContinuationsAsynchronously);
@@ -87,6 +90,14 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
     public void QueuePermissionResolve(bool ok, string? error = null) => ArmPermissionResolve().SetResult(new PermissionAckDto(ok, error));
     public void QueuePermissionResolveFailure(string reason) => ArmPermissionResolve().SetException(new LocalControlOpsException(reason, reason));
 
+    public TaskCompletionSource<SendTextResult> ArmSendText() {
+        var tcs = new TaskCompletionSource<SendTextResult>(TaskCreationOptions.RunContinuationsAsynchronously);
+        _sendTexts.Enqueue(tcs);
+        return tcs;
+    }
+
+    public void QueueSendText(SendTextResult result) => ArmSendText().SetResult(result);
+
     public Task<ConsentPolicyDto> GetConsentPolicyAsync(CancellationToken ct) {
         Interlocked.Increment(ref GetCalls);
         if (ct.IsCancellationRequested) return Task.FromCanceled<ConsentPolicyDto>(ct);
@@ -144,5 +155,13 @@ sealed class ScriptedLocalControlOps : ILocalControlOps {
         var tcs = _permissionResolves.Dequeue();
         ct.Register(() => tcs.TrySetCanceled(ct));
         return tcs.Task;
+    }
+
+    public Task<SendTextResult> SendTextAsync(string agentId, string text, CancellationToken ct) {
+        SendTextCalls++;
+        SendTextPayloads.Add((agentId, text));
+        if (ct.IsCancellationRequested) return Task.FromCanceled<SendTextResult>(ct);
+        var tcs = _sendTexts.Count > 0 ? _sendTexts.Dequeue() : throw new InvalidOperationException("arm SendText first");
+        return tcs.Task.WaitAsync(ct);
     }
 }

--- a/test/Capacitor.App.Tests.Unit/TerminalChatInputTests.cs
+++ b/test/Capacitor.App.Tests.Unit/TerminalChatInputTests.cs
@@ -1,0 +1,67 @@
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.ViewModels;
+using Capacitor.Cli.Core.LocalIpc;
+using DynamicData;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class TerminalChatInputTests {
+    static async Task<(TerminalTabViewModel Terminal, TerminalChatInput Input, FakeTerminalAttachClient Client, FakeTimeProvider Time)> BuildAttachedAsync() {
+        var daemon = new FakeDaemonClientService();
+        var factory = new FakeTerminalAttachClientFactory();
+        var time = new FakeTimeProvider();
+        var terminal = new TerminalTabViewModel("a1", daemon, factory.Factory, () => new FakeTerminalSurface(), time);
+        var input = new TerminalChatInput(terminal);
+        daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true) with { Status = "Running" });
+        Dispatcher.UIThread.RunJobs();
+        await (terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+        var client = factory.Created.Single();
+        await client.TriggerAttached([]);
+        return (terminal, input, client, time);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Mirrors_the_terminal_availability_and_wording() {
+        await RunOnUiAsync(async () => {
+            var (terminal, input, client, time) = await BuildAttachedAsync();
+            await Assert.That(input.Availability).IsEqualTo(SendAvailability.Ready);
+            await Assert.That(input.Hint).IsEqualTo("Enter sends · Shift+Enter for a new line");
+            await Assert.That(input.CanAcceptText).IsTrue();
+
+            var raised = new List<string>();
+            input.PropertyChanged += (_, e) => raised.Add(e.PropertyName!);
+            await Assert.That(await input.SendAsync("hello", CancellationToken.None)).IsTrue();
+            await Assert.That(input.Availability).IsEqualTo(SendAvailability.Sending);
+            await Assert.That(input.Hint).IsEqualTo("Sending…");
+            await Assert.That(raised).Contains(nameof(ChatInput.Availability));
+
+            time.Advance(TimeSpan.FromMilliseconds(150));
+            await terminal.PendingDeliveryForTesting!;
+            await Assert.That(input.Availability).IsEqualTo(SendAvailability.Ready);
+            await Assert.That(client.SentInput).Count().IsEqualTo(2);
+            input.Dispose();
+            await terminal.TeardownAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Dispose_detaches_from_the_terminal() {
+        await RunOnUiAsync(async () => {
+            var (terminal, input, client, _) = await BuildAttachedAsync();
+            input.Dispose();
+            var raised = 0;
+            input.PropertyChanged += (_, _) => raised++;
+            client.Result.SetResult(new AttachOutcome.Exited(0));
+            await terminal.CurrentRunForTesting!;
+            await Assert.That(raised).IsEqualTo(0);
+            await Assert.That(await input.SendAsync("x", CancellationToken.None)).IsFalse();
+            await terminal.TeardownAsync();
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceNavigationTests.cs
@@ -86,7 +86,8 @@ public class WorkspaceNavigationTests {
             workspaceFactory: agentId => {
                 opened.Add(agentId);
                 return new WorkspaceViewModel(
-                    agentId, daemon, actions, attach.Factory, () => new FakeTerminalSurface(), time, new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource());
+                    agentId, daemon, actions, attach.Factory, () => new FakeTerminalSurface(), time, new RecordingOpener(),
+                    new FakePermissionService(), new FakeWorkContextSource(), new ScriptedLocalControlOps());
             });
 
         return new Nav {

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -150,6 +150,32 @@ public class WorkspaceViewModelTests {
         });
     }
 
+    /// The banner layer (session-ended card, detach/reattach controls) is Terminal-tab-only: a
+    /// non-PTY session's chat surface owns the pane on every other tab, so it must never render
+    /// underneath ChatHost.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task ShowsTerminalBanners_is_true_only_on_the_Terminal_tab_pty_or_not() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var vm = Build(daemon, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider());
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: false));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(vm.ShowsTerminalBanners).IsFalse();
+            await vm.ShowTerminalCommand.Execute();
+            await Assert.That(vm.ShowsTerminalBanners).IsTrue();
+
+            daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(vm.ShowsTerminalBanners).IsTrue();
+            await vm.ShowChatCommand.Execute();
+            await Assert.That(vm.ShowsTerminalBanners).IsFalse();
+
+            await vm.TeardownAsync();
+        });
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Chat_is_built_on_the_first_dto_of_any_vendor_with_the_reader_the_format_names() {

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewModelTests.cs
@@ -13,7 +13,7 @@ using static Capacitor.App.Tests.Unit.WorkspaceFixtures;
 namespace Capacitor.App.Tests.Unit;
 
 /// WorkspaceViewModel's header projections (Title/RepoLabelText/
-/// ShowsTerminalTab/NoTerminalNote), SessionEnded, and Stop routing. WorkspaceViewModel always
+/// ShowsTerminalTab), SessionEnded, Chat construction, and Stop routing. WorkspaceViewModel always
 /// builds a real TerminalTabViewModel internally, so pushing a matching AgentStatusDto into the
 /// shared daemon.Agents cache also drives Terminal's OWN resolve gate -- which reaches
 /// Dispatcher.UIThread.InvokeAsync regardless of hasTerminal (both the NoTerminal and the attach
@@ -25,7 +25,8 @@ public class WorkspaceViewModelTests {
     static WorkspaceViewModel Build(
             FakeDaemonClientService daemon, AgentActionService actions, FakeTerminalAttachClientFactory factory,
             FakeTimeProvider time, string agentId = "a1") =>
-        new(agentId, daemon, actions, factory.Factory, () => new FakeTerminalSurface(), time, new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource());
+        new(agentId, daemon, actions, factory.Factory, () => new FakeTerminalSurface(), time, new RecordingOpener(),
+            new FakePermissionService(), new FakeWorkContextSource(), new ScriptedLocalControlOps());
 
     static AgentActionService NewActions(
             ScriptedLocalControlOps ops, RecordingNotifier notifier, RecordingOpener opener,
@@ -52,38 +53,6 @@ public class WorkspaceViewModelTests {
             await Assert.That(vm.Title).IsEqualTo("myproj");
             await Assert.That(vm.RepoLabelText).IsEqualTo("myproj");
             await Assert.That(vm.ShowsTerminalTab).IsTrue();
-            await Assert.That(vm.NoTerminalNote).IsEqualTo("");
-        });
-    }
-
-    [Test]
-    [NotInParallel("AvaloniaSession")]
-    public async Task Has_terminal_false_hides_the_tab_and_sets_the_family_aware_note() {
-        await RunOnUiAsync(async () => {
-            // Case 1: an ACP vendor (gemini) -- note says "runs over ACP", never the vendor name.
-            var daemon1 = new FakeDaemonClientService();
-            var actions1 = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
-            var factory1 = new FakeTerminalAttachClientFactory();
-            var vm1 = Build(daemon1, actions1, factory1, new FakeTimeProvider(), agentId: "a1");
-
-            daemon1.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: false));
-            await (vm1.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
-
-            await Assert.That(vm1.ShowsTerminalTab).IsFalse();
-            await Assert.That(vm1.NoTerminalNote).Contains("runs over ACP");
-            await Assert.That(vm1.NoTerminalNote).DoesNotContain("Gemini");
-
-            // Case 2: a non-ACP vendor (pi maps to rpc) -- bare note, no family token leaked.
-            var daemon2 = new FakeDaemonClientService();
-            var actions2 = NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener());
-            var factory2 = new FakeTerminalAttachClientFactory();
-            var vm2 = Build(daemon2, actions2, factory2, new FakeTimeProvider(), agentId: "a2");
-
-            daemon2.Agents.AddOrUpdate(Agent("a2", "pi", hasTerminal: false));
-            await (vm2.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
-
-            await Assert.That(vm2.ShowsTerminalTab).IsFalse();
-            await Assert.That(vm2.NoTerminalNote).IsEqualTo("This session has no terminal.");
         });
     }
 
@@ -183,20 +152,17 @@ public class WorkspaceViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Chat_is_built_for_a_pty_dto_only_and_torn_down_with_the_workspace() {
+    public async Task Chat_is_built_on_the_first_dto_of_any_vendor_with_the_reader_the_format_names() {
         await RunOnUiAsync(async () => {
             var daemon = new FakeDaemonClientService();
             var vm = Build(daemon, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider());
             await Assert.That(vm.Chat).IsNull();
 
-            daemon.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: false));
-            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
-            await Assert.That(vm.Chat).IsNull();
-
-            daemon.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: true));
+            daemon.Agents.AddOrUpdate(Agent("a1", "pi", hasTerminal: false) with { TranscriptFormat = TranscriptFormats.Envelopes });
             await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
             await Assert.That(vm.Chat).IsNotNull();
-            await Assert.That(vm.Chat!.Phase).IsEqualTo(ChatTabPhase.Unavailable); // gemini has no transcript projection
+            await Assert.That(vm.Chat!.Phase).IsEqualTo(ChatTabPhase.Waiting); // journal reader, no path yet
+            await Assert.That(vm.ShowsTerminalTab).IsFalse();
 
             var chat = vm.Chat;
             daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true));
@@ -204,6 +170,28 @@ public class WorkspaceViewModelTests {
 
             await vm.TeardownAsync();
             await Assert.That(chat.PendingReadForTesting!).IsNull();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Null_format_non_pty_dto_is_the_older_daemon_and_a_vendor_pty_dto_takes_the_vendor_reader() {
+        await RunOnUiAsync(async () => {
+            var daemon = new FakeDaemonClientService();
+            var older = Build(daemon, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider());
+            daemon.Agents.AddOrUpdate(Agent("a1", "gemini", hasTerminal: false));
+            await (older.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(older.Chat!.Phase).IsEqualTo(ChatTabPhase.Unavailable);
+            await Assert.That(older.Chat.PhaseNote).IsEqualTo("Update the daemon to view this session");
+            await older.TeardownAsync();
+
+            var daemon2 = new FakeDaemonClientService();
+            var pty = Build(daemon2, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()), new FakeTerminalAttachClientFactory(), new FakeTimeProvider(), agentId: "a2");
+            daemon2.Agents.AddOrUpdate(Agent("a2", "claude", hasTerminal: true) with { TranscriptFormat = TranscriptFormats.Vendor });
+            await (pty.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            await Assert.That(pty.Chat!.Phase).IsEqualTo(ChatTabPhase.Waiting);
+            await Assert.That(pty.ShowsTerminalTab).IsTrue();
+            await pty.TeardownAsync();
         });
     }
 
@@ -258,7 +246,8 @@ public class WorkspaceViewModelTests {
             var source = new FakeWorkContextSource();
             var factory = new FakeTerminalAttachClientFactory();
             var vm = new WorkspaceViewModel("a1", daemon, NewActions(new ScriptedLocalControlOps(), new RecordingNotifier(), new RecordingOpener()),
-                factory.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(), new FakePermissionService(), source);
+                factory.Factory, () => new FakeTerminalSurface(), new FakeTimeProvider(), new RecordingOpener(), new FakePermissionService(), source,
+                new ScriptedLocalControlOps());
             await Assert.That(vm.WorkContext.Phase).IsEqualTo(WorkContextPhase.WaitingForSession);
 
             daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true, repoPath: "/repo/myproj", sessionId: "0123456789abcdef0123456789abcdef"));

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -42,7 +42,8 @@ public class WorkspaceViewSmokeTests {
         var attach = new FakeTerminalAttachClientFactory();
         var vm = new WorkspaceViewModel(
             agentId, daemon, NewActions(), attach.Factory, surface ?? (() => new FakeTerminalSurface()),
-            new FakeTimeProvider(), new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource());
+            new FakeTimeProvider(), new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource(),
+            new ScriptedLocalControlOps());
         return (new WorkspaceView { DataContext = vm }, vm, daemon, attach);
     }
 
@@ -65,8 +66,7 @@ public class WorkspaceViewSmokeTests {
     }
 
     /// Effectively visible under this window. A name that never gets realized into the visual
-    /// tree — the collapsed chat surface's own controls — reads as not visible, which is exactly
-    /// what the gate promises.
+    /// tree — a collapsed surface's own controls — reads as not visible rather than throwing.
     static bool Visible(Window window, string name) => Find<Control>(window, name) is { IsEffectivelyVisible: true };
 
     static bool IsOffscreen(Control control) =>
@@ -88,10 +88,9 @@ public class WorkspaceViewSmokeTests {
     }
 
     /// Pins that every x:Name the view's code-behind and the suite reach for resolves before any
-    /// dto arrives — the tab strip included, which is collapsed in this state and must still be
-    /// in the tree for the code-behind to find. The chat surface is collapsed too, and a
-    /// collapsed UserControl is never measured, so its own names resolve through its name scope
-    /// rather than the window's visual tree.
+    /// dto arrives — the Terminal tab button and pane included, which are collapsed in this state
+    /// and must still be in the tree for the code-behind to find. The chat surface's own names are
+    /// resolved through its name scope, which holds whether or not it has been measured.
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task WorkspaceView_resolves_all_named_controls() {
@@ -103,7 +102,7 @@ public class WorkspaceViewSmokeTests {
 
             var names = new[] {
                 "WorkspaceTitle", "WorkspaceSubtitle", "ChatTabButton",
-                "TerminalTabButton", "NoTerminalNote", "TerminalHost", "TerminalBanners",
+                "TerminalTabButton", "TerminalHost", "TerminalBanners",
                 "DetachButton", "ReattachButton", "SessionEndedNote", "ChatHost", "WorkContextHost",
             };
             foreach (var name in names)
@@ -146,21 +145,22 @@ public class WorkspaceViewSmokeTests {
         });
     }
 
-    /// Run-and-observe: drives ONE workspace through both has_terminal values for the same agent id
-    /// and asserts the tab/note pair actually flips, not just that one arrangement renders
-    /// correctly. The tab buttons share one IsVisible-bound strip, so the button is read through
-    /// IsEffectivelyVisible while the note, which binds the negation itself, is read directly.
+    /// Run-and-observe: drives ONE workspace through both has_terminal values for the same agent
+    /// id. Chat is offered either way; only the Terminal button and pane follow the PTY gate, and
+    /// nothing stands in their place. The tab buttons share one IsVisible-bound strip, so a button
+    /// is read through IsEffectivelyVisible.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Tab_and_note_visibility_flip_with_ShowsTerminalTab() {
+    public async Task Chat_is_always_offered_and_the_terminal_pair_follows_ShowsTerminalTab() {
         await RunOnUiAsync(async () => {
             var (view, vm, daemon, _) = Build();
             var window = new Window { Content = view };
             window.Show();
             Dispatcher.UIThread.RunJobs();
 
+            var chatButton = Find<Control>(window, "ChatTabButton")!;
+            var chatHost = Find<Control>(window, "ChatHost")!;
             var tabButton = Find<Control>(window, "TerminalTabButton")!;
-            var note = Find<Control>(window, "NoTerminalNote")!;
             var terminalHost = Find<Control>(window, "TerminalHost")!;
 
             daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: false));
@@ -168,23 +168,23 @@ public class WorkspaceViewSmokeTests {
             Dispatcher.UIThread.RunJobs();
 
             await Assert.That(vm.ShowsTerminalTab).IsFalse();
+            await Assert.That(chatButton.IsEffectivelyVisible).IsTrue();
+            await Assert.That(chatHost.IsVisible).IsTrue(); // Chat is the default tab
             await Assert.That(tabButton.IsEffectivelyVisible).IsFalse();
-            await Assert.That(note.IsVisible).IsTrue();
             await Assert.That(terminalHost.IsVisible).IsFalse();
-            await Assert.That(vm.NoTerminalNote).IsNotEmpty();
+            await Assert.That(Find<Control>(window, "NoTerminalNote")).IsNull();
 
-            // Same agent id, has_terminal flips to true: WorkspaceViewModel's ShowsTerminalTab/
-            // NoTerminalNote are plain Rx projections off the daemon cache (not gated by
-            // TerminalTabViewModel's own one-shot resolve CAS), so a later update still moves them.
+            // Same agent id, has_terminal flips to true: WorkspaceViewModel's ShowsTerminalTab is a
+            // plain Rx projection off the daemon cache (not gated by TerminalTabViewModel's own
+            // one-shot resolve CAS), so a later update still moves it.
             daemon.Agents.AddOrUpdate(Agent(AgentId, hasTerminal: true));
             await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
             Dispatcher.UIThread.RunJobs();
 
             await Assert.That(vm.ShowsTerminalTab).IsTrue();
+            await Assert.That(chatButton.IsEffectivelyVisible).IsTrue();
             await Assert.That(tabButton.IsEffectivelyVisible).IsTrue();
-            await Assert.That(note.IsVisible).IsFalse();
             await Assert.That(terminalHost.IsVisible).IsTrue();
-            await Assert.That(vm.NoTerminalNote).IsEmpty();
 
             window.Close();
             Dispatcher.UIThread.RunJobs();
@@ -337,12 +337,12 @@ public class WorkspaceViewSmokeTests {
         });
     }
 
-    /// Pins the one gate the chat surface hangs off: a session with no PTY renders no chat at
-    /// all — not the host, not the composer, not Send — and keeps the banner layer it has no
-    /// Terminal tab to reach, so its end is still announced.
+    /// A session with no PTY gets the whole chat surface — host, composer and Send, focused as the
+    /// active tab — and keeps the banner layer it has no Terminal tab to reach, so its end is
+    /// still announced.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task A_session_without_a_terminal_shows_no_chat_surface_and_still_banners_its_end() {
+    public async Task A_session_without_a_terminal_shows_the_chat_surface_and_still_banners_its_end() {
         await RunOnUiAsync(async () => {
             var (view, vm, daemon, _) = Build();
             var window = new Window { Content = view, Width = 900, Height = 600 };
@@ -356,11 +356,10 @@ public class WorkspaceViewSmokeTests {
 
             var chatHost = Find<ChatTabView>(window, "ChatHost")!;
             await Assert.That(vm.IsChatActive).IsTrue();
-            await Assert.That(chatHost.IsEffectivelyVisible).IsFalse();
-            await Assert.That(Visible(window, "ComposerInput")).IsFalse();
-            await Assert.That(Visible(window, "SendButton")).IsFalse();
-            await Assert.That(chatHost.FindControl<TextBox>("ComposerInput")!.IsFocused).IsFalse();
-            await Assert.That(Find<Control>(window, "NoTerminalNote")!.IsVisible).IsTrue();
+            await Assert.That(chatHost.IsEffectivelyVisible).IsTrue();
+            await Assert.That(Visible(window, "ComposerInput")).IsTrue();
+            await Assert.That(Visible(window, "SendButton")).IsTrue();
+            await Assert.That(chatHost.FindControl<TextBox>("ComposerInput")!.IsFocused).IsTrue();
 
             daemon.Agents.Remove(AgentId);
             Dispatcher.UIThread.RunJobs();

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -338,11 +338,11 @@ public class WorkspaceViewSmokeTests {
     }
 
     /// A session with no PTY gets the whole chat surface — host, composer and Send, focused as the
-    /// active tab — and keeps the banner layer it has no Terminal tab to reach, so its end is
-    /// still announced.
+    /// active tab — and its own end is announced through the composer hint, not the terminal
+    /// banner layer, which stays off the Chat tab entirely.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task A_session_without_a_terminal_shows_the_chat_surface_and_still_banners_its_end() {
+    public async Task A_session_without_a_terminal_shows_the_chat_surface_and_ends_in_the_composer() {
         await RunOnUiAsync(async () => {
             var (view, vm, daemon, _) = Build();
             var window = new Window { Content = view, Width = 900, Height = 600 };
@@ -366,7 +366,10 @@ public class WorkspaceViewSmokeTests {
             window.UpdateLayout();
 
             await Assert.That(vm.Terminal.State.Phase).IsEqualTo(TerminalSessionPhase.SessionEnded);
-            await Assert.That(Find<Control>(window, "SessionEndedNote")!.IsEffectivelyVisible).IsTrue();
+            await Assert.That(Find<Control>(window, "TerminalBanners")!.IsEffectivelyVisible).IsFalse();
+            await Assert.That(Find<Control>(window, "SessionEndedNote")!.IsEffectivelyVisible).IsFalse();
+            await Assert.That(chatHost.IsEffectivelyVisible).IsTrue();
+            await Assert.That(vm.Chat!.ComposerHint).IsEqualTo("This session has ended");
 
             window.Close();
             Dispatcher.UIThread.RunJobs();

--- a/test/Capacitor.Cli.Core.Tests.Unit/EnvelopeJournalFormatTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/EnvelopeJournalFormatTests.cs
@@ -1,0 +1,35 @@
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class EnvelopeJournalFormatTests {
+    [Test]
+    public async Task Round_trip_pins_the_bytes() {
+        var e = new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: "hi", TimestampIso: "2026-09-09T10:00:00.000Z");
+        var line = EnvelopeJournalFormat.Write(e);
+        await Assert.That(line).StartsWith("""{"contract_version":1,"seq":0,"kind":"user_message","text":"hi",""");
+        await Assert.That(line).Contains("\"timestamp_iso\":\"2026-09-09T10:00:00.000Z\"");
+        await Assert.That(line).DoesNotContain("\n");
+        await Assert.That(EnvelopeJournalFormat.TryRead(line, out var back)).IsTrue();
+        await Assert.That(back).IsEqualTo(e);
+    }
+
+    [Test]
+    [Arguments("not json")]
+    [Arguments("{}")]
+    [Arguments("42")]
+    [Arguments("[]")]
+    [Arguments("""{"contract_version":1,"kind":null}""")]
+    [Arguments("""{"contract_version":1,"kind":""}""")]
+    [Arguments("""{"contract_version":2,"kind":"user_message","text":"x"}""")]
+    public async Task Structurally_invalid_lines_are_rejected(string line) =>
+        await Assert.That(EnvelopeJournalFormat.TryRead(line, out _)).IsFalse();
+
+    [Test]
+    public async Task Unknown_kind_on_a_v1_line_is_accepted() {
+        await Assert.That(EnvelopeJournalFormat.TryRead("""{"contract_version":1,"kind":"future_kind"}""", out var e)).IsTrue();
+        await Assert.That(e.Kind).IsEqualTo("future_kind");
+    }
+
+    [Test]
+    public async Task Missing_contract_version_reads_as_v1() =>
+        await Assert.That(EnvelopeJournalFormat.TryRead("""{"kind":"assistant_text","text":"a"}""", out _)).IsTrue();
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/EnvelopeJournalProjectionTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/EnvelopeJournalProjectionTests.cs
@@ -1,0 +1,43 @@
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class EnvelopeJournalProjectionTests {
+    static readonly IChatTranscriptProjection Sut = TranscriptChat.Journal;
+
+    [Test]
+    [Arguments(AcpEventKind.UserMessage)]
+    [Arguments(AcpEventKind.AssistantText)]
+    [Arguments(AcpEventKind.SystemNote)]
+    [Arguments(AcpEventKind.ToolCall)]
+    [Arguments(AcpEventKind.Usage)]
+    [Arguments("future_kind")]
+    public async Task Every_kind_passes_through_as_one_envelope(string kind) {
+        var line = EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: kind, Text: "t", ToolCallId: "c1"));
+        var context = Sut.CreateContext("s", "a1");
+        var result = Sut.Project(line, 1, DateTimeOffset.UnixEpoch, context);
+        await Assert.That(result).Count().IsEqualTo(1);
+        await Assert.That(result[0].Kind).IsEqualTo(kind);
+    }
+
+    [Test]
+    public async Task Malformed_line_throws_so_the_tab_logs_it_once() {
+        var context = Sut.CreateContext("s", null);
+        await Assert.That(() => Sut.Project("{}", 1, DateTimeOffset.UnixEpoch, context)).Throws<FormatException>();
+    }
+
+    [Test]
+    public async Task Context_is_stateless_and_reusable() {
+        var context = Sut.CreateContext("s", null);
+        context.BeginBatch();
+        var line = EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "x"));
+        await Assert.That(Sut.Project(line, 1, DateTimeOffset.UnixEpoch, context)).Count().IsEqualTo(1);
+        await Assert.That(Sut.Project(line, 2, DateTimeOffset.UnixEpoch, context)).Count().IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task Vendor_registry_is_unchanged() {
+        await Assert.That(TranscriptChat.For("claude")).IsNotNull();
+        await Assert.That(TranscriptChat.For("gemini")).IsNull();
+        IChatTranscriptProjection asInterface = TranscriptChat.For("codex")!;
+        await Assert.That(asInterface).IsNotNull();
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/FrameCodecInputTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/FrameCodecInputTests.cs
@@ -1,0 +1,29 @@
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Core.Tests.Unit.LocalIpc;
+
+public class FrameCodecInputTests {
+    static async Task<LocalFrame> RoundTrip(LocalFrame f) {
+        using var ms = new MemoryStream();
+        await FrameCodec.WriteAsync(ms, f, CancellationToken.None);
+        ms.Position = 0;
+        return (await FrameCodec.ReadAsync(ms, CancellationToken.None))!;
+    }
+
+    [Test]
+    [Arguments(FrameType.SendText)]
+    [Arguments(FrameType.SendTextAck)]
+    public async Task Input_frames_roundtrip_with_text_payload(FrameType type) {
+        var f = await RoundTrip(LocalFrame.InputJson(type, """{"k":"v"}"""));
+        await Assert.That(f.Type).IsEqualTo(type);
+        await Assert.That(f.Text).IsEqualTo("""{"k":"v"}""");
+    }
+
+    [Test]
+    public async Task Input_frame_values_are_stable_wire_bytes() {
+#pragma warning disable TUnitAssertions0005
+        await Assert.That((byte)FrameType.SendText).IsEqualTo((byte)22);
+        await Assert.That((byte)FrameType.SendTextAck).IsEqualTo((byte)80);
+#pragma warning restore TUnitAssertions0005
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/InputWireContractsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/InputWireContractsTests.cs
@@ -1,0 +1,40 @@
+using System.Text.Json;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Core.Tests.Unit.LocalIpc;
+
+public class InputWireContractsTests {
+    [Test]
+    public async Task Send_text_serializes_snake_case() =>
+        await Assert.That(JsonSerializer.Serialize(new SendTextDto("a1", "hello"), InputIpcJsonContext.Default.SendTextDto))
+            .IsEqualTo("""{"agent_id":"a1","text":"hello"}""");
+
+    [Test]
+    public async Task Ack_serializes_every_member_with_outcome_last() {
+        await Assert.That(JsonSerializer.Serialize(new SendTextAckDto(true, null, null, SendTextOutcomes.Delivered), InputIpcJsonContext.Default.SendTextAckDto))
+            .IsEqualTo("""{"ok":true,"reason":null,"error":null,"outcome":"delivered"}""");
+        await Assert.That(JsonSerializer.Serialize(new SendTextAckDto(false, SendTextReasons.QueueFull, "full", null), InputIpcJsonContext.Default.SendTextAckDto))
+            .IsEqualTo("""{"ok":false,"reason":"queue_full","error":"full","outcome":null}""");
+    }
+
+    [Test]
+    public async Task Ack_without_outcome_deserializes_to_null_outcome() {
+        var ack = JsonSerializer.Deserialize("""{"ok":true,"reason":null,"error":null}""", InputIpcJsonContext.Default.SendTextAckDto)!;
+        await Assert.That(ack.Ok).IsTrue();
+        await Assert.That(ack.Outcome).IsNull();
+    }
+
+    [Test]
+    [Arguments("{}")]
+    [Arguments("""{"agent_id":"a1"}""")]
+    [Arguments("""{"agent_id":null,"text":"x"}""")]
+    [Arguments("""{"agent_id":"a1","text":null}""")]
+    public async Task Missing_or_null_members_are_structurally_invalid(string json) {
+        var dto = JsonSerializer.Deserialize(json, InputIpcJsonContext.Default.SendTextDto);
+        await Assert.That(InputWire.IsStructurallyValid(dto)).IsFalse();
+    }
+
+    [Test]
+    public async Task Empty_text_is_structurally_valid_so_the_handler_can_name_it() =>
+        await Assert.That(InputWire.IsStructurallyValid(new SendTextDto("a1", ""))).IsTrue();
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/LocalControlOpsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/LocalControlOpsTests.cs
@@ -583,4 +583,73 @@ public class LocalControlOpsTests {
             await Assert.ThrowsAsync<OperationCanceledException>(async () => await task);
         }, configure: ops => ops.StopReplyTimeout = TimeSpan.FromSeconds(30));
     }
+
+    // ---- SendTextAsync ----
+
+    static ConnScript SendTextAckThen(string json, Action<string>? capture = null) => async (_, s, ct) => {
+        var f = await FrameCodec.ReadAsync(s, ct);
+        if (f?.Type == FrameType.SendText) {
+            capture?.Invoke(f.Text);
+            await FrameCodec.WriteAsync(s, LocalFrame.InputJson(FrameType.SendTextAck, json), ct);
+        }
+    };
+
+    [Test]
+    public async Task SendText_passes_all_four_ack_members_through() {
+        if (OperatingSystem.IsWindows()) return;
+        string? sent = null;
+        await WithOpsAsync([SendTextAckThen("""{"ok":true,"reason":null,"error":null,"outcome":"stopped"}""", j => sent = j)], async ops => {
+            var result = await ops.SendTextAsync("a1", "/quit", CancellationToken.None);
+            await Assert.That(result).IsEqualTo(new SendTextResult(true, null, null, "stopped"));
+            await Assert.That(sent).IsEqualTo("""{"agent_id":"a1","text":"/quit"}""");
+        });
+    }
+
+    [Test]
+    public async Task SendText_maps_eof_to_transport() {
+        if (OperatingSystem.IsWindows()) return;
+        await WithOpsAsync([Eof()], async ops => {
+            var result = await ops.SendTextAsync("a1", "hi", CancellationToken.None);
+            await Assert.That(result.Ok).IsFalse();
+            await Assert.That(result.Reason).IsEqualTo(SendTextReasons.Transport);
+            await Assert.That(result.Outcome).IsNull();
+        });
+    }
+
+    [Test]
+    public async Task SendText_waits_past_the_reply_timeout_for_a_late_ack() {
+        if (OperatingSystem.IsWindows()) return;
+        var release = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ConnScript late = async (_, s, ct) => {
+            await FrameCodec.ReadAsync(s, ct);
+            await release.Task;
+            await FrameCodec.WriteAsync(s, LocalFrame.InputJson(FrameType.SendTextAck, """{"ok":true,"reason":null,"error":null,"outcome":"delivered"}"""), ct);
+        };
+        await WithOpsAsync([late], async ops => {
+            var pending = ops.SendTextAsync("a1", "hi", CancellationToken.None);
+            await Task.Delay(300);
+            await Assert.That(pending.IsCompleted).IsFalse();
+            release.SetResult();
+            await Assert.That((await pending).Outcome).IsEqualTo("delivered");
+        }, configure: ops => { ops.ReplyTimeout = TimeSpan.FromMilliseconds(50); ops.StopReplyTimeout = TimeSpan.FromMilliseconds(50); });
+    }
+
+    [Test]
+    public async Task SendText_cancellation_closes_the_connection_and_propagates() {
+        if (OperatingSystem.IsWindows()) return;
+        var closed = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        ConnScript holdUntilEof = async (_, s, ct) => {
+            await FrameCodec.ReadAsync(s, ct);
+            var eof = await FrameCodec.ReadAsync(s, ct); // null once the client closes
+            if (eof is null) closed.SetResult();
+        };
+        using var cts = new CancellationTokenSource();
+        await WithOpsAsync([holdUntilEof], async ops => {
+            var pending = ops.SendTextAsync("a1", "hi", cts.Token);
+            await Task.Delay(100);
+            cts.Cancel();
+            await Assert.That(async () => await pending).Throws<OperationCanceledException>();
+            await closed.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        });
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/StatusIpcJsonTests.cs
@@ -29,7 +29,7 @@ public class StatusIpcJsonTests {
         var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.DaemonStatusDto);
 
         await Assert.That(json).IsEqualTo(
-            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1,"pid":4242,"instance_id":"inst-abc","supported_vendors":null},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex","requester_display":"Ada Lovelace","has_terminal":null,"title":"Fix the flaky test","transcript_path":null,"worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null,"requester_display":null,"has_terminal":null,"title":null,"transcript_path":null,"worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null}]}""");
+            """{"daemon":{"name":"main","version":"0.12.3","server_url":"https://tenant.example.com","connection":"connected","max_agents":5,"active_agents":1,"pid":4242,"instance_id":"inst-abc","supported_vendors":null},"agents":[{"id":"agent-abc123","kind":"review-flow","vendor":"codex","repo_path":"/Users/x/dev/repo","status":"Live","flow_run_id":"flow_1","flow_role":"reviewer","requester":"github:12345","created_at":"2026-08-01T12:34:56.789Z","model":"gpt-5-codex","requester_display":"Ada Lovelace","has_terminal":null,"title":"Fix the flaky test","transcript_path":null,"worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null,"transcript_format":null},{"id":"agent-b","kind":"agent","vendor":"claude","repo_path":null,"status":"Starting","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T12:35:00Z","model":null,"requester_display":null,"has_terminal":null,"title":null,"transcript_path":null,"worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null,"transcript_format":null}]}""");
     }
 
     [Test]
@@ -107,8 +107,8 @@ public class StatusIpcJsonTests {
         var json = JsonSerializer.Serialize(withPath, StatusIpcJsonContext.Default.AgentStatusDto);
         var jsonNull = JsonSerializer.Serialize(without, StatusIpcJsonContext.Default.AgentStatusDto);
 
-        await Assert.That(json).EndsWith(""","has_terminal":true,"title":"t","transcript_path":"/home/u/.claude/projects/-repo/abc.jsonl","worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null}""");
-        await Assert.That(jsonNull).EndsWith(""","has_terminal":true,"title":"t","transcript_path":null,"worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null}""");
+        await Assert.That(json).EndsWith(""","has_terminal":true,"title":"t","transcript_path":"/home/u/.claude/projects/-repo/abc.jsonl","worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null,"transcript_format":null}""");
+        await Assert.That(jsonNull).EndsWith(""","has_terminal":true,"title":"t","transcript_path":null,"worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null,"transcript_format":null}""");
     }
 
     [Test]
@@ -139,8 +139,8 @@ public class StatusIpcJsonTests {
         var json = JsonSerializer.Serialize(borrowed, StatusIpcJsonContext.Default.AgentStatusDto);
         var jsonNull = JsonSerializer.Serialize(older, StatusIpcJsonContext.Default.AgentStatusDto);
 
-        await Assert.That(json).EndsWith(""","transcript_path":"/x.jsonl","worktree_path":"/repo/.capacitor/worktrees/agent-1","work_location":"borrowed","borrowed_from":"/repo/.capacitor/worktrees/agent-1","session_id":null,"branch":null,"awaiting_input":null}""");
-        await Assert.That(jsonNull).EndsWith(""","transcript_path":"/x.jsonl","worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null}""");
+        await Assert.That(json).EndsWith(""","transcript_path":"/x.jsonl","worktree_path":"/repo/.capacitor/worktrees/agent-1","work_location":"borrowed","borrowed_from":"/repo/.capacitor/worktrees/agent-1","session_id":null,"branch":null,"awaiting_input":null,"transcript_format":null}""");
+        await Assert.That(jsonNull).EndsWith(""","transcript_path":"/x.jsonl","worktree_path":null,"work_location":null,"borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null,"transcript_format":null}""");
     }
 
     [Test]
@@ -174,8 +174,8 @@ public class StatusIpcJsonTests {
         var json = JsonSerializer.Serialize(full, StatusIpcJsonContext.Default.AgentStatusDto);
         var jsonNull = JsonSerializer.Serialize(older, StatusIpcJsonContext.Default.AgentStatusDto);
 
-        await Assert.That(json).EndsWith(""","borrowed_from":null,"session_id":"0123456789abcdef0123456789abcdef","branch":"feature/sidebar","awaiting_input":null}""");
-        await Assert.That(jsonNull).EndsWith(""","borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null}""");
+        await Assert.That(json).EndsWith(""","borrowed_from":null,"session_id":"0123456789abcdef0123456789abcdef","branch":"feature/sidebar","awaiting_input":null,"transcript_format":null}""");
+        await Assert.That(jsonNull).EndsWith(""","borrowed_from":null,"session_id":null,"branch":null,"awaiting_input":null,"transcript_format":null}""");
     }
 
     /// The daemon's own verdict on whether the agent finished its turn and waits on the user; an
@@ -183,7 +183,7 @@ public class StatusIpcJsonTests {
     [Test]
     [Arguments(true)]
     [Arguments(false)]
-    public async Task Awaiting_input_serializes_last_and_never_omitted(bool value) {
+    public async Task Awaiting_input_serializes_before_transcript_format_and_never_omitted(bool value) {
         var dto = new AgentStatusDto(
             "a1", "agent", "claude", "/repo", "Running",
             null, null, null, new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc), null, null,
@@ -191,7 +191,7 @@ public class StatusIpcJsonTests {
 
         var json = JsonSerializer.Serialize(dto, StatusIpcJsonContext.Default.AgentStatusDto);
 
-        await Assert.That(json).EndsWith($$$""","branch":"main","awaiting_input":{{{value.ToString().ToLowerInvariant()}}}}""");
+        await Assert.That(json).EndsWith($$$""","branch":"main","awaiting_input":{{{value.ToString().ToLowerInvariant()}}},"transcript_format":null}""");
     }
 
     [Test]
@@ -219,5 +219,24 @@ public class StatusIpcJsonTests {
 
         await Assert.That(back!.SessionId).IsNull();
         await Assert.That(back.Branch).IsNull();
+    }
+
+    [Test]
+    public async Task Transcript_format_is_the_trailing_member_and_always_emitted() {
+        var vendor    = new AgentStatusDto("a", "agent", "claude", null, "Running", null, null, null, DateTime.UnixEpoch, null, null, TranscriptFormat: TranscriptFormats.Vendor);
+        var envelopes = vendor with { TranscriptFormat = TranscriptFormats.Envelopes };
+        var unset     = vendor with { TranscriptFormat = null };
+
+        await Assert.That(JsonSerializer.Serialize(vendor, StatusIpcJsonContext.Default.AgentStatusDto)).EndsWith(""","awaiting_input":null,"transcript_format":"vendor"}""");
+        await Assert.That(JsonSerializer.Serialize(envelopes, StatusIpcJsonContext.Default.AgentStatusDto)).EndsWith(""","transcript_format":"envelopes"}""");
+        await Assert.That(JsonSerializer.Serialize(unset, StatusIpcJsonContext.Default.AgentStatusDto)).EndsWith(""","transcript_format":null}""");
+    }
+
+    [Test]
+    public async Task Old_agent_json_without_transcript_format_deserializes_to_null() {
+        var json = """{"id":"a","kind":"agent","vendor":"codex","repo_path":null,"status":"Live","flow_run_id":null,"flow_role":null,"requester":null,"created_at":"2026-08-01T00:00:00Z","model":null,"requester_display":null,"awaiting_input":true}""";
+        var dto = JsonSerializer.Deserialize(json, StatusIpcJsonContext.Default.AgentStatusDto)!;
+        await Assert.That(dto.TranscriptFormat).IsNull();
+        await Assert.That(dto.AwaitingInput).IsTrue();
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/PlatformPathsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/PlatformPathsTests.cs
@@ -1,0 +1,21 @@
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class PlatformPathsTests {
+    [Test]
+    public async Task Trailing_separator_is_ignored_by_the_comparer() {
+        await Assert.That(PlatformPaths.Comparer.Equals("/a/b", "/a/b/")).IsTrue();
+        await Assert.That(PlatformPaths.Comparer.GetHashCode("/a/b")).IsEqualTo(PlatformPaths.Comparer.GetHashCode("/a/b/"));
+    }
+
+    [Test]
+    public async Task Leaf_is_the_last_segment_after_normalization() {
+        await Assert.That(PlatformPaths.Leaf("/a/b/")).IsEqualTo("b");
+        await Assert.That(PlatformPaths.Normalize("/a/b/")).IsEqualTo("/a/b");
+    }
+
+    [Test]
+    public async Task Case_rule_follows_the_platform() {
+        var equal = PlatformPaths.Comparer.Equals("/A", "/a");
+        await Assert.That(equal).IsEqualTo(!OperatingSystem.IsLinux());
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/SessionIdsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/SessionIdsTests.cs
@@ -1,0 +1,17 @@
+namespace Capacitor.Cli.Core.Tests.Unit;
+
+public class SessionIdsTests {
+    [Test]
+    public async Task Dashed_guid_becomes_its_n_form() =>
+        await Assert.That(SessionIds.Canonical("8BC7255F-2453-4EFD-A733-0AF4B6AE9F20")).IsEqualTo("8bc7255f24534efda7330af4b6ae9f20");
+
+    [Test]
+    public async Task Opaque_id_is_returned_trimmed_and_unchanged() =>
+        await Assert.That(SessionIds.Canonical("  sess-1 ")).IsEqualTo("sess-1");
+
+    [Test]
+    public async Task Null_and_blank_are_null() {
+        await Assert.That(SessionIds.Canonical(null)).IsNull();
+        await Assert.That(SessionIds.Canonical("   ")).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/WorkItems/WorkContextClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/WorkItems/WorkContextClientTests.cs
@@ -78,15 +78,14 @@ public class WorkContextClientTests {
     [Arguments("..")]
     [Arguments("")]
     [Arguments("   ")]
-    [Arguments("---")]
     public async Task An_id_that_would_escape_or_empty_the_route_is_refused_before_any_request(string id) {
         using var http = new HttpClient(new ThrowingHandler(new InvalidOperationException("a request was sent")));
         var client = new WorkContextClient(http, "http://localhost:1");
 
         var assignments = await client.GetSessionAssignmentsAsync(id, CancellationToken.None);
         var summary = await client.GetSessionSummaryAsync(id, CancellationToken.None);
-        var topology = await client.GetTopologyAsync(id == "---" ? "." : id, CancellationToken.None);
-        var item = await client.GetWorkItemAsync(id == "---" ? ".." : id, CancellationToken.None);
+        var topology = await client.GetTopologyAsync(id, CancellationToken.None);
+        var item = await client.GetWorkItemAsync(id, CancellationToken.None);
 
         await Assert.That(assignments.StatusCode).IsEqualTo(0);
         await Assert.That(summary.StatusCode).IsEqualTo(0);

--- a/test/Capacitor.Cli.Core.Tests.Unit/WorkItems/WorkContextIdsTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/WorkItems/WorkContextIdsTests.cs
@@ -1,0 +1,20 @@
+using Capacitor.Cli.Core.WorkItems;
+
+namespace Capacitor.Cli.Core.Tests.Unit.WorkItems;
+
+public class WorkContextIdsTests {
+    [Test]
+    public async Task Guid_session_id_reaches_the_route_in_n_form() =>
+        await Assert.That(WorkContextIds.CanonicalSessionId("8bc7255f-2453-4efd-a733-0af4b6ae9f20")).IsEqualTo("8bc7255f24534efda7330af4b6ae9f20");
+
+    [Test]
+    public async Task Opaque_dashed_id_reaches_the_route_unchanged() =>
+        await Assert.That(WorkContextIds.CanonicalSessionId("sess-1")).IsEqualTo("sess-1");
+
+    [Test]
+    public async Task Dot_segments_and_blanks_are_still_rejected() {
+        await Assert.That(WorkContextIds.CanonicalSessionId(".")).IsNull();
+        await Assert.That(WorkContextIds.CanonicalSessionId("..")).IsNull();
+        await Assert.That(WorkContextIds.CanonicalSessionId(" ")).IsNull();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/FakeAcpAgent.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/FakeAcpAgent.cs
@@ -249,6 +249,19 @@ public sealed class FakeAcpAgent : IAsyncDisposable {
     /// </summary>
     public void SimulateCrash() => _toClient.Writer.Complete();
 
+    /// <summary>Pushes an unsolicited <c>agent_message_chunk</c> update outside any prompt script —
+    /// for a test driving agent output at an arbitrary moment rather than through a turn's response.
+    /// Fire-and-forget, like <see cref="RunAsync"/>'s own dispatch: a fault is captured the same way
+    /// so it still surfaces via <see cref="DisposeAsync"/> instead of being silently lost.</summary>
+    public void EmitAgentText(string text) {
+        var write = WriteRawFrameAsync(DefaultAgentMessageChunkUpdate(FixedSessionId, text), CancellationToken.None);
+        _ = write.ContinueWith(t => {
+            if (!t.IsFaulted) return;
+            var captured = ExceptionDispatchInfo.Capture(t.Exception!.InnerException ?? t.Exception);
+            Interlocked.CompareExchange(ref _dispatchFault, captured, null);
+        }, CancellationToken.None, TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+    }
+
     /// <summary>
     /// Arranges the NEXT <c>initialize</c> request to be answered with a JSON-RPC error instead of
     /// a success result — models a logged-out/unsubscribed <c>cursor-agent</c> rejecting

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityActivityClockTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityActivityClockTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Harness.Antigravity;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
@@ -207,7 +208,10 @@ public class AntigravityActivityClockTests {
         await rt.WaitForTurnIdleAsync(CancellationToken.None).WaitAsync(HangGuard);
 
         var envelopes = 0;
-        while (rt.Envelopes.TryRead(out _)) envelopes++;
+        while (rt.Envelopes.TryRead(out var env))
+            // The synthesized user_message is daemon-authored (Write(agentActivity: false)), not
+            // agent-forwarded, so it never advances the clock and must not count here.
+            if (env.Kind != AcpEventKind.UserMessage) envelopes++;
 
         await Assert.That(envelopes).IsGreaterThan(0);
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityRuntimeFakes.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityRuntimeFakes.cs
@@ -1,5 +1,6 @@
 using System.Runtime.CompilerServices;
 using Capacitor.Cli.Daemon.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
@@ -126,9 +127,11 @@ internal static class AntigravityRuntimeFakes {
     /// directly with its own spawn closure instead.
     /// </summary>
     public static AntigravityHostedAgentRuntime FakeRuntime(
-            FakeTurn        turn     = FakeTurn.Normal,
-            Action<string>? onSpawn  = null,
-            int             queueCap = 64) {
+            FakeTurn           turn     = FakeTurn.Normal,
+            Action<string>?    onSpawn  = null,
+            int                queueCap = 64,
+            TimeProvider?      time     = null,
+            TranscriptJournal? journal  = null) {
         Func<string, string?, CancellationToken, Task<IAgyTurnProcess>> spawn = (prompt, _, _) => {
             onSpawn?.Invoke(prompt);
             return Task.FromResult<IAgyTurnProcess>(new FakeAgyTurnProcess(turn, FixedConversationId));
@@ -137,6 +140,8 @@ internal static class AntigravityRuntimeFakes {
         return new AntigravityHostedAgentRuntime(
             spawnTurn: spawn,
             logger: NullLogger.Instance,
-            pendingTurnsCapacity: queueCap);
+            pendingTurnsCapacity: queueCap,
+            timeProvider: time,
+            journal: journal);
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityRuntimeLifecycleTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityRuntimeLifecycleTests.cs
@@ -172,7 +172,8 @@ public class AntigravityRuntimeLifecycleTests {
         await using var rt = FakeRuntime(onSpawn: _ => spawns++);
         await rt.TerminateAsync(TimeSpan.FromSeconds(5)).WaitAsync(HangGuard);
 
-        await rt.SendUserInputAsync("hello").WaitAsync(HangGuard);
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => rt.SendUserInputAsync("hello").WaitAsync(HangGuard));
         await Task.Delay(100);
 
         await Assert.That(spawns).IsEqualTo(0);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityUserTurnTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityUserTurnTests.cs
@@ -1,0 +1,80 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
+
+/// <summary>
+/// The daemon-synthesized <c>user_message</c> the single turn worker emits ahead of a turn's own
+/// output (ACP's <c>session/prompt</c> never round-trips through <c>session/update</c>, so there is
+/// no natural agent-sourced envelope for the prompt itself) — its ordering, its clock reading, and
+/// its journal fidelity.
+/// </summary>
+public class AntigravityUserTurnTests {
+    static readonly FakeTimeProvider Time = new(new DateTimeOffset(2026, 9, 9, 10, 0, 0, TimeSpan.Zero));
+
+    static async Task<List<AcpEventEnvelope>> Drain(AntigravityHostedAgentRuntime rt, int count) {
+        var list = new List<AcpEventEnvelope>();
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        while (list.Count < count) list.Add(await rt.Envelopes.ReadAsync(cts.Token));
+        return list;
+    }
+
+    [Test]
+    public async Task One_user_message_per_admitted_turn_ordered_before_that_turns_output_with_the_injected_clock() {
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(time: Time);
+        await rt.SendUserInputAsync("first");
+        await rt.SendUserInputAsync("second");
+
+        // Turn 1: user("first"), session_started (init's own envelope, emitted once ever). Turn 2's
+        // init never re-emits session_started, so it contributes only its own user_message.
+        var envelopes = await Drain(rt, 3);
+        var users = envelopes.Where(e => e.Kind == AcpEventKind.UserMessage).ToList();
+        await Assert.That(users.Select(u => u.Text!)).IsEquivalentTo(new[] { "first", "second" });
+        await Assert.That(users.All(u => u.TimestampIso == "2026-09-09T10:00:00.0000000+00:00")).IsTrue();
+        await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+        var secondIndex = envelopes.FindIndex(e => e.Kind == AcpEventKind.UserMessage && e.Text == "second");
+        await Assert.That(envelopes.Take(secondIndex).Count(e => e.Kind != AcpEventKind.UserMessage)).IsGreaterThan(0);
+    }
+
+    [Test]
+    public async Task A_refused_turn_emits_only_the_not_delivered_note() {
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1, time: Time);
+        await rt.SendUserInputAsync("first");
+
+        // Turn 1 is genuinely executing (its init has been read, freeing the capacity-1 pending-turns
+        // slot) before "queued" is sent — otherwise "queued" races the worker's own dequeue and can be
+        // rejected instead of queued.
+        await rt.WaitForConversationIdAsync(CancellationToken.None);
+
+        await rt.SendUserInputAsync("queued");
+        await Assert.That(async () => await rt.SendUserInputAsync("refused")).Throws<Exception>();
+        await Task.Delay(100);
+        var seen = new List<AcpEventEnvelope>();
+        while (rt.Envelopes.TryRead(out var e)) seen.Add(e);
+        await Assert.That(seen.Count(e => e.Kind == AcpEventKind.UserMessage && e.Text == "refused")).IsEqualTo(0);
+        await Assert.That(seen.Any(e => e.Kind == AcpEventKind.SystemNote && e.Text!.Contains("not delivered"))).IsTrue();
+    }
+
+    [Test]
+    public async Task Journal_matches_channel_order_under_worker_and_queue_full_notice_writers() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/w", null);
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1, time: Time, journal: journal);
+        await rt.SendUserInputAsync("first");
+        await rt.WaitForConversationIdAsync(CancellationToken.None);
+        await rt.SendUserInputAsync("queued");
+        var refusals = Task.Run(async () => { for (var i = 0; i < 50; i++) { try { await rt.SendUserInputAsync($"r{i}"); } catch { } } });
+        await refusals;
+        await Task.Delay(200);
+        var drained = new List<AcpEventEnvelope>();
+        while (rt.Envelopes.TryRead(out var e)) drained.Add(e);
+        await journal.CompleteAsync();
+
+        var journaled = File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
+        await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)));
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityUserTurnTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityUserTurnTests.cs
@@ -3,6 +3,7 @@ using Capacitor.Cli.Daemon.Harness.Antigravity;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
+using TUnit.Assertions.Enums;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
 
@@ -32,7 +33,7 @@ public class AntigravityUserTurnTests {
         // init never re-emits session_started, so it contributes only its own user_message.
         var envelopes = await Drain(rt, 3);
         var users = envelopes.Where(e => e.Kind == AcpEventKind.UserMessage).ToList();
-        await Assert.That(users.Select(u => u.Text!)).IsEquivalentTo(new[] { "first", "second" });
+        await Assert.That(users.Select(u => u.Text!)).IsEquivalentTo(new[] { "first", "second" }, CollectionOrdering.Matching);
         await Assert.That(users.All(u => u.TimestampIso == "2026-09-09T10:00:00.0000000+00:00")).IsTrue();
         await Assert.That(envelopes[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
         var secondIndex = envelopes.FindIndex(e => e.Kind == AcpEventKind.UserMessage && e.Text == "second");
@@ -75,6 +76,6 @@ public class AntigravityUserTurnTests {
         await journal.CompleteAsync();
 
         var journaled = File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
-        await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)));
+        await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)), CollectionOrdering.Matching);
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityUserTurnTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityUserTurnTests.cs
@@ -75,7 +75,7 @@ public class AntigravityUserTurnTests {
         while (rt.Envelopes.TryRead(out var e)) drained.Add(e);
         await journal.CompleteAsync();
 
-        var journaled = File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
+        var journaled = JournalFiles.ReadLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
         await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)), CollectionOrdering.Matching);
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexForwardBufferTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexForwardBufferTests.cs
@@ -1,5 +1,7 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Harness.Codex;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
 
@@ -13,8 +15,22 @@ public class CodexForwardBufferTests {
     static AcpEventEnvelope Ephemeral(string text) =>
         new(Kind: AcpEventKind.AssistantText, Text: text, Ephemeral: true, ItemId: "i1");
 
-    static CodexForwardBuffer New(int capacity, TimeSpan stall, Action<TimeSpan>? onStall = null) =>
-        new(capacity, stall, CancellationToken.None, onStall ?? (_ => { }));
+    static CodexForwardBuffer New(
+            int capacity, TimeSpan stall, Action<TimeSpan>? onStall = null,
+            TranscriptJournal? journal = null, CancellationToken shutdown = default) =>
+        new(capacity, stall, shutdown, onStall ?? (_ => { }), journal);
+
+    static (TranscriptJournal Journal, TempDir Tmp) OpenJournal() {
+        var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/w", null);
+        return (journal, tmp);
+    }
+
+    static async Task<List<string?>> JournaledTexts(TranscriptJournal journal) {
+        await journal.CompleteAsync();
+        return File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Text; }).ToList();
+    }
 
     [Test]
     public async Task Canonical_envelopes_are_delivered_in_order() {
@@ -92,5 +108,57 @@ public class CodexForwardBufferTests {
         buf.Emit(Canonical("after"));
         buf.Emit(Ephemeral("after"));
         await Assert.That(buf.DroppedEphemeralCount).IsEqualTo(0); // not even counted — buffer is dead
+    }
+
+    [Test]
+    public async Task Canonical_envelopes_are_journaled_and_ephemerals_dropped_from_a_full_buffer_are_not() {
+        var (journal, tmp) = OpenJournal(); using var _ = tmp;
+        using var buf = New(1, TimeSpan.FromSeconds(5), journal: journal);
+        buf.Emit(Canonical("a"));
+        buf.Emit(Ephemeral("live"));  // full: dropped
+        await Assert.That(buf.DroppedEphemeralCount).IsEqualTo(1);
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a" });
+    }
+
+    [Test]
+    public async Task Blocking_canonical_write_is_journaled_only_after_it_completes() {
+        var (journal, tmp) = OpenJournal(); using var _ = tmp;
+        using var buf = New(1, TimeSpan.FromSeconds(5), journal: journal);
+        buf.Emit(Canonical("a"));
+        var blocked = Task.Run(() => buf.Emit(Canonical("b")));
+        await Task.Delay(100);
+        await Assert.That(blocked.IsCompleted).IsFalse();
+        await Assert.That(File.ReadAllText(journal.Path)).DoesNotContain("\"b\"");
+        await buf.Reader.ReadAsync(); // frees the slot
+        await blocked.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a", "b" });
+    }
+
+    [Test]
+    public async Task Stalled_buffer_journals_nothing_further_and_the_watchdog_fires_once() {
+        var (journal, tmp) = OpenJournal(); using var _ = tmp;
+        var stalls = 0;
+        using var buf = New(1, TimeSpan.FromMilliseconds(100), onStall: _ => stalls++, journal: journal);
+        buf.Emit(Canonical("a"));
+        buf.Emit(Canonical("stalled")); // blocks 100 ms, then faults
+        buf.Emit(Canonical("after"));
+        await Assert.That(stalls).IsEqualTo(1);
+        await Assert.That(buf.Stalled).IsTrue();
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a" });
+    }
+
+    [Test]
+    public async Task Shutdown_cancelled_wait_and_emit_after_complete_are_not_journaled_and_do_not_throw() {
+        var (journal, tmp) = OpenJournal(); using var _ = tmp;
+        using var shutdown = new CancellationTokenSource();
+        using var buf = New(1, TimeSpan.FromSeconds(30), journal: journal, shutdown: shutdown.Token);
+        buf.Emit(Canonical("a"));
+        var blocked = Task.Run(() => buf.Emit(Canonical("cancelled")));
+        await Task.Delay(50);
+        shutdown.Cancel();
+        await blocked.WaitAsync(TimeSpan.FromSeconds(5)); // returned, no throw
+        buf.Complete();
+        buf.Emit(Canonical("after-complete")); // no throw
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a" });
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexForwardBufferTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexForwardBufferTests.cs
@@ -2,6 +2,7 @@ using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Harness.Codex;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using TUnit.Assertions.Enums;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
 
@@ -117,7 +118,7 @@ public class CodexForwardBufferTests {
         buf.Emit(Canonical("a"));
         buf.Emit(Ephemeral("live"));  // full: dropped
         await Assert.That(buf.DroppedEphemeralCount).IsEqualTo(1);
-        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a" });
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a" }, CollectionOrdering.Matching);
     }
 
     [Test]
@@ -131,7 +132,7 @@ public class CodexForwardBufferTests {
         await Assert.That(File.ReadAllText(journal.Path)).DoesNotContain("\"b\"");
         await buf.Reader.ReadAsync(); // frees the slot
         await blocked.WaitAsync(TimeSpan.FromSeconds(5));
-        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a", "b" });
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a", "b" }, CollectionOrdering.Matching);
     }
 
     [Test]
@@ -144,7 +145,7 @@ public class CodexForwardBufferTests {
         buf.Emit(Canonical("after"));
         await Assert.That(stalls).IsEqualTo(1);
         await Assert.That(buf.Stalled).IsTrue();
-        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a" });
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a" }, CollectionOrdering.Matching);
     }
 
     [Test]
@@ -159,6 +160,6 @@ public class CodexForwardBufferTests {
         await blocked.WaitAsync(TimeSpan.FromSeconds(5)); // returned, no throw
         buf.Complete();
         buf.Emit(Canonical("after-complete")); // no throw
-        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a" });
+        await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a" }, CollectionOrdering.Matching);
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexForwardBufferTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexForwardBufferTests.cs
@@ -30,7 +30,7 @@ public class CodexForwardBufferTests {
 
     static async Task<List<string?>> JournaledTexts(TranscriptJournal journal) {
         await journal.CompleteAsync();
-        return File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Text; }).ToList();
+        return JournalFiles.ReadLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Text; }).ToList();
     }
 
     [Test]
@@ -129,7 +129,7 @@ public class CodexForwardBufferTests {
         var blocked = Task.Run(() => buf.Emit(Canonical("b")));
         await Task.Delay(100);
         await Assert.That(blocked.IsCompleted).IsFalse();
-        await Assert.That(File.ReadAllText(journal.Path)).DoesNotContain("\"b\"");
+        await Assert.That(JournalFiles.ReadText(journal.Path)).DoesNotContain("\"b\"");
         await buf.Reader.ReadAsync(); // frees the slot
         await blocked.WaitAsync(TimeSpan.FromSeconds(5));
         await Assert.That(await JournaledTexts(journal)).IsEquivalentTo(new string?[] { "a", "b" }, CollectionOrdering.Matching);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
@@ -1,5 +1,6 @@
 using System.Threading.Channels;
 using Capacitor.Cli.Daemon.Harness.Codex;
+using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
@@ -222,6 +223,28 @@ public class CodexTurnInputDispatcherTests {
         d.FaultAll(new ObjectDisposedException("runtime"));
 
         await Assert.That(async () => await ack2.WaitAsync(Guard)).Throws<ObjectDisposedException>();
+    }
+
+    [Test]
+    public async Task Enqueue_after_fault_all_is_refused_never_left_pending() {
+        var sink = new FakeTurnSink();
+        var d = new CodexTurnInputDispatcher(sink.Start, sink.Steer, NullLogger.Instance, CancellationToken.None);
+        d.FaultAll(new ObjectDisposedException("runtime"));
+
+        await Assert.That(() => d.EnqueueAsync("late")).Throws<InputNotAdmittedException>();
+    }
+
+    [Test]
+    public async Task Enqueue_racing_fault_all_is_either_faulted_or_refused() {
+        for (var round = 0; round < 50; round++) {
+            var sink = new FakeTurnSink();
+            var d = new CodexTurnInputDispatcher(sink.Start, sink.Steer, NullLogger.Instance, CancellationToken.None, sealedAtStart: true);
+            var fault = Task.Run(() => d.FaultAll(new ObjectDisposedException("runtime")));
+            Task ack;
+            try { ack = d.EnqueueAsync("racing"); } catch (InputNotAdmittedException) { await fault; continue; }
+            await fault;
+            await Assert.That(async () => await ack.WaitAsync(TimeSpan.FromSeconds(2))).Throws<Exception>(); // faulted, not pending
+        }
     }
 
     // ── Deferred-first-turn seal ─────────────────────────────────────────────────────────────────

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
@@ -243,7 +243,11 @@ public class CodexTurnInputDispatcherTests {
             Task ack;
             try { ack = d.EnqueueAsync("racing"); } catch (InputNotAdmittedException) { await fault; continue; }
             await fault;
-            await Assert.That(async () => await ack.WaitAsync(TimeSpan.FromSeconds(2))).Throws<Exception>(); // faulted, not pending
+            // Settled, then faulted: awaiting a WaitAsync would accept its own TimeoutException and
+            // pass on exactly the stranded ack this exists to catch.
+            await Task.WhenAny(ack, Task.Delay(TimeSpan.FromSeconds(2)));
+            await Assert.That(ack.IsCompleted).IsTrue();
+            await Assert.That(ack.IsFaulted).IsTrue();
         }
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexTurnInputDispatcherTests.cs
@@ -248,6 +248,7 @@ public class CodexTurnInputDispatcherTests {
             await Task.WhenAny(ack, Task.Delay(TimeSpan.FromSeconds(2)));
             await Assert.That(ack.IsCompleted).IsTrue();
             await Assert.That(ack.IsFaulted).IsTrue();
+            _ = ack.Exception; // observed: 50 faulted tasks must not raise UnobservedTaskException on GC
         }
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
@@ -537,7 +537,9 @@ public class PiRpcHostedAgentRuntimeTests {
     [Test]
     public async Task Journal_matches_channel_order_under_concurrent_pump_and_send_time_writers() {
         using var tmp = new TempDir();
-        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        // The stock completion grace bounds the writer against a hung disk, which turns an assertion
+        // over 400 fsynced appends into a throughput race the suite's own load can lose.
+        var journal = new TranscriptJournal(tmp.PathTo("journal.jsonl"), NullLogger.Instance, completeGrace: TimeSpan.FromMinutes(1));
         journal.Open("/w", null);
         var (runtime, process) = NewRuntime(journal: journal);
         await using var _ = runtime;
@@ -551,7 +553,8 @@ public class PiRpcHostedAgentRuntimeTests {
         await Task.Delay(200);
         process.EndOfStream();
         await drain.WaitAsync(TimeSpan.FromSeconds(10));
-        await journal.CompleteAsync();
+        // Without this the comparison below reports a 400-item diff instead of the abandoned writer.
+        await Assert.That(await journal.CompleteAsync()).IsTrue();
 
         var journaled = File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
         await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)), CollectionOrdering.Matching);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
@@ -2,6 +2,7 @@ using System.Threading.Channels;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Harness.Pi;
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 using static Capacitor.Cli.Daemon.Tests.Unit.Harness.Pi.PiRpcRuntimeFakes;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Pi;
@@ -528,5 +529,63 @@ public class PiRpcHostedAgentRuntimeTests {
 
         await Assert.That(disposals).IsEqualTo(1);
         await Assert.That(proc.DisposeCalls).IsEqualTo(1);
+    }
+
+    // ---- Journal ----
+
+    [Test]
+    public async Task Journal_matches_channel_order_under_concurrent_pump_and_send_time_writers() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/w", null);
+        var (runtime, process) = NewRuntime(journal: journal);
+        await using var _ = runtime;
+        await runtime.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+
+        var drained = new List<AcpEventEnvelope>();
+        var drain = Task.Run(async () => { await foreach (var e in runtime.Envelopes.ReadAllAsync()) drained.Add(e); });
+        var pump  = Task.Run(() => { for (var i = 0; i < 200; i++) process.Push(AssistantText($"a{i}")); });
+        var sends = Task.Run(async () => { for (var i = 0; i < 200; i++) await runtime.SendUserInputAsync($"u{i}"); });
+        await Task.WhenAll(pump, sends);
+        await Task.Delay(200);
+        process.EndOfStream();
+        await drain.WaitAsync(TimeSpan.FromSeconds(10));
+        await journal.CompleteAsync();
+
+        var journaled = File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
+        await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)));
+    }
+
+    /// <summary>
+    /// <c>WaitForExitAsync</c> alone does not prove the transcript channel is completed — the fake's
+    /// own <c>WaitForExitAsync</c> is a no-op, and even against a real process, <c>EnterTerminal</c>
+    /// completing the channel races the caller's own continuation. Draining
+    /// <see cref="PiRpcHostedAgentRuntime.Envelopes"/> to its natural end is what actually proves it:
+    /// that enumeration cannot end until <c>_transcript.Writer.TryComplete()</c> has run.
+    /// </summary>
+    [Test]
+    public async Task Envelope_written_after_channel_completion_is_not_journaled() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/w", null);
+        var (runtime, process) = NewRuntime(journal: journal);
+        await runtime.WaitForSessionReadyAsync(CancellationToken.None).WaitAsync(HangGuard);
+        process.EndOfStream();
+
+        using var cts = new CancellationTokenSource(HangGuard);
+        try {
+            await foreach (var _ in runtime.Envelopes.ReadAllAsync(cts.Token)) { }
+        } catch (ChannelClosedException) {
+            // ends normally on completion; guarded defensively like the sibling terminal test.
+        }
+
+        try {
+            await runtime.SendUserInputAsync("late");
+        } catch (Exception ex) when (ex is InvalidOperationException or IOException) {
+            // the channel is already completed — the send itself may fault once the process is gone
+        }
+        await runtime.DisposeAsync();
+        await journal.CompleteAsync();
+        await Assert.That(File.ReadAllText(journal.Path)).DoesNotContain("\"late\"");
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
@@ -3,6 +3,7 @@ using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Harness.Pi;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
+using TUnit.Assertions.Enums;
 using static Capacitor.Cli.Daemon.Tests.Unit.Harness.Pi.PiRpcRuntimeFakes;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Pi;
@@ -553,7 +554,7 @@ public class PiRpcHostedAgentRuntimeTests {
         await journal.CompleteAsync();
 
         var journaled = File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
-        await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)));
+        await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)), CollectionOrdering.Matching);
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
@@ -556,7 +556,7 @@ public class PiRpcHostedAgentRuntimeTests {
         // Without this the comparison below reports a 400-item diff instead of the abandoned writer.
         await Assert.That(await journal.CompleteAsync()).IsTrue();
 
-        var journaled = File.ReadAllLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
+        var journaled = JournalFiles.ReadLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
         await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)), CollectionOrdering.Matching);
     }
 
@@ -590,6 +590,6 @@ public class PiRpcHostedAgentRuntimeTests {
         }
         await runtime.DisposeAsync();
         await journal.CompleteAsync();
-        await Assert.That(File.ReadAllText(journal.Path)).DoesNotContain("\"late\"");
+        await Assert.That(JournalFiles.ReadText(journal.Path)).DoesNotContain("\"late\"");
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcRuntimeFakes.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcRuntimeFakes.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Threading.Channels;
 using Capacitor.Cli.Daemon.Harness.Pi;
+using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Pi;
@@ -183,7 +184,8 @@ internal static class PiRpcRuntimeFakes {
             string?    requestedModel = RequestedModel,
             TimeSpan?  readyDeadline  = null,
             TimeSpan?  stopGrace      = null,
-            Action?    onDisposed     = null) {
+            Action?    onDisposed     = null,
+            TranscriptJournal? journal = null) {
         var process = new FakePiRpcProcess {
             AutoStateResponse = answerGetState ? stateResponse ?? GetStateResponse() : null,
         };
@@ -196,7 +198,8 @@ internal static class PiRpcRuntimeFakes {
             cwd:            "/w",
             readyDeadline:  readyDeadline,
             stopGrace:      stopGrace,
-            onDisposed:     onDisposed);
+            onDisposed:     onDisposed,
+            journal:        journal);
 
         return (runtime, process);
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/AlwaysThrowsPtyProcess.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Pty/AlwaysThrowsPtyProcess.cs
@@ -6,7 +6,7 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Pty;
 /// <summary>PTY double whose every write throws — simulates a dead/closed PTY
 /// (<see cref="IPtyProcess.WriteAsync(string)"/> is documented "unguarded and throws on a closed
 /// pipe" — see <c>PtyHostedAgentRuntime.WriteSubmitCarriageReturnAsync</c>'s remarks), so
-/// <c>AgentOrchestrator.HandleSendInput</c>'s delivery await never completes without an
+/// <c>AgentOrchestrator.DeliverInputAsync</c>'s delivery await never completes without an
 /// exception and the activity-clock advance it gates on must not run.</summary>
 internal sealed class AlwaysThrowsPtyProcess : IPtyProcess {
     public int  Pid       => 5151;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
@@ -913,4 +913,32 @@ public class AcpHostedAgentRuntimeTests {
 
         h.Fake.HoldPromptResponses.TrySetResult();
     }
+
+    /// <summary>A dispose racing the tail of the handshake can complete <c>_pendingTurns</c> before
+    /// <c>StartAsync</c>'s initial-prompt enqueue runs, so that enqueue must survive a refusal rather
+    /// than let <see cref="InputNotAdmittedException"/> propagate out of the launch. Forces the
+    /// channel closed BEFORE <c>StartAsync</c> runs (<see cref="AcpHostedAgentRuntime.CompletePendingTurnsForTest"/>)
+    /// so the handshake still completes in full and the refusal happens exactly at the enqueue call,
+    /// rather than racing a concurrent dispose to hit the same narrow window.</summary>
+    [Test]
+    public async Task StartAsync_survives_the_initial_prompt_enqueue_being_refused() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        h.Runtime.CompletePendingTurnsForTest();
+
+        await h.Runtime.StartAsync("/abs/worktree", "first", h.Cts.Token).WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (h.Fake.ReceivedCalls.Count < 2 && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        var calls = h.Fake.ReceivedCalls;
+        await Assert.That(calls.Count).IsGreaterThanOrEqualTo(2);
+        await Assert.That(calls[0].Method).IsEqualTo("initialize");
+        await Assert.That(calls[1].Method).IsEqualTo("session/new");
+
+        // The refused turn never reached the agent — no session/prompt was ever sent.
+        await Assert.That(calls.Any(c => c.Method == "session/prompt")).IsFalse();
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Capacitor.Cli.Daemon.Tests.Unit.Acp;
@@ -70,11 +71,12 @@ public class AcpHostedAgentRuntimeTests {
 
         Task _fakeRunTask = Task.CompletedTask;
 
-        public Harness() {
+        public Harness(TranscriptJournal? journal = null, int? transcriptCapacity = null) {
             Fake    = new FakeAcpAgent();
             Conn    = new AcpConnection(Fake.ClientWriteStream, Fake.ClientReadStream, NullLogger.Instance);
             Process = new FakeAcpProcess();
-            Runtime = new AcpHostedAgentRuntime(Conn, Process, NullLogger.Instance);
+            Runtime = new AcpHostedAgentRuntime(
+                Conn, Process, NullLogger.Instance, transcriptCapacity: transcriptCapacity, journal: journal);
         }
 
         public void StartFakeAgentLoop() => _fakeRunTask = Fake.RunAsync(Cts.Token);
@@ -833,5 +835,57 @@ public class AcpHostedAgentRuntimeTests {
         var result = AcpHostedAgentRuntime.SanitizeForForward("anything at all", maxLength: 0);
 
         await Assert.That(result).IsEqualTo("…");
+    }
+
+    static async Task<List<AcpEventEnvelope>> JournalEnvelopes(string path) {
+        var list = new List<AcpEventEnvelope>();
+        foreach (var line in await File.ReadAllLinesAsync(path)) if (EnvelopeJournalFormat.TryRead(line, out var e)) list.Add(e);
+        return list;
+    }
+
+    [Test]
+    public async Task Journal_receives_every_accepted_envelope_in_channel_order_including_the_initial_user_message() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/abs/worktree", null);
+        await using var h = new Harness(journal);
+        h.StartFakeAgentLoop();
+        await h.Runtime.StartAsync("/abs/worktree", "do the thing", h.Cts.Token).WaitAsync(HangGuard);
+        h.Fake.EmitAgentText("hello");
+        var fromChannel = new List<AcpEventEnvelope>();
+        while (fromChannel.Count < 2) fromChannel.Add(await h.Runtime.Envelopes.ReadAsync(h.Cts.Token).AsTask().WaitAsync(HangGuard));
+
+        await journal.CompleteAsync();
+        var fromJournal = (await JournalEnvelopes(journal.Path)).Skip(1).ToList(); // header first
+
+        await Assert.That(fromJournal.Select(e => (e.Kind, e.Text))).IsEquivalentTo(fromChannel.Select(e => (e.Kind, e.Text)));
+        await Assert.That(fromJournal[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
+    }
+
+    /// <summary>
+    /// Consecutive agent_message_chunk updates aggregate into one buffered run until a turn boundary
+    /// flushes it, so two chunks emitted close together can land in the SAME envelope rather than
+    /// two — asserting against the joined text of every journaled envelope (not a single envelope's
+    /// own <c>Text</c>) is what makes this test correct regardless of which way that aggregation falls.
+    /// </summary>
+    [Test]
+    public async Task Envelope_evicted_by_drop_oldest_is_still_in_the_journal_and_one_after_completion_is_not() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open("/abs/worktree", null);
+        await using var h = new Harness(journal, transcriptCapacity: 1);
+        h.StartFakeAgentLoop();
+        await h.Runtime.StartAsync("/abs/worktree", "p", h.Cts.Token).WaitAsync(HangGuard);
+        h.Fake.EmitAgentText("marker-a"); h.Fake.EmitAgentText("marker-b"); // capacity 1: earlier envelopes are evicted from the live channel
+        await Task.Delay(100);
+        await h.Runtime.DisposeAsync();  // flushes any open run, then completes the channel
+        h.Fake.EmitAgentText("marker-late");
+        await Task.Delay(100);
+        await journal.CompleteAsync();
+
+        var joined = string.Join("\n", (await JournalEnvelopes(journal.Path)).Select(e => e.Text));
+        await Assert.That(joined).Contains("marker-a");
+        await Assert.That(joined).Contains("marker-b");
+        await Assert.That(joined).DoesNotContain("marker-late");
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
@@ -71,12 +71,13 @@ public class AcpHostedAgentRuntimeTests {
 
         Task _fakeRunTask = Task.CompletedTask;
 
-        public Harness(TranscriptJournal? journal = null, int? transcriptCapacity = null) {
+        public Harness(TranscriptJournal? journal = null, int? transcriptCapacity = null, int? pendingTurnsCapacity = null) {
             Fake    = new FakeAcpAgent();
             Conn    = new AcpConnection(Fake.ClientWriteStream, Fake.ClientReadStream, NullLogger.Instance);
             Process = new FakeAcpProcess();
             Runtime = new AcpHostedAgentRuntime(
-                Conn, Process, NullLogger.Instance, transcriptCapacity: transcriptCapacity, journal: journal);
+                Conn, Process, NullLogger.Instance, transcriptCapacity: transcriptCapacity, journal: journal,
+                pendingTurnsCapacity: pendingTurnsCapacity);
         }
 
         public void StartFakeAgentLoop() => _fakeRunTask = Fake.RunAsync(Cts.Token);
@@ -887,5 +888,28 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(joined).Contains("marker-a");
         await Assert.That(joined).Contains("marker-b");
         await Assert.That(joined).DoesNotContain("marker-late");
+    }
+
+    [Test]
+    public async Task Full_pending_turns_queue_refuses_with_input_not_admitted_on_both_send_paths() {
+        await using var h = new Harness(pendingTurnsCapacity: 1);
+        h.StartFakeAgentLoop();
+        h.Fake.HoldPromptResponses = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        await h.Runtime.StartAsync("/abs/worktree", "first", h.Cts.Token).WaitAsync(HangGuard);
+
+        // The worker must have genuinely dequeued and dispatched "first" (its session/prompt sent
+        // and held open) before "queued" is sent below, or "queued" races the worker's own dequeue
+        // and the 1-deep queue never actually fills.
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (h.Fake.ReceivedCalls.All(c => c.Method != "session/prompt") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/prompt")).IsTrue();
+
+        await h.Runtime.SendUserInputAsync("queued");
+
+        await Assert.That(() => h.Runtime.SendUserInputAsync("refused")).Throws<InputNotAdmittedException>();
+        await Assert.That(async () => await h.Runtime.SendUserInputAndWaitForWriteAsync("refused-ack")).Throws<InputNotAdmittedException>();
+
+        h.Fake.HoldPromptResponses.TrySetResult();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
@@ -3,6 +3,7 @@ using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Capacitor.Cli.Daemon.Tests.Unit.Acp;
 using Microsoft.Extensions.Logging.Abstractions;
+using TUnit.Assertions.Enums;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
@@ -859,7 +860,7 @@ public class AcpHostedAgentRuntimeTests {
         await journal.CompleteAsync();
         var fromJournal = (await JournalEnvelopes(journal.Path)).Skip(1).ToList(); // header first
 
-        await Assert.That(fromJournal.Select(e => (e.Kind, e.Text))).IsEquivalentTo(fromChannel.Select(e => (e.Kind, e.Text)));
+        await Assert.That(fromJournal.Select(e => (e.Kind, e.Text))).IsEquivalentTo(fromChannel.Select(e => (e.Kind, e.Text)), CollectionOrdering.Matching);
         await Assert.That(fromJournal[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
@@ -839,9 +839,9 @@ public class AcpHostedAgentRuntimeTests {
         await Assert.That(result).IsEqualTo("…");
     }
 
-    static async Task<List<AcpEventEnvelope>> JournalEnvelopes(string path) {
+    static List<AcpEventEnvelope> JournalEnvelopes(string path) {
         var list = new List<AcpEventEnvelope>();
-        foreach (var line in await File.ReadAllLinesAsync(path)) if (EnvelopeJournalFormat.TryRead(line, out var e)) list.Add(e);
+        foreach (var line in JournalFiles.ReadLines(path)) if (EnvelopeJournalFormat.TryRead(line, out var e)) list.Add(e);
         return list;
     }
 
@@ -858,7 +858,7 @@ public class AcpHostedAgentRuntimeTests {
         while (fromChannel.Count < 2) fromChannel.Add(await h.Runtime.Envelopes.ReadAsync(h.Cts.Token).AsTask().WaitAsync(HangGuard));
 
         await journal.CompleteAsync();
-        var fromJournal = (await JournalEnvelopes(journal.Path)).Skip(1).ToList(); // header first
+        var fromJournal = JournalEnvelopes(journal.Path).Skip(1).ToList(); // header first
 
         await Assert.That(fromJournal.Select(e => (e.Kind, e.Text))).IsEquivalentTo(fromChannel.Select(e => (e.Kind, e.Text)), CollectionOrdering.Matching);
         await Assert.That(fromJournal[0].Kind).IsEqualTo(AcpEventKind.UserMessage);
@@ -885,7 +885,7 @@ public class AcpHostedAgentRuntimeTests {
         await Task.Delay(100);
         await journal.CompleteAsync();
 
-        var joined = string.Join("\n", (await JournalEnvelopes(journal.Path)).Select(e => e.Text));
+        var joined = string.Join("\n", JournalEnvelopes(journal.Path).Select(e => e.Text));
         await Assert.That(joined).Contains("marker-a");
         await Assert.That(joined).Contains("marker-b");
         await Assert.That(joined).DoesNotContain("marker-late");

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentFileNamesTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentFileNamesTests.cs
@@ -1,0 +1,31 @@
+using System.Security.Cryptography;
+using System.Text;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class AgentFileNamesTests {
+    [Test]
+    [Arguments("../x")]
+    [Arguments("a/b")]
+    [Arguments("a\\b")]
+    [Arguments("/etc/passwd")]
+    [Arguments("agent-1")]
+    public async Task Every_id_yields_a_fixed_length_lowercase_hex_name(string id) {
+        var name = AgentFileNames.For(id);
+        await Assert.That(name).Length().IsEqualTo(64);
+        await Assert.That(name).Matches("^[0-9a-f]{64}$");
+        await Assert.That(AgentFileNames.For(id)).IsEqualTo(name);
+    }
+
+    [Test]
+    public async Task Name_is_the_sha256_the_pid_record_store_always_used() {
+        var expected = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes("agent-1"))).ToLowerInvariant();
+        await Assert.That(AgentFileNames.For("agent-1")).IsEqualTo(expected);
+        using var tmp = new TempDir();
+        var store = new AgentPidRecordStore(tmp.Path, Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+        store.Write(new AgentPidRecord("agent-1", 1, "", PidIdentityKind.IdentityUnavailable, "agent", "pi", null, null, "d", "e", DateTimeOffset.UnixEpoch));
+        await Assert.That(File.Exists(Path.Combine(tmp.Path, "agents", expected + ".json"))).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorHarness.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorHarness.cs
@@ -1,6 +1,7 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Http;
+using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Pty;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Hosting;
@@ -215,6 +216,28 @@ internal static class AgentOrchestratorHarness {
             new CancellationTokenSource()) {
             Status = status,
             ActivityClock = activityClock ?? new AgentActivityClock(TimeProvider.System)
+        };
+
+        orch.RegisterAgentForTest(agent);
+
+        return agent;
+    }
+
+    /// <summary>A borrowed-checkout reviewer: it takes the acknowledging send path, and its
+    /// <see cref="WorkLocation.BorrowedCwd"/> work location is what keeps a delivery from trying to
+    /// refresh a snapshot that no daemon-owned worktree exists to receive.</summary>
+    internal static AgentInstance SeedBorrowedAcpAgent(
+            AgentOrchestrator orch, string agentId, IHostedAgentRuntime runtime, string status = "Running",
+            AgentActivityClock? activityClock = null) {
+        var agent = new AgentInstance(
+            agentId, "review this", "default", null, "/repo", "cursor",
+            runtime,
+            new WorktreeInfo("/repo", "b", "/repo"),
+            new CancellationTokenSource()) {
+            Status                 = status,
+            ActivityClock          = activityClock ?? new AgentActivityClock(TimeProvider.System),
+            Work                   = WorkLocation.BorrowedCwd,
+            BorrowedSnapshotSource = "/repo"
         };
 
         orch.RegisterAgentForTest(agent);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorHarness.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorHarness.cs
@@ -208,20 +208,26 @@ internal static class AgentOrchestratorHarness {
     /// clock passes one; omitting it keeps every existing caller's real-time default.</summary>
     internal static AgentInstance SeedAcpAgent(
             AgentOrchestrator orch, string agentId, IHostedAgentRuntime runtime, string status = "Running",
-            AgentActivityClock? activityClock = null) {
+            AgentActivityClock? activityClock = null, LaunchKind kind = LaunchKind.Default, bool isPrivate = false) {
         var agent = new AgentInstance(
             agentId, "review this", "default", null, "/repo", "cursor",
             runtime,
             new WorktreeInfo("/repo", "b", "/repo"),
             new CancellationTokenSource()) {
             Status = status,
-            ActivityClock = activityClock ?? new AgentActivityClock(TimeProvider.System)
+            ActivityClock = activityClock ?? new AgentActivityClock(TimeProvider.System),
+            Kind = kind,
+            IsPrivate = isPrivate
         };
 
         orch.RegisterAgentForTest(agent);
 
         return agent;
     }
+
+    /// <summary>Latches the reap claim the way the reaper's own claim does, so a delivery can be made
+    /// to meet a condemned agent without standing up a sweep to condemn it.</summary>
+    internal static void ClaimReap(AgentInstance agent) => Interlocked.CompareExchange(ref agent.ReapClaimed, 1, 0);
 
     /// <summary>A borrowed-checkout reviewer: it takes the acknowledging send path, and its
     /// <see cref="WorkLocation.BorrowedCwd"/> work location is what keeps a delivery from trying to

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Harness.Codex;
 using Capacitor.Cli.Daemon.Services;
 using Capacitor.Cli.Daemon.Tests.Unit.Pty;
 
@@ -92,6 +93,35 @@ public class AgentOrchestratorJournalTests {
             LastJournal = ctx.Journal;
             ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
             throw new InvalidOperationException("boom");
+        }
+    }
+
+    [Test]
+    public async Task Codex_preflight_failure_after_open_discards_the_journal() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var factory = new FailingWithCodexPreflightFactory();
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-codex-preflight", repoPath));
+
+        var journal = factory.LastJournal!;
+        await Assert.That(File.Exists(journal.Path)).IsFalse();
+        await Assert.That(journal.Drained).IsTrue();
+    }
+
+    /// The inner Codex-preflight catch has its own return, before the outer catch's journal
+    /// cleanup — this pins that arm discards the journal too. Vendor "cursor" is fine here: the
+    /// catch filters on exception type, not vendor.
+    sealed class FailingWithCodexPreflightFactory : IHostedAgentRuntimeFactory {
+        public string CliPath => "x"; public string Vendor => "cursor"; public bool SupportsUnattended => false;
+        public TranscriptJournal? LastJournal { get; private set; }
+        public bool IsAvailable() => true;
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+            LastJournal = ctx.Journal;
+            ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
+            throw new CodexHooksNotInstalledException("Run plugin install --codex");
         }
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
@@ -46,6 +46,60 @@ public class AgentOrchestratorJournalTests {
         await Assert.That(orch.CodexProbesArmedForTest).IsEqualTo(0);
     }
 
+    [Test]
+    public async Task Cleanup_completes_the_journal_after_disposing_the_runtime() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var factory = new OpeningAcpFactory();
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+        orch.GracefulExitWait = TimeSpan.FromMilliseconds(50);
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-cleanup", repoPath));
+        var journal = factory.LastContext!.Journal!;
+        journal.Record(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "bye"));
+
+        await orch.HandleLocalStopV2Async(force: true, "agent-cleanup", Stream.Null, CancellationToken.None);
+        await WaitUntil(() => journal.Drained);
+
+        await Assert.That(File.Exists(journal.Path)).IsTrue(); // agent exit never deletes a journal
+        await Assert.That(File.ReadAllText(journal.Path)).Contains("\"bye\"");
+    }
+
+    [Test]
+    public async Task Factory_failure_after_open_deletes_only_a_journal_this_launch_created() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var factory = new FailingAfterOpenFactory();
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-fail-fresh", repoPath));
+        await Assert.That(File.Exists(factory.LastJournal!.Path)).IsFalse();
+
+        // A pre-existing file (a rebind whose factory fails) keeps the prior incarnation's bytes.
+        var existing = TranscriptJournal.ForAgent(orch.PidRecordRootForTest, "agent-fail-rebind", Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+        existing.Open("/w", null); await existing.CompleteAsync();
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-fail-rebind", repoPath));
+        await Assert.That(File.Exists(existing.Path)).IsTrue();
+        await Assert.That(File.ReadLines(existing.Path).Count()).IsEqualTo(2); // its header plus the failed launch's header
+    }
+
+    sealed class FailingAfterOpenFactory : IHostedAgentRuntimeFactory {
+        public string CliPath => "x"; public string Vendor => "cursor"; public bool SupportsUnattended => false;
+        public TranscriptJournal? LastJournal { get; private set; }
+        public bool IsAvailable() => true;
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+            LastJournal = ctx.Journal;
+            ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
+            throw new InvalidOperationException("boom");
+        }
+    }
+
+    static async Task WaitUntil(Func<bool> condition) {
+        for (var i = 0; i < 500 && !condition(); i++) await Task.Delay(10);
+        await Assert.That(condition()).IsTrue();
+    }
+
     /// The real factories call Open before constructing the runtime; this double does the same.
     sealed class OpeningAcpFactory(string vendor = "cursor") : IHostedAgentRuntimeFactory {
         readonly SpyAcpHostedAgentRuntimeFactory _inner = new(vendor);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
@@ -1,0 +1,63 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class AgentOrchestratorJournalTests {
+    [Test]
+    public async Task Launch_hands_the_factory_an_unopened_journal_and_publishes_the_opened_path_before_registration() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var factory = new OpeningAcpFactory();
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-journal", repoPath));
+
+        var ctx = factory.LastContext!;
+        await Assert.That(ctx.Journal).IsNotNull();
+        await Assert.That(ctx.Journal!.Path).IsEqualTo(Path.Combine(orch.PidRecordRootForTest, "transcripts", AgentFileNames.For("agent-journal") + ".jsonl"));
+        var row = orch.SnapshotAgentsForStatus().Single();
+        await Assert.That(row.TranscriptPath).IsEqualTo(ctx.Journal.Path);
+        await Assert.That(row.TranscriptFormat).IsEqualTo(TranscriptFormats.Envelopes);
+        await Assert.That(row.SessionId).IsEqualTo("acp-sess-1");
+        await Assert.That(File.Exists(ctx.Journal.Path)).IsTrue();
+        // The first status the server saw for this agent already carried the canonical id.
+        await Assert.That(server.StatusChangedWithSession.First(c => c.AgentId == "agent-journal").SessionId).IsEqualTo("acp-sess-1");
+        // Discovery never started for an envelope-sourced agent.
+        await Assert.That(orch.DiscoveryStartsForTest).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Envelope_sourced_codex_keeps_the_journal_path_and_arms_no_probe() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var factory = new OpeningAcpFactory("codex");
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            allowedRepoPath: repoPath, extraRuntimeFactories: [factory]);
+
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-codex-env", repoPath) with { Vendor = "codex" });
+        await orch.HandleSendInputForTest(new SendInputCommand("agent-codex-env", "hello", null));
+
+        await Assert.That(orch.SnapshotAgentsForStatus().Single().TranscriptPath).IsEqualTo(factory.LastContext!.Journal!.Path);
+        await Assert.That(orch.DiscoveryStartsForTest).IsEqualTo(0);
+        await Assert.That(orch.CodexProbesArmedForTest).IsEqualTo(0);
+    }
+
+    /// The real factories call Open before constructing the runtime; this double does the same.
+    sealed class OpeningAcpFactory(string vendor = "cursor") : IHostedAgentRuntimeFactory {
+        readonly SpyAcpHostedAgentRuntimeFactory _inner = new(vendor);
+        public string CliPath => _inner.CliPath;
+        public string Vendor => _inner.Vendor;
+        public bool SupportsUnattended => false;
+        public RuntimeStartContext? LastContext => _inner.LastContext;
+        public FakeAcpRuntime? LastRuntime => _inner.LastRuntime;
+        public bool IsAvailable() => true;
+        public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
+            ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
+            return _inner.StartAsync(ctx, ct);
+        }
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
@@ -63,7 +63,7 @@ public class AgentOrchestratorJournalTests {
         await WaitUntil(() => journal.Drained);
 
         await Assert.That(File.Exists(journal.Path)).IsTrue(); // agent exit never deletes a journal
-        await Assert.That(File.ReadAllText(journal.Path)).Contains("\"bye\"");
+        await Assert.That(JournalFiles.ReadText(journal.Path)).Contains("\"bye\"");
     }
 
     [Test]
@@ -82,7 +82,7 @@ public class AgentOrchestratorJournalTests {
         existing.Open("/w", null); await existing.CompleteAsync();
         await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-fail-rebind", repoPath));
         await Assert.That(File.Exists(existing.Path)).IsTrue();
-        await Assert.That(File.ReadLines(existing.Path).Count()).IsEqualTo(2); // its header plus the failed launch's header
+        await Assert.That(JournalFiles.ReadLines(existing.Path).Length).IsEqualTo(2); // its header plus the failed launch's header
     }
 
     sealed class FailingAfterOpenFactory : IHostedAgentRuntimeFactory {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentStatusSnapshotTests.cs
@@ -440,4 +440,49 @@ public class AgentStatusSnapshotTests {
             await Assert.That(json).Contains("\"branch\":\"feature/sidebar\"");
         } finally { await fx.CleanupAsync(); }
     }
+
+    [Test]
+    public async Task Envelope_sourced_agent_reports_envelopes_format_canonical_session_id_and_journal_path() {
+        var f = Build();
+        try {
+            var journal = TranscriptJournal.ForAgent(f.Daemons.Store.StateDirectory("status-snapshot-test"), "acp-1", NullLogger.Instance);
+            journal.Open("/w", "m");
+            var runtime = new FakeAcpRuntime { AcpSessionId = "8BC7255F-2453-4EFD-A733-0AF4B6AE9F20" };
+            f.Orchestrator.RegisterAgentForTest(new AgentInstance("acp-1", "p", "m", null, "/repo", "cursor", runtime, new WorktreeInfo("/repo", "b", "/w"), new CancellationTokenSource()) {
+                SessionId = SessionIds.Canonical(runtime.AcpSessionId), TranscriptPath = journal.Path, Journal = journal });
+
+            var row = f.Orchestrator.SnapshotAgentsForStatus().Single();
+
+            await Assert.That(row.TranscriptFormat).IsEqualTo(TranscriptFormats.Envelopes);
+            await Assert.That(row.SessionId).IsEqualTo("8bc7255f24534efda7330af4b6ae9f20");
+            await Assert.That(row.TranscriptPath).IsEqualTo(journal.Path);
+            await journal.CompleteAsync();
+        } finally { await f.CleanupAsync(); }
+    }
+
+    [Test]
+    public async Task Pty_agent_reports_vendor_format_and_null_path_until_discovery() {
+        var f = Build();
+        try {
+            f.Orchestrator.RegisterAgentForTest(new AgentInstance("pty-1", "p", "m", null, "/repo", "claude",
+                new PtyHostedAgentRuntime("claude", NoopPtyProcess.Instance), new WorktreeInfo("/repo", "b", "/w"), new CancellationTokenSource()));
+
+            var row = f.Orchestrator.SnapshotAgentsForStatus().Single();
+
+            await Assert.That(row.TranscriptFormat).IsEqualTo(TranscriptFormats.Vendor);
+            await Assert.That(row.TranscriptPath).IsNull();
+            await Assert.That(row.SessionId).IsNull();
+        } finally { await f.CleanupAsync(); }
+    }
+
+    [Test]
+    public async Task Opaque_acp_session_id_is_reported_unchanged() {
+        var f = Build();
+        try {
+            var runtime = new FakeAcpRuntime { AcpSessionId = "sess-1" };
+            f.Orchestrator.RegisterAgentForTest(new AgentInstance("acp-2", "p", "m", null, "/repo", "cursor", runtime, new WorktreeInfo("/repo", "b", "/w"), new CancellationTokenSource()) {
+                SessionId = SessionIds.Canonical(runtime.AcpSessionId) });
+            await Assert.That(f.Orchestrator.SnapshotAgentsForStatus().Single().SessionId).IsEqualTo("sess-1");
+        } finally { await f.CleanupAsync(); }
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/CaptureServerConnection.cs
@@ -280,6 +280,10 @@ sealed class CaptureServerConnection() : ServerConnection(
     /// drove (e.g. Fix B/E's immediate Running flip for a no-terminal runtime).</summary>
     public List<(string AgentId, string Status)> StatusChangedCalls { get; } = [];
 
+    /// <summary>The same calls with the session id the daemon reported alongside each status — the
+    /// only place a test can see whether the FIRST status a server saw already named the session.</summary>
+    public List<(string AgentId, string Status, string? SessionId)> StatusChangedWithSession { get; } = [];
+
     public override Task AgentStatusChangedAsync(string agentId, string status, string? sessionId) {
         // Capture BEFORE recording: was a launch-window verdict already published when this
         // non-failure status was sent? (finding 1 — the invariant a check-to-send race breaks.)
@@ -288,6 +292,7 @@ sealed class CaptureServerConnection() : ServerConnection(
             NonFailureStatusSentAfterVerdictPublished = true;
 
         lock (StatusChangedCalls) StatusChangedCalls.Add((agentId, status));
+        lock (StatusChangedWithSession) StatusChangedWithSession.Add((agentId, status, sessionId));
 
         return Task.CompletedTask;
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/DeliveryTriggeredStatusReportTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/DeliveryTriggeredStatusReportTests.cs
@@ -71,11 +71,10 @@ public class DeliveryTriggeredStatusReportTests {
 
         time.Advance(TimeSpan.FromSeconds(10));
 
-        await Assert.ThrowsAsync<IOException>(
-            async () => await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null)));
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null));
 
-        // The emission is fire-and-forget, so a wrongly-placed one would land shortly AFTER the throw
-        // propagates — wait before asserting absence rather than reading the count immediately.
+        // The emission is fire-and-forget, so a wrongly-placed one would land shortly AFTER the
+        // handler returns — wait before asserting absence rather than reading the count immediately.
         await Task.Delay(100);
         await Assert.That(server.StatusReportCount).IsEqualTo(0);
         await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(1UL);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FakeAcpRuntime.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FakeAcpRuntime.cs
@@ -74,6 +74,10 @@ internal sealed class FakeAcpRuntime : IHostedAgentRuntime, IAcpTranscriptSource
     public List<string> Inputs             { get; } = [];
     public List<string> WaitForWriteInputs { get; } = [];
 
+    /// <summary>Every input either path took, in the order the runtime accepted them — for a caller
+    /// that cares about how many messages landed and in what order rather than which path carried them.</summary>
+    public List<string> SentInputs { get; } = [];
+
     /// <summary>Thrown by both send paths instead of recording the input — a runtime whose transport
     /// has failed under it.</summary>
     public Exception? SendUserInputThrow { get; init; }
@@ -85,11 +89,13 @@ internal sealed class FakeAcpRuntime : IHostedAgentRuntime, IAcpTranscriptSource
     public async Task SendUserInputAsync(string text) {
         await AdmitAsync();
         lock (Inputs) Inputs.Add(text);
+        lock (SentInputs) SentInputs.Add(text);
     }
 
     public async Task SendUserInputAndWaitForWriteAsync(string text) {
         await AdmitAsync();
         lock (WaitForWriteInputs) WaitForWriteInputs.Add(text);
+        lock (SentInputs) SentInputs.Add(text);
     }
 
     async Task AdmitAsync() {
@@ -103,8 +109,12 @@ internal sealed class FakeAcpRuntime : IHostedAgentRuntime, IAcpTranscriptSource
     public Task RequestGracefulStopAsync() => Task.CompletedTask;
     public Task WaitForExitAsync(TimeSpan?    timeout = null) => Task.CompletedTask;
 
+    /// <summary>A runtime a terminate cannot finish off: <see cref="HasExited"/> stays false, so a stop
+    /// that runs to completion still cannot confirm the process is gone.</summary>
+    public bool NeverExits { get; init; }
+
     public Task TerminateAsync(TimeSpan? timeout = null) {
-        ExitGate.TrySetResult();
+        if (!NeverExits) ExitGate.TrySetResult();
 
         return Task.CompletedTask;
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FakeAcpRuntime.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FakeAcpRuntime.cs
@@ -68,7 +68,35 @@ internal sealed class FakeAcpRuntime : IHostedAgentRuntime, IAcpTranscriptSource
         return BeginFirstTurnThrow is { } ex ? Task.FromException(ex) : Task.CompletedTask;
     }
 
-    public Task SendUserInputAsync(string  text) => Task.CompletedTask;
+    /// <summary>What each send path was handed, kept apart so a test can tell which path a delivery
+    /// chose — the acknowledging one is the borrowed round's, and the interface's default
+    /// implementation would forward it to the plain one and hide the difference.</summary>
+    public List<string> Inputs             { get; } = [];
+    public List<string> WaitForWriteInputs { get; } = [];
+
+    /// <summary>Thrown by both send paths instead of recording the input — a runtime whose transport
+    /// has failed under it.</summary>
+    public Exception? SendUserInputThrow { get; init; }
+
+    /// <summary>Awaited by both send paths before the input is recorded, so a test can hold a
+    /// delivery in flight for as long as it likes.</summary>
+    public TaskCompletionSource? SendUserInputGate { get; init; }
+
+    public async Task SendUserInputAsync(string text) {
+        await AdmitAsync();
+        lock (Inputs) Inputs.Add(text);
+    }
+
+    public async Task SendUserInputAndWaitForWriteAsync(string text) {
+        await AdmitAsync();
+        lock (WaitForWriteInputs) WaitForWriteInputs.Add(text);
+    }
+
+    async Task AdmitAsync() {
+        if (SendUserInputThrow is { } ex) throw ex;
+        if (SendUserInputGate is { } gate) await gate.Task;
+    }
+
     public Task SendSpecialKeyAsync(string key) => Task.CompletedTask;
     public Task SendRawInputAsync(byte[]   data) => Task.CompletedTask;
     public void Resize(ushort              cols, ushort rows) { }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FakeAcpRuntime.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/FakeAcpRuntime.cs
@@ -17,7 +17,7 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 internal sealed class FakeAcpRuntime : IHostedAgentRuntime, IAcpTranscriptSource {
     readonly Channel<AcpEventEnvelope> _envelopes = Channel.CreateUnbounded<AcpEventEnvelope>();
 
-    public string Vendor              => "cursor";
+    public string Vendor              { get; init; } = "cursor";
     public int    Pid                 => 0;
     public bool   HasExited           => ExitGate.Task.IsCompleted;
     public int?   ExitCode            => 0;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/InputAdmissionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/InputAdmissionTests.cs
@@ -1,0 +1,32 @@
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>Cross-runtime: a runtime that will not queue or write input fails with
+/// <see cref="InputNotAdmittedException"/> on both send entry points, not just the acknowledging one
+/// — the per-runtime suites (<c>AntigravityRuntimeLifecycleTests</c>,
+/// <c>AcpHostedAgentRuntimeTests</c>) cover the rest of each runtime's own behavior.</summary>
+public class InputAdmissionTests {
+    [Test]
+    public async Task Antigravity_full_queue_refuses_with_input_not_admitted_on_both_send_paths() {
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1);
+        await rt.SendUserInputAsync("first");
+
+        // Turn 1 must be genuinely executing (its init read, freeing the capacity-1 slot) before
+        // "queued" is sent, or "queued" races the worker's own dequeue and is rejected instead.
+        await rt.WaitForConversationIdAsync(CancellationToken.None);
+        await rt.SendUserInputAsync("queued");
+
+        await Assert.That(() => rt.SendUserInputAsync("refused")).Throws<InputNotAdmittedException>();
+        await Assert.That(async () => await rt.SendUserInputAndWaitForWriteAsync("refused-ack")).Throws<InputNotAdmittedException>();
+    }
+
+    [Test]
+    public async Task Antigravity_terminal_runtime_refuses_the_acknowledging_path_with_input_not_admitted() {
+        await using var rt = AntigravityRuntimeFakes.FakeRuntime();
+        await rt.SendUserInputAsync("first");
+        await rt.TerminateAsync(TimeSpan.FromSeconds(1));
+        await Assert.That(async () => await rt.SendUserInputAndWaitForWriteAsync("late")).Throws<InputNotAdmittedException>();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/InputDeliveryCoreTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/InputDeliveryCoreTests.cs
@@ -1,0 +1,156 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// The delivery core both input callers share. It answers with a typed outcome and does two things
+/// less than the handler around it: it never reports a drop to the server and never stops an agent,
+/// so a caller with its own sender to answer can reuse the same write path without inheriting the
+/// server-origin handler's replies.
+/// </summary>
+public class InputDeliveryCoreTests {
+    static AgentOrchestrator Build(CaptureServerConnection server) =>
+        AgentOrchestratorHarness.BuildOrchestrator(
+            server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+    /// <summary>A real Antigravity runtime whose pending-turns queue is genuinely full: capacity 1,
+    /// a turn that never ends, one message executing and one queued behind it. The conversation-id
+    /// barrier is load-bearing — without it the second send races the worker's own dequeue and the
+    /// refusal this class is about lands on the wrong message.</summary>
+    static async Task<AntigravityHostedAgentRuntime> FullQueueRuntime() {
+        var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1);
+        await rt.SendUserInputAsync("first");
+        await rt.WaitForConversationIdAsync(CancellationToken.None);
+        await rt.SendUserInputAsync("queued");
+
+        return rt;
+    }
+
+    static async Task WaitForExit(FakeAcpRuntime runtime) {
+        for (var i = 0; i < 300; i++) {
+            if (runtime.HasExited) return;
+
+            await Task.Delay(10);
+        }
+
+        throw new TimeoutException("Timed out waiting for the quit command to stop the agent.");
+    }
+
+    [Test]
+    public async Task A_refused_turn_maps_to_queue_full_and_the_server_caller_reports_it() {
+        var server = new CaptureServerConnection();
+        await using var rt   = await FullQueueRuntime();
+        await using var orch = Build(server);
+
+        var clock = new AgentActivityClock(new FakeTimeProvider());
+        var agent = AgentOrchestratorHarness.SeedAcpAgent(orch, "agy-full", rt, activityClock: clock);
+        clock.SetAwaitingInput(true);
+        var before = clock.ActivitySeq;
+
+        var outcome = await orch.DeliverInputAsync(agent, "refused", null);
+
+        await Assert.That(outcome.Kind).IsEqualTo(InputDeliveryKind.Dropped);
+        await Assert.That(outcome.Reason).IsEqualTo(AgentOrchestrator.SendInputDropReason.QueueFull);
+        // Nothing was handed over, so the agent is no less idle and still needs the person who typed.
+        await Assert.That(clock.ActivitySeq).IsEqualTo(before);
+        await Assert.That(clock.AwaitingInput).IsTrue();
+
+        var dispatch = Guid.NewGuid();
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "refused-again", null, dispatch));
+
+        await Assert.That(server.InputRejections)
+            .Contains((dispatch, agent.Id, AgentOrchestrator.SendInputDropReason.QueueFull));
+    }
+
+    /// <summary>A borrowed round waits for the write to actually land rather than for the queue to
+    /// accept it — the snapshot under the runtime is refreshed per round, so "queued" is not enough
+    /// to know the round is reading the generation this delivery published.</summary>
+    [Test]
+    public async Task A_borrowed_round_delivers_through_the_wait_for_write_path() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        var rt    = new FakeAcpRuntime();
+        var agent = AgentOrchestratorHarness.SeedBorrowedAcpAgent(orch, "acp-borrowed", rt);
+
+        var outcome = await orch.DeliverInputAsync(agent, "hi", null);
+
+        await Assert.That(outcome.Kind).IsEqualTo(InputDeliveryKind.Delivered);
+        await Assert.That(rt.WaitForWriteInputs).Contains("hi");
+        await Assert.That(rt.Inputs).IsEmpty();
+    }
+
+    [Test]
+    public async Task A_borrowed_round_on_a_full_queue_still_maps_to_queue_full() {
+        var server = new CaptureServerConnection();
+        await using var rt   = await FullQueueRuntime();
+        await using var orch = Build(server);
+        var agent = AgentOrchestratorHarness.SeedBorrowedAcpAgent(orch, "agy-borrowed", rt);
+
+        var outcome = await orch.DeliverInputAsync(agent, "refused", null);
+
+        await Assert.That(outcome.Reason).IsEqualTo(AgentOrchestrator.SendInputDropReason.QueueFull);
+    }
+
+    [Test]
+    public async Task Quit_on_a_non_pty_runtime_is_reported_not_delivered_and_the_server_caller_stops_the_agent() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        orch.GracefulExitWait = TimeSpan.FromMilliseconds(50);
+        var rt    = new FakeAcpRuntime();
+        var agent = AgentOrchestratorHarness.SeedAcpAgent(orch, "acp-quit", rt);
+
+        var outcome = await orch.DeliverInputAsync(agent, "/quit", null);
+
+        await Assert.That(outcome.Kind).IsEqualTo(InputDeliveryKind.QuitRequested);
+        await Assert.That(rt.HasExited).IsFalse();
+        await Assert.That(rt.Inputs).IsEmpty();
+
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "/exit", null));
+
+        await WaitForExit(rt);
+    }
+
+    [Test]
+    public async Task A_runtime_fault_maps_to_delivery_failed_with_the_runtimes_own_message() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        var rt    = new FakeAcpRuntime { SendUserInputThrow = new IOException("pipe closed") };
+        var clock = new AgentActivityClock(new FakeTimeProvider());
+        var agent = AgentOrchestratorHarness.SeedAcpAgent(orch, "acp-fault", rt, activityClock: clock);
+
+        var outcome = await orch.DeliverInputAsync(agent, "hi", null);
+
+        await Assert.That(outcome.Kind).IsEqualTo(InputDeliveryKind.Dropped);
+        await Assert.That(outcome.Reason).IsEqualTo(AgentOrchestrator.SendInputDropReason.DeliveryFailed);
+        await Assert.That(outcome.Error).IsEqualTo("pipe closed");
+        await Assert.That(clock.ActivitySeq).IsEqualTo(1UL);
+    }
+
+    /// <summary>The outcome describes a write that has finished, not one that has been started: a
+    /// caller rendering "sent" off an early return would be reporting a message the runtime has not
+    /// taken yet.</summary>
+    [Test]
+    public async Task Delivery_completes_only_when_the_runtimes_own_write_settles() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        var rt = new FakeAcpRuntime {
+            SendUserInputGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
+        };
+        var agent = AgentOrchestratorHarness.SeedAcpAgent(orch, "acp-slow", rt);
+
+        var pending = orch.DeliverInputAsync(agent, "hi", null);
+        await Task.Delay(100);
+
+        await Assert.That(pending.IsCompleted).IsFalse();
+
+        rt.SendUserInputGate!.SetResult();
+
+        await Assert.That((await pending).Kind).IsEqualTo(InputDeliveryKind.Delivered);
+        await Assert.That(rt.Inputs).Contains("hi");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/JournalPathLocksTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/JournalPathLocksTests.cs
@@ -1,0 +1,56 @@
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class JournalPathLocksTests {
+    [Test]
+    public async Task Acquire_release_churn_leaves_the_map_empty() {
+        var locks = new JournalPathLocks();
+        for (var i = 0; i < 200; i++) {
+            using var lease = await locks.AcquireAsync($"/j/{i}.jsonl", TimeSpan.FromSeconds(1), CancellationToken.None);
+            await Assert.That(lease).IsNotNull();
+        }
+        await Assert.That(locks.LiveEntries).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task A_waiter_keeps_the_entry_alive_until_it_too_releases() {
+        var locks = new JournalPathLocks();
+        var owner = await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromSeconds(1), CancellationToken.None);
+        var waiter = locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromSeconds(5), CancellationToken.None);
+        await Task.Delay(50);
+        await Assert.That(locks.LiveEntries).IsEqualTo(1);
+        owner!.Dispose();
+        await Assert.That(locks.LiveEntries).IsEqualTo(1);
+        (await waiter)!.Dispose();
+        await Assert.That(locks.LiveEntries).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Timed_out_and_cancelled_waits_release_nothing_and_leave_no_entry() {
+        var locks = new JournalPathLocks();
+        var owner = await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        var timedOut = await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromMilliseconds(20), CancellationToken.None);
+        await Assert.That(timedOut).IsNull();
+
+        using var cts = new CancellationTokenSource(20);
+        await Assert.That(async () => await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromSeconds(5), cts.Token)).Throws<OperationCanceledException>();
+
+        // Still held: a third waiter must not get in.
+        await Assert.That(await locks.AcquireAsync("/j/a.jsonl", TimeSpan.FromMilliseconds(20), CancellationToken.None)).IsNull();
+        owner!.Dispose();
+        await Assert.That(locks.LiveEntries).IsEqualTo(0);
+    }
+
+    [Test]
+    public async Task Two_spellings_of_one_path_share_one_entry() {
+        var locks = new JournalPathLocks();
+        using var tmp = new TempDir();
+        var a = tmp.PathTo("j.jsonl");
+        var b = Path.Combine(tmp.Path, ".", "j.jsonl");
+        using var owner = await locks.AcquireAsync(a, TimeSpan.FromSeconds(1), CancellationToken.None);
+        await Assert.That(await locks.AcquireAsync(b, TimeSpan.FromMilliseconds(20), CancellationToken.None)).IsNull();
+        await Assert.That(locks.LiveEntries).IsEqualTo(1);
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalControlCapabilitiesTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalControlCapabilitiesTests.cs
@@ -1,0 +1,18 @@
+using Capacitor.Cli.Daemon.Services;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// The advertised capability list, pinned whole. Nothing may appear here that
+/// <see cref="LocalControlServer"/> does not route to a live handler, so a new entry landing without
+/// its routing case fails here rather than reaching a client that then asks for behavior the daemon
+/// has not got.
+/// </summary>
+public class LocalControlCapabilitiesTests {
+    [Test]
+    public async Task The_advertised_list_is_exactly_the_routed_capabilities() =>
+        await Assert.That(LocalControlCapabilities.Current)
+            .IsEquivalentTo(new[] { "consent/1", "consent/2", "consent/3", "status/1", "permission/1", "input/1" },
+                CollectionOrdering.Matching);
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalControlHelloTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalControlHelloTests.cs
@@ -135,7 +135,7 @@ public class LocalControlHelloTests {
             await Assert.That(dto!.ProtocolVersion).IsEqualTo(1);
             await Assert.That(dto.DaemonVersion).IsNotEmpty();
             await Assert.That(dto.DaemonName).IsEqualTo(h.Config.Name);
-            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "consent/2", "consent/3", "status/1", "permission/1" });
+            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "consent/2", "consent/3", "status/1", "permission/1", "input/1" });
         });
     }
 
@@ -151,7 +151,7 @@ public class LocalControlHelloTests {
             await Assert.That(dto!.ProtocolVersion).IsEqualTo(1);
             await Assert.That(dto.DaemonVersion).IsNotEmpty();
             await Assert.That(dto.DaemonName).IsEqualTo(h.Config.Name);
-            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "consent/2", "consent/3", "status/1", "permission/1" });
+            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "consent/2", "consent/3", "status/1", "permission/1", "input/1" });
         });
     }
 
@@ -170,7 +170,7 @@ public class LocalControlHelloTests {
             await Assert.That(dto!.ProtocolVersion).IsEqualTo(1);
             await Assert.That(dto.DaemonVersion).IsNotEmpty();
             await Assert.That(dto.DaemonName).IsEqualTo(h.Config.Name);
-            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "consent/2", "consent/3", "status/1", "permission/1" });
+            await Assert.That(dto.Capabilities).IsEquivalentTo(new[] { "consent/1", "consent/2", "consent/3", "status/1", "permission/1", "input/1" });
         });
     }
 
@@ -196,6 +196,20 @@ public class LocalControlHelloTests {
 
             var resp = await FrameCodec.ReadAsync(s, ct);
             await Assert.That(resp!.Type).IsEqualTo(FrameType.AgentList);
+        });
+    }
+
+    [Test]
+    public async Task SendText_frame_is_routed_and_answered_with_an_ack() {
+        await RunAsync("hello-sendtext", async (h, ct) => {
+            await using var s = await ConnectAsync(h.SockPath, ct);
+            var json = JsonSerializer.Serialize(new SendTextDto("nope", "hi"), InputIpcJsonContext.Default.SendTextDto);
+            await FrameCodec.WriteAsync(s, LocalFrame.InputJson(FrameType.SendText, json), ct);
+
+            var resp = await FrameCodec.ReadAsync(s, ct);
+            await Assert.That(resp!.Type).IsEqualTo(FrameType.SendTextAck);
+            var ack = JsonSerializer.Deserialize(resp.Text, InputIpcJsonContext.Default.SendTextAckDto)!;
+            await Assert.That(ack.Reason).IsEqualTo(SendTextReasons.NoSuchAgent);
         });
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalSendTextTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/LocalSendTextTests.cs
@@ -1,0 +1,210 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Services;
+using Capacitor.Cli.Daemon.Tests.Unit.Harness.Antigravity;
+using Capacitor.Cli.Daemon.Tests.Unit.Pty;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// The composer's SendText handler. Every outcome — refusal, drop, delivery, quit — is one
+/// SendTextAck the composer can word, written only once the delivery core has settled, and no
+/// path lets an exception escape onto the socket handler.
+/// </summary>
+public class LocalSendTextTests {
+    static AgentOrchestrator Build() =>
+        AgentOrchestratorHarness.BuildOrchestrator(
+            new CaptureServerConnection(), new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
+
+    static async Task<SendTextAckDto> Send(AgentOrchestrator orch, string payload) {
+        using var ms = new MemoryStream();
+        await orch.HandleLocalSendTextAsync(payload, ms, CancellationToken.None);
+        ms.Position = 0;
+        var frame = await FrameCodec.ReadAsync(ms, CancellationToken.None);
+        await Assert.That(frame!.Type).IsEqualTo(FrameType.SendTextAck);
+
+        return JsonSerializer.Deserialize(frame.Text, InputIpcJsonContext.Default.SendTextAckDto)!;
+    }
+
+    static string Payload(string agentId, string text) =>
+        JsonSerializer.Serialize(new SendTextDto(agentId, text), InputIpcJsonContext.Default.SendTextDto);
+
+    /// <summary>A real Antigravity runtime whose pending-turns queue is genuinely full: capacity 1,
+    /// a turn that never ends, one message executing and one queued behind it. The conversation-id
+    /// barrier is load-bearing — without it the second send races the worker's own dequeue and the
+    /// refusal lands on the wrong message.</summary>
+    static async Task<AntigravityHostedAgentRuntime> FullQueueRuntime() {
+        var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1);
+        await rt.SendUserInputAsync("first");
+        await rt.WaitForConversationIdAsync(CancellationToken.None);
+        await rt.SendUserInputAsync("queued");
+
+        return rt;
+    }
+
+    [Test]
+    [Arguments("not json")]
+    [Arguments("{}")]
+    [Arguments("""{"agent_id":"a1"}""")]
+    [Arguments("""{"agent_id":null,"text":"x"}""")]
+    [Arguments("""{"agent_id":"a1","text":null}""")]
+    [Arguments("[]")]
+    public async Task Malformed_payloads_ack_malformed(string payload) {
+        await using var orch = Build();
+
+        var ack = await Send(orch, payload);
+
+        await Assert.That(ack.Ok).IsFalse();
+        await Assert.That(ack.Reason).IsEqualTo(SendTextReasons.Malformed);
+    }
+
+    [Test]
+    public async Task Empty_and_oversized_text_and_unknown_agent_are_named() {
+        await using var orch = Build();
+
+        await Assert.That((await Send(orch, Payload("a1", "   "))).Reason).IsEqualTo(SendTextReasons.TextEmpty);
+        await Assert.That((await Send(orch, Payload("a1", new string('x', InputWire.MaxTextBytes + 1)))).Reason)
+            .IsEqualTo(SendTextReasons.TooLarge);
+        await Assert.That((await Send(orch, Payload("nope", "hi"))).Reason).IsEqualTo(SendTextReasons.NoSuchAgent);
+    }
+
+    [Test]
+    public async Task Protected_kind_and_not_running_are_refused_before_the_core() {
+        await using var orch = Build();
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "rev", new FakeAcpRuntime(), kind: LaunchKind.Review);
+
+        var ack = await Send(orch, Payload("rev", "hi"));
+
+        await Assert.That(ack.Reason).IsEqualTo(SendTextReasons.ProtectedKind);
+        await Assert.That(ack.Error).Contains("review");
+
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "starting", new FakeAcpRuntime(), status: "Starting");
+        await Assert.That((await Send(orch, Payload("starting", "hi"))).Reason).IsEqualTo(SendTextReasons.NotRunning);
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "done", new FakeAcpRuntime(), status: "Completed");
+        await Assert.That((await Send(orch, Payload("done", "hi"))).Reason).IsEqualTo(SendTextReasons.NotRunning);
+    }
+
+    [Test]
+    public async Task Delivery_acks_ok_delivered_only_when_the_core_settles() {
+        await using var orch = Build();
+        var rt = new FakeAcpRuntime { SendUserInputGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously) };
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "a1", rt);
+
+        var pending = Send(orch, Payload("a1", "hello"));
+        await Task.Delay(200);
+
+        await Assert.That(pending.IsCompleted).IsFalse();
+
+        rt.SendUserInputGate!.SetResult();
+        var ack = await pending;
+
+        await Assert.That(ack).IsEqualTo(new SendTextAckDto(true, null, null, SendTextOutcomes.Delivered));
+        await Assert.That(rt.SentInputs).IsEquivalentTo(new[] { "hello" });
+    }
+
+    [Test]
+    public async Task Queue_full_reaper_claim_and_delivery_failure_are_coded() {
+        await using var orch = Build();
+        await using var agy  = await FullQueueRuntime();
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "full", agy);
+
+        await Assert.That((await Send(orch, Payload("full", "x"))).Reason).IsEqualTo(SendTextReasons.QueueFull);
+
+        var claimed = AgentOrchestratorHarness.SeedAcpAgent(orch, "claimed", new FakeAcpRuntime());
+        AgentOrchestratorHarness.ClaimReap(claimed);
+
+        await Assert.That((await Send(orch, Payload("claimed", "x"))).Reason).IsEqualTo(SendTextReasons.ReaperClaimed);
+
+        var late = AgentOrchestratorHarness.SeedAcpAgent(orch, "late", new FakeAcpRuntime());
+        orch.SendInputBeforeWriteHookForTest = () => { AgentOrchestratorHarness.ClaimReap(late); return Task.CompletedTask; };
+
+        await Assert.That((await Send(orch, Payload("late", "x"))).Reason).IsEqualTo(SendTextReasons.ReaperClaimedLate);
+
+        orch.SendInputBeforeWriteHookForTest = null;
+
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "faulty", new FakeAcpRuntime { SendUserInputThrow = new IOException("pipe closed") });
+        var ack = await Send(orch, Payload("faulty", "x"));
+
+        await Assert.That(ack.Reason).IsEqualTo(SendTextReasons.DeliveryFailed);
+        await Assert.That(ack.Error).IsEqualTo("pipe closed");
+    }
+
+    /// <summary>A quit rides the owner's stop, which a private agent is eligible for — the
+    /// server-origin stop handler would refuse it, and the composer typing into its own local agent
+    /// would then get an ack for a stop that never happened.</summary>
+    [Test]
+    public async Task Quit_stops_a_private_and_a_public_agent_through_the_owner_stop_and_acks_stopped() {
+        await using var orch = Build();
+        orch.GracefulExitWait = TimeSpan.FromMilliseconds(50);
+        var pub = new FakeAcpRuntime();
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "pub", pub);
+        var prv = new FakeAcpRuntime();
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "prv", prv, isPrivate: true);
+
+        await Assert.That((await Send(orch, Payload("pub", "/quit"))).Outcome).IsEqualTo(SendTextOutcomes.Stopped);
+        await Assert.That(pub.HasExited).IsTrue();
+        await Assert.That((await Send(orch, Payload("prv", "/exit"))).Outcome).IsEqualTo(SendTextOutcomes.Stopped);
+        await Assert.That(prv.HasExited).IsTrue();
+
+        var stuck = new FakeAcpRuntime { NeverExits = true };
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "stuck", stuck);
+
+        await Assert.That((await Send(orch, Payload("stuck", "/quit"))).Reason).IsEqualTo(SendTextReasons.StopFailed);
+    }
+
+    [Test]
+    public async Task Two_frames_against_a_pending_write_deliver_two_turns_in_order() {
+        await using var orch = Build();
+        var rt = new FakeAcpRuntime { SendUserInputGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously) };
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "a1", rt);
+
+        var first  = Send(orch, Payload("a1", "one"));
+        var second = Send(orch, Payload("a1", "two"));
+        await Task.Delay(100);
+        rt.SendUserInputGate!.SetResult();
+        await Task.WhenAll(first, second);
+
+        await Assert.That(rt.SentInputs).IsEquivalentTo(new[] { "one", "two" }, CollectionOrdering.Matching);
+    }
+
+    [Test]
+    public async Task A_cancelled_wait_and_a_failing_ack_write_each_still_deliver_exactly_once() {
+        await using var orch = Build();
+        var rt = new FakeAcpRuntime { SendUserInputGate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously) };
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "a1", rt);
+
+        using var cts       = new CancellationTokenSource();
+        using var ackStream = new MemoryStream();
+        var       cancelled = orch.HandleLocalSendTextAsync(Payload("a1", "one"), ackStream, cts.Token);
+        await Task.Delay(50);
+        await cts.CancelAsync();
+        rt.SendUserInputGate!.SetResult();
+        try { await cancelled; } catch (OperationCanceledException) { /* the ack never crossed; the write did */ }
+
+        var rt2 = new FakeAcpRuntime();
+        AgentOrchestratorHarness.SeedAcpAgent(orch, "a2", rt2);
+        using var throwing = new ThrowingStream();
+        await orch.HandleLocalSendTextAsync(Payload("a2", "two"), throwing, CancellationToken.None);
+
+        await Assert.That(rt.SentInputs).IsEquivalentTo(new[] { "one" });
+        await Assert.That(rt2.SentInputs).IsEquivalentTo(new[] { "two" });
+    }
+
+    sealed class ThrowingStream : Stream {
+        public override bool CanRead  => false;
+        public override bool CanSeek  => false;
+        public override bool CanWrite => true;
+        public override long Length   => 0;
+
+        public override long Position { get => 0; set { } }
+
+        public override void Flush() { }
+        public override int  Read(byte[]  buffer, int offset, int count) => throw new NotSupportedException();
+        public override long Seek(long    offset, SeekOrigin origin) => throw new NotSupportedException();
+        public override void SetLength(long value) { }
+        public override void Write(byte[] buffer, int offset, int count) => throw new IOException("socket closed");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SendInputActivityClockTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SendInputActivityClockTests.cs
@@ -15,7 +15,7 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 /// output before the next reap sweep — looked idle to the reaper even while a human/driver was
 /// actively working with it.
 ///
-/// <c>AgentOrchestrator.HandleSendInput</c> calls <c>Advance()</c> only once delivery is
+/// <c>AgentOrchestrator.DeliverInputAsync</c> calls <c>Advance()</c> only once delivery is
 /// KNOWN to have succeeded — the runtime write returned without throwing. A failed/cancelled
 /// delivery must leave the clock untouched: a false advance would mask a genuinely wedged/dead
 /// agent from the reaper, which is exactly the failure mode this whole clock exists to catch.
@@ -43,7 +43,7 @@ public class SendInputActivityClockTests {
     /// <summary>Pins the mechanism the design's residual note is about: ACP's default (non-borrowed)
     /// <c>SendUserInputAsync</c> is fire-and-forget — its non-throwing return means "enqueued", not
     /// "the agent read it" (<c>AcpHostedAgentRuntime.EnqueueTurn</c>'s full-queue branch drops
-    /// silently, no throw) — yet <c>AgentOrchestrator.HandleSendInput</c> still advances the
+    /// silently, no throw) — yet <c>AgentOrchestrator.DeliverInputAsync</c> still advances the
     /// clock on it, by design (a false advance only delays a reap/silence verdict, never manufactures
     /// one). Uses <see cref="FakeAcpRuntime"/> (an <see cref="IHostedAgentRuntime"/> test double
     /// from <see cref="AgentOrchestratorHarness"/>) via <c>SeedAcpAgent</c> — its
@@ -115,23 +115,27 @@ public class SendInputActivityClockTests {
         await Assert.That(agent.ActivityClock.AwaitingInput).IsTrue();
     }
 
+    /// <summary>A write the runtime would not take is a drop the sender is told about rather than an
+    /// exception escaping the handler — either way the clock must show nothing happened.</summary>
     [Test]
     public async Task Failed_delivery_advances_nothing() {
-        var server = new CaptureServerConnection();
-        var time   = new FakeTimeProvider();
-        var clock  = new AgentActivityClock(time);
+        var server     = new CaptureServerConnection();
+        var time       = new FakeTimeProvider();
+        var clock      = new AgentActivityClock(time);
+        var dispatchId = Guid.NewGuid();
 
         await using var orch  = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>());
         var             agent = orch.SeedAgentForTest("send-input-fail", pty: new AlwaysThrowsPtyProcess(), activityClock: clock);
 
         time.Advance(TimeSpan.FromSeconds(10));
 
-        await Assert.ThrowsAsync<IOException>(
-            async () => await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null)));
+        await orch.HandleSendInputForTest(new SendInputCommand(agent.Id, "hello", null, dispatchId));
 
         // The write failed before "delivered" — seq and idle are exactly where spawn left them.
         await Assert.That(agent.ActivityClock.ActivitySeq).IsEqualTo(1UL);
         await Assert.That(agent.ActivityClock.IdleForMs).IsGreaterThanOrEqualTo(9_900UL);
+        await Assert.That(server.InputRejections)
+            .Contains((dispatchId, agent.Id, AgentOrchestrator.SendInputDropReason.DeliveryFailed));
     }
 
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SendInputActivityClockTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SendInputActivityClockTests.cs
@@ -11,8 +11,8 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 /// delivered <c>SendInput</c> must advance the same per-agent <see cref="AgentActivityClock"/> that
 /// PTY output, ACP envelopes, and turn transitions already advance (see
 /// <c>AgentActivityClockTests.PTY_output_chunk_advances_the_agents_activity_clock</c> for the
-/// output-side precedent). Before this, an agent that only ever RECEIVED input — never producing
-/// output before the next reap sweep — looked idle to the reaper even while a human/driver was
+/// output-side precedent). An agent that only ever RECEIVES input — never producing output before
+/// the next reap sweep — reads as idle to the reaper otherwise, even while a human or driver is
 /// actively working with it.
 ///
 /// <c>AgentOrchestrator.DeliverInputAsync</c> calls <c>Advance()</c> only once delivery is

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpyAcpHostedAgentRuntimeFactory.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/SpyAcpHostedAgentRuntimeFactory.cs
@@ -35,6 +35,7 @@ internal sealed class SpyAcpHostedAgentRuntimeFactory(string vendor = "cursor") 
         LastContext = ctx;
 
         var runtime = new FakeAcpRuntime {
+            Vendor = Vendor,
             ResolvedModel = ResolvedModel, DeferFirstTurn = DeferFirstTurn, BeginFirstTurnThrow = BeginFirstTurnThrow
         };
         LastRuntime = runtime;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
@@ -1,0 +1,100 @@
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class TranscriptJournalSweepTests {
+    static readonly DateTimeOffset Now = new(2026, 9, 9, 10, 0, 0, TimeSpan.Zero);
+
+    static string Journal(TempDir tmp, string agentId, TimeSpan age) {
+        var path = Path.Combine(tmp.CreateDir("transcripts"), AgentFileNames.For(agentId) + ".jsonl");
+        File.WriteAllText(path, "{}\n");
+        File.SetLastWriteTimeUtc(path, (Now - age).UtcDateTime);
+        return path;
+    }
+
+    static void PidRecord(TempDir tmp, string agentId) =>
+        File.WriteAllText(Path.Combine(tmp.CreateDir("agents"), AgentFileNames.For(agentId) + ".json"), "{}");
+
+    static TranscriptJournalSweep Sweep(TempDir tmp, FakeTimeProvider time, JournalPathLocks? locks = null) =>
+        new(tmp.Path, time, NullLogger<TranscriptJournalSweep>.Instance, locks);
+
+    [Test]
+    public async Task Deletes_only_old_journals_without_a_pid_record() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var old        = Journal(tmp, "old", TimeSpan.FromDays(31));
+        var fresh      = Journal(tmp, "fresh", TimeSpan.FromDays(1));
+        var oldButLive = Journal(tmp, "live", TimeSpan.FromDays(31)); PidRecord(tmp, "live");
+        var other      = Path.Combine(tmp.Path, "transcripts", "notes.txt"); File.WriteAllText(other, "x"); File.SetLastWriteTimeUtc(other, (Now - TimeSpan.FromDays(40)).UtcDateTime);
+
+        await Sweep(tmp, time).RunOnceAsync(CancellationToken.None);
+
+        await Assert.That(File.Exists(old)).IsFalse();
+        await Assert.That(File.Exists(fresh)).IsTrue();
+        await Assert.That(File.Exists(oldButLive)).IsTrue();
+        await Assert.That(File.Exists(other)).IsTrue();
+    }
+
+    [Test]
+    public async Task Skips_a_journal_whose_lock_is_held() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var locks = new JournalPathLocks();
+        var old = Journal(tmp, "old", TimeSpan.FromDays(31));
+        using var held = await locks.AcquireAsync(old, TimeSpan.FromSeconds(1), CancellationToken.None);
+
+        await Sweep(tmp, time, locks).RunOnceAsync(CancellationToken.None);
+
+        await Assert.That(File.Exists(old)).IsTrue();
+    }
+
+    [Test]
+    public async Task Missing_directory_and_enumeration_faults_never_escape() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        await Sweep(tmp, time).RunOnceAsync(CancellationToken.None); // no transcripts dir
+        tmp.CreateFile("transcripts"); // a file where the directory belongs: enumeration throws
+        await Sweep(tmp, time).RunOnceAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task Runs_again_after_24_hours_without_a_restart() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var sweep = Sweep(tmp, time);
+        await sweep.StartAsync(CancellationToken.None);
+        await Assert.That(sweep.SweepsStarted).IsEqualTo(0);
+
+        var journal = Journal(tmp, "old", TimeSpan.FromDays(31));
+        time.Advance(TimeSpan.FromHours(24));
+        await WaitUntil(() => sweep.SweepsStarted == 1);
+        await Assert.That(File.Exists(journal)).IsFalse();
+
+        time.Advance(TimeSpan.FromHours(24));
+        await WaitUntil(() => sweep.SweepsStarted == 2);
+        await sweep.StopAsync(CancellationToken.None);
+    }
+
+    [Test]
+    public async Task A_tick_during_a_sweep_is_skipped() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var locks = new JournalPathLocks();
+        var old = Journal(tmp, "old", TimeSpan.FromDays(31));
+        using var held = await locks.AcquireAsync(old, TimeSpan.FromSeconds(1), CancellationToken.None); // the sweep waits ≤ LockBound on this
+        var sweep = Sweep(tmp, time, locks);
+
+        var first = sweep.RunOnceAsync(CancellationToken.None);
+        var second = sweep.RunOnceAsync(CancellationToken.None);
+        await Task.WhenAll(first, second);
+
+        await Assert.That(sweep.SweepsStarted).IsEqualTo(1);
+    }
+
+    static async Task WaitUntil(Func<bool> condition) {
+        for (var i = 0; i < 500 && !condition(); i++) await Task.Delay(10);
+        await Assert.That(condition()).IsTrue();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
@@ -17,8 +17,25 @@ public class TranscriptJournalSweepTests {
     static void PidRecord(TempDir tmp, string agentId) =>
         File.WriteAllText(Path.Combine(tmp.CreateDir("agents"), AgentFileNames.For(agentId) + ".json"), "{}");
 
-    static TranscriptJournalSweep Sweep(TempDir tmp, FakeTimeProvider time, JournalPathLocks? locks = null) =>
+    static TranscriptJournalSweep Sweep(TempDir tmp, TimeProvider time, JournalPathLocks? locks = null) =>
         new(tmp.Path, time, NullLogger<TranscriptJournalSweep>.Instance, locks);
+
+    /// A fake clock only fires the timers that exist when it advances, and StartAsync returns before
+    /// the hosted service has necessarily armed its own: advancing first drops the tick for a whole
+    /// period. Armed completes when the service asks for the timer.
+    sealed class ArmedProbe(FakeTimeProvider inner) : TimeProvider {
+        readonly TaskCompletionSource _armed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public Task Armed => _armed.Task;
+
+        public override DateTimeOffset GetUtcNow() => inner.GetUtcNow();
+
+        public override ITimer CreateTimer(TimerCallback callback, object? state, TimeSpan dueTime, TimeSpan period) {
+            var timer = inner.CreateTimer(callback, state, dueTime, period);
+            _armed.TrySetResult();
+            return timer;
+        }
+    }
 
     [Test]
     public async Task Deletes_only_old_journals_without_a_pid_record() {
@@ -51,11 +68,29 @@ public class TranscriptJournalSweepTests {
     }
 
     [Test]
-    public async Task Missing_directory_and_enumeration_faults_never_escape() {
+    public async Task A_reopen_while_the_sweep_waits_for_the_lock_keeps_the_journal() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var locks = new JournalPathLocks();
+        var old = Journal(tmp, "old", TimeSpan.FromDays(31));
+        var held = await locks.AcquireAsync(old, TimeSpan.FromSeconds(5), CancellationToken.None);
+        var sweep = Sweep(tmp, time, locks);
+
+        var running = sweep.RunOnceAsync(CancellationToken.None);
+        await Task.Delay(100); // long enough that the sweep is parked on the lock, not still deciding
+        File.SetLastWriteTimeUtc(old, Now.UtcDateTime);
+        held!.Dispose();
+        await running;
+
+        await Assert.That(File.Exists(old)).IsTrue();
+    }
+
+    [Test]
+    public async Task Missing_or_shadowed_transcripts_directory_never_throws() {
         using var tmp = new TempDir();
         var time = new FakeTimeProvider(Now);
         await Sweep(tmp, time).RunOnceAsync(CancellationToken.None); // no transcripts dir
-        tmp.CreateFile("transcripts"); // a file where the directory belongs: enumeration throws
+        tmp.CreateFile("transcripts"); // a file where the directory belongs
         await Sweep(tmp, time).RunOnceAsync(CancellationToken.None);
     }
 
@@ -63,17 +98,22 @@ public class TranscriptJournalSweepTests {
     public async Task Runs_again_after_24_hours_without_a_restart() {
         using var tmp = new TempDir();
         var time = new FakeTimeProvider(Now);
-        var sweep = Sweep(tmp, time);
+        var probe = new ArmedProbe(time);
+        var sweep = Sweep(tmp, probe);
         await sweep.StartAsync(CancellationToken.None);
+        await probe.Armed.WaitAsync(TimeSpan.FromSeconds(30));
         await Assert.That(sweep.SweepsStarted).IsEqualTo(0);
 
         var journal = Journal(tmp, "old", TimeSpan.FromDays(31));
         time.Advance(TimeSpan.FromHours(24));
-        await WaitUntil(() => sweep.SweepsStarted == 1);
+        // Completion, not the start: a tick that arrives while the sweep still runs is dropped by
+        // the single flight, and the delete this asserts on happens after the count rises.
+        await WaitUntil(() => sweep.SweepsCompleted == 1);
         await Assert.That(File.Exists(journal)).IsFalse();
 
         time.Advance(TimeSpan.FromHours(24));
-        await WaitUntil(() => sweep.SweepsStarted == 2);
+        await WaitUntil(() => sweep.SweepsCompleted == 2);
+        await Assert.That(sweep.SweepsStarted).IsEqualTo(2);
         await sweep.StopAsync(CancellationToken.None);
     }
 
@@ -93,8 +133,11 @@ public class TranscriptJournalSweepTests {
         await Assert.That(sweep.SweepsStarted).IsEqualTo(1);
     }
 
+    /// Bounded on the wall clock, not on a poll count: each poll's delay is itself a thread-pool
+    /// continuation, so under load 500 of them is nothing like the five seconds it reads as.
     static async Task WaitUntil(Func<bool> condition) {
-        for (var i = 0; i < 500 && !condition(); i++) await Task.Delay(10);
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition() && sw.Elapsed < TimeSpan.FromSeconds(30)) await Task.Delay(10);
         await Assert.That(condition()).IsTrue();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
@@ -8,14 +8,13 @@ public class TranscriptJournalSweepTests {
     static readonly DateTimeOffset Now = new(2026, 9, 9, 10, 0, 0, TimeSpan.Zero);
 
     static string Journal(TempDir tmp, string agentId, TimeSpan age) {
-        var path = Path.Combine(tmp.CreateDir("transcripts"), AgentFileNames.For(agentId) + ".jsonl");
-        File.WriteAllText(path, "{}\n");
+        var path = tmp.CreateFile(["transcripts", AgentFileNames.For(agentId) + ".jsonl"], "{}\n");
         File.SetLastWriteTimeUtc(path, (Now - age).UtcDateTime);
         return path;
     }
 
     static void PidRecord(TempDir tmp, string agentId) =>
-        File.WriteAllText(Path.Combine(tmp.CreateDir("agents"), AgentFileNames.For(agentId) + ".json"), "{}");
+        tmp.CreateFile(["agents", AgentFileNames.For(agentId) + ".json"], "{}");
 
     static TranscriptJournalSweep Sweep(TempDir tmp, TimeProvider time, JournalPathLocks? locks = null) =>
         new(tmp.Path, time, NullLogger<TranscriptJournalSweep>.Instance, locks);
@@ -44,7 +43,7 @@ public class TranscriptJournalSweepTests {
         var old        = Journal(tmp, "old", TimeSpan.FromDays(31));
         var fresh      = Journal(tmp, "fresh", TimeSpan.FromDays(1));
         var oldButLive = Journal(tmp, "live", TimeSpan.FromDays(31)); PidRecord(tmp, "live");
-        var other      = Path.Combine(tmp.Path, "transcripts", "notes.txt"); File.WriteAllText(other, "x"); File.SetLastWriteTimeUtc(other, (Now - TimeSpan.FromDays(40)).UtcDateTime);
+        var other      = tmp.CreateFile(["transcripts", "notes.txt"], "x"); File.SetLastWriteTimeUtc(other, (Now - TimeSpan.FromDays(40)).UtcDateTime);
 
         await Sweep(tmp, time).RunOnceAsync(CancellationToken.None);
 
@@ -89,9 +88,31 @@ public class TranscriptJournalSweepTests {
     public async Task Missing_or_shadowed_transcripts_directory_never_throws() {
         using var tmp = new TempDir();
         var time = new FakeTimeProvider(Now);
-        await Sweep(tmp, time).RunOnceAsync(CancellationToken.None); // no transcripts dir
+        var sweep = Sweep(tmp, time);
+        await sweep.RunOnceAsync(CancellationToken.None); // no transcripts dir
         tmp.CreateFile("transcripts"); // a file where the directory belongs
-        await Sweep(tmp, time).RunOnceAsync(CancellationToken.None);
+        await sweep.RunOnceAsync(CancellationToken.None);
+
+        await Assert.That(sweep.SweepsCompleted).IsEqualTo(2);
+    }
+
+    /// An unreadable directory is the one fault that hits enumeration itself rather than a file, and
+    /// the outer catch is all that stands between it and a daemon that cannot connect.
+    [Test]
+    public async Task An_unreadable_transcripts_directory_never_throws() {
+        if (OperatingSystem.IsWindows()) return; // no mode bits to take away
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var dir = tmp.CreateDir("transcripts");
+        Journal(tmp, "old", TimeSpan.FromDays(31));
+        File.SetUnixFileMode(dir, UnixFileMode.UserWrite | UnixFileMode.UserExecute); // no read
+        var sweep = Sweep(tmp, time);
+        try {
+            await sweep.RunOnceAsync(CancellationToken.None);
+            await Assert.That(sweep.SweepsCompleted).IsEqualTo(1);
+        } finally {
+            File.SetUnixFileMode(dir, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+        }
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
@@ -101,6 +101,7 @@ public class TranscriptJournalSweepTests {
     [Test]
     public async Task An_unreadable_transcripts_directory_never_throws() {
         if (OperatingSystem.IsWindows()) return; // no mode bits to take away
+        if (Environment.UserName == "root") return; // root ignores the missing read bit: the directory would stay readable
         using var tmp = new TempDir();
         var time = new FakeTimeProvider(Now);
         var dir = tmp.CreateDir("transcripts");

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
@@ -133,15 +133,21 @@ public class TranscriptJournalTests {
         public void Dispose() => Release.Dispose();
     }
 
+    /// Held until a test has enqueued everything it means to: the writer's first read is what the
+    /// gap assertions race, and completing a TaskCompletionSource inline would run that read here.
+    static TaskCompletionSource WriterGate() => new(TaskCreationOptions.RunContinuationsAsynchronously);
+
     [Test]
     public async Task Gap_note_lands_between_the_last_kept_and_the_first_after_the_loss() {
         using var tmp = new TempDir();
         var sink = new GatedSink();
-        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 2);
+        var gate = WriterGate();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 2, writerStartGate: gate.Task);
         journal.Open(null, null);
-        journal.Record(Text("a")); journal.Record(Text("b")); // fill the queue (writer is blocked)
+        journal.Record(Text("a")); journal.Record(Text("b")); // fill the queue (the writer has not read yet)
         journal.Record(Text("lost-1")); journal.Record(Text("lost-2"));
         await Assert.That(journal.PendingGap).IsEqualTo(2);
+        gate.SetResult();
         sink.Release.Release(); // the writer takes "a": one slot frees
         await Task.Delay(100);
         journal.Record(Text("c")); // exactly one slot free: this item carries the gap
@@ -159,9 +165,11 @@ public class TranscriptJournalTests {
     public async Task Gap_pending_at_completion_is_written_last() {
         using var tmp = new TempDir();
         var sink = new GatedSink();
-        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 1);
+        var gate = WriterGate();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 1, writerStartGate: gate.Task);
         journal.Open(null, null);
         journal.Record(Text("a")); journal.Record(Text("lost"));
+        gate.SetResult();
         sink.Release.Release(10);
         await Assert.That(await journal.CompleteAsync()).IsTrue();
         var last = Lines(journal.Path).Last();
@@ -174,9 +182,11 @@ public class TranscriptJournalTests {
         using var tmp = new TempDir();
         var sink = new GatedSink();
         var log = new CapturingLogger();
-        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), log, Time, sink.Append, capacity: 2, completeGrace: TimeSpan.FromMilliseconds(200));
+        var gate = WriterGate();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), log, Time, sink.Append, capacity: 2, completeGrace: TimeSpan.FromMilliseconds(200), writerStartGate: gate.Task);
         journal.Open(null, null);
         journal.Record(Text("a")); journal.Record(Text("b")); journal.Record(Text("lost"));
+        gate.SetResult();
         await Task.Delay(50);
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
@@ -227,14 +237,16 @@ public class TranscriptJournalTests {
     public async Task Torn_gap_item_renders_the_note_and_drops_the_torn_envelope() {
         using var tmp = new TempDir();
         var path = tmp.PathTo("j.jsonl");
+        var gate = WriterGate();
         // The crash model: a buffer cut after its note line.
         var journal = new TranscriptJournal(path, NullLogger.Instance, Time, append: (p, bytes) => {
             var text = System.Text.Encoding.UTF8.GetString(bytes);
             var cut = text.IndexOf('\n', StringComparison.Ordinal) + 1 + 5;
             File.AppendAllText(p, text[..Math.Min(cut, text.Length)]);
-        }, capacity: 1);
+        }, capacity: 1, writerStartGate: gate.Task);
         journal.Open(null, null);
         journal.Record(Text("a")); journal.Record(Text("lost")); // "a" carries no gap
+        gate.SetResult();
         await Task.Delay(50);
         journal.Record(Text("c")); // carries gap 1: note + torn "c"
         await journal.CompleteAsync();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
@@ -1,0 +1,118 @@
+using System.Globalization;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+public class TranscriptJournalTests {
+    static readonly FakeTimeProvider Time = new(new DateTimeOffset(2026, 9, 9, 10, 0, 0, TimeSpan.Zero));
+
+    static string[] Lines(string path) {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(fs);
+        return reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    static AcpEventEnvelope Text(string t) => new(Kind: AcpEventKind.AssistantText, Text: t);
+
+    [Test]
+    public async Task Open_writes_the_header_synchronously_and_reports_created() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+
+        await Assert.That(journal.Open("/w", "m1")).IsTrue();
+
+        await Assert.That(journal.IsOpen).IsTrue();
+        await Assert.That(journal.CreatedFile).IsTrue();
+        await Assert.That(journal.Path).IsEqualTo(Path.Combine(tmp.Path, "transcripts", AgentFileNames.For("agent-1") + ".jsonl"));
+        var lines = Lines(journal.Path);
+        await Assert.That(lines).Count().IsEqualTo(1);
+        await Assert.That(EnvelopeJournalFormat.TryRead(lines[0], out var header)).IsTrue();
+        await Assert.That(header.Kind).IsEqualTo(AcpEventKind.SessionStarted);
+        await Assert.That(header.Cwd).IsEqualTo("/w");
+        await Assert.That(header.Model).IsEqualTo("m1");
+        await Assert.That(header.RawSessionId).IsNull();
+        await journal.CompleteAsync();
+    }
+
+    [Test]
+    public async Task Second_open_of_the_same_agent_appends_a_header_and_keeps_every_byte() {
+        using var tmp = new TempDir();
+        var first = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        first.Open("/w", null);
+        first.Record(Text("a"));
+        await Assert.That(await first.CompleteAsync()).IsTrue();
+        var before = Lines(first.Path);
+
+        var second = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        second.Open("/w", null);
+        await Assert.That(second.CreatedFile).IsFalse();
+        await second.CompleteAsync();
+
+        var after = Lines(second.Path);
+        await Assert.That(after.Take(before.Length)).IsEquivalentTo(before);
+        await Assert.That(after).Count().IsEqualTo(before.Length + 1);
+    }
+
+    [Test]
+    public async Task Record_appends_in_order_skips_ephemerals_and_drains_on_complete() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open(null, null);
+        journal.Record(Text("a"));
+        journal.Record(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "live", Ephemeral: true));
+        journal.Record(Text("b"));
+
+        await Assert.That(await journal.CompleteAsync()).IsTrue();
+
+        var texts = Lines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Text; });
+        await Assert.That(texts).IsEquivalentTo(new string?[] { "a", "b" });
+    }
+
+    [Test]
+    public async Task No_handle_is_held_between_writes() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open(null, null);
+        journal.Record(Text("a"));
+        await journal.CompleteAsync();
+
+        // Exclusive open and delete both succeed: nothing else holds the file.
+        using (new FileStream(journal.Path, FileMode.Open, FileAccess.ReadWrite, FileShare.None)) { }
+        File.Delete(journal.Path);
+        await Assert.That(File.Exists(journal.Path)).IsFalse();
+    }
+
+    [Test]
+    public async Task Header_failure_leaves_the_journal_closed_and_record_a_noop() {
+        using var tmp = new TempDir();
+        var blockedDir = tmp.CreateFile("transcripts"); // a FILE where the directory should be
+        var journal = new TranscriptJournal(Path.Combine(blockedDir, "x.jsonl"), NullLogger.Instance);
+
+        await Assert.That(journal.Open(null, null)).IsFalse();
+
+        await Assert.That(journal.IsOpen).IsFalse();
+        journal.Record(Text("a")); // must not throw
+        await Assert.That(await journal.CompleteAsync()).IsTrue();
+    }
+
+    [Test]
+    public async Task Record_never_blocks_while_the_sink_hangs() {
+        using var tmp = new TempDir();
+        using var hang = new ManualResetEventSlim(false);
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time,
+            append: (path, bytes) => { if (Lines(path).Length >= 1) hang.Wait(); File.AppendAllText(path, System.Text.Encoding.UTF8.GetString(bytes)); },
+            capacity: 4);
+        journal.Open(null, null);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        for (var i = 0; i < 100; i++) journal.Record(Text(i.ToString(CultureInfo.InvariantCulture)));
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(500));
+
+        await Assert.That(journal.PendingGap).IsGreaterThan(0);
+        hang.Set();
+        await journal.CompleteAsync();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
@@ -3,6 +3,7 @@ using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Time.Testing;
+using TUnit.Assertions.Enums;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
@@ -52,7 +53,7 @@ public class TranscriptJournalTests {
         await second.CompleteAsync();
 
         var after = Lines(second.Path);
-        await Assert.That(after.Take(before.Length)).IsEquivalentTo(before);
+        await Assert.That(after.Take(before.Length)).IsEquivalentTo(before, CollectionOrdering.Matching);
         await Assert.That(after).Count().IsEqualTo(before.Length + 1);
     }
 
@@ -68,7 +69,7 @@ public class TranscriptJournalTests {
         await Assert.That(await journal.CompleteAsync()).IsTrue();
 
         var texts = Lines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Text; });
-        await Assert.That(texts).IsEquivalentTo(new string?[] { "a", "b" });
+        await Assert.That(texts).IsEquivalentTo(new string?[] { "a", "b" }, CollectionOrdering.Matching);
     }
 
     [Test]
@@ -158,7 +159,8 @@ public class TranscriptJournalTests {
         var texts = Lines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); }).ToList();
         await Assert.That(texts).IsEquivalentTo(new (string, string?)[] {
             (AcpEventKind.AssistantText, "a"), (AcpEventKind.AssistantText, "b"),
-            (AcpEventKind.SystemNote, "2 envelopes were not recorded to this journal"), (AcpEventKind.AssistantText, "c") });
+            (AcpEventKind.SystemNote, "2 envelopes were not recorded to this journal"), (AcpEventKind.AssistantText, "c") },
+            CollectionOrdering.Matching);
     }
 
     [Test]
@@ -279,7 +281,7 @@ public class TranscriptJournalTests {
         await third.CompleteAsync();
 
         var texts = Lines(first.Path).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Kind == AcpEventKind.SessionStarted ? "header" : e.Text; });
-        await Assert.That(texts).IsEquivalentTo(new string?[] { "header", "late", "header" });
+        await Assert.That(texts).IsEquivalentTo(new string?[] { "header", "late", "header" }, CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
@@ -115,4 +115,184 @@ public class TranscriptJournalTests {
         hang.Set();
         await journal.CompleteAsync();
     }
+
+    /// A sink that blocks every append until released, then writes for real.
+    sealed class GatedSink : IDisposable {
+        public readonly SemaphoreSlim Release = new(0);
+        public int Appends;
+
+        public void Append(string path, byte[] bytes) {
+            Release.Wait();
+            Interlocked.Increment(ref Appends);
+            using var fs = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
+            fs.Seek(0, SeekOrigin.End);
+            fs.Write(bytes);
+            fs.Flush(true);
+        }
+
+        public void Dispose() => Release.Dispose();
+    }
+
+    [Test]
+    public async Task Gap_note_lands_between_the_last_kept_and_the_first_after_the_loss() {
+        using var tmp = new TempDir();
+        var sink = new GatedSink();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 2);
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("b")); // fill the queue (writer is blocked)
+        journal.Record(Text("lost-1")); journal.Record(Text("lost-2"));
+        await Assert.That(journal.PendingGap).IsEqualTo(2);
+        sink.Release.Release(); // the writer takes "a": one slot frees
+        await Task.Delay(100);
+        journal.Record(Text("c")); // exactly one slot free: this item carries the gap
+        await Assert.That(journal.PendingGap).IsEqualTo(0);
+        sink.Release.Release(10);
+        await Assert.That(await journal.CompleteAsync()).IsTrue();
+
+        var texts = Lines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); }).ToList();
+        await Assert.That(texts).IsEquivalentTo(new (string, string?)[] {
+            (AcpEventKind.AssistantText, "a"), (AcpEventKind.AssistantText, "b"),
+            (AcpEventKind.SystemNote, "2 envelopes were not recorded to this journal"), (AcpEventKind.AssistantText, "c") });
+    }
+
+    [Test]
+    public async Task Gap_pending_at_completion_is_written_last() {
+        using var tmp = new TempDir();
+        var sink = new GatedSink();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 1);
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("lost"));
+        sink.Release.Release(10);
+        await Assert.That(await journal.CompleteAsync()).IsTrue();
+        var last = Lines(journal.Path).Last();
+        EnvelopeJournalFormat.TryRead(last, out var e);
+        await Assert.That(e.Text).IsEqualTo("1 envelopes were not recorded to this journal");
+    }
+
+    [Test]
+    public async Task Complete_against_a_hung_sink_returns_within_the_grace_and_reports_not_drained() {
+        using var tmp = new TempDir();
+        var sink = new GatedSink();
+        var log = new CapturingLogger();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), log, Time, sink.Append, capacity: 2, completeGrace: TimeSpan.FromMilliseconds(200));
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("b")); journal.Record(Text("lost"));
+        await Task.Delay(50);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var drained = await journal.CompleteAsync();
+
+        await Assert.That(drained).IsFalse();
+        await Assert.That(journal.Drained).IsFalse();
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+        await Assert.That(log.Warnings.Single()).Contains("assistant_text").And.Contains("1 queued").And.Contains("1 unrecorded");
+        journal.Record(Text("after")); // latched: silently ignored
+        sink.Release.Release(10);
+    }
+
+    [Test]
+    public async Task Cancellation_never_splits_a_gap_bearing_item() {
+        using var tmp = new TempDir();
+        var sink = new GatedSink();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 1, completeGrace: TimeSpan.FromMilliseconds(100));
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("lost"));
+        await Task.Delay(50);
+        journal.Record(Text("c")); // still full: counted
+        var complete = journal.CompleteAsync(); // expires while the sink still blocks on "a"
+        await Assert.That(await complete).IsFalse();
+        sink.Release.Release(10);
+        await Task.Delay(200);
+
+        // The abandoned writer finished "a" (one item, whole) and then observed cancellation: no torn note.
+        var lines = Lines(journal.Path);
+        foreach (var line in lines) await Assert.That(EnvelopeJournalFormat.TryRead(line, out _)).IsTrue();
+        await Assert.That(sink.Appends).IsEqualTo(1);
+    }
+
+    [Test]
+    public async Task First_append_failure_latches_after_one_warning_and_counts_the_queue() {
+        using var tmp = new TempDir();
+        var log = new CapturingLogger();
+        var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), log, Time, append: (_, _) => throw new IOException("disk gone"));
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("b"));
+        await Assert.That(await journal.CompleteAsync()).IsTrue(); // the writer exited (by faulting), so it drained
+        await Assert.That(log.Warnings).Count().IsEqualTo(1);
+        await Assert.That(log.Warnings[0]).Contains("write failed");
+        await Assert.That(Lines(journal.Path)).Count().IsEqualTo(1); // header only
+    }
+
+    [Test]
+    public async Task Torn_gap_item_renders_the_note_and_drops_the_torn_envelope() {
+        using var tmp = new TempDir();
+        var path = tmp.PathTo("j.jsonl");
+        // The crash model: a buffer cut after its note line.
+        var journal = new TranscriptJournal(path, NullLogger.Instance, Time, append: (p, bytes) => {
+            var text = System.Text.Encoding.UTF8.GetString(bytes);
+            var cut = text.IndexOf('\n', StringComparison.Ordinal) + 1 + 5;
+            File.AppendAllText(p, text[..Math.Min(cut, text.Length)]);
+        }, capacity: 1);
+        journal.Open(null, null);
+        journal.Record(Text("a")); journal.Record(Text("lost")); // "a" carries no gap
+        await Task.Delay(50);
+        journal.Record(Text("c")); // carries gap 1: note + torn "c"
+        await journal.CompleteAsync();
+
+        var tail = new JsonlTail(path).ReadAppended();
+        await Assert.That(tail.Lines.Count(l => l.Contains("not recorded", StringComparison.Ordinal))).IsEqualTo(1);
+        await Assert.That(tail.Lines.Any(l => l.Contains("\"c\"", StringComparison.Ordinal))).IsFalse();
+    }
+
+    [Test]
+    public async Task Same_id_open_waits_out_an_abandoned_writer_and_appends_after_its_line() {
+        if (OperatingSystem.IsWindows()) return;
+        using var tmp = new TempDir();
+        var locks = new JournalPathLocks();
+        var sink = new GatedSink();
+        var first = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, locks, capacity: 1, completeGrace: TimeSpan.FromMilliseconds(100), lockBound: TimeSpan.FromMilliseconds(100));
+        first.Open(null, null);
+        first.Record(Text("late"));
+        await Task.Delay(50);
+        await Assert.That(await first.CompleteAsync()).IsFalse(); // writer abandoned inside the (gated) append, holding the path lock
+
+        var second = new TranscriptJournal(first.Path, NullLogger.Instance, Time, locks: locks, lockBound: TimeSpan.FromMilliseconds(100));
+        await Assert.That(second.Open(null, null)).IsFalse(); // the lock is held by the abandoned call
+        await Assert.That(second.IsOpen).IsFalse();
+
+        sink.Release.Release(10);
+        await Task.Delay(200);
+        var third = new TranscriptJournal(first.Path, NullLogger.Instance, Time, locks: locks, lockBound: TimeSpan.FromMilliseconds(100));
+        await Assert.That(third.Open(null, null)).IsTrue();
+        await third.CompleteAsync();
+
+        var texts = Lines(first.Path).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Kind == AcpEventKind.SessionStarted ? "header" : e.Text; });
+        await Assert.That(texts).IsEquivalentTo(new string?[] { "header", "late", "header" });
+    }
+
+    [Test]
+    public async Task Same_agent_id_under_two_state_dirs_takes_two_locks() {
+        using var a = new TempDir(); using var b = new TempDir();
+        var locks = new JournalPathLocks();
+        var sink = new GatedSink();
+        var hung = new TranscriptJournal(TranscriptJournal.ForAgent(a.Path, "agent-1", NullLogger.Instance).Path, NullLogger.Instance, Time, sink.Append, locks, capacity: 1, completeGrace: TimeSpan.FromMilliseconds(100));
+        hung.Open(null, null); hung.Record(Text("x"));
+        await Task.Delay(50);
+        await hung.CompleteAsync();
+
+        var other = new TranscriptJournal(TranscriptJournal.ForAgent(b.Path, "agent-1", NullLogger.Instance).Path, NullLogger.Instance, Time, locks: locks, lockBound: TimeSpan.FromMilliseconds(100));
+        await Assert.That(other.Open(null, null)).IsTrue();
+        await other.CompleteAsync();
+        sink.Release.Release(10);
+    }
+
+    [Test]
+    public async Task Abrupt_disposal_leaves_exactly_the_lines_the_writer_reached() {
+        using var tmp = new TempDir();
+        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        journal.Open(null, null);
+        for (var i = 0; i < 50; i++) journal.Record(Text(i.ToString(CultureInfo.InvariantCulture)));
+        await Task.Delay(300); // no CompleteAsync: the process "dies"
+        foreach (var line in Lines(journal.Path)) await Assert.That(EnvelopeJournalFormat.TryRead(line, out _)).IsTrue();
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
@@ -211,7 +211,7 @@ public class TranscriptJournalTests {
         var complete = journal.CompleteAsync(); // expires while the sink still blocks on "a"
         await Assert.That(await complete).IsFalse();
         sink.Release.Release(10);
-        await Task.Delay(200);
+        await WaitUntil(() => sink.Appends >= 1);
 
         // The abandoned writer finished "a" (one item, whole) and then observed cancellation: no torn note.
         var lines = JournalFiles.ReadLines(journal.Path);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
@@ -10,12 +10,6 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 public class TranscriptJournalTests {
     static readonly FakeTimeProvider Time = new(new DateTimeOffset(2026, 9, 9, 10, 0, 0, TimeSpan.Zero));
 
-    static string[] Lines(string path) {
-        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
-        using var reader = new StreamReader(fs);
-        return reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
-    }
-
     static AcpEventEnvelope Text(string t) => new(Kind: AcpEventKind.AssistantText, Text: t);
 
     [Test]
@@ -28,7 +22,7 @@ public class TranscriptJournalTests {
         await Assert.That(journal.IsOpen).IsTrue();
         await Assert.That(journal.CreatedFile).IsTrue();
         await Assert.That(journal.Path).IsEqualTo(Path.Combine(tmp.Path, "transcripts", AgentFileNames.For("agent-1") + ".jsonl"));
-        var lines = Lines(journal.Path);
+        var lines = JournalFiles.ReadLines(journal.Path);
         await Assert.That(lines).Count().IsEqualTo(1);
         await Assert.That(EnvelopeJournalFormat.TryRead(lines[0], out var header)).IsTrue();
         await Assert.That(header.Kind).IsEqualTo(AcpEventKind.SessionStarted);
@@ -45,14 +39,14 @@ public class TranscriptJournalTests {
         first.Open("/w", null);
         first.Record(Text("a"));
         await Assert.That(await first.CompleteAsync()).IsTrue();
-        var before = Lines(first.Path);
+        var before = JournalFiles.ReadLines(first.Path);
 
         var second = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
         second.Open("/w", null);
         await Assert.That(second.CreatedFile).IsFalse();
         await second.CompleteAsync();
 
-        var after = Lines(second.Path);
+        var after = JournalFiles.ReadLines(second.Path);
         await Assert.That(after.Take(before.Length)).IsEquivalentTo(before, CollectionOrdering.Matching);
         await Assert.That(after).Count().IsEqualTo(before.Length + 1);
     }
@@ -68,7 +62,7 @@ public class TranscriptJournalTests {
 
         await Assert.That(await journal.CompleteAsync()).IsTrue();
 
-        var texts = Lines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Text; });
+        var texts = JournalFiles.ReadLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Text; });
         await Assert.That(texts).IsEquivalentTo(new string?[] { "a", "b" }, CollectionOrdering.Matching);
     }
 
@@ -104,7 +98,7 @@ public class TranscriptJournalTests {
         using var tmp = new TempDir();
         using var hang = new ManualResetEventSlim(false);
         var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time,
-            append: (path, bytes) => { if (Lines(path).Length >= 1) hang.Wait(); File.AppendAllText(path, System.Text.Encoding.UTF8.GetString(bytes)); },
+            append: (path, bytes) => { if (JournalFiles.ReadLines(path).Length >= 1) hang.Wait(); File.AppendAllText(path, System.Text.Encoding.UTF8.GetString(bytes)); },
             capacity: 4);
         journal.Open(null, null);
 
@@ -117,12 +111,15 @@ public class TranscriptJournalTests {
         await journal.CompleteAsync();
     }
 
-    /// A sink that blocks every append until released, then writes for real.
+    /// A sink that blocks every append until released, then writes for real. Both counters are what
+    /// the tests wait on: Entered rises when the writer reaches an append, Appends when it finishes one.
     sealed class GatedSink : IDisposable {
         public readonly SemaphoreSlim Release = new(0);
         public int Appends;
+        public int Entered;
 
         public void Append(string path, byte[] bytes) {
+            Interlocked.Increment(ref Entered);
             Release.Wait();
             Interlocked.Increment(ref Appends);
             using var fs = new FileStream(path, FileMode.Open, FileAccess.Write, FileShare.ReadWrite | FileShare.Delete);
@@ -150,13 +147,13 @@ public class TranscriptJournalTests {
         await Assert.That(journal.PendingGap).IsEqualTo(2);
         gate.SetResult();
         sink.Release.Release(); // the writer takes "a": one slot frees
-        await Task.Delay(100);
+        await WaitUntil(() => Volatile.Read(ref sink.Appends) >= 1);
         journal.Record(Text("c")); // exactly one slot free: this item carries the gap
         await Assert.That(journal.PendingGap).IsEqualTo(0);
         sink.Release.Release(10);
         await Assert.That(await journal.CompleteAsync()).IsTrue();
 
-        var texts = Lines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); }).ToList();
+        var texts = JournalFiles.ReadLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); }).ToList();
         await Assert.That(texts).IsEquivalentTo(new (string, string?)[] {
             (AcpEventKind.AssistantText, "a"), (AcpEventKind.AssistantText, "b"),
             (AcpEventKind.SystemNote, "2 envelopes were not recorded to this journal"), (AcpEventKind.AssistantText, "c") },
@@ -174,7 +171,7 @@ public class TranscriptJournalTests {
         gate.SetResult();
         sink.Release.Release(10);
         await Assert.That(await journal.CompleteAsync()).IsTrue();
-        var last = Lines(journal.Path).Last();
+        var last = JournalFiles.ReadLines(journal.Path).Last();
         EnvelopeJournalFormat.TryRead(last, out var e);
         await Assert.That(e.Text).IsEqualTo("1 envelopes were not recorded to this journal");
     }
@@ -189,7 +186,7 @@ public class TranscriptJournalTests {
         journal.Open(null, null);
         journal.Record(Text("a")); journal.Record(Text("b")); journal.Record(Text("lost"));
         gate.SetResult();
-        await Task.Delay(50);
+        await WaitUntil(() => Volatile.Read(ref sink.Entered) >= 1); // "a" is in flight, blocked in the sink
 
         var sw = System.Diagnostics.Stopwatch.StartNew();
         var drained = await journal.CompleteAsync();
@@ -209,15 +206,15 @@ public class TranscriptJournalTests {
         var journal = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, capacity: 1, completeGrace: TimeSpan.FromMilliseconds(100));
         journal.Open(null, null);
         journal.Record(Text("a")); journal.Record(Text("lost"));
-        await Task.Delay(50);
-        journal.Record(Text("c")); // still full: counted
+        await WaitUntil(() => Volatile.Read(ref sink.Entered) >= 1);
+        journal.Record(Text("c")); // the writer holds "a", so this item enters carrying the gap
         var complete = journal.CompleteAsync(); // expires while the sink still blocks on "a"
         await Assert.That(await complete).IsFalse();
         sink.Release.Release(10);
         await Task.Delay(200);
 
         // The abandoned writer finished "a" (one item, whole) and then observed cancellation: no torn note.
-        var lines = Lines(journal.Path);
+        var lines = JournalFiles.ReadLines(journal.Path);
         foreach (var line in lines) await Assert.That(EnvelopeJournalFormat.TryRead(line, out _)).IsTrue();
         await Assert.That(sink.Appends).IsEqualTo(1);
     }
@@ -232,7 +229,7 @@ public class TranscriptJournalTests {
         await Assert.That(await journal.CompleteAsync()).IsTrue(); // the writer exited (by faulting), so it drained
         await Assert.That(log.Warnings).Count().IsEqualTo(1);
         await Assert.That(log.Warnings[0]).Contains("write failed");
-        await Assert.That(Lines(journal.Path)).Count().IsEqualTo(1); // header only
+        await Assert.That(JournalFiles.ReadLines(journal.Path)).Count().IsEqualTo(1); // header only
     }
 
     [Test]
@@ -240,21 +237,26 @@ public class TranscriptJournalTests {
         using var tmp = new TempDir();
         var path = tmp.PathTo("j.jsonl");
         var gate = WriterGate();
-        // The crash model: a buffer cut after its note line.
+        var appends = 0;
+        // The crash model: only the gap-bearing buffer is cut, after its note line. An ordinary
+        // record is written whole, so "a" proves the truncation is the item's and not the sink's.
         var journal = new TranscriptJournal(path, NullLogger.Instance, Time, append: (p, bytes) => {
+            Interlocked.Increment(ref appends);
             var text = System.Text.Encoding.UTF8.GetString(bytes);
-            var cut = text.IndexOf('\n', StringComparison.Ordinal) + 1 + 5;
-            File.AppendAllText(p, text[..Math.Min(cut, text.Length)]);
+            var noteEnd = text.IndexOf('\n', StringComparison.Ordinal) + 1;
+            var whole = !text.Contains("not recorded", StringComparison.Ordinal);
+            File.AppendAllText(p, whole ? text : text[..Math.Min(noteEnd + 5, text.Length)]);
         }, capacity: 1, writerStartGate: gate.Task);
         journal.Open(null, null);
         journal.Record(Text("a")); journal.Record(Text("lost")); // "a" carries no gap
         gate.SetResult();
-        await Task.Delay(50);
+        await WaitUntil(() => Volatile.Read(ref appends) >= 1);
         journal.Record(Text("c")); // carries gap 1: note + torn "c"
         await journal.CompleteAsync();
 
         var tail = new JsonlTail(path).ReadAppended();
         await Assert.That(tail.Lines.Count(l => l.Contains("not recorded", StringComparison.Ordinal))).IsEqualTo(1);
+        await Assert.That(tail.Lines.Any(l => l.Contains("\"a\"", StringComparison.Ordinal))).IsTrue();
         await Assert.That(tail.Lines.Any(l => l.Contains("\"c\"", StringComparison.Ordinal))).IsFalse();
     }
 
@@ -267,7 +269,7 @@ public class TranscriptJournalTests {
         var first = new TranscriptJournal(tmp.PathTo("j.jsonl"), NullLogger.Instance, Time, sink.Append, locks, capacity: 1, completeGrace: TimeSpan.FromMilliseconds(100), lockBound: TimeSpan.FromMilliseconds(100));
         first.Open(null, null);
         first.Record(Text("late"));
-        await Task.Delay(50);
+        await WaitUntil(() => Volatile.Read(ref sink.Entered) >= 1);
         await Assert.That(await first.CompleteAsync()).IsFalse(); // writer abandoned inside the (gated) append, holding the path lock
 
         var second = new TranscriptJournal(first.Path, NullLogger.Instance, Time, locks: locks, lockBound: TimeSpan.FromMilliseconds(100));
@@ -275,12 +277,12 @@ public class TranscriptJournalTests {
         await Assert.That(second.IsOpen).IsFalse();
 
         sink.Release.Release(10);
-        await Task.Delay(200);
+        await WaitUntil(() => Volatile.Read(ref sink.Appends) >= 1); // the abandoned append returned and freed the path lock
         var third = new TranscriptJournal(first.Path, NullLogger.Instance, Time, locks: locks, lockBound: TimeSpan.FromMilliseconds(100));
         await Assert.That(third.Open(null, null)).IsTrue();
         await third.CompleteAsync();
 
-        var texts = Lines(first.Path).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Kind == AcpEventKind.SessionStarted ? "header" : e.Text; });
+        var texts = JournalFiles.ReadLines(first.Path).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return e.Kind == AcpEventKind.SessionStarted ? "header" : e.Text; });
         await Assert.That(texts).IsEquivalentTo(new string?[] { "header", "late", "header" }, CollectionOrdering.Matching);
     }
 
@@ -291,13 +293,21 @@ public class TranscriptJournalTests {
         var sink = new GatedSink();
         var hung = new TranscriptJournal(TranscriptJournal.ForAgent(a.Path, "agent-1", NullLogger.Instance).Path, NullLogger.Instance, Time, sink.Append, locks, capacity: 1, completeGrace: TimeSpan.FromMilliseconds(100));
         hung.Open(null, null); hung.Record(Text("x"));
-        await Task.Delay(50);
+        await WaitUntil(() => Volatile.Read(ref sink.Entered) >= 1);
         await hung.CompleteAsync();
 
         var other = new TranscriptJournal(TranscriptJournal.ForAgent(b.Path, "agent-1", NullLogger.Instance).Path, NullLogger.Instance, Time, locks: locks, lockBound: TimeSpan.FromMilliseconds(100));
         await Assert.That(other.Open(null, null)).IsTrue();
         await other.CompleteAsync();
         sink.Release.Release(10);
+    }
+
+    /// Bounded on the wall clock, not on a poll count: each poll's delay is itself a thread-pool
+    /// continuation, so under load 500 of them is nothing like the five seconds it reads as.
+    static async Task WaitUntil(Func<bool> condition) {
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        while (!condition() && sw.Elapsed < TimeSpan.FromSeconds(30)) await Task.Delay(10);
+        await Assert.That(condition()).IsTrue();
     }
 
     [Test]
@@ -307,6 +317,6 @@ public class TranscriptJournalTests {
         journal.Open(null, null);
         for (var i = 0; i < 50; i++) journal.Record(Text(i.ToString(CultureInfo.InvariantCulture)));
         await Task.Delay(300); // no CompleteAsync: the process "dies"
-        foreach (var line in Lines(journal.Path)) await Assert.That(EnvelopeJournalFormat.TryRead(line, out _)).IsTrue();
+        foreach (var line in JournalFiles.ReadLines(journal.Path)) await Assert.That(EnvelopeJournalFormat.TryRead(line, out _)).IsTrue();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/ArgParsingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/ArgParsingTests.cs
@@ -135,7 +135,7 @@ public class ArgParsingTests {
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
-    public async Task ResolveSessionIdFromEnv_returns_kcap_env_stripped_of_dashes() {
+    public async Task ResolveSessionIdFromEnv_keeps_an_opaque_kcap_env_id_unchanged() {
         var savedKap = Environment.GetEnvironmentVariable(CapacitorSessionIdEnvVar);
         var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, "abc-def-123");
@@ -144,7 +144,7 @@ public class ArgParsingTests {
         try {
             var id = ArgParsing.ResolveSessionIdFromEnv();
 
-            await Assert.That(id).IsEqualTo("abcdef123");
+            await Assert.That(id).IsEqualTo("abc-def-123");
         } finally {
             Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, savedKap);
             Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
@@ -153,7 +153,7 @@ public class ArgParsingTests {
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
-    public async Task ResolveSessionIdFromEnv_returns_codex_env_stripped_of_dashes_when_kcap_unset() {
+    public async Task ResolveSessionIdFromEnv_keeps_an_opaque_codex_env_id_when_kcap_unset() {
         var savedKap = Environment.GetEnvironmentVariable(CapacitorSessionIdEnvVar);
         var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
         Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, null);
@@ -162,7 +162,7 @@ public class ArgParsingTests {
         try {
             var id = ArgParsing.ResolveSessionIdFromEnv();
 
-            await Assert.That(id).IsEqualTo("threaduuid1");
+            await Assert.That(id).IsEqualTo("thread-uuid-1");
         } finally {
             Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, savedKap);
             Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
@@ -180,7 +180,7 @@ public class ArgParsingTests {
         try {
             var id = ArgParsing.ResolveSessionIdFromEnv();
 
-            await Assert.That(id).IsEqualTo("kap1");
+            await Assert.That(id).IsEqualTo("kap-1");
         } finally {
             Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, savedKap);
             Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
@@ -198,7 +198,7 @@ public class ArgParsingTests {
         try {
             var id = ArgParsing.ResolveSessionIdFromEnv();
 
-            await Assert.That(id).IsEqualTo("cdx3");
+            await Assert.That(id).IsEqualTo("cdx-3");
         } finally {
             Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, savedKap);
             Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
@@ -219,11 +219,24 @@ public class ArgParsingTests {
                 valueFlags: ["--model"]
             );
 
-            await Assert.That(id).IsEqualTo("cdxonly");
+            await Assert.That(id).IsEqualTo("cdx-only");
         } finally {
             Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, savedKap);
             Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);
         }
+    }
+
+    /// The ambient id must land on the same key an explicit `session_id` does: an opaque vendor id
+    /// keeps its dashes (stripping them names a session the server has never seen) and a GUID
+    /// collapses to the 32-hex form the server files it under.
+    [Test]
+    [Arguments("sess-1", "sess-1")]
+    [Arguments("fixed-conversation-id", "fixed-conversation-id")]
+    [Arguments("1234abcd-56ef-78ab-90cd-1234567890ab", "1234abcd56ef78ab90cd1234567890ab")]
+    public async Task ResolveSessionIdFromEnv_canonicalizes_like_the_server(string exported, string expected) {
+        var id = ArgParsing.ResolveSessionIdFromEnv(key => key == "KCAP_SESSION_ID" ? exported : null);
+
+        await Assert.That(id).IsEqualTo(expected);
     }
 
     [Test]
@@ -260,10 +273,10 @@ public class ArgParsingTests {
 
     [Test]
     [NotInParallel(nameof(SessionEnvVarMutation))]
-    public async Task ResolveSessionId_strips_dashes_from_kcap_env_fallback() {
+    public async Task ResolveSessionId_canonicalizes_a_guid_kcap_env_fallback() {
         var savedKap = Environment.GetEnvironmentVariable(CapacitorSessionIdEnvVar);
         var savedCdx = Environment.GetEnvironmentVariable(CodexThreadIdEnvVar);
-        Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, "abc-def");
+        Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, "1234abcd-56ef-78ab-90cd-1234567890ab");
         Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      null);
 
         try {
@@ -272,7 +285,7 @@ public class ArgParsingTests {
                 valueFlags: ["--model"]
             );
 
-            await Assert.That(id).IsEqualTo("abcdef");
+            await Assert.That(id).IsEqualTo("1234abcd56ef78ab90cd1234567890ab");
         } finally {
             Environment.SetEnvironmentVariable(CapacitorSessionIdEnvVar, savedKap);
             Environment.SetEnvironmentVariable(CodexThreadIdEnvVar,      savedCdx);

--- a/test/Capacitor.Cli.Tests.Unit/HarnessRequesterContextTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/HarnessRequesterContextTests.cs
@@ -103,7 +103,7 @@ public class HarnessRequesterContextTests {
             }),
             directoryExists: _ => true);
 
-        await Assert.That(resolved.SessionId).IsEqualTo("abcdef");
+        await Assert.That(resolved.SessionId).IsEqualTo("abc-def"); // opaque: canonicalization keeps it
         await Assert.That(resolved.ProjectDir).IsNull();
     }
 

--- a/test/Capacitor.Tests.Helpers/CapturingLogger.cs
+++ b/test/Capacitor.Tests.Helpers/CapturingLogger.cs
@@ -1,0 +1,30 @@
+using Microsoft.Extensions.Logging;
+
+namespace Capacitor.Tests.Helpers;
+
+/// <summary>An <see cref="ILogger"/> that keeps the rendered warnings, for code whose only visible
+/// output on a degraded path is what it logged.</summary>
+public sealed class CapturingLogger : ILogger {
+    readonly List<string> _warnings = [];
+
+    public IReadOnlyList<string> Warnings { get { lock (_warnings) return [.. _warnings]; } }
+
+    public IDisposable? BeginScope<TState>(TState state) where TState : notnull => NoScope.Instance;
+
+    public bool IsEnabled(LogLevel logLevel) => true;
+
+    public void Log<TState>(
+            LogLevel                         logLevel,
+            EventId                          eventId,
+            TState                           state,
+            Exception?                       exception,
+            Func<TState, Exception?, string> formatter) {
+        if (logLevel != LogLevel.Warning) return;
+        lock (_warnings) _warnings.Add(formatter(state, exception));
+    }
+
+    sealed class NoScope : IDisposable {
+        public static readonly NoScope Instance = new();
+        public void Dispose() { }
+    }
+}

--- a/test/Capacitor.Tests.Helpers/JournalFiles.cs
+++ b/test/Capacitor.Tests.Helpers/JournalFiles.cs
@@ -1,0 +1,14 @@
+namespace Capacitor.Tests.Helpers;
+
+/// Reads a file a live writer still owns. <c>File.ReadAllText</c> and friends open
+/// <c>FileShare.Read</c>, which DENIES Write to every other handle — mandatory on Windows, so such a
+/// read stops the writer appending to its own journal while the test looks at it.
+public static class JournalFiles {
+    public static string[] ReadLines(string path) {
+        using var fs = new FileStream(path, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+        using var reader = new StreamReader(fs);
+        return reader.ReadToEnd().Split('\n', StringSplitOptions.RemoveEmptyEntries);
+    }
+
+    public static string ReadText(string path) => string.Join("\n", ReadLines(path));
+}


### PR DESCRIPTION
Closes #839 — AI-2625 (first slice of AI-2197)

## What & why

Hosted sessions without a PTY (Cursor, Copilot, Gemini, Kiro, OpenCode, Antigravity, Pi, Codex app-server) had no Chat tab and no way to send a follow-up from the desktop app: the chat needs a local transcript file, and only Claude and Codex wrote one. The daemon now appends every accepted envelope to a per-agent journal under its state directory and reports it as `transcript_path` with a new `transcript_format`; the app tails it with the same `JsonlTail` and renders it through a passthrough projection. Input rides a new one-shot local frame, `SendText`/`SendTextAck` (capability `input/1`), routed into the same delivery core the web's `SendInput` uses, so a local send and a web send behave identically. Design: `docs/superpowers/specs/2026-09-09-ai2197-non-pty-chat-and-composer-design.md`.

## Where to look

`TranscriptJournal`: `Record` is one `TryWrite` on the runtime's thread and never touches the disk; a hung filesystem costs journal lines, not protocol liveness. `HandleLocalSendTextAsync` answers only when the delivery settles — there is no reply timeout on this frame by design.

Two server-visible changes ride the shared delivery core: a failed borrowed-snapshot refresh now reports a `delivery_failed` drop where it reported nothing, and a runtime that refuses a write is logged at Warning with the drop reported to the sender rather than at Error with nothing sent.

## Verification

- `dotnet test --solution Capacitor.slnx`: 12464 total, 6 failed — all pre-existing on untouched files (`Installed_codex_schema_matches_the_vendored_pin`, the two 32 MB flood tests against a 10 s bound, load-sensitive timing tests).
- AOT publish (CLI and daemon): no IL2xxx/IL3xxx.
- Against an isolated daemon built from this branch: `HelloReply` advertises `input/1`; status rows carry `transcript_format`; `SendText` acks `no_such_agent`, `malformed`, `text_empty` and `Ok/delivered`. The journal path still needs a server-driven non-PTY launch to exercise end to end.
