### PR TITLE
Capture the alias script's output before grepping it in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -217,8 +217,11 @@ jobs:
           bash scripts/assert-bundle-digest.sh "$APP" publish/daemon.sha256
           "$APP/Contents/MacOS/kcap" --version --no-update-check
           "$APP/Contents/MacOS/kcap-daemon" --version
-          # Pins the manifest field names the alias-promotion script depends on.
-          bash scripts/promote-desktop-aliases.sh releases/releases.osx-arm64.json "${{ steps.version.outputs.VERSION }}" | grep -qx beta
+          # Pins the manifest field names the alias-promotion script depends on. Captured rather
+          # than piped: grep -q closes the pipe at its first match, and a stable candidate prints a
+          # second line after it.
+          aliases="$(bash scripts/promote-desktop-aliases.sh releases/releases.osx-arm64.json "${{ steps.version.outputs.VERSION }}")"
+          grep -qx beta <<<"$aliases"
 
       - name: Upload unsigned bundle
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
No tracker issue on either side: the failure surfaced on the v1.0.0 tag build (CI run 34466915928).

## What & why

The bundle assertion pipes the alias-promotion script into `grep -qx beta`, and `grep -q` exits at its first match and closes the pipe. Every earlier tag was a beta, so the script printed one line and stopped. A stable tag prints `beta` then `stable`, and the second line hits the closed pipe: bash's `echo` returns 1 under `set -e`, and the step's `pipefail` fails the job that the Release workflow waits on. The output is now captured first, then grepped.

## Verification

Reproduced against a one-version manifest with SIGPIPE ignored, as under the Actions runner:

```
old pipeline, 1.0.0         -> "line 38: echo: write error: Broken pipe", rc=1
old pipeline, 0.12.0-beta.3 -> rc=0
fixed lines,  1.0.0         -> rc=0 (aliases: beta stable)
fixed lines,  0.12.0-beta.3 -> rc=0 (aliases: beta)
```

`bash scripts/run-shell-tests.sh`: every suite reports `ok`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
