### PR TITLE
Hide the Pull request tab until the session has a linked PR

### DIFF
--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Projections.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Projections.cs
@@ -74,7 +74,8 @@ public sealed partial class PullRequestContextViewModel {
             : _primaryRepo?.Invoke() is { } repository ? _readers.NoteFor(repository.Provider, repository.Host) : null;
         var rows = CanDisplayReader ? CurrentSection?.Pages.SelectMany(page => page.Rows).ToArray() ?? [] : [];
         if (!_visibleRows.SequenceEqual(rows)) _visibleRows = rows;
-        foreach (var property in new[] { nameof(Notice), nameof(IsReading), nameof(HasChoice), nameof(IsLegacy), nameof(Section), nameof(CanReveal), nameof(CanDisplay),
+        if (!_disposed && _hasPullRequest.Value != HasPullRequest) _hasPullRequest.OnNext(HasPullRequest);
+        foreach (var property in new[] { nameof(Notice), nameof(IsReading), nameof(HasChoice), nameof(HasPullRequest), nameof(IsLegacy), nameof(Section), nameof(CanReveal), nameof(CanDisplay),
             nameof(Title), nameof(Lifecycle), nameof(Branches), nameof(FetchedLabel), nameof(AccessLabel), nameof(ReviewSummary), nameof(CheckSummary),
             nameof(Description), nameof(DescriptionTruncated), nameof(DescriptionNote), nameof(IsOverview), nameof(IsThreads), nameof(IsThreadComments), nameof(IncludeResolved),
             nameof(HasNotice), nameof(ShowsSignIn), nameof(ShowsLinkGitHub), nameof(ShowReaderContent), nameof(Rows), nameof(HasMore),

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Reads.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Reads.cs
@@ -37,6 +37,7 @@ public sealed partial class PullRequestContextViewModel {
                 _legacy = capability.Kind is PullRequestCapabilityKind.Legacy or PullRequestCapabilityKind.Unsupported;
                 if (links is null) {
                     _retryAt = capability.RetryAt;
+                    if (capability.Kind == PullRequestCapabilityKind.SignedOut) ForgetChoices();
                     ClearProtected();
                     SetNotice(capability.Kind == PullRequestCapabilityKind.SignedOut ? "Sign in to see pull requests."
                         : "Couldn't discover pull request support. Retry when the server is reachable.");
@@ -44,7 +45,7 @@ public sealed partial class PullRequestContextViewModel {
                 }
                 if (links.Kind != PullRequestReadKind.Ready || links.Data is null) {
                     if (links.Kind is PullRequestReadKind.SubjectUnavailable or PullRequestReadKind.SignedOut || links.AccessFailure is "invalid" or "denied") {
-                        CancelReads(); _choices.Clear(); _selected = null; ClearProtected();
+                        ForgetChoices(); ClearProtected();
                         _stopped = links.Reason == "retries_stopped";
                     } else EnterGrace();
                     SetNotice(_stopped ? "This session's pull requests are unavailable. Use Retry to check again."
@@ -188,5 +189,6 @@ public sealed partial class PullRequestContextViewModel {
         else ClearProtected();
         SetNotice(Reason(read));
     }
+    void ForgetChoices() { CancelReads(); _choices.Clear(); _selected = null; }
     void FailProtocol() { ClearProtected(); SetNotice("The server returned an inconsistent PR response. Retry after updating the server and app."); }
 }

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
@@ -2,6 +2,7 @@ using System.Reactive;
 using System.Reactive.Disposables;
 using System.Reactive.Disposables.Fluent;
 using System.Reactive.Linq;
+using System.Reactive.Subjects;
 using Avalonia.Collections;
 using Avalonia.Threading;
 using Capacitor.App.Services;
@@ -27,6 +28,8 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
     readonly Dictionary<PullRequestSubjectDto, Position> _positions = [];
     readonly HashSet<string> _pageRequests = new(StringComparer.Ordinal);
     readonly AvaloniaList<PullRequestChoice> _choices = [];
+    // Subject, not WhenAnyValue — same RxAppBuilder init trap as SessionRailViewModel.SelectedAgentId.
+    readonly BehaviorSubject<bool> _hasPullRequest = new(false);
     readonly ITimer _timer;
     CancellationTokenSource _cancel = new();
     long _generation;
@@ -73,6 +76,8 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
     public string InstallToolLabel => _readerNote is null ? "" : "Install " + _readerNote.ToolName;
     public bool IsReading => _refreshing || _overviewPending || _pageRequests.Count > 0;
     public bool HasChoice => _selected is not null;
+    public bool HasPullRequest => _choices.Count > 0;
+    public IObservable<bool> HasPullRequestChanges => _hasPullRequest;
     public bool IsLegacy => _legacy;
     public string Section => _section;
     public double ScrollOffset { get; set; }
@@ -286,5 +291,6 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
         try { await Task.WhenAll(_tasks.ToArray()); } catch (OperationCanceledException) { }
         _cancel.Dispose(); foreach (var retired in _retired) retired.Dispose();
         _tasks.Clear(); _retired.Clear(); _positions.Clear(); _choices.Clear(); ClearProtected();
+        _hasPullRequest.Dispose();
     }
 }

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
@@ -28,7 +28,7 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
     readonly Dictionary<PullRequestSubjectDto, Position> _positions = [];
     readonly HashSet<string> _pageRequests = new(StringComparer.Ordinal);
     readonly AvaloniaList<PullRequestChoice> _choices = [];
-    // Subject, not WhenAnyValue — same RxAppBuilder init trap as SessionRailViewModel.SelectedAgentId.
+    // A subject, not WhenAnyValue: that needs ReactiveUI's global init, which a headless test run does not reliably prime first.
     readonly BehaviorSubject<bool> _hasPullRequest = new(false);
     readonly ITimer _timer;
     CancellationTokenSource _cancel = new();
@@ -76,7 +76,7 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
     public string InstallToolLabel => _readerNote is null ? "" : "Install " + _readerNote.ToolName;
     public bool IsReading => _refreshing || _overviewPending || _pageRequests.Count > 0;
     public bool HasChoice => _selected is not null;
-    public bool HasPullRequest => _choices.Count > 0;
+    public bool HasPullRequest => _choices.Any(choice => choice.IsAvailable);
     public IObservable<bool> HasPullRequestChanges => _hasPullRequest;
     public bool IsLegacy => _legacy;
     public string Section => _section;

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -47,7 +47,11 @@ public sealed class WorkspaceViewModel : ReactiveObject {
     /// subscription per workspace, not two.
     public WorkContextViewModel WorkContext { get; }
     public PullRequestContextViewModel? PullRequests { get; }
-    public bool ShowsPullRequestTab => PullRequests is not null;
+    bool _showsPullRequestTab;
+    public bool ShowsPullRequestTab {
+        get => _showsPullRequestTab;
+        private set => this.RaiseAndSetIfChanged(ref _showsPullRequestTab, value);
+    }
 
     WorkspaceTab _activeTab = WorkspaceTab.Chat;
     public WorkspaceTab ActiveTab {
@@ -99,6 +103,10 @@ public sealed class WorkspaceViewModel : ReactiveObject {
         PullRequests = pullRequests is null ? null : new PullRequestContextViewModel(presence.Select(p => p.Dto), pullRequests, time, opener,
             () => ActiveTab = WorkspaceTab.PullRequest, requestSignIn, linkGitHub, signInCompleted, () => WorkContext.PrimaryRepository);
         WorkContext.PullRequests = PullRequests;
+        PullRequests?.HasPullRequestChanges.Subscribe(has => {
+            ShowsPullRequestTab = has;
+            if (!has && IsPullRequestActive) ActiveTab = WorkspaceTab.Chat;
+        }).DisposeWith(_disposables);
         daemon.Status.Select(status => status.State).DistinctUntilChanged().Skip(1)
             .Where(state => state == AttachState.Connected).ObserveOn(RxSchedulers.MainThreadScheduler)
             .Subscribe(_ => PullRequests?.Reconnected()).DisposeWith(_disposables);
@@ -133,7 +141,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
 
         ShowChatCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Chat; });
         ShowTerminalCommand = ReactiveCommand.Create(() => { ActiveTab = WorkspaceTab.Terminal; });
-        ShowPullRequestCommand = ReactiveCommand.Create(() => { if (PullRequests is not null) ActiveTab = WorkspaceTab.PullRequest; });
+        ShowPullRequestCommand = ReactiveCommand.Create(() => { if (ShowsPullRequestTab) ActiveTab = WorkspaceTab.PullRequest; });
         _disposables.Add(ShowChatCommand);
         _disposables.Add(ShowTerminalCommand);
         _disposables.Add(ShowPullRequestCommand);

--- a/src/Capacitor.App/Views/WorkContextView.axaml
+++ b/src/Capacitor.App/Views/WorkContextView.axaml
@@ -248,7 +248,7 @@
                 </Border>
 
                 <ItemsControl x:Name="LinkCards" ItemsSource="{Binding Links}" ItemTemplate="{StaticResource LinkCard}" IsVisible="{Binding ShowsLegacyLinks}" />
-                <views:PullRequestCard DataContext="{Binding PullRequests}"
+                <views:PullRequestCard x:Name="PullRequestCard" DataContext="{Binding PullRequests}"
                     IsVisible="{Binding $parent[views:WorkContextView].((vm:WorkContextViewModel)DataContext).HasPullRequestContext}" />
                 <ContentControl x:Name="IssueCard" Content="{Binding Issue}" ContentTemplate="{StaticResource LinkCard}" IsVisible="{Binding HasIssue}" />
 

--- a/test/Capacitor.App.Tests.Unit/FakePullRequestSource.cs
+++ b/test/Capacitor.App.Tests.Unit/FakePullRequestSource.cs
@@ -14,7 +14,8 @@ internal sealed class FakePullRequestSource(FakeTimeProvider time) : IPullReques
     public string OverviewTitle = "Private PR";
     public readonly Queue<Func<PullRequestSubjectDto, CancellationToken, Task<PullRequestRead<PullRequestOverviewDto>>>> OverviewResponses = new();
     public readonly List<CancellationToken> OverviewTokens = [];
-    public Task<PullRequestCapability> DiscoverAsync(bool refresh, CancellationToken ct) => Task.FromResult(new PullRequestCapability(PullRequestCapabilityKind.Supported, 1));
+    public PullRequestCapabilityKind Capability = PullRequestCapabilityKind.Supported;
+    public Task<PullRequestCapability> DiscoverAsync(bool refresh, CancellationToken ct) => Task.FromResult(new PullRequestCapability(Capability, 1));
     public void ResetSession(string sessionId) { }
     public Task<PullRequestRead<PullRequestLinkListDto>> ListAsync(string sessionId, CancellationToken ct) {
         Lists++;

--- a/test/Capacitor.App.Tests.Unit/PullRequestContextViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PullRequestContextViewModelTests.cs
@@ -204,6 +204,33 @@ public class PullRequestContextViewModelTests {
     });
 
     [Test]
+    public Task An_unlinked_explicit_selection_does_not_count_as_a_linked_PR() => RunOnUiAsync(async () => {
+        var h = new Harness(); h.Push(); await h.Show();
+        h.Vm.Selected = h.Vm.Choices[1];
+        await WaitUntilAsync(() => h.Vm.CanReveal, what: "explicit PR admitted");
+        h.Source.Links = [];
+        h.Time.Advance(TimeSpan.FromSeconds(16)); await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "unlink applied");
+        await Assert.That(h.Vm.Selected!.IsAvailable).IsFalse();
+        await Assert.That(h.Vm.HasPullRequest).IsFalse();
+        await h.Dispose();
+    });
+
+    [Test]
+    public Task A_signed_out_discovery_forgets_the_linked_PRs_until_discovery_succeeds_again() => RunOnUiAsync(async () => {
+        var h = new Harness(); h.Push(); await h.Show();
+        h.Source.Capability = PullRequestCapabilityKind.SignedOut;
+        h.Time.Advance(TimeSpan.FromSeconds(16)); await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => !h.Vm.IsReading, what: "signed-out discovery applied");
+        await Assert.That(h.Vm.HasPullRequest).IsFalse();
+        await Assert.That(h.Vm.ShowsSignIn).IsTrue();
+        h.Source.Capability = PullRequestCapabilityKind.Supported;
+        h.Time.Advance(TimeSpan.FromSeconds(16)); await h.Vm.RefreshCommand.Execute();
+        await WaitUntilAsync(() => h.Vm.HasPullRequest && !h.Vm.IsReading, what: "PRs rediscovered");
+        await h.Dispose();
+    });
+
+    [Test]
     [Arguments("https://example.com/example/repo/pull/1", false)]
     [Arguments("https://github.com/example/repo/pull/99", false)]
     [Arguments("https://github.com/example/other/pull/1", false)]

--- a/test/Capacitor.App.Tests.Unit/PullRequestViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PullRequestViewSmokeTests.cs
@@ -58,4 +58,45 @@ public class PullRequestViewSmokeTests {
             await Assert.That(vm.PullRequests.Description).IsNull();
         } finally { window.Close(); await vm.TeardownAsync(); }
     });
+
+    [Test]
+    public Task The_tab_shows_only_while_the_session_has_a_linked_PR_and_the_sidebar_card_always_shows() => RunOnUiAsync(async () => {
+        var daemon = new FakeDaemonClientService();
+        var time = new FakeTimeProvider();
+        var source = new FakePullRequestSource(time) { Links = [] };
+        var vm = new WorkspaceViewModel("agent", daemon, NewActions(), new FakeTerminalAttachClientFactory().Factory, () => new FakeTerminalSurface(), time,
+            new RecordingOpener(), new FakePermissionService(), new FakeWorkContextSource(), new ScriptedLocalControlOps(), pullRequests: source);
+        var view = new WorkspaceView { DataContext = vm };
+        var window = new Window { Content = view, Width = 1200, Height = 800 };
+        window.Show();
+        try {
+            daemon.Agents.AddOrUpdate(Agent("agent", "claude", hasTerminal: false, sessionId: "session"));
+            await (vm.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+            var tab = view.FindControl<Button>("PullRequestTabButton")!;
+            var card = view.FindControl<WorkContextView>("WorkContextHost")!.FindControl<PullRequestCard>("PullRequestCard")!;
+            vm.PullRequests!.SetForeground(true);
+            await WaitUntilAsync(() => source.Lists == 1 && !vm.PullRequests.IsReading, what: "empty PR list applied");
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(tab.IsVisible).IsFalse();
+            await Assert.That(card.IsVisible).IsTrue();
+
+            source.Links = [FakePullRequestSource.Link(1)];
+            time.Advance(TimeSpan.FromSeconds(16));
+            await vm.PullRequests.RefreshCommand.Execute();
+            await WaitUntilAsync(() => vm.PullRequests.CanReveal, what: "linked PR loaded");
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(tab.IsVisible).IsTrue();
+            await Assert.That(card.IsVisible).IsTrue();
+
+            await vm.ShowPullRequestCommand.Execute();
+            source.Links = [];
+            time.Advance(TimeSpan.FromSeconds(16));
+            await vm.PullRequests.RefreshCommand.Execute();
+            await WaitUntilAsync(() => !vm.PullRequests.HasPullRequest, what: "PR unlinked");
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(tab.IsVisible).IsFalse();
+            await Assert.That(card.IsVisible).IsTrue();
+            await Assert.That(vm.IsChatActive).IsTrue();
+        } finally { window.Close(); await vm.TeardownAsync(); }
+    });
 }


### PR DESCRIPTION
Closes #855 — AI-2682

## What & why

The Pull request tab appears only while the session has at least one linked PR, so a session without one gets no tab holding placeholder text. If the PR goes away (unlinked, access lost, signed out) the tab hides, and an active PR tab falls back to Chat. The sidebar PR card stays unconditional: it carries the sign-in and `gh` install/sign-in prompts, and a ready `gh` can discover the PR from the session's branch.

## Where to look

`HasPullRequestChanges` is a `BehaviorSubject` rather than `WhenAnyValue` (the RxAppBuilder init trap). `Notify` pushes to it only on a change and only while not disposed, because `SetReaderVisible` can still reach `Notify` after teardown.

## Verification

- `dotnet build test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj --no-incremental`: 0 warnings, 0 errors
- `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj`: 1638/1638 passed, including `The_tab_shows_only_while_the_session_has_a_linked_PR_and_the_sidebar_card_always_shows` (tab hidden → shown → hidden with Chat fallback; card visible throughout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
