### PR TITLE
Fix the sidebar's link-card hover, doubled key title and people count

### DIFF
--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
@@ -58,7 +58,7 @@ public sealed partial class WorkContextViewModel {
         set {
             if (_sessionCount == value) return;
             _sessionCount = value;
-            this.RaisePropertyChanged(nameof(SessionCountText));
+            this.RaisePropertyChanged(nameof(WhoCountText));
         }
     }
 
@@ -72,11 +72,20 @@ public sealed partial class WorkContextViewModel {
     public bool HasBlockers => _blockedBy.Count > 0;
     public bool HasIssue => Issue is not null;
     public bool HasContributors => _contributors.Count > 0;
-    public string SessionCountText => _sessionCount switch {
-        0     => "",
-        1     => "1 session",
-        var n => $"{n} sessions",
-    };
+    /// People first, since that is what the section lists; the session count follows because one
+    /// person can hold several. With nobody listed the session count stands alone.
+    public string WhoCountText {
+        get {
+            var sessions = _sessionCount switch {
+                0     => "",
+                1     => "1 session",
+                var n => $"{n} sessions",
+            };
+            if (_contributors.Count == 0) return sessions;
+            var people = _contributors.Count == 1 ? "1 person" : $"{_contributors.Count} people";
+            return sessions.Length == 0 ? people : $"{people} · {sessions}";
+        }
+    }
 
     string _requester = "You";
     public string Requester { get => _requester; private set => this.RaiseAndSetIfChanged(ref _requester, value); }
@@ -156,6 +165,7 @@ public sealed partial class WorkContextViewModel {
         this.RaisePropertyChanged(nameof(HasParts));
         this.RaisePropertyChanged(nameof(HasBlockers));
         this.RaisePropertyChanged(nameof(HasContributors));
+        this.RaisePropertyChanged(nameof(WhoCountText));
     }
 
     void ApplyReady(WorkContextRead read) {
@@ -194,7 +204,9 @@ public sealed partial class WorkContextViewModel {
 
     void ApplyItem(WorkItemDto item, IReadOnlyList<SessionWorkItemAssignmentDto> assignments) {
         Key = FirstNonBlank(item.Key?.ShortKey);
-        Title = FirstNonBlank(item.EnrichedTitle, item.Title) ?? "";
+        // An item with no tracker or generated title arrives with its key as the title.
+        var title = FirstNonBlank(item.EnrichedTitle, item.Title) ?? "";
+        Title = string.Equals(title, Key, StringComparison.OrdinalIgnoreCase) ? "" : title;
         Overview = item.IsOverviewMechanical ? null : FirstNonBlank(item.Overview);
         ApplyState(item.State?.Kind);
 
@@ -234,7 +246,7 @@ public sealed partial class WorkContextViewModel {
             Issue = null;
             return;
         }
-        var title = FirstNonBlank(link.Title) ?? $"Issue {link.ShortKey}";
+        var title = FirstNonBlank(link.Title) ?? "";
         if (Issue is { } current && current.Key == link.ShortKey && current.Title == title && current.Url == link.Url) return;
         Issue = new WorkContextLinkViewModel("ISSUE", link.ShortKey, title, link.Url, _opener);
     }
@@ -279,7 +291,7 @@ public sealed partial class WorkContextViewModel {
     }
 
     WorkContextLinkViewModel Link(int number, string? title, string? url) =>
-        new("PULL REQUEST", $"#{number}", title ?? $"Pull request #{number}", url, _opener);
+        new("PULL REQUEST", $"#{number}", title ?? "", url, _opener);
 
     static (string Provider, string Host) RepositoryIdentity(SessionSummaryDto summary, string repoHash) {
         var link = summary.PullRequests.FirstOrDefault(pr => pr.RepoHash == repoHash && PullRequestWire.SafeLink(pr.Url) is not null);

--- a/src/Capacitor.App/Views/WorkContextView.axaml
+++ b/src/Capacitor.App/Views/WorkContextView.axaml
@@ -61,13 +61,21 @@
             <Setter Property="HorizontalAlignment" Value="Center" />
             <Setter Property="VerticalAlignment" Value="Center" />
         </Style>
-        <!-- Transparent stretch wrapper for cards / nested chrome — not a hit-target of its own. -->
+        <!-- Stretch wrapper around a card: the card is the chrome, so the wrapper paints nothing in
+             any state — Fluent's hover fill lands on the presenter at the button's own radius and
+             would show behind the card's corners. -->
         <Style Selector="Button.toggle">
             <Setter Property="Background" Value="Transparent" />
             <Setter Property="BorderThickness" Value="0" />
             <Setter Property="Padding" Value="0" />
+            <Setter Property="CornerRadius" Value="10" />
             <Setter Property="HorizontalAlignment" Value="Stretch" />
             <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+        </Style>
+        <Style Selector="Button.toggle:pointerover /template/ ContentPresenter#PART_ContentPresenter,
+                         Button.toggle:pressed /template/ ContentPresenter#PART_ContentPresenter">
+            <Setter Property="Background" Value="Transparent" />
+            <Setter Property="BorderBrush" Value="Transparent" />
         </Style>
         <!-- Section rows (Who's on it / Session): real padding so hover and click aren't tight to glyphs. -->
         <Style Selector="Button.sectionHeader">
@@ -111,6 +119,9 @@
             <Setter Property="CornerRadius" Value="10" />
             <Setter Property="Padding" Value="13" />
         </Style>
+        <Style Selector="Button.toggle:pointerover Border.card">
+            <Setter Property="BorderBrush" Value="{StaticResource KcapFaintBrush}" />
+        </Style>
         <Style Selector="Path.chevron">
             <Setter Property="Stroke" Value="{StaticResource KcapMutedBrush}" />
             <Setter Property="StrokeThickness" Value="1.8" />
@@ -125,8 +136,9 @@
                     <StackPanel Spacing="6">
                         <TextBlock Text="{Binding Eyebrow}" Classes="cardEyebrow" />
                         <StackPanel Orientation="Horizontal" Spacing="8">
-                            <TextBlock Text="{Binding Key}" FontSize="11.5" FontWeight="Bold" Foreground="{StaticResource KcapSuccessBrush}" VerticalAlignment="Center" />
-                            <TextBlock Text="{Binding Title}" FontSize="11.5" Foreground="{StaticResource KcapTextBrush}" TextTrimming="CharacterEllipsis" VerticalAlignment="Center" />
+                            <TextBlock x:Name="LinkKey" Text="{Binding Key}" FontSize="11.5" FontWeight="Bold" Foreground="{StaticResource KcapSuccessBrush}" VerticalAlignment="Center" />
+                            <TextBlock x:Name="LinkTitle" Text="{Binding Title}" FontSize="11.5" Foreground="{StaticResource KcapTextBrush}" TextTrimming="CharacterEllipsis" VerticalAlignment="Center"
+                                       IsVisible="{Binding Title, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                         </StackPanel>
                     </StackPanel>
                 </Border>
@@ -175,7 +187,8 @@
                                        Foreground="{StaticResource KcapSuccessBrush}" Margin="0,8,0,0"
                                        IsVisible="{Binding Key, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                             <TextBlock x:Name="WorkContextTitle" Text="{Binding Title}" FontSize="12.5" LineHeight="18"
-                                       Foreground="{StaticResource KcapTextBrush}" TextWrapping="Wrap" Margin="0,4,0,0" />
+                                       Foreground="{StaticResource KcapTextBrush}" TextWrapping="Wrap" Margin="0,4,0,0"
+                                       IsVisible="{Binding Title, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                             <TextBlock x:Name="OverviewText" Text="{Binding Overview}" FontSize="11" LineHeight="16"
                                        Foreground="{StaticResource KcapMutedBrush}" TextWrapping="Wrap" Margin="0,6,0,0"
                                        IsVisible="{Binding Overview, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
@@ -259,9 +272,9 @@
                             <Path Classes="chevron" Data="M3,4.5 L6,7.5 L9,4.5" IsVisible="{Binding PeopleExpanded}" />
                             <Path Classes="chevron" Data="M4.5,3 L7.5,6 L4.5,9" IsVisible="{Binding !PeopleExpanded}" />
                         </Panel>
-                        <TextBlock x:Name="SessionCountText" DockPanel.Dock="Right" Text="{Binding SessionCountText}" FontSize="10.5"
+                        <TextBlock x:Name="WhoCountText" DockPanel.Dock="Right" Text="{Binding WhoCountText}" FontSize="10.5"
                                    Foreground="{StaticResource KcapMutedBrush}" VerticalAlignment="Center" Margin="0,0,10,0"
-                                   IsVisible="{Binding SessionCountText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
+                                   IsVisible="{Binding WhoCountText, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
                         <TextBlock Text="WHO'S ON IT" Classes="eyebrow" />
                     </DockPanel>
                 </Button>

--- a/test/Capacitor.App.Tests.Unit/WorkContextViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkContextViewModelTests.cs
@@ -507,6 +507,27 @@ public class WorkContextViewModelTests {
         });
     }
 
+    /// The server sends the key as the title when an item has no tracker or generated title, so
+    /// the card would otherwise print the key twice.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_key_titled_item_with_no_other_title_shows_the_key_once() {
+        await RunOnUiAsync(async () => {
+            var h = new Harness();
+            h.Source.Enqueue(
+                ReadyWith(Row("w1", "WK-2198"), Item(title: "WK-2198", enriched: null)),
+                ReadyWith(Row("w1", "WK-2198 — Desktop shell"), Item(title: "WK-2198", enriched: "Desktop shell")));
+
+            await h.PushAsync(Dto());
+            await Assert.That(h.Vm.Key).IsEqualTo("WK-2198");
+            await Assert.That(h.Vm.Title).IsEqualTo("");
+
+            await h.TickAsync();
+            await Assert.That(h.Vm.Title).IsEqualTo("Desktop shell");
+            await h.Vm.TeardownAsync();
+        });
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task Without_an_item_a_new_primary_shows_the_assignment_label_whole_with_no_key() {
@@ -686,7 +707,8 @@ public class WorkContextViewModelTests {
             await Assert.That(h.Opener.Opened).IsEquivalentTo(new[] { "https://github.com/kurrent-io/kcap-cli/issues/777" });
 
             await h.TickAsync();
-            await Assert.That(h.Vm.Issue!.Title).IsEqualTo("Issue WK-2521");
+            await Assert.That(h.Vm.Issue!.Key).IsEqualTo("WK-2521");
+            await Assert.That(h.Vm.Issue.Title).IsEqualTo("");
             await Assert.That(h.Vm.Issue.CanOpen).IsFalse();
 
             await h.TickAsync();
@@ -696,29 +718,42 @@ public class WorkContextViewModelTests {
         });
     }
 
+    /// The section lists people, so its count names people first; the session count stays beside
+    /// it because one person can hold several sessions. Without a listed contributor the requester
+    /// row stands in and the session count alone is shown.
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Contributors_and_the_session_count_come_from_the_item_and_the_requester_row_is_the_fallback() {
+    public async Task The_who_count_names_people_before_sessions_and_the_requester_row_is_the_fallback() {
         await RunOnUiAsync(async () => {
             var h = new Harness();
             var now = h.Time.GetUtcNow();
             var crowded = Item() with {
                 Contributors = [Person("u1", " Ada Lovelace ", now.AddHours(-2)), Person("github:7", null, now.AddDays(-3)), Person("u3", "👩 Grace")],
-                SessionCount = 3,
+                SessionCount = 4,
             };
-            h.Source.Enqueue(ReadyWith(Row("w1", "t"), crowded), ReadyWith(Row("w1", "t"), Item() with { SessionCount = 1 }));
+            h.Source.Enqueue(
+                ReadyWith(Row("w1", "t"), crowded),
+                ReadyWith(Row("w1", "t"), Item() with { Contributors = [Person("u1", "Ada")], SessionCount = 2 }),
+                ReadyWith(Row("w1", "t"), Item() with { Contributors = [Person("u1", "Ada")], SessionCount = 1 }),
+                ReadyWith(Row("w1", "t"), Item() with { SessionCount = 1 }));
             await h.PushAsync(Dto());
 
             await Assert.That(h.Vm.HasContributors).IsTrue();
             await Assert.That(h.Vm.Contributors.Select(c => c.Name)).IsEquivalentTo(new[] { "Ada Lovelace", "github:7", "👩 Grace" }, TUnit.Assertions.Enums.CollectionOrdering.Matching);
             await Assert.That(h.Vm.Contributors.Select(c => c.Initial)).IsEquivalentTo(new[] { "A", "G", "👩" }, TUnit.Assertions.Enums.CollectionOrdering.Matching);
             await Assert.That(h.Vm.Contributors.Select(c => c.LastActivityText)).IsEquivalentTo(new[] { "2h ago", "3d ago", "" }, TUnit.Assertions.Enums.CollectionOrdering.Matching);
-            await Assert.That(h.Vm.SessionCountText).IsEqualTo("3 sessions");
+            await Assert.That(h.Vm.WhoCountText).IsEqualTo("3 people · 4 sessions");
+
+            await h.TickAsync();
+            await Assert.That(h.Vm.WhoCountText).IsEqualTo("1 person · 2 sessions");
+
+            await h.TickAsync();
+            await Assert.That(h.Vm.WhoCountText).IsEqualTo("1 person · 1 session");
 
             await h.TickAsync();
             await Assert.That(h.Vm.HasContributors).IsFalse();
             await Assert.That(h.Vm.Contributors).IsEmpty();
-            await Assert.That(h.Vm.SessionCountText).IsEqualTo("1 session");
+            await Assert.That(h.Vm.WhoCountText).IsEqualTo("1 session");
             await Assert.That(h.Vm.Requester).IsEqualTo("You");
             await h.Vm.TeardownAsync();
         });
@@ -754,7 +789,8 @@ public class WorkContextViewModelTests {
             };
             var otherRepo = dup with { PullRequests = [Pr("kurrent-io", "kcap-server", 42, "https://github.com/kurrent-io/kcap-server/pull/42", "Server")] };
             var noIdentity = dup with { RepoOwner = null, RepoName = null, PullRequests = [Pr("x", "y", 42, null, "Elsewhere")] };
-            h.Source.Enqueue(ReadyWith(null, summary: dup), ReadyWith(null, summary: otherRepo), ReadyWith(null, summary: noIdentity));
+            var untitled = dup with { PrTitle = null, PullRequests = [] };
+            h.Source.Enqueue(ReadyWith(null, summary: dup), ReadyWith(null, summary: otherRepo), ReadyWith(null, summary: noIdentity), ReadyWith(null, summary: untitled));
 
             await h.PushAsync(Dto());
             await Assert.That(h.Vm.Links.Select(l => l.Title)).IsEquivalentTo(new[] { "Listed" });
@@ -766,6 +802,9 @@ public class WorkContextViewModelTests {
 
             await h.TickAsync();
             await Assert.That(h.Vm.Links.Select(l => l.Title)).IsEquivalentTo(new[] { "Elsewhere" });
+
+            await h.TickAsync();
+            await Assert.That(h.Vm.Links.Select(l => (l.Key, l.Title))).IsEquivalentTo(new[] { ("#42", "") });
             await h.Vm.TeardownAsync();
         });
     }
@@ -894,7 +933,7 @@ public class WorkContextViewModelTests {
                 await Assert.That(h.Vm.Links).IsEmpty();
                 await Assert.That(h.Vm.Issue).IsNull();
                 await Assert.That(h.Vm.Contributors).IsEmpty();
-                await Assert.That(h.Vm.SessionCountText).IsEqualTo("");
+                await Assert.That(h.Vm.WhoCountText).IsEqualTo("");
                 await Assert.That(h.Vm.Repository).IsEqualTo("myproj");
                 await Assert.That(h.Vm.Requester).IsEqualTo("You");
                 await h.Vm.TeardownAsync();

--- a/test/Capacitor.App.Tests.Unit/WorkContextViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkContextViewSmokeTests.cs
@@ -1,0 +1,143 @@
+using System.Reactive.Subjects;
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
+using Avalonia.Headless;
+using Avalonia.Media;
+using Avalonia.Threading;
+using Avalonia.VisualTree;
+using Capacitor.App.ViewModels;
+using Capacitor.App.Views;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Core.WorkItems;
+using Microsoft.Extensions.Time.Testing;
+using static Capacitor.App.Tests.Unit.AvaloniaSession;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// Headless rendering acceptance for the work-context pane on its own: the view is hosted in a
+/// plain Window with its view model set directly, as WorkspaceViewSmokeTests hosts the workspace.
+public class WorkContextViewSmokeTests {
+    const string SessionA = "0123456789abcdef0123456789abcdef";
+
+    sealed class Host {
+        public BehaviorSubject<AgentStatusDto?> Presence { get; } = new(null);
+        public FakeWorkContextSource Source { get; } = new();
+        public WorkContextViewModel Vm { get; }
+        public Window Window { get; }
+
+        public Host() {
+            Vm = new WorkContextViewModel(Presence, Source, new FakeTimeProvider(), new RecordingOpener());
+            Window = new Window { Content = new WorkContextView { DataContext = Vm }, Width = 400, Height = 900 };
+        }
+
+        public async Task ShowAsync(WorkContextRead read) {
+            Source.Enqueue(read);
+            Window.Show();
+            Dispatcher.UIThread.RunJobs();
+            Presence.OnNext(WorkspaceFixtures.Agent("a1", "claude", hasTerminal: true, repoPath: "/repo/myproj", sessionId: SessionA));
+            await (Vm.PendingReadForTesting ?? Task.CompletedTask);
+            Dispatcher.UIThread.RunJobs();
+            Window.UpdateLayout();
+        }
+
+        public T Find<T>(string name) where T : Control =>
+            Window.GetVisualDescendants().OfType<T>().First(c => c.Name == name);
+
+        public async Task CloseAsync() {
+            Window.Close();
+            Dispatcher.UIThread.RunJobs();
+            await Vm.TeardownAsync();
+        }
+    }
+
+    /// A key-titled item with no tracker title, its seed issue untitled too, one contributor
+    /// holding two sessions: the shape the server serves for a fresh key-only declaration.
+    static WorkContextRead KeyOnlyRead() {
+        var row = new SessionWorkItemAssignmentDto { WorkItemId = "w1", Label = "WK-2198", Source = "mcp", Confidence = 1, IsPrimary = true };
+        var item = new WorkItemDto {
+            WorkItemId = "w1",
+            Title = "WK-2198",
+            Key = new WorkItemKeyDto { ShortKey = "WK-2198", Provider = "linear", Kind = "issue", Value = "WK-2198" },
+            State = new WorkItemStateDto { Kind = "in_flight" },
+            Links = [new WorkItemLinkDto {
+                Kind = "issue", Provider = "linear", Value = "WK-2198", ShortKey = "WK-2198",
+                Url = "https://linear.app/x/issue/WK-2198", LinkClass = "link", IsSeed = true,
+            }],
+            Contributors = [new WorkItemContributorDto { UserId = "u1", DisplayName = "Ada" }],
+            SessionCount = 2,
+        };
+        return new WorkContextRead(WorkContextReadKind.Ready, [row], row, item, null, new SessionSummaryDto { SessionId = SessionA }, false, false, false, null);
+    }
+
+    static byte Alpha(IBrush? brush) => brush switch {
+        null               => 0,
+        ISolidColorBrush s => s.Color.A,
+        _                  => 255,
+    };
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_key_only_item_and_an_untitled_issue_each_show_their_key_once() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.ShowAsync(KeyOnlyRead());
+
+            var key = host.Find<TextBlock>("WorkContextKey");
+            await Assert.That(key.Text).IsEqualTo("WK-2198");
+            await Assert.That(key.IsEffectivelyVisible).IsTrue();
+            await Assert.That(host.Find<TextBlock>("WorkContextTitle").IsEffectivelyVisible).IsFalse();
+
+            var issueCard = host.Find<ContentControl>("IssueCard");
+            var linkKey = issueCard.GetVisualDescendants().OfType<TextBlock>().First(t => t.Name == "LinkKey");
+            var linkTitle = issueCard.GetVisualDescendants().OfType<TextBlock>().First(t => t.Name == "LinkTitle");
+            await Assert.That(linkKey.Text).IsEqualTo("WK-2198");
+            await Assert.That(linkKey.IsEffectivelyVisible).IsTrue();
+            await Assert.That(linkTitle.IsEffectivelyVisible).IsFalse();
+
+            await host.CloseAsync();
+        });
+    }
+
+    /// The card is its own chrome: the wrapping button must paint nothing on hover, or the theme's
+    /// hover fill shows at the button's smaller corner radius behind the card's rounded border.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Hovering_a_link_card_paints_no_chrome_outside_its_rounded_border() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.ShowAsync(KeyOnlyRead());
+
+            var button = host.Find<ContentControl>("IssueCard").GetVisualDescendants().OfType<Button>().First();
+            var card = button.GetVisualDescendants().OfType<Border>().First(b => b.Classes.Contains("card"));
+            var centre = button.TranslatePoint(new Point(button.Bounds.Width / 2, button.Bounds.Height / 2), host.Window)!.Value;
+            host.Window.MouseMove(centre);
+            Dispatcher.UIThread.RunJobs();
+            await Assert.That(button.Classes.Contains(":pointerover")).IsTrue().Because("the hover must register for the assertion to mean anything");
+
+            var presenter = button.GetVisualDescendants().OfType<ContentPresenter>().First(p => p.Name == "PART_ContentPresenter");
+            await Assert.That(Alpha(presenter.Background)).IsEqualTo((byte)0);
+            await Assert.That(Alpha(presenter.BorderBrush)).IsEqualTo((byte)0);
+            await Assert.That(presenter.CornerRadius).IsEqualTo(card.CornerRadius);
+            await Assert.That(ReferenceEquals(card.BorderBrush, host.Window.FindResource("KcapFaintBrush"))).IsTrue()
+                .Because("the hover cue is the card's own border, inside its rounded outline");
+
+            await host.CloseAsync();
+        });
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_who_row_counts_people_before_sessions() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.ShowAsync(KeyOnlyRead());
+
+            var count = host.Find<TextBlock>("WhoCountText");
+            await Assert.That(count.Text).IsEqualTo("1 person · 2 sessions");
+            await Assert.That(count.IsEffectivelyVisible).IsTrue();
+
+            await host.CloseAsync();
+        });
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/WorkContextViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkContextViewSmokeTests.cs
@@ -20,7 +20,9 @@ namespace Capacitor.App.Tests.Unit;
 public class WorkContextViewSmokeTests {
     const string SessionA = "0123456789abcdef0123456789abcdef";
 
-    sealed class Host {
+    /// Disposal closes the window and tears the view model down, so a failed assertion leaves
+    /// neither behind in the shared headless session.
+    sealed class Host : IAsyncDisposable {
         public BehaviorSubject<AgentStatusDto?> Presence { get; } = new(null);
         public FakeWorkContextSource Source { get; } = new();
         public WorkContextViewModel Vm { get; }
@@ -44,7 +46,7 @@ public class WorkContextViewSmokeTests {
         public T Find<T>(string name) where T : Control =>
             Window.GetVisualDescendants().OfType<T>().First(c => c.Name == name);
 
-        public async Task CloseAsync() {
+        public async ValueTask DisposeAsync() {
             Window.Close();
             Dispatcher.UIThread.RunJobs();
             await Vm.TeardownAsync();
@@ -80,7 +82,7 @@ public class WorkContextViewSmokeTests {
     [NotInParallel("AvaloniaSession")]
     public async Task A_key_only_item_and_an_untitled_issue_each_show_their_key_once() {
         await RunOnUiAsync(async () => {
-            var host = new Host();
+            await using var host = new Host();
             await host.ShowAsync(KeyOnlyRead());
 
             var key = host.Find<TextBlock>("WorkContextKey");
@@ -94,8 +96,6 @@ public class WorkContextViewSmokeTests {
             await Assert.That(linkKey.Text).IsEqualTo("WK-2198");
             await Assert.That(linkKey.IsEffectivelyVisible).IsTrue();
             await Assert.That(linkTitle.IsEffectivelyVisible).IsFalse();
-
-            await host.CloseAsync();
         });
     }
 
@@ -105,7 +105,7 @@ public class WorkContextViewSmokeTests {
     [NotInParallel("AvaloniaSession")]
     public async Task Hovering_a_link_card_paints_no_chrome_outside_its_rounded_border() {
         await RunOnUiAsync(async () => {
-            var host = new Host();
+            await using var host = new Host();
             await host.ShowAsync(KeyOnlyRead());
 
             var button = host.Find<ContentControl>("IssueCard").GetVisualDescendants().OfType<Button>().First();
@@ -121,8 +121,6 @@ public class WorkContextViewSmokeTests {
             await Assert.That(presenter.CornerRadius).IsEqualTo(card.CornerRadius);
             await Assert.That(ReferenceEquals(card.BorderBrush, host.Window.FindResource("KcapFaintBrush"))).IsTrue()
                 .Because("the hover cue is the card's own border, inside its rounded outline");
-
-            await host.CloseAsync();
         });
     }
 
@@ -130,14 +128,12 @@ public class WorkContextViewSmokeTests {
     [NotInParallel("AvaloniaSession")]
     public async Task The_who_row_counts_people_before_sessions() {
         await RunOnUiAsync(async () => {
-            var host = new Host();
+            await using var host = new Host();
             await host.ShowAsync(KeyOnlyRead());
 
             var count = host.Find<TextBlock>("WhoCountText");
             await Assert.That(count.Text).IsEqualTo("1 person · 2 sessions");
             await Assert.That(count.IsEffectivelyVisible).IsTrue();
-
-            await host.CloseAsync();
         });
     }
 }

--- a/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkspaceViewSmokeTests.cs
@@ -116,7 +116,7 @@ public class WorkspaceViewSmokeTests {
             foreach (var name in new[] {
                 "RefreshButton", "StaleDot", "StatePill", "WorkContextKey", "WorkContextTitle", "OverviewText", "PartOfLine", "PartsToggle", "PartsList",
                 "BlockedByBlock", "CycleNoteText", "PhaseNoteText", "SignInButton", "RetryButton", "LinkCards", "IssueCard",
-                "WhoToggle", "ContributorStack", "ContributorList", "SessionCountText", "RequesterRow", "SessionToggle", "SessionSummaryText", "SessionFacts",
+                "WhoToggle", "ContributorStack", "ContributorList", "WhoCountText", "RequesterRow", "SessionToggle", "SessionSummaryText", "SessionFacts",
             })
                 await Assert.That(pane.FindControl<Control>(name)).IsNotNull().Because($"{name} should resolve");
 


### PR DESCRIPTION
Closes #857 — AI-2683

## What & why

Three sidebar defects on a key-only work item. The link card's wrapper button left Fluent's hover chrome in place, so hovering painted a square-cornered fill behind the rounded card; the wrapper now paints nothing and the card's border carries the hover cue. The server serves the key as the title for an item with no tracker or generated title, so the card printed the key twice; a title equal to the key is dropped, and an untitled issue or pull-request link shows its key alone under its eyebrow. The "Who's on it" header counted sessions while the section lists people; it now reads people first, then sessions.

## Where to look

`WhoCountText` replaces `SessionCountText`. With nobody listed the requester row stands in and the session count alone is shown, as before.

## Verification

- `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj`: 1641 passed, 0 failed.
- New `WorkContextViewSmokeTests` hosts the pane headlessly, hovers the issue card, checks the hover registered, and asserts the presenter paints nothing and the card border carries the cue. Every new assertion was watched failing before its fix.
- `dotnet build src/Capacitor.App/Capacitor.App.csproj --no-incremental`: 0 warnings.
- The "2 sessions" case is real data: the analytics views show two attached sessions on AI-2681, both the same owner.
