### PR TITLE
Read the server-selection environment through one type

### DIFF
--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -48,6 +48,9 @@ public partial class App : Application {
 
     // And its one read of KCAP_CONFIG_DIR.
     readonly ConfigRoot _config = ConfigRoot.FromEnvironment();
+
+    // And its one read of KCAP_URL / KCAP_PROFILE.
+    readonly ProfileOverrides _serverEnv = ProfileOverrides.FromEnvironment();
     readonly UserHome   _userHome = UserHome.FromEnvironment();
 
     /// Process-lifetime rather than per wizard run — a provisioning poll can outlive the window that
@@ -55,7 +58,7 @@ public partial class App : Application {
     /// holds, and why it holds only that, is <see cref="AppHttpServices.AddAppForeignHttp"/>.
     readonly ServiceProvider _foreignHttp;
 
-    public App() => _foreignHttp = new ServiceCollection().AddAppForeignHttp(_config).BuildValidated();
+    public App() => _foreignHttp = new ServiceCollection().AddAppForeignHttp(_config, _serverEnv).BuildValidated();
 
     /// The authenticated lanes. They cannot join <see cref="_foreignHttp"/>: their handlers need a
     /// resolved server, and the app starts before a profile has named one. Process-lifetime for the
@@ -69,7 +72,7 @@ public partial class App : Application {
             .AddSingleton(_config)
             .AddSingleton(profiles)
             .AddSingleton(new CapacitorServer(url, _config, profiles))
-            .AddCapacitorHttp()
+            .AddCapacitorHttp(_serverEnv)
             .BuildValidated();
 
         return _serverHttp.GetRequiredService<ICapacitorHttpClient>();
@@ -223,7 +226,7 @@ public partial class App : Application {
                 TimeProvider.System);
             _lane = lane;
 
-            var (gate, profiles) = await ResolveAndEvaluateGateAsync(_config, _foreignHttp.GetRequiredService<TokenStore>(), _shutdown.Token);
+            var (gate, profiles) = await ResolveAndEvaluateGateAsync(_config, _foreignHttp.GetRequiredService<TokenStore>(), _serverEnv, _shutdown.Token);
             // A graph built while the lane still owns a live action must not also drive automatic
             // ones (spec §6a) — only the wizard's own handoff can answer this with anything but true.
             var laneQuiesced = true;
@@ -234,7 +237,7 @@ public partial class App : Application {
             if (gate is GateResult.Incomplete) {
                 laneQuiesced = await RunWizardModeAsync(desktop, lane, channel, laneRunner, laneProbe, profiles);
                 if (_shutdown.IsCancellationRequested) return; // quit during onboarding — nothing left to build
-                (gate, profiles) = await ResolveAndEvaluateGateAsync(_config, _foreignHttp.GetRequiredService<TokenStore>(), _shutdown.Token);
+                (gate, profiles) = await ResolveAndEvaluateGateAsync(_config, _foreignHttp.GetRequiredService<TokenStore>(), _serverEnv, _shutdown.Token);
             }
 
             BuildDaemonGraph(desktop, lane, channel, gate, profiles, laneQuiesced);
@@ -376,8 +379,8 @@ public partial class App : Application {
     // cannot be read off a second one, and the post-wizard build re-runs this rather than reusing a
     // startup value the wizard may have invalidated.
     internal static Task<(GateResult Gate, ProfileContext? Profiles)> ResolveAndEvaluateGateAsync(
-            ConfigRoot config, TokenStore tokenStore, CancellationToken ct) =>
-        EvaluateGateSafelyAsync(new OnboardingGate(config, tokenStore).EvaluateAsync, ct);
+            ConfigRoot config, TokenStore tokenStore, ProfileOverrides env, CancellationToken ct) =>
+        EvaluateGateSafelyAsync(new OnboardingGate(config, tokenStore, env).EvaluateAsync, ct);
 
     // The steady-state graph, over the resolution the gate was evaluated on (never a second resolve).
     void BuildDaemonGraph(
@@ -484,8 +487,8 @@ public partial class App : Application {
         // disposed at teardown.
         var serverLane = new ServerConnectionService(profiles, _foreignHttp.GetRequiredService<TokenStore>());
         serverLane.Start();
-        var workContext = new ServerWorkContextSource(_config, profiles);
-        var pullRequests = new ServerPullRequestSource(_config, profiles);
+        var workContext = new ServerWorkContextSource(_config, profiles, _serverEnv);
+        var pullRequests = new ServerPullRequestSource(_config, profiles, _serverEnv);
         var ghRunner = new ProcessRunner();
         var gh = new GitHubCliRunner(ghRunner, OperatingSystem.IsWindows() ? null : new LoginShellProbe(ghRunner, Environment.GetEnvironmentVariable), Environment.GetEnvironmentVariable);
         // Registration order is precedence: local CLI readers before the server.
@@ -693,7 +696,7 @@ public partial class App : Application {
             surface,
             ResolveCli: () => NewWizardCli(_config, runner, cliPath, probe),
             ResolveOps: name => new LocalControlOps(_daemonStore, name),
-            ResolveIdentity: () => ResolveWizardIdentity(_config),
+            ResolveIdentity: () => ResolveWizardIdentity(_config, _serverEnv),
             ResolveConsentFlipIdentity: () => ResolveConsentFlipIdentity(_config),
             RunMutation: lane.RunAsync,
             Observation: new OneShotObservation(_daemonStore, OneShotProbeTimeout),
@@ -705,7 +708,7 @@ public partial class App : Application {
             CliPath: cliPath,
             ShimApplicable: shimApplicable,
             ShimTarget: shimTarget,
-            DefaultDaemonName: ResolveWizardIdentity(_config)?.DaemonName,
+            DefaultDaemonName: ResolveWizardIdentity(_config, _serverEnv)?.DaemonName,
             Time: TimeProvider.System,
             ShutdownToken: _shutdown.Token));
 
@@ -1071,13 +1074,11 @@ public partial class App : Application {
     /// the resolution the gate was evaluated on, and side-effect-free. Null — never
     /// an empty-string sentinel — when nothing resolves, which is what keeps its factories fail-closed.
     /// </summary>
-    internal static (string Profile, string Server, string DaemonName)? ResolveWizardIdentity(ConfigRoot root) {
+    internal static (string Profile, string Server, string DaemonName)? ResolveWizardIdentity(ConfigRoot root, ProfileOverrides env) {
         if (!ConfigMutator.TryLoadPure(AppConfig.GetConfigPath(root), out var config)) return null;
 
-        var envUrl     = Environment.GetEnvironmentVariable("KCAP_URL");
-        var envProfile = Environment.GetEnvironmentVariable("KCAP_PROFILE");
         var resolved = new ProfileResolver(
-            config, cliServerUrl: null, envUrl, envProfile,
+            config, cliServerUrl: null, env.Url, env.Profile,
             repoConfig: null, repoRemoteUrls: [], repoPath: null).Resolve();
 
         if (resolved.ProfileName is not { Length: > 0 } profileName) return null;

--- a/src/Capacitor.App/AppHttpServices.cs
+++ b/src/Capacitor.App/AppHttpServices.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -15,8 +16,10 @@ public static class AppHttpServices {
     /// unregistered name yields a plain pooled client rather than an error — which is what this
     /// process wants, since that lane's handlers need a server it does not have.</para>
     /// </summary>
-    public static IServiceCollection AddAppForeignHttp(this IServiceCollection services, ConfigRoot config) {
+    public static IServiceCollection AddAppForeignHttp(
+            this IServiceCollection services, ConfigRoot config, ProfileOverrides env) {
         services.AddSingleton(config);
+        services.AddSingleton(env);
         services.AddCapacitorForeignClients();
         services.AddSingleton<TokenStore>();
 

--- a/src/Capacitor.App/Services/AuthenticatedServerReads.cs
+++ b/src/Capacitor.App/Services/AuthenticatedServerReads.cs
@@ -24,15 +24,18 @@ public sealed class AuthenticatedServerReads<TChannel> : IAsyncDisposable where 
     readonly CancellationTokenSource _dispose = new();
     readonly List<Task> _active = [];
     Lease? _lease;
+    readonly ProfileOverrides _env;
     ServiceProvider? _lane;
     readonly bool _allowAutoRedirect;
     long _generation;
     bool _disposed;
 
-    public AuthenticatedServerReads(ConfigRoot config, ProfileContext? profiles, Func<HttpClient, string, TChannel> channelFactory,
+    public AuthenticatedServerReads(ConfigRoot config, ProfileContext? profiles, ProfileOverrides env,
+        Func<HttpClient, string, TChannel> channelFactory,
         ClientFactory? factory = null, bool allowAutoRedirect = true) {
         _config = config;
         _profiles = profiles;
+        _env = env;
         _channelFactory = channelFactory;
         _allowAutoRedirect = allowAutoRedirect;
         _factory = factory ?? RegisteredLaneAsync;
@@ -43,7 +46,7 @@ public sealed class AuthenticatedServerReads<TChannel> : IAsyncDisposable where 
             .AddSingleton(config)
             .AddSingleton(profiles)
             .AddSingleton(new CapacitorServer(url, config, profiles))
-            .AddCapacitorHttp()
+            .AddCapacitorHttp(_env)
             .BuildValidated();
         var clients = _lane.GetRequiredService<ICapacitorHttpClient>();
         var attempt = _allowAutoRedirect

--- a/src/Capacitor.App/Services/KcapCli.cs
+++ b/src/Capacitor.App/Services/KcapCli.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.App.Services;
 
@@ -207,7 +208,7 @@ public sealed class KcapCli : IKcapCli {
 
     // Every child carries the pinned profile and the app-spawn telemetry-suppression marker.
     Dictionary<string, string> Env() => new() {
-        ["KCAP_PROFILE"]      = _profileName,
+        [ProfileOverrides.ProfileVar]      = _profileName,
         [SpawnNoTelemetryVar] = "1",
     };
 

--- a/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
+++ b/src/Capacitor.App/Services/Onboarding/OnboardingGate.cs
@@ -21,7 +21,7 @@ public enum GateReason { NoProfile, InvalidServerUrl, NoToken, TokenUnusableBind
 /// inverse of "does TokenStore already consider this profile authenticated" — so every branch
 /// here mirrors a specific TokenStore rule rather than inventing its own.
 /// </summary>
-public sealed class OnboardingGate(ConfigRoot config, TokenStore tokenStore) {
+public sealed class OnboardingGate(ConfigRoot config, TokenStore tokenStore, ProfileOverrides env) {
     /// <summary>
     /// The ONE shared validator for "is this usable as a server identity" — also used by
     /// <c>App.ValidProfileName</c> so the gate and the lifecycle-controller precondition can
@@ -37,7 +37,7 @@ public sealed class OnboardingGate(ConfigRoot config, TokenStore tokenStore) {
     /// different profiles.
     public async Task<(GateResult Result, ProfileContext Profiles)> EvaluateAsync(CancellationToken ct) {
         // Daemon-style resolution — no repo/git discovery, matching decision 1's "local" scope.
-        var profiles = await AppConfig.ResolveActiveProfile([], config);
+        var profiles = await AppConfig.ResolveActiveProfile([], config, env);
         GateResult result;
         try {
             result = await EvaluateResolvedAsync(profiles.Resolution.ProfileName, profiles.Resolution.Profile, ct);

--- a/src/Capacitor.App/Services/ServerPullRequestSource.cs
+++ b/src/Capacitor.App/Services/ServerPullRequestSource.cs
@@ -9,9 +9,9 @@ public sealed class ServerPullRequestSource : IPullRequestSource, IAsyncDisposab
     readonly Lock _lock = new();
     readonly Dictionary<string, int> _missing = new(StringComparer.Ordinal);
     long _generation;
-    public ServerPullRequestSource(ConfigRoot config, ProfileContext? profiles,
+    public ServerPullRequestSource(ConfigRoot config, ProfileContext? profiles, ProfileOverrides env,
         AuthenticatedServerReads<PullRequestClient>.ClientFactory? factory = null, TimeProvider? time = null) {
-        _reads = new(config, profiles, (http, url) => new PullRequestClient(http, url, time), factory, allowAutoRedirect: false);
+        _reads = new(config, profiles, env, (http, url) => new PullRequestClient(http, url, time), factory, allowAutoRedirect: false);
     }
     public Task<PullRequestCapability> DiscoverAsync(bool refresh, CancellationToken ct) => _reads.ReadAsync((channel, token) => channel.DiscoverAsync(refresh, token),
         read => read.Kind == PullRequestCapabilityKind.SignedOut, new PullRequestCapability(PullRequestCapabilityKind.SignedOut),

--- a/src/Capacitor.App/Services/ServerWorkContextSource.cs
+++ b/src/Capacitor.App/Services/ServerWorkContextSource.cs
@@ -8,8 +8,8 @@ public sealed class ServerWorkContextSource : IWorkContextSource, IAsyncDisposab
     public delegate Task<(HttpClient Client, AuthStatus Status)> ClientFactory(ConfigRoot config, ProfileContext profiles, string serverUrl, CancellationToken ct);
     readonly AuthenticatedServerReads<WorkContextClient> _reads;
 
-    public ServerWorkContextSource(ConfigRoot config, ProfileContext? profiles, ClientFactory? factory = null) {
-        _reads = new(config, profiles, (http, url) => new WorkContextClient(http, url),
+    public ServerWorkContextSource(ConfigRoot config, ProfileContext? profiles, ProfileOverrides env, ClientFactory? factory = null) {
+        _reads = new(config, profiles, env, (http, url) => new WorkContextClient(http, url),
             factory is null ? null : (c, p, url, ct) => factory(c, p, url, ct));
     }
     public Task<WorkContextRead> ReadAsync(string sessionId, CancellationToken ct) => _reads.ReadAsync(

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -59,7 +59,7 @@ public sealed record TokenResolution(
 // treats Contended quietly — no warning, no backoff.
 public enum ProactiveRefreshOutcome { NotDue, Refreshed, Failed, Contended }
 
-public sealed class TokenStore(ConfigRoot config, IHttpClientFactory httpFactory, WorkOSClient workos) {
+public sealed class TokenStore(ConfigRoot config, ProfileOverrides env, IHttpClientFactory httpFactory, WorkOSClient workos) {
     string LegacyTokenPath { get; } = config.Path("tokens.json");
     string TokenDir        { get; } = config.Path("tokens");
 
@@ -625,7 +625,7 @@ public sealed class TokenStore(ConfigRoot config, IHttpClientFactory httpFactory
         // it falls back to KCAP_URL and then to the profile's own server_url.
         var configured = tokens.ServerUrl is not null
             ? null
-            : Environment.GetEnvironmentVariable("KCAP_URL")
+            : env.Url
               ?? (await AppConfig.LoadProfileConfig(config, ct)).Profiles.GetValueOrDefault(profile)?.ServerUrl;
 
         var baseUrl = tokens.ServerUrl ?? configured ?? "http://localhost:5108";

--- a/src/Capacitor.Cli.Core/Commands/ReviewLaunchBuilder.cs
+++ b/src/Capacitor.Cli.Core/Commands/ReviewLaunchBuilder.cs
@@ -1,6 +1,7 @@
 using System.Globalization;
 using System.Text.Json;
 using System.Text.Json.Nodes;
+using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli.Core.Commands;
 
@@ -30,7 +31,7 @@ public static class ReviewLaunchBuilder {
         var mcp = new ReviewMcpServer(
             Command: cliPath,
             Args: ["mcp", "review", "--owner", owner, "--repo", repo, "--pr", prNumber.ToString(CultureInfo.InvariantCulture)],
-            Env: new Dictionary<string, string> { ["KCAP_URL"] = baseUrl });
+            Env: new Dictionary<string, string> { [ProfileOverrides.UrlVar] = baseUrl });
 
         string? configPath = null;
 

--- a/src/Capacitor.Cli.Core/Config/AppConfig.cs
+++ b/src/Capacitor.Cli.Core/Config/AppConfig.cs
@@ -56,18 +56,16 @@ public static class AppConfig {
     /// remote matching — used by the daemon, which is not bound to a working
     /// directory.
     /// </summary>
-    public static async Task<ProfileContext> ResolveActiveProfile(string[] args, ConfigRoot config) {
+    public static async Task<ProfileContext> ResolveActiveProfile(string[] args, ConfigRoot config, ProfileOverrides env) {
         var idx          = Array.IndexOf(args, "--server-url");
         var cliServerUrl = (idx >= 0 && idx + 1 < args.Length) ? args[idx + 1] : null;
-        var envUrl       = Environment.GetEnvironmentVariable("KCAP_URL");
-        var envProfile   = Environment.GetEnvironmentVariable("KCAP_PROFILE");
 
         var loaded   = await LoadProfileConfig(config);
         var resolver = new ProfileResolver(
             loaded,
             cliServerUrl,
-            envUrl,
-            envProfile,
+            env.Url,
+            env.Profile,
             repoConfig: null,
             repoRemoteUrls: [],
             repoPath: null
@@ -82,22 +80,21 @@ public static class AppConfig {
         return new(resolved, loaded);
     }
 
-    public static async Task<ProfileContext> ResolveForRepo(string[] args, ConfigRoot root, int gitTimeoutMs = 5000) {
+    public static async Task<ProfileContext> ResolveForRepo(string[] args, ConfigRoot root, ProfileOverrides env, int gitTimeoutMs = 5000) {
         var idx          = Array.IndexOf(args, "--server-url");
         var cliServerUrl = (idx >= 0 && idx + 1 < args.Length) ? args[idx + 1] : null;
 
-        var envUrl     = Environment.GetEnvironmentVariable("KCAP_URL");
-        var envProfile = Environment.GetEnvironmentVariable("KCAP_PROFILE");
-
-        // Short-circuit: if explicit URL is provided, skip all profile/repo resolution
-        if (cliServerUrl is not null || envUrl is not null) {
+        // Short-circuit: if an explicit URL is provided, skip all profile/repo resolution. Empty is
+        // not one — the resolver skips an empty value, so short-circuiting on it would withhold the
+        // repo inputs from the very resolution that then has to fall back to them.
+        if (!string.IsNullOrEmpty(cliServerUrl) || env.Url is not null) {
             var config = await LoadProfileConfig(root);
 
             var resolver = new ProfileResolver(
                 config,
                 cliServerUrl,
-                envUrl,
-                envProfile,
+                env.Url,
+                env.Profile,
                 repoConfig: null,
                 repoRemoteUrls: [],
                 repoPath: null
@@ -129,8 +126,8 @@ public static class AppConfig {
             var resolver = new ProfileResolver(
                 config,
                 cliServerUrl,
-                envUrl,
-                envProfile,
+                env.Url,
+                env.Profile,
                 repoConfig,
                 remoteUrls,
                 repoRoot

--- a/src/Capacitor.Cli.Core/Config/ProfileOverrides.cs
+++ b/src/Capacitor.Cli.Core/Config/ProfileOverrides.cs
@@ -1,0 +1,38 @@
+namespace Capacitor.Cli.Core.Config;
+
+/// <summary>
+/// What the environment says about which server this process talks to, resolved once at the
+/// composition root: a URL that outranks every profile, and a profile name that outranks repo
+/// discovery. <see cref="ProfileResolver"/> owns what they outrank; this owns what counts as set.
+///
+/// <para>The names are a contract between the two executables and the service unit — kcap stamps
+/// them onto the watchers, agents and units it spawns, and each of those reads them back — so a
+/// name that drifts on one side fails silently. Both sides take them from here.</para>
+/// </summary>
+public sealed record ProfileOverrides(string? Url, string? Profile) {
+    public const string UrlVar     = "KCAP_URL";
+    public const string ProfileVar = "KCAP_PROFILE";
+
+    /// <summary>
+    /// An exported variable can be empty, and an empty value names no server. Discarded on the way
+    /// in — on every construction path, not just <see cref="FromEnvironment"/> — so a caller testing
+    /// this for null cannot disagree with <see cref="ProfileResolver"/>, which skips an empty value
+    /// and lets the next input win. A value of blanks was set by someone and still counts as one.
+    /// </summary>
+    public string? Url { get => _url; init => _url = Named(value); }
+
+    /// <inheritdoc cref="Url"/>
+    public string? Profile { get => _profile; init => _profile = Named(value); }
+
+    readonly string? _url     = Named(Url);
+    readonly string? _profile = Named(Profile);
+
+    static string? Named(string? value) => value is { Length: > 0 } ? value : null;
+
+    /// <summary>Nothing overridden — selection falls through to the repo and the active profile.</summary>
+    public static readonly ProfileOverrides None = new(null, null);
+
+    /// <summary>This process's overrides. Call once, in <c>Main</c> or the composition root.</summary>
+    public static ProfileOverrides FromEnvironment() =>
+        new(Environment.GetEnvironmentVariable(UrlVar), Environment.GetEnvironmentVariable(ProfileVar));
+}

--- a/src/Capacitor.Cli.Core/Eval/EvalService.cs
+++ b/src/Capacitor.Cli.Core/Eval/EvalService.cs
@@ -124,7 +124,7 @@ public static class EvalService {
                 [JudgeMcpServerName] = new JsonObject {
                     ["command"] = commandPath,
                     ["args"]    = new JsonArray("mcp", "judge", "--session", sessionId),
-                    ["env"]     = new JsonObject { ["KCAP_URL"] = baseUrl }
+                    ["env"]     = new JsonObject { [ProfileOverrides.UrlVar] = baseUrl }
                 }
             }
         }.ToJsonString();

--- a/src/Capacitor.Cli.Core/Http/CapacitorHttpServices.cs
+++ b/src/Capacitor.Cli.Core/Http/CapacitorHttpServices.cs
@@ -11,8 +11,9 @@ public static class CapacitorHttpServices {
     /// so it records the response finally returned rather than a discarded 401, and the observation
     /// headers so a resend carries one copy of each rather than two.
     /// </summary>
-    public static IServiceCollection AddCapacitorHttp(this IServiceCollection services) {
+    public static IServiceCollection AddCapacitorHttp(this IServiceCollection services, ProfileOverrides env) {
         services.AddCapacitorForeignClients();
+        services.AddSingleton(env);
         // Here rather than beside ConfigRoot: the refreshes need the anonymous and WorkOS lanes, so a
         // host that never stands up HTTP is never handed a store that can reach the network.
         services.AddSingleton<TokenStore>();

--- a/src/Capacitor.Cli.Core/UnusableUrlDiagnostic.cs
+++ b/src/Capacitor.Cli.Core/UnusableUrlDiagnostic.cs
@@ -1,3 +1,5 @@
+using Capacitor.Cli.Core.Config;
+
 namespace Capacitor.Cli.Core;
 
 /// <summary>Where the resolved server URL came from, so remediation can name the right thing to fix.</summary>
@@ -53,8 +55,8 @@ public static class UnusableUrlDiagnostic {
         var (name, fix) = source switch {
             UrlSource.CommandLine => ("--server-url",
                                       "Pass --server-url https://<host>."),
-            UrlSource.Environment => ("KCAP_URL",
-                                      "Set KCAP_URL to https://<host>, or unset it to use the configured profile."),
+            UrlSource.Environment => (ProfileOverrides.UrlVar,
+                                      $"Set {ProfileOverrides.UrlVar} to https://<host>, or unset it to use the configured profile."),
             _                     => ("server_url",
                                       "Run: kcap config set server_url https://<host>"),
         };

--- a/src/Capacitor.Cli.Daemon/DaemonHttpServices.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonHttpServices.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -11,9 +12,9 @@ public static class DaemonHttpServices {
     /// headers to drift out of step.
     /// </summary>
     public static IServiceCollection AddDaemonHttp(
-            this IServiceCollection services, ConfigRoot configRoot, DaemonConfig config) {
+            this IServiceCollection services, ConfigRoot configRoot, DaemonConfig config, ProfileOverrides env) {
         services.AddSingleton(_ => new CapacitorServer(config.ServerUrl, configRoot, config.Profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(env);
 
         return services;
     }

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -94,7 +94,8 @@ public static partial class DaemonRunner {
         // Program.cs, but the daemon is a separate process so its statics start
         // empty. Skips repo discovery (the daemon isn't bound to a working dir);
         // honors --server-url, KCAP_URL, KCAP_PROFILE.
-        var profiles = await AppConfig.ResolveActiveProfile(args, configRoot);
+        var serverEnv = ProfileOverrides.FromEnvironment();
+        var profiles  = await AppConfig.ResolveActiveProfile(args, configRoot, serverEnv);
         config.Profiles  = profiles;
         config.ServerUrl = profiles.Resolution.ServerUrl ?? "";
 
@@ -371,7 +372,7 @@ public static partial class DaemonRunner {
         builder.Services.AddSingleton(config);
         builder.Services.AddSingleton(harnesses);
         builder.Services.AddSingleton(daemonLock);
-        builder.Services.AddDaemonHttp(configRoot, config);
+        builder.Services.AddDaemonHttp(configRoot, config, serverEnv);
         builder.Services.AddSingleton<ServerConnection>();
 
         // The owner consent gate — policy store + append-only decision log share the

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
@@ -3,6 +3,7 @@ using System.Runtime.CompilerServices;
 using System.Text;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
@@ -579,7 +580,7 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
         // its config, MCP servers and result channel at the operator's profile, not this home.
         psi.Environment.Remove("GEMINI_CLI_HOME");
 
-        if (!string.IsNullOrEmpty(ctx.ServerUrl)) psi.Environment["KCAP_URL"] = ctx.ServerUrl;
+        if (!string.IsNullOrEmpty(ctx.ServerUrl)) psi.Environment[ProfileOverrides.UrlVar] = ctx.ServerUrl;
 
         // Without these a surviving turn child is invisible to OrphanReaper's env-marker pass — and
         // nothing fails visibly when they are omitted, which is exactly why they are stamped here

--- a/src/Capacitor.Cli.Daemon/Harness/Claude/ClaudeLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Claude/ClaudeLauncher.cs
@@ -1,6 +1,7 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Core.Harness.Claude;
 using Capacitor.Cli.Core.LocalIpc;
@@ -209,8 +210,8 @@ internal sealed partial class ClaudeLauncher(
             ["command"] = (JsonNode?)config.CapacitorPath,
             ["args"]    = argsNode,
             ["env"]     = new JsonObject {
-                ["KCAP_URL"]            = (JsonNode?)config.ServerUrl,
-                ["KCAP_FLOW_AGENT_ID"] = (JsonNode?)ctx.AgentId
+                [ProfileOverrides.UrlVar] = (JsonNode?)config.ServerUrl,
+                ["KCAP_FLOW_AGENT_ID"]    = (JsonNode?)ctx.AgentId
             }
         };
 
@@ -238,7 +239,7 @@ internal sealed partial class ClaudeLauncher(
                 ["command"] = (JsonNode?)config.CapacitorPath,
                 ["args"]    = entryArgs,
                 ["env"]     = new JsonObject {
-                    ["KCAP_URL"] = (JsonNode?)config.ServerUrl
+                    [ProfileOverrides.UrlVar] = (JsonNode?)config.ServerUrl
                 }
             };
         }

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexHostedAgentRuntimeFactory.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging;
@@ -181,9 +182,9 @@ internal sealed class CodexHostedAgentRuntimeFactory : IHostedAgentRuntimeFactor
             [HostedAgent.RenderedVar] = HostedAgent.Rendered,
             [HostedAgent.AgentIdVar]  = ctx.AgentId,
         };
-        if (!string.IsNullOrEmpty(ctx.DaemonId))        env["KCAP_DAEMON_ID"]    = ctx.DaemonId;
-        if (!string.IsNullOrEmpty(ctx.DaemonEpoch))     env["KCAP_DAEMON_EPOCH"] = ctx.DaemonEpoch;
-        if (!string.IsNullOrEmpty(ctx.ServerUrl))       env["KCAP_URL"]          = ctx.ServerUrl;
+        if (!string.IsNullOrEmpty(ctx.DaemonId))        env["KCAP_DAEMON_ID"]         = ctx.DaemonId;
+        if (!string.IsNullOrEmpty(ctx.DaemonEpoch))     env["KCAP_DAEMON_EPOCH"]      = ctx.DaemonEpoch;
+        if (!string.IsNullOrEmpty(ctx.ServerUrl))       env[ProfileOverrides.UrlVar]  = ctx.ServerUrl;
         if (!string.IsNullOrEmpty(ctx.DaemonBridgeUrl)) env[HostedAgent.BridgeUrlVar] = ctx.DaemonBridgeUrl;
         // guard-1: only an envelope-sourced session carries this marker; the codex hook + watcher read it
         // and stand down so the rollout is not double-ingested alongside the envelopes.

--- a/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Codex/CodexLauncher.cs
@@ -1,6 +1,7 @@
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Commands;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Core.Harness.Codex;
 using Capacitor.Cli.Core.LocalIpc;
@@ -342,7 +343,7 @@ internal sealed partial class CodexLauncher(
         args.Add("-c");
         args.Add($"mcp_servers.{name}.args=[{TomlString("mcp")},{TomlString("flow-result")}]");
         args.Add("-c");
-        args.Add($"mcp_servers.{name}.env={{KCAP_URL={TomlString(config.ServerUrl)},KCAP_FLOW_AGENT_ID={TomlString(ctx.AgentId)}}}");
+        args.Add($"mcp_servers.{name}.env={{{ProfileOverrides.UrlVar}={TomlString(config.ServerUrl)},KCAP_FLOW_AGENT_ID={TomlString(ctx.AgentId)}}}");
         AddAppServerApprovalMode(args, name, appServer);
     }
 
@@ -384,7 +385,7 @@ internal sealed partial class CodexLauncher(
             args.Add("-c");
             args.Add($"mcp_servers.{id}.args=[{argsList}]");
             args.Add("-c");
-            args.Add($"mcp_servers.{id}.env={{KCAP_URL={TomlString(config.ServerUrl)}}}");
+            args.Add($"mcp_servers.{id}.env={{{ProfileOverrides.UrlVar}={TomlString(config.ServerUrl)}}}");
             AddAppServerApprovalMode(args, id, appServer);
         }
     }

--- a/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Pi/PiRpcHostedAgentRuntimeFactory.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics;
 using System.Text;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Services;
 using Microsoft.Extensions.Logging;
@@ -238,7 +239,7 @@ internal sealed partial class PiRpcHostedAgentRuntimeFactory(
         // The dual-capture gate — unconditional, see PiLaunchEnvironment's doc.
         PiLaunchEnvironment.Apply(psi.Environment);
 
-        if (!string.IsNullOrEmpty(ctx.ServerUrl)) psi.Environment["KCAP_URL"] = ctx.ServerUrl;
+        if (!string.IsNullOrEmpty(ctx.ServerUrl)) psi.Environment[ProfileOverrides.UrlVar] = ctx.ServerUrl;
 
         psi.Environment[HostedAgent.AgentIdVar] = ctx.AgentId;
         if (!string.IsNullOrEmpty(ctx.DaemonId))    psi.Environment["KCAP_DAEMON_ID"]    = ctx.DaemonId;

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -3,6 +3,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Harness.Cursor;
@@ -920,7 +921,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         };
 
         if (!string.IsNullOrEmpty(ctx.ServerUrl))
-            psi.Environment["KCAP_URL"] = ctx.ServerUrl;
+            psi.Environment[ProfileOverrides.UrlVar] = ctx.ServerUrl;
 
         // The isolated home is what suppresses the operator's GLOBAL MCP servers — the flows server
         // among them, which would let a reviewer start nested review flows. Created here rather than

--- a/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpReviewFlowMcp.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli.Daemon.Services;
 
@@ -39,7 +40,7 @@ internal static class AcpReviewFlowMcp {
         var resultEnv = ctx.RequiresBrokeredResultDelivery
             ? new AcpMcpServerEnvVar[] { new("KCAP_FLOW_CAPABILITY_URL", ctx.FlowResultCapabilityUrl!),
                                          new("KCAP_FLOW_AGENT_ID", ctx.AgentId) }
-            : [new("KCAP_URL", ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)];
+            : [new(ProfileOverrides.UrlVar, ctx.ServerUrl!), new("KCAP_FLOW_AGENT_ID", ctx.AgentId)];
 
         var servers = new List<AcpMcpServerSpec> {
             new(channelName, ctx.CapacitorPath, ["mcp", "flow-result"], resultEnv)
@@ -52,7 +53,7 @@ internal static class AcpReviewFlowMcp {
             // vendor's name gate would be the same impersonation hole the result channel's alias closes.
             var descriptor = KcapMcpRegistry.Resolve(id)!;
             servers.Add(new(WireName(ctx, descriptor.Id), ctx.CapacitorPath, descriptor.Args,
-                [new("KCAP_URL", ctx.ServerUrl!)]));
+                [new(ProfileOverrides.UrlVar, ctx.ServerUrl!)]));
         }
 
         if (ctx.IsBorrowedSnapshot) {

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.LocalIpc.cs
@@ -1,6 +1,7 @@
 using System.Text;
 using System.Text.Json;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.LocalIpc;
 using Microsoft.Extensions.Logging;
 
@@ -251,7 +252,7 @@ internal partial class AgentOrchestrator {
             // normal local auth survives UnixPtyProcess.Spawn's headless scrub (it applies
             // extraEnv after unsetenv).
             var env = new Dictionary<string, string>();
-            if (!string.IsNullOrEmpty(_config.ServerUrl)) env["KCAP_URL"] = _config.ServerUrl;
+            if (!string.IsNullOrEmpty(_config.ServerUrl)) env[ProfileOverrides.UrlVar] = _config.ServerUrl;
             var apiKey = Environment.GetEnvironmentVariable("ANTHROPIC_API_KEY");
             if (!string.IsNullOrEmpty(apiKey)) env["ANTHROPIC_API_KEY"] = apiKey;
 

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3656,7 +3656,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 UseShellExecute        = false,
                 CreateNoWindow         = true,
                 Environment = {
-                    ["KCAP_URL"] = _config.ServerUrl,
+                    [ProfileOverrides.UrlVar] = _config.ServerUrl,
                     [ConfigRoot.ConfigDirEnvVar] = _config.ConfigRoot.Directory
                 }
             };

--- a/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PtyHostedAgentRuntimeFactory.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core.Commands;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Daemon.Harness.Codex;
 using Capacitor.Cli.Daemon.Pty;
 using Microsoft.Extensions.Logging;
@@ -100,7 +101,7 @@ internal sealed partial class PtyHostedAgentRuntimeFactory(
         if (!string.IsNullOrEmpty(ctx.DaemonEpoch)) env["KCAP_DAEMON_EPOCH"] = ctx.DaemonEpoch;
 
         if (!string.IsNullOrEmpty(ctx.ServerUrl)) {
-            env["KCAP_URL"] = ctx.ServerUrl;
+            env[ProfileOverrides.UrlVar] = ctx.ServerUrl;
         }
 
         // Tell the spawned Claude's permission-request hook where to find this daemon's local

--- a/src/Capacitor.Cli/Commands/CommandServices.cs
+++ b/src/Capacitor.Cli/Commands/CommandServices.cs
@@ -18,7 +18,7 @@ public static class CommandServices {
     /// </summary>
     public static IServiceCollection AddCapacitorCli(
             this IServiceCollection services, ConfigRoot config, UserHome home, DaemonStore daemons,
-            ProfileContext profiles, HookClock clock, string? baseUrl) {
+            ProfileContext profiles, ProfileOverrides env, HookClock clock, string? baseUrl) {
         services
             .AddCapacitorContext(config, home, daemons, profiles)
             .AddCapacitorCommands();
@@ -38,7 +38,7 @@ public static class CommandServices {
                 sp.GetRequiredService<HarnessRegistry>()));
 
         services.AddSingleton(_ => new CapacitorServer(baseUrl, config, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(env);
 
         return services;
     }

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -935,8 +935,8 @@ public sealed class DaemonCommands(
 /// reject at startup.</summary>
 static class ServiceInstallViability {
     public static async Task<bool> PinnedProfileServerUrlValidAsync(IReadOnlyDictionary<string, string> env, ConfigRoot root) {
-        var envUrl     = env.GetValueOrDefault("KCAP_URL");
-        var envProfile = env.GetValueOrDefault("KCAP_PROFILE");
+        var envUrl     = env.GetValueOrDefault(ProfileOverrides.UrlVar);
+        var envProfile = env.GetValueOrDefault(ProfileOverrides.ProfileVar);
 
         var config   = await AppConfig.LoadProfileConfig(root);
         var resolver = new ProfileResolver(config, cliServerUrl: null, envUrl, envProfile,

--- a/src/Capacitor.Cli/Commands/DaemonServiceCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonServiceCommands.cs
@@ -534,8 +534,8 @@ sealed class DaemonServiceCommands(
         };
         // Same "explicit pin wins" rule as ServiceEnvironment.Build — only a real profile is pinned.
         if (!string.IsNullOrEmpty(profileName)) {
-            env["KCAP_PROFILE"] = profileName;
-            env.Remove("KCAP_URL");
+            env[ProfileOverrides.ProfileVar] = profileName;
+            env.Remove(ProfileOverrides.UrlVar);
         }
         return env;
     }
@@ -570,7 +570,7 @@ sealed class DaemonServiceCommands(
     /// process env for anything else, so an operator's own KCAP_* exports still apply.</summary>
     static Func<string, string?> EnsureGateEnv(string? profileName, string? serverUrl) => k => k switch {
         "KCAP_CONSENT_SEED_DEFAULT" => "prompt",
-        "KCAP_PROFILE"              => profileName,
+        ProfileOverrides.ProfileVar => profileName,
         "KCAP_EXPECT_SERVER_URL"    => serverUrl,
         _                           => Environment.GetEnvironmentVariable(k),
     };
@@ -601,11 +601,11 @@ sealed class DaemonServiceCommands(
 
         try {
             var env = LaunchdUnit.EnvFromPlist(File.ReadAllText(LaunchdUnit.PlistPath(home, id)));
-            env.TryGetValue("KCAP_PROFILE", out var profile);
+            env.TryGetValue(ProfileOverrides.ProfileVar, out var profile);
             env.TryGetValue("KCAP_EXPECT_SERVER_URL", out var expectedServer);
             env.TryGetValue("KCAP_CONSENT_SEED_DEFAULT", out var consentSeed);
 
-            var serverUrl = env.TryGetValue("KCAP_URL", out var bakedUrl)
+            var serverUrl = env.TryGetValue(ProfileOverrides.UrlVar, out var bakedUrl)
                 ? bakedUrl
                 : BakedProfileServerUrl(env, profile, root);
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -414,7 +414,7 @@ sealed class SetupMachineActions : IFirstRunMachineActions {
 }
 
 public sealed class SetupCommand(
-        ConfigRoot config, ProfileContext profiles, TokenStore store, IHttpClientFactory httpFactory,
+        ConfigRoot config, ProfileContext profiles, ProfileOverrides env, TokenStore store, IHttpClientFactory httpFactory,
         IAuthProxyClient proxy, WorkOSClient workos, GitHubOAuthClient github, IBrowserLauncher browser,
         UserHome home, HarnessRegistry harnesses, AgentsPaths agents, ICapacitorHttpClient http,
         TenantProvisioningClient provisioning, AuthProviderDiscovery discovery) {
@@ -1268,7 +1268,7 @@ public sealed class SetupCommand(
             .AddSingleton(config)
             .AddSingleton(context)
             .AddSingleton(new CapacitorServer(serverUrl, config, context))
-            .AddCapacitorHttp()
+            .AddCapacitorHttp(env)
             .BuildValidated();
     }
 

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -94,13 +94,15 @@ if (isHook && args.Contains("--claude")) {
 // KCAP_DAEMONS_DIR is dead to the process from this line on.
 var daemonPaths = DaemonStore.FromEnvironment();
 
-var profiles = await AppConfig.ResolveForRepo(args, config, gitTimeoutMs: isHook ? 1000 : 5000);
+var serverEnv = ProfileOverrides.FromEnvironment();
+
+var profiles = await AppConfig.ResolveForRepo(args, config, serverEnv, gitTimeoutMs: isHook ? 1000 : 5000);
 var baseUrl  = profiles.Resolution.ServerUrl;
 
 // Composition root. Every context resolved above is registered once here; the dispatch switch below
 // asks for a command rather than handing each one its arguments.
 var services = new ServiceCollection()
-    .AddCapacitorCli(config, home, daemonPaths, profiles, clock, baseUrl);
+    .AddCapacitorCli(config, home, daemonPaths, profiles, serverEnv, clock, baseUrl);
 
 await using var sp = services.BuildValidated();
 
@@ -194,7 +196,7 @@ string[] offlineCommands = ["--help", "-h", "help", "--version", "-v", "logout",
 var offlineDiscover = command == "import" && args.Contains("--discover");
 
 if (baseUrl is null && !offlineCommands.Contains(command) && !offlineDiscover) {
-    Console.Error.WriteLine("No server configured. Run `kcap setup` or set KCAP_URL.");
+    Console.Error.WriteLine($"No server configured. Run `kcap setup` or set {ProfileOverrides.UrlVar}.");
 
     return 1;
 }

--- a/src/Capacitor.Cli/Services/ServiceEnvironment.cs
+++ b/src/Capacitor.Cli/Services/ServiceEnvironment.cs
@@ -1,4 +1,5 @@
 using System.Collections;
+using Capacitor.Cli.Core.Config;
 
 namespace Capacitor.Cli.Services;
 
@@ -12,7 +13,7 @@ static class ServiceEnvironment {
     /// <summary>Variables carried from the installing shell into the service unit. No credentials —
     /// the unit is a file on disk.</summary>
     static readonly string[] Keys =
-        ["PATH", "KCAP_PROFILE", "KCAP_URL", "KCAP_CLAUDE_PATH", "KCAP_CODEX_PATH",
+        ["PATH", ProfileOverrides.ProfileVar, ProfileOverrides.UrlVar, "KCAP_CLAUDE_PATH", "KCAP_CODEX_PATH",
          "KCAP_CONSENT_SEED_DEFAULT", "KCAP_EXPECT_SERVER_URL",
          // Codex transport selection + interactive opt-in: the daemon reads both from its own
          // environment and nowhere else, so the install has to carry them into the unit.
@@ -158,7 +159,7 @@ static class ServiceEnvironment {
             if (!source.TryGetValue(key, out var v)) continue;
             if (!string.IsNullOrEmpty(v) || BakeEvenEmptyKeys.Contains(key)) env[key] = v;
         }
-        if (!string.IsNullOrEmpty(profileName)) env["KCAP_PROFILE"] = profileName; // explicit pin wins
+        if (!string.IsNullOrEmpty(profileName)) env[ProfileOverrides.ProfileVar] = profileName; // explicit pin wins
 
         // POSIX only: Windows carries no GOOGLE_APPLICATION_CREDENTIALS at all (no owner-only unit
         // guarantee), so the trio can never complete there and a derived half would only mislead.

--- a/src/Capacitor.Cli/Services/ServiceVerify.cs
+++ b/src/Capacitor.Cli/Services/ServiceVerify.cs
@@ -187,8 +187,8 @@ sealed class ServiceVerify(
     internal string? LastBootRefusalToken { get; private set; }
 
     const string ConsentSeedVar = "KCAP_CONSENT_SEED_DEFAULT";
-    const string ProfileVar     = "KCAP_PROFILE";
-    const string UrlVar         = "KCAP_URL";
+    const string ProfileVar     = ProfileOverrides.ProfileVar;
+    const string UrlVar         = ProfileOverrides.UrlVar;
     const string ExpectVar      = "KCAP_EXPECT_SERVER_URL";
 
     /// <summary>Closed-stdio tolerance: the npm grandchild shares the GUI's pipes, so a broken pipe

--- a/src/Capacitor.Cli/WatcherManager.cs
+++ b/src/Capacitor.Cli/WatcherManager.cs
@@ -150,7 +150,7 @@ sealed partial class WatcherManager(ConfigRoot config, ProfileContext profiles, 
                 UseShellExecute        = false,
                 CreateNoWindow         = true,
                 Environment = {
-                    ["KCAP_URL"]                 = Url,
+                    [ProfileOverrides.UrlVar]    = Url,
                     [ConfigRoot.ConfigDirEnvVar] = config.Directory
                 }
             };
@@ -500,7 +500,7 @@ sealed partial class WatcherManager(ConfigRoot config, ProfileContext profiles, 
                 UseShellExecute        = false,
                 CreateNoWindow         = true,
                 Environment = {
-                    ["KCAP_URL"]                 = Url,
+                    [ProfileOverrides.UrlVar]    = Url,
                     [ConfigRoot.ConfigDirEnvVar] = config.Directory
                 }
             };
@@ -566,7 +566,7 @@ sealed partial class WatcherManager(ConfigRoot config, ProfileContext profiles, 
                 UseShellExecute        = false,
                 CreateNoWindow         = true,
                 Environment = {
-                    ["KCAP_URL"]                 = Url,
+                    [ProfileOverrides.UrlVar]    = Url,
                     [ConfigRoot.ConfigDirEnvVar] = config.Directory
                 }
             };

--- a/test/Capacitor.App.Tests.Unit/AppForeignHttpTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppForeignHttpTests.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -14,7 +15,7 @@ public class AppForeignHttpTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
     ServiceProvider Build() =>
-        new ServiceCollection().AddAppForeignHttp(Config.Root).BuildValidated();
+        new ServiceCollection().AddAppForeignHttp(Config.Root, ProfileOverrides.None).BuildValidated();
 
     [Test]
     public async Task The_foreign_container_resolves_what_the_app_takes_from_it() {

--- a/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppStartupCarveOutTests.cs
@@ -19,7 +19,7 @@ namespace Capacitor.App.Tests.Unit;
 public class AppStartupCarveOutTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
-    OnboardingGate Gate() => new(Config.Root, AuthFixtures.NewTokenStore(Config.Root));
+    OnboardingGate Gate() => new(Config.Root, AuthFixtures.NewTokenStore(Config.Root), ProfileOverrides.None);
 
     const string ProfileName = "acme";
     const string ServerUrl = "https://acme.example";

--- a/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
+++ b/test/Capacitor.App.Tests.Unit/OnboardingGateTests.cs
@@ -14,7 +14,7 @@ namespace Capacitor.App.Tests.Unit;
 public class OnboardingGateTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
-    OnboardingGate Gate() => new(Config.Root, AuthFixtures.NewTokenStore(Config.Root));
+    OnboardingGate Gate() => new(Config.Root, AuthFixtures.NewTokenStore(Config.Root), ProfileOverrides.None);
 
     const string ProfileName = "acme";
     const string ServerUrl = "https://acme.example";
@@ -253,7 +253,7 @@ public class OnboardingGateTests {
     public async Task EvaluateResolvedAsync_never_re_resolves_ignoring_a_config_change_after_capture() {
         WriteConfig(SingleProfileConfig(
             new Profile { ServerUrl = ServerUrl, AuthProvider = new AuthProviderStamp(AuthProvider.None, ServerUrl) }));
-        var resolved = (await AppConfig.ResolveActiveProfile([], Config.Root)).Resolution;
+        var resolved = (await AppConfig.ResolveActiveProfile([], Config.Root, ProfileOverrides.None)).Resolution;
 
         // Mutates the identity underneath the already-captured resolution — a fresh self-resolving
         // EvaluateAsync call at this point would see NoProfile instead.

--- a/test/Capacitor.App.Tests.Unit/ServerPullRequestSourceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerPullRequestSourceTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.PullRequests;
 
 namespace Capacitor.App.Tests.Unit;
@@ -12,7 +13,7 @@ public class ServerPullRequestSourceTests {
     [Test]
     public async Task Three_missing_reads_stop_only_that_session_and_retry_resets_it() {
         using var handler = new Handler();
-        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root),
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None,
             (_, _, _, _) => Task.FromResult((new HttpClient(handler), AuthStatus.Ok)));
         for (var i = 0; i < 4; i++) await source.ListAsync("missing", default);
         await Assert.That(handler.Lists).IsEqualTo(3);
@@ -27,7 +28,7 @@ public class ServerPullRequestSourceTests {
         using var handler = new Handler();
         var gate = new TaskCompletionSource<(HttpClient, AuthStatus)>();
         var calls = 0;
-        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), (_, _, _, _) => {
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None, (_, _, _, _) => {
             calls++;
             return calls == 1 ? gate.Task : Task.FromResult((new HttpClient(new Handler()), AuthStatus.Ok));
         });

--- a/test/Capacitor.App.Tests.Unit/ServerReaderProviderTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerReaderProviderTests.cs
@@ -2,6 +2,7 @@ using System.Net;
 using System.Text;
 using Capacitor.App.Services;
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.PullRequests;
 using Capacitor.Cli.Core.PullRequests.Readers;
 
@@ -15,7 +16,7 @@ public class ServerReaderProviderTests {
     [Test]
     public async Task Probe_maps_the_server_capability_and_serves_github_com_only_while_supported() {
         using var handler = new Handler { Versions = "[1]" };
-        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root),
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None,
             (_, _, _, _) => Task.FromResult((new HttpClient(handler), AuthStatus.Ok)));
         var provider = new ServerReaderProvider(source);
         await Assert.That(provider.Name).IsEqualTo("server");
@@ -35,7 +36,7 @@ public class ServerReaderProviderTests {
     [Test]
     public async Task An_older_server_probes_as_failed_with_its_capability_named() {
         using var handler = new Handler { Versions = null };
-        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root),
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None,
             (_, _, _, _) => Task.FromResult((new HttpClient(handler), AuthStatus.Ok)));
         var provider = new ServerReaderProvider(source);
         var status = await provider.ProbeAsync(false, default);

--- a/test/Capacitor.App.Tests.Unit/ServerWorkContextSourceLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerWorkContextSourceLaneTests.cs
@@ -1,5 +1,6 @@
 using Capacitor.App.Services;
 using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.WorkItems;
 
 namespace Capacitor.App.Tests.Unit;
@@ -32,7 +33,7 @@ public class ServerWorkContextSourceLaneTests {
             ServerUrl      = Url,
         });
 
-        await using var source = new ServerWorkContextSource(Config.Root, profiles);
+        await using var source = new ServerWorkContextSource(Config.Root, profiles, ProfileOverrides.None);
 
         var read = await source.ReadAsync(Session, CancellationToken.None);
 

--- a/test/Capacitor.App.Tests.Unit/ServerWorkContextSourceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerWorkContextSourceTests.cs
@@ -43,7 +43,7 @@ public class ServerWorkContextSourceTests {
     static (ServerWorkContextSource Source, List<ScriptedHandler> Handlers) Build(
             ConfigRoot config, ProfileContext? profiles, Func<AuthStatus>? status = null) {
         var handlers = new List<ScriptedHandler>();
-        var source = new ServerWorkContextSource(config, profiles, (_, _, _, _) => {
+        var source = new ServerWorkContextSource(config, profiles, ProfileOverrides.None, (_, _, _, _) => {
             var handler = new ScriptedHandler();
             handlers.Add(handler);
             return Task.FromResult((new HttpClient(handler), status?.Invoke() ?? AuthStatus.Ok));

--- a/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
@@ -1249,7 +1249,7 @@ public class WizardStartupResolutionTests {
         WriteConfig(SingleProfileConfig(new Profile { ServerUrl = "file:///tmp/x" }));
 
         var (before, _) = await AppUnderTest.ResolveAndEvaluateGateAsync(
-                Config.Root, AuthFixtures.NewTokenStore(Config.Root), CancellationToken.None);
+                Config.Root, AuthFixtures.NewTokenStore(Config.Root), ProfileOverrides.None, CancellationToken.None);
 
         // What a committed wizard sign-in leaves behind: a real server plus its provider stamp.
         WriteConfig(SingleProfileConfig(new Profile {
@@ -1258,7 +1258,7 @@ public class WizardStartupResolutionTests {
         }));
 
         var (after, afterProfiles) = await AppUnderTest.ResolveAndEvaluateGateAsync(
-                Config.Root, AuthFixtures.NewTokenStore(Config.Root), CancellationToken.None);
+                Config.Root, AuthFixtures.NewTokenStore(Config.Root), ProfileOverrides.None, CancellationToken.None);
 
         await Assert.That(before).IsTypeOf<GateResult.Incomplete>();
         await Assert.That(((GateResult.Incomplete)before).Reason).IsEqualTo(GateReason.InvalidServerUrl);
@@ -1274,7 +1274,7 @@ public class WizardStartupResolutionTests {
     public async Task ResolveWizardIdentity_unreadable_config_is_null() {
         File.WriteAllText(ConfigPath, "{ this is not valid json");
 
-        var identity = AppUnderTest.ResolveWizardIdentity(Config.Root);
+        var identity = AppUnderTest.ResolveWizardIdentity(Config.Root, ProfileOverrides.None);
 
         await Assert.That(identity).IsNull();
     }
@@ -1283,7 +1283,7 @@ public class WizardStartupResolutionTests {
     public async Task ResolveWizardIdentity_a_profile_with_an_invalid_server_is_null() {
         WriteConfig(SingleProfileConfig(new Profile { ServerUrl = "file:///tmp/x" }));
 
-        var identity = AppUnderTest.ResolveWizardIdentity(Config.Root);
+        var identity = AppUnderTest.ResolveWizardIdentity(Config.Root, ProfileOverrides.None);
 
         await Assert.That(identity).IsNull();
     }
@@ -1295,7 +1295,7 @@ public class WizardStartupResolutionTests {
             Daemon    = new DaemonSettings { Name = "acme-daemon" },
         }));
 
-        var identity = AppUnderTest.ResolveWizardIdentity(Config.Root);
+        var identity = AppUnderTest.ResolveWizardIdentity(Config.Root, ProfileOverrides.None);
 
         await Assert.That(identity).IsNotNull();
         await Assert.That(identity!.Value.Profile).IsEqualTo(ProfileName);
@@ -1313,7 +1313,7 @@ public class WizardStartupResolutionTests {
             harness.Operation = (_, _) => Task.FromResult<AuthResult>(
                 new AuthResult.Committed("default", "https://acme.example:443", AuthProvider.None, "someone", []));
 
-            var options = harness.Options() with { ResolveIdentity = () => AppUnderTest.ResolveWizardIdentity(Config.Root) };
+            var options = harness.Options() with { ResolveIdentity = () => AppUnderTest.ResolveWizardIdentity(Config.Root, ProfileOverrides.None) };
             var graph  = WizardComposition.BuildGraph(options);
             var daemon = graph.Steps.OfType<DaemonStepViewModel>().Single();
             var signIn = graph.Steps.OfType<SignInStepViewModel>().Single();
@@ -1351,7 +1351,7 @@ public class WizardStartupResolutionTests {
                 .WaitAsync(TimeSpan.FromSeconds(5));
 
             var (gate, _) = await AppUnderTest.ResolveAndEvaluateGateAsync(
-                Config.Root, AuthFixtures.NewTokenStore(Config.Root), CancellationToken.None);
+                Config.Root, AuthFixtures.NewTokenStore(Config.Root), ProfileOverrides.None, CancellationToken.None);
 
             await Assert.That(harness.Lane.Requests).IsEmpty();
             await Assert.That(harness.Ops.GetCalls).IsEqualTo(0);
@@ -1392,7 +1392,7 @@ public class WizardStartupResolutionTests {
                 .WaitAsync(TimeSpan.FromSeconds(5));
 
             var (gate, _) = await AppUnderTest.ResolveAndEvaluateGateAsync(
-                Config.Root, AuthFixtures.NewTokenStore(Config.Root), CancellationToken.None);
+                Config.Root, AuthFixtures.NewTokenStore(Config.Root), ProfileOverrides.None, CancellationToken.None);
 
             await Assert.That(await attempt.Result).IsTypeOf<AuthResult.Cancelled>();
             await Assert.That(await File.ReadAllTextAsync(ConfigPath)).IsEqualTo(configBefore);

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/MachineAuthTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/MachineAuthTests.cs
@@ -1,6 +1,7 @@
 using System.Net;
 using System.Text;
 using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Microsoft.Extensions.DependencyInjection;
 using WireMock.RequestBuilders;
@@ -62,7 +63,7 @@ public class MachineAuthTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(_server.Urls[0], Config.Root, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(ProfileOverrides.None);
 
         return services.BuildServiceProvider();
     }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/RefreshServerSelectionTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/RefreshServerSelectionTests.cs
@@ -1,0 +1,69 @@
+using System.Net;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Auth;
+
+/// <summary>
+/// Which server an UNBOUND token refreshes against. A bound token names its own minter and never
+/// reaches this precedence; a pre-binding one has to be told, and getting it wrong reports a
+/// perfectly good credential as expired.
+/// </summary>
+public class RefreshServerSelectionTests {
+    [TempConfigRoot] public required TempConfigRoot Config { get; init; }
+
+    const string ProfileUrl = "https://profile.example";
+
+    /// Records where the refresh was posted and answers a token so the lane completes.
+    sealed class RefreshRecorder : HttpMessageHandler {
+        public Uri? PostedTo { get; private set; }
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage r, CancellationToken ct) {
+            PostedTo = r.RequestUri;
+
+            return Task.FromResult(new HttpResponseMessage(HttpStatusCode.OK) {
+                Content = new StringContent("""{"access_token":"fresh","expires_in":3600}""",
+                                            System.Text.Encoding.UTF8, "application/json")
+            });
+        }
+    }
+
+    async Task WriteProfile() =>
+        await ConfigMutator.MutateAsync(Config.Root, _ => new ProfileConfig {
+            ActiveProfile = "default",
+            Profiles      = new() { ["default"] = new Profile { ServerUrl = ProfileUrl } }
+        });
+
+    static StoredTokens UnboundExpired() => new() {
+        AccessToken    = "stale",
+        RefreshToken   = "rt",
+        ExpiresAt      = DateTimeOffset.UtcNow.AddMinutes(-10),
+        GitHubUsername = "alice",
+        Provider       = "GitHubApp"
+    };
+
+    async Task<Uri?> RefreshUnder(ProfileOverrides env) {
+        await WriteProfile();
+        await AuthFixtures.NewTokenStore(Config.Root).SaveAsync("default", UnboundExpired());
+
+        var recorder = new RefreshRecorder();
+        await AuthFixtures.NewTokenStore(Config.Root, recorder, env).GetValidTokensForProfileAsync("default");
+
+        return recorder.PostedTo;
+    }
+
+    /// <summary>With nothing overridden the profile's own server_url is the only endpoint on offer.
+    /// An empty variable names no server, so it must not outrank the profile: the endpoint that
+    /// would leave is just the path, which no refresh can reach and which reads as a dead credential.</summary>
+    [Test]
+    public async Task An_unoverridden_refresh_posts_to_the_profiles_own_server() =>
+        await Assert.That(await RefreshUnder(ProfileOverrides.None))
+                    .IsEqualTo(new Uri($"{ProfileUrl}/auth/refresh"));
+
+    /// <summary>A named override still outranks the profile — the same precedence the resolution at
+    /// startup applied, reached a second time for a profile that resolution never selected.</summary>
+    [Test]
+    public async Task A_named_override_still_outranks_the_profile() =>
+        await Assert.That(await RefreshUnder(new ProfileOverrides("https://override.example", null)))
+                    .IsEqualTo(new Uri("https://override.example/auth/refresh"));
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/RefreshServerSelectionTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/RefreshServerSelectionTests.cs
@@ -52,9 +52,9 @@ public class RefreshServerSelectionTests {
         return recorder.PostedTo;
     }
 
-    /// <summary>With nothing overridden the profile's own server_url is the only endpoint on offer.
-    /// An empty variable names no server, so it must not outrank the profile: the endpoint that
-    /// would leave is just the path, which no refresh can reach and which reads as a dead credential.</summary>
+    /// <summary>With nothing overridden the profile's own server_url is the only endpoint on offer —
+    /// the refresh reaches for the named profile's config, not the resolution the process started
+    /// with, which for a token minted before server-binding names nothing.</summary>
     [Test]
     public async Task An_unoverridden_refresh_posts_to_the_profiles_own_server() =>
         await Assert.That(await RefreshUnder(ProfileOverrides.None))

--- a/test/Capacitor.Cli.Core.Tests.Unit/Config/ProfileOverridesTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Config/ProfileOverridesTests.cs
@@ -1,0 +1,61 @@
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Config;
+
+/// <summary>
+/// What the environment contributes to server selection, and what it takes for a variable to count
+/// as set. Bare <c>[NotInParallel]</c>: both variables are process-global, and a concurrent peer
+/// spawning a child would hand them on.
+/// </summary>
+public class ProfileOverridesTests {
+    [Test, NotInParallel]
+    [Arguments("https://server.example", "https://server.example")]
+    [Arguments("", null)]
+    [Arguments(null, null)]
+    public async Task An_empty_url_names_no_server(string? raw, string? url) {
+        using var _ = EnvScope.Exclusive(ProfileOverrides.UrlVar, raw);
+
+        await Assert.That(ProfileOverrides.FromEnvironment().Url).IsEqualTo(url);
+    }
+
+    [Test, NotInParallel]
+    [Arguments("work", "work")]
+    [Arguments("", null)]
+    [Arguments(null, null)]
+    public async Task An_empty_profile_names_no_profile(string? raw, string? profile) {
+        using var _ = EnvScope.Exclusive(ProfileOverrides.ProfileVar, raw);
+
+        await Assert.That(ProfileOverrides.FromEnvironment().Profile).IsEqualTo(profile);
+    }
+
+    /// <summary>
+    /// A value of blanks was set by someone, and <see cref="ProfileResolver"/> lets it win — so
+    /// reading it as absent here would select a different server than the resolver's own rule does,
+    /// and leave the remediation naming a variable it had already discarded.
+    /// </summary>
+    [Test, NotInParallel]
+    public async Task A_url_of_blanks_is_still_a_url() {
+        using var _ = EnvScope.Exclusive(ProfileOverrides.UrlVar, "  ");
+
+        await Assert.That(ProfileOverrides.FromEnvironment().Url).IsEqualTo("  ");
+    }
+
+    /// <summary>The rule belongs to the type, not to <see cref="ProfileOverrides.FromEnvironment"/>:
+    /// a caller that builds one directly — every test that pins resolution does — must get the same
+    /// answer, or the null test each consumer makes stops meaning what the resolver means by it.</summary>
+    [Test]
+    public async Task An_empty_value_is_discarded_however_the_overrides_are_built() {
+        await Assert.That(new ProfileOverrides("", "")).IsEqualTo(ProfileOverrides.None);
+        await Assert.That(ProfileOverrides.None with { Url = "" }).IsEqualTo(ProfileOverrides.None);
+    }
+
+    /// <summary>The two are independently absent: a profile pinned into a service unit names no URL,
+    /// and a URL override deliberately selects no profile at all.</summary>
+    [Test, NotInParallel]
+    public async Task Each_variable_is_read_on_its_own() {
+        using var url     = EnvScope.Exclusive(ProfileOverrides.UrlVar, null);
+        using var profile = EnvScope.Exclusive(ProfileOverrides.ProfileVar, "work");
+
+        await Assert.That(ProfileOverrides.FromEnvironment()).IsEqualTo(new ProfileOverrides(null, "work"));
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/Config/ResolveForRepoTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Config/ResolveForRepoTests.cs
@@ -1,0 +1,68 @@
+using Capacitor.Cli.Core.Config;
+
+namespace Capacitor.Cli.Core.Tests.Unit.Config;
+
+/// <summary>
+/// The short-circuit that skips repo discovery when an explicit URL is given. Bare
+/// <c>[NotInParallel]</c>: the repo is discovered from the working directory, which is
+/// process-global.
+/// </summary>
+public class ResolveForRepoTests {
+    [TempConfigRoot] public required TempConfigRoot Config { get; init; }
+    [TempDir]        public required TempDir        Repo   { get; init; }
+
+    const string ActiveUrl = "https://active.example";
+    const string PinnedUrl = "https://pinned.example";
+
+    /// A repo pinned to a profile that is NOT the active one, so a resolution that skipped repo
+    /// discovery answers a different server than one that did.
+    async Task WriteRepoPinnedToAnotherProfile() {
+        await ConfigMutator.MutateAsync(Config.Root, _ => new ProfileConfig {
+            ActiveProfile = "active",
+            Profiles = new() {
+                ["active"] = new Profile { ServerUrl = ActiveUrl },
+                ["pinned"] = new Profile { ServerUrl = PinnedUrl }
+            }
+        });
+        Repo.CreateFile(".kcap.json", """{"profile":"pinned"}""");
+    }
+
+    async Task<string?> ResolveIn(string[] args, ProfileOverrides env) {
+        var originalCwd = Environment.CurrentDirectory;
+        try {
+            Environment.CurrentDirectory = Repo.Path;
+
+            return (await AppConfig.ResolveForRepo(args, Config.Root, env, gitTimeoutMs: 1000))
+                   .Resolution.ServerUrl;
+        } finally {
+            Environment.CurrentDirectory = originalCwd;
+        }
+    }
+
+    [Test, NotInParallel]
+    public async Task Nothing_overridden_resolves_the_repos_own_profile() {
+        await WriteRepoPinnedToAnotherProfile();
+
+        await Assert.That(await ResolveIn([], ProfileOverrides.None)).IsEqualTo(PinnedUrl);
+    }
+
+    /// <summary>An override genuinely names a server, so the repo has nothing left to decide and the
+    /// git probe behind discovery is not worth paying for.</summary>
+    [Test, NotInParallel]
+    public async Task A_named_override_skips_repo_discovery() {
+        await WriteRepoPinnedToAnotherProfile();
+
+        await Assert.That(await ResolveIn([], new ProfileOverrides("https://env.example", null)))
+                    .IsEqualTo("https://env.example");
+    }
+
+    /// <summary>An empty <c>--server-url</c> names no server: the resolver discards it and falls
+    /// through, so withholding the repo inputs from that fall-through would silently answer the
+    /// active profile instead of the one the repo pins.</summary>
+    [Test, NotInParallel]
+    public async Task An_empty_server_url_flag_still_resolves_the_repos_profile() {
+        await WriteRepoPinnedToAnotherProfile();
+
+        await Assert.That(await ResolveIn(["--server-url", ""], ProfileOverrides.None)).IsEqualTo(PinnedUrl);
+    }
+}

--- a/test/Capacitor.Cli.Core.Tests.Unit/Config/ResolveForRepoTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Config/ResolveForRepoTests.cs
@@ -46,10 +46,11 @@ public class ResolveForRepoTests {
         await Assert.That(await ResolveIn([], ProfileOverrides.None)).IsEqualTo(PinnedUrl);
     }
 
-    /// <summary>An override genuinely names a server, so the repo has nothing left to decide and the
-    /// git probe behind discovery is not worth paying for.</summary>
+    /// <summary>A named override outranks what the repo pins, so the profile named in
+    /// <c>.kcap.json</c> loses to it. Says nothing about whether discovery ran — both paths feed the
+    /// resolver the same override, and only the git probe tells them apart.</summary>
     [Test, NotInParallel]
-    public async Task A_named_override_skips_repo_discovery() {
+    public async Task A_named_override_outranks_the_repos_own_profile() {
         await WriteRepoPinnedToAnotherProfile();
 
         await Assert.That(await ResolveIn([], new ProfileOverrides("https://env.example", null)))

--- a/test/Capacitor.Cli.Core.Tests.Unit/Http/CapacitorHttpContainerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Http/CapacitorHttpContainerTests.cs
@@ -1,5 +1,6 @@
 using System.Net;
 using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Microsoft.Extensions.DependencyInjection;
 using WireMock.RequestBuilders;
@@ -52,7 +53,7 @@ public class CapacitorHttpContainerTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(target, Config.Root, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(ProfileOverrides.None);
 
         return services.BuildServiceProvider();
     }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonHttpServicesTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonHttpServicesTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -18,7 +19,7 @@ public class DaemonHttpServicesTests {
         return new ServiceCollection()
             .AddSingleton(Config.Root)
             .AddSingleton(profiles)
-            .AddDaemonHttp(Config.Root, new DaemonConfig { ServerUrl = serverUrl, Profiles = profiles })
+            .AddDaemonHttp(Config.Root, new DaemonConfig { ServerUrl = serverUrl, Profiles = profiles }, ProfileOverrides.None)
             .BuildServiceProvider();
     }
 

--- a/test/Capacitor.Cli.Tests.Integration/PermissionRequestRecoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PermissionRequestRecoveryTests.cs
@@ -1,7 +1,8 @@
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Microsoft.Extensions.DependencyInjection;
-using Capacitor.Cli.Core.Auth;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 using WireMock.Server;
@@ -74,7 +75,7 @@ public class PermissionRequestRecoveryTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(Url, Config.Root, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(ProfileOverrides.None);
 
         var sp = services.BuildServiceProvider();
         _containers.Add(sp);

--- a/test/Capacitor.Cli.Tests.Integration/SessionStartMemoryRedirectTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/SessionStartMemoryRedirectTests.cs
@@ -84,7 +84,7 @@ public class SessionStartMemoryRedirectTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(_server.Url!, Config.Root, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(ProfileOverrides.None);
 
         await using var sp = services.BuildServiceProvider();
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/CommandContainerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/CommandContainerTests.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core.Config;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Capacitor.Cli.Tests.Unit.Commands;
@@ -19,7 +20,7 @@ public class CommandContainerTests {
             .AddCapacitorCli(
                 Config.Root, Home, Daemons.Store,
                 baseUrl is null ? Resolutions.None(Config.Root) : Resolutions.At(baseUrl, Config.Root),
-                new HookClock(TimeProvider.System), baseUrl)
+                ProfileOverrides.None, new HookClock(TimeProvider.System), baseUrl)
             // What Program.cs builds with, so a registration this rejects is one a run would too.
             .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ObservationHeaderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ObservationHeaderTests.cs
@@ -36,7 +36,7 @@ public class ObservationHeaderTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(_server.Urls[0], Config.Root, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(ProfileOverrides.None);
         _sp = services.BuildServiceProvider();
 
         return new WhoamiCommand(
@@ -53,7 +53,7 @@ public class ObservationHeaderTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(_server.Urls[0], Config.Root, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(ProfileOverrides.None);
         _sp = services.BuildServiceProvider();
 
         return await _sp.GetRequiredService<ICapacitorHttpClient>().ForCommandAsync();

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ReportVersionCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ReportVersionCommandTests.cs
@@ -46,7 +46,7 @@ public class ReportVersionCommandTests : IDisposable {
         // no-base-url case has to exercise, and a placeholder would hand it a reachable one.
         services.AddSingleton(
             new CapacitorServer(profiles.Resolution.ServerUrl ?? "", Config.Root, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(ProfileOverrides.None);
         _sp = services.BuildServiceProvider();
 
         return new ReportVersionCommand(

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupChosenServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupChosenServerTests.cs
@@ -22,7 +22,7 @@ public class SetupChosenServerTests {
         var factory = new PlainHttpClientFactory();
 
         return new SetupCommand(
-            Config.Root, startup, AuthFixtures.NewTokenStore(Config.Root), factory,
+            Config.Root, startup, ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), factory,
             new AuthProxyClient(new HttpClient()), new WorkOSClient(factory), new GitHubOAuthClient(factory),
             new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), new TenantProvisioningClient(new HttpClient()),
             new AuthProviderDiscovery(factory));

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupCommandTests.cs
@@ -871,7 +871,7 @@ public class SetupCommandTests {
         var passed = Resolutions.At("https://example.test", Config.Root);
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -902,7 +902,7 @@ public class SetupCommandTests {
         };
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -925,7 +925,7 @@ public class SetupCommandTests {
         try {
             // Completing without an unhandled exception is the assertion: a non-zero exit
             // code must be swallowed (warned about, not propagated) so setup still finishes.
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -946,7 +946,7 @@ public class SetupCommandTests {
         try {
             // Completing without the InvalidOperationException escaping is the assertion —
             // import is best-effort and must never fail setup.
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -965,7 +965,7 @@ public class SetupCommandTests {
         SetupCommand.ImportRunnerOverride = _ => throw new InvalidOperationException("must not run import");
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       null,
                 authSatisfied:     true,
                 skipImport:        false,
@@ -984,7 +984,7 @@ public class SetupCommandTests {
         SetupCommand.ImportRunnerOverride = _ => throw new InvalidOperationException("must not run import");
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        true,
@@ -1049,7 +1049,7 @@ public class SetupCommandTests {
         try {
             var args = BuildArgs("--server-url", server.Url!, "--no-prompt", "--default-visibility", "org_public");
 
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(captured).IsNotNull();
@@ -1085,7 +1085,7 @@ public class SetupCommandTests {
 
             // Completing with exit 0 without the override's exception escaping is the
             // assertion — --skip-import must suppress the Step 6 call entirely.
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
         } finally {
@@ -1113,7 +1113,7 @@ public class SetupCommandTests {
         try {
             var args = BuildArgs("--server-url", schemeLessServerUrl, "--no-prompt");
 
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(captured).IsNotNull();
@@ -1148,7 +1148,7 @@ public class SetupCommandTests {
         try {
             var args = BuildArgs("--server-url", server.Url!, "--no-prompt");
 
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(captured).IsNotNull();
@@ -1335,7 +1335,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_rejects_half_a_pair_before_doing_anything() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme"]);
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme"]);
 
         await Assert.That(exit).IsEqualTo(1);
         await Assert.That(capture.GetCapturedError()).Contains("--slug");
@@ -1346,7 +1346,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_rejects_creating_and_pointing_at_a_server_at_once() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(
             ["setup", "--org", "Acme", "--slug", "acme", "--server-url", "https://other.kcap.ai"]);
 
         await Assert.That(exit).IsEqualTo(1);
@@ -1358,7 +1358,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_rejects_a_provider_that_cannot_create() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme", "--slug", "acme", "--github"]);
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme", "--slug", "acme", "--github"]);
 
         await Assert.That(exit).IsEqualTo(1);
         await Assert.That(capture.GetCapturedError()).Contains("--github");
@@ -1369,7 +1369,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_still_requires_a_server_url_with_no_prompt_and_no_answers() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--no-prompt"]);
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--no-prompt"]);
 
         await Assert.That(exit).IsEqualTo(1);
         await Assert.That(capture.GetCapturedError()).Contains("--server-url is required");

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
@@ -110,7 +110,7 @@ public class SetupFacadeParityTests {
         SetupCommand.FacadeOverride = _ =>
             NewFacade(Config.Root, new RecordingAuthProgress(), handler, PickerReturningFirst());
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNotNull();
         await Assert.That(discovered!.Value.LoginComplete).IsTrue();
@@ -136,7 +136,7 @@ public class SetupFacadeParityTests {
         SetupCommand.FacadeOverride = _ =>
             NewFacade(Config.Root, new RecordingAuthProgress(), handler, PickerReturningFirst());
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNotNull();
         await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
@@ -151,7 +151,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         // Today's setup fires SigninCompleted unconditionally once the token is acquired, and
@@ -171,7 +171,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
@@ -188,7 +188,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
@@ -203,7 +203,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         // Other/Unreachable failures map to nothing beyond SigninOpened — only SigninDenied and
@@ -221,7 +221,7 @@ public class SetupFacadeParityTests {
 
         using var console = ConsoleOutput.StartErrorCapture("\n");
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         await Assert.That(console.GetCapturedError()).Contains(SetupAuthProgress.UnreachableGuidance);
@@ -240,7 +240,7 @@ public class SetupFacadeParityTests {
             return NewFacade(Config.Root, new RecordingAuthProgress(), handler);
         };
 
-        await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery)
+        await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery)
             .RunDiscoveryAsync([], forceDevice: true, new RequestedWorkspace("Acme", "acme"));
 
         await Assert.That(captured).IsTypeOf<SpectreTenantProvisioner>();
@@ -351,7 +351,7 @@ public class SetupFacadeParityTests {
         int exitCode;
 
         try {
-            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
                 loginComplete: true, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
                 forceDevice: false, activeProfile: "acme");
         } finally {
@@ -369,7 +369,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.None, serverUrl: "https://none.example",
             forceDevice: false, activeProfile: "default");
 
@@ -391,7 +391,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.None, serverUrl: "https://none.example",
             forceDevice: false, activeProfile: "default");
 
@@ -404,7 +404,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
             forceDevice: true, activeProfile: "acme");
 
@@ -428,7 +428,7 @@ public class SetupFacadeParityTests {
 
         using var console = ConsoleOutput.StartCapture();
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
             forceDevice: true, activeProfile: "acme");
 
@@ -453,7 +453,7 @@ public class SetupFacadeParityTests {
         int exitCode;
 
         try {
-            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
                 loginComplete: true, provider: provider, serverUrl: "https://acme.kcap.ai",
                 forceDevice: false, activeProfile: "acme");
         } finally {
@@ -472,7 +472,7 @@ public class SetupFacadeParityTests {
 
         // The provider param is Step 1's resolved value; Step 2 re-fetches /auth/config for the
         // actual login, so a server reporting an unrelated/unknown provider by then still fails.
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
             forceDevice: false, activeProfile: "acme");
 

--- a/test/Capacitor.Cli.Tests.Unit/Harness/Claude/ClaudeMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Harness/Claude/ClaudeMemoryIndexLiveCertTests.cs
@@ -38,13 +38,13 @@ public class ClaudeMemoryIndexLiveCertTests {
     /// <summary>The real container, built against this machine's actual config — a stub client
     /// cannot exercise the real refresh/discovery chain a live-cert run is meant to certify.</summary>
     static async Task<ServiceProvider> AuthenticatedContainerAsync(ConfigRoot root, string baseUrl) {
-        var profiles = await AppConfig.ResolveActiveProfile([], root);
+        var profiles = await AppConfig.ResolveActiveProfile([], root, ProfileOverrides.None);
         var services = new ServiceCollection();
 
         services.AddSingleton(root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(baseUrl, root, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(ProfileOverrides.None);
 
         return services.BuildServiceProvider();
     }

--- a/test/Capacitor.Cli.Tests.Unit/Harness/Cursor/CursorMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Harness/Cursor/CursorMemoryIndexLiveCertTests.cs
@@ -45,13 +45,13 @@ public class CursorMemoryIndexLiveCertTests {
     /// <summary>The real container, built against this machine's actual config — a stub client
     /// cannot exercise the real refresh/discovery chain a live-cert run is meant to certify.</summary>
     static async Task<ServiceProvider> AuthenticatedContainerAsync(ConfigRoot root, string baseUrl) {
-        var profiles = await AppConfig.ResolveActiveProfile([], root);
+        var profiles = await AppConfig.ResolveActiveProfile([], root, ProfileOverrides.None);
         var services = new ServiceCollection();
 
         services.AddSingleton(root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(baseUrl, root, profiles));
-        services.AddCapacitorHttp();
+        services.AddCapacitorHttp(ProfileOverrides.None);
 
         return services.BuildServiceProvider();
     }

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/MemoryIndexLiveCertHarness.cs
@@ -97,7 +97,7 @@ internal static partial class MemoryIndexLiveCertHarness {
         // The operator's REAL root, named rather than resolved: this assembly pins KCAP_CONFIG_DIR at
         // a throwaway directory, and a cert that resolved that would read an empty config — the same
         // 401-in-a-different-costume the child processes below strip the variable to avoid.
-        var profiles = await AppConfig.ResolveForRepo([], ConfigRoot.UnderHome(UserHome.FromEnvironment().Path));
+        var profiles = await AppConfig.ResolveForRepo([], ConfigRoot.UnderHome(UserHome.FromEnvironment().Path), ProfileOverrides.None);
 
         return profiles.Resolution.ServerUrl ?? RequiredServerUrl();
     }

--- a/test/Capacitor.Tests.Helpers/AuthFixtures.cs
+++ b/test/Capacitor.Tests.Helpers/AuthFixtures.cs
@@ -1,5 +1,6 @@
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Duende.IdentityModel.OidcClient.Browser;
 using NSubstitute;
@@ -14,10 +15,13 @@ public static class AuthFixtures {
     /// constructor the suites reach from eighty-odd files. A test that scripts what the refresh lanes
     /// answer passes a handler.
     /// </summary>
-    public static TokenStore NewTokenStore(ConfigRoot root, HttpMessageHandler? handler = null) {
+    /// <param name="env">The environment overrides the refresh lanes resolve a server through. Pass
+    /// one only when the test is about that resolution.</param>
+    public static TokenStore NewTokenStore(
+            ConfigRoot root, HttpMessageHandler? handler = null, ProfileOverrides? env = null) {
         var factory = new PlainHttpClientFactory(handler);
 
-        return new TokenStore(root, factory, new WorkOSClient(factory));
+        return new TokenStore(root, env ?? ProfileOverrides.None, factory, new WorkOSClient(factory));
     }
 
     public static OnboardingFacade NewFacade(

--- a/test/Capacitor.Tests.Helpers/Guards/ProfileOverridesGlobalSetup.cs
+++ b/test/Capacitor.Tests.Helpers/Guards/ProfileOverridesGlobalSetup.cs
@@ -1,3 +1,5 @@
+using Capacitor.Cli.Core.Config;
+
 namespace Capacitor.Tests.Helpers.Guards;
 
 /// <summary>
@@ -13,15 +15,15 @@ public class ProfileOverridesGlobalSetup {
 
     [BeforeEvery(Assembly)]
     public static void PinProfileOverrides() {
-        _savedKcapUrl     = Environment.GetEnvironmentVariable("KCAP_URL");
-        _savedKcapProfile = Environment.GetEnvironmentVariable("KCAP_PROFILE");
-        Environment.SetEnvironmentVariable("KCAP_URL", null);
-        Environment.SetEnvironmentVariable("KCAP_PROFILE", null);
+        _savedKcapUrl     = Environment.GetEnvironmentVariable(ProfileOverrides.UrlVar);
+        _savedKcapProfile = Environment.GetEnvironmentVariable(ProfileOverrides.ProfileVar);
+        Environment.SetEnvironmentVariable(ProfileOverrides.UrlVar, null);
+        Environment.SetEnvironmentVariable(ProfileOverrides.ProfileVar, null);
     }
 
     [AfterEvery(Assembly)]
     public static void RestoreProfileOverrides() {
-        Environment.SetEnvironmentVariable("KCAP_URL", _savedKcapUrl);
-        Environment.SetEnvironmentVariable("KCAP_PROFILE", _savedKcapProfile);
+        Environment.SetEnvironmentVariable(ProfileOverrides.UrlVar, _savedKcapUrl);
+        Environment.SetEnvironmentVariable(ProfileOverrides.ProfileVar, _savedKcapProfile);
     }
 }


### PR DESCRIPTION
Closes #843 — AI-2642

## What & why

`ProfileResolver` owns server selection and the rule for what an environment override counts as: it skips an empty value and lets the next input win. Four sites read `KCAP_URL`/`KCAP_PROFILE` to feed it and two applied a different rule, so an exported-but-empty variable selected a server the resolver never would — silently downgrading repo-aware resolution to the active profile, and reporting a good credential as expired.

One type in Core now owns both names and resolves both once at each composition root. The rule is a construction invariant rather than a property of the factory, so a caller testing the value for null cannot disagree with the resolver however the record was built.

## Where to look

`TokenStore` takes the overrides, not a `ProfileContext`: the desktop app builds a token store in its foreign container before any profile resolves. That is also why `AddCapacitorHttp` takes the value as a parameter — each host states what it resolved, checked at compile time.

Three consequences of the fix, all reachable only with an empty value or an empty `--server-url ""`, which takes the same branch by the same test:

| | main | here |
|---|---|---|
| repo profile (`.kcap.json`, remote match, `kcap use`) | skipped | honoured |
| `Warning: Profile 'x' not found.` | dropped silently | printed to stderr |
| git probe on the hook path | skipped | runs, within the 1000 ms budget |

## Verification

`dotnet test --solution Capacitor.slnx` — 12519 tests, 1 failure, reproducing on `main`: `Installed_codex_schema_matches_the_vendored_pin` (installed codex 0.153.4 vs the vendored 0.147.0 pin).

Each new assertion was checked by mutation. Dropping the field-initializer normalization kills 3 of 9 `ProfileOverrides` tests, dropping the `init` accessor kills 1; restoring the old null-only flag test kills the `--server-url ""` case alone; reading the wrong override field, or dropping the profile fallback, kills one refresh test each.

`dotnet publish -c Release` clean for both executables, no IL3050/IL2026.
