### PR TITLE
Echo /quit in the chat and show a starting/working note before first output

### DIFF
--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -99,6 +99,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
             if (_phase == value) return;
             this.RaiseAndSetIfChanged(ref _phase, value);
             this.RaisePropertyChanged(nameof(PhaseNote));
+            RefreshActivityNote();
         }
     }
 
@@ -142,6 +143,33 @@ public sealed class ChatTabViewModel : ReactiveObject {
 
     string _statusText = "";
     public string StatusText { get => _statusText; private set => this.RaiseAndSetIfChanged(ref _statusText, value); }
+
+    string _activityNote = "";
+    /// One line under the rows for the stretches the transcript itself shows nothing: the agent
+    /// starting, or a turn in flight before its first output. "" whenever the rows speak for themselves.
+    public string ActivityNote { get => _activityNote; private set => this.RaiseAndSetIfChanged(ref _activityNote, value); }
+
+    string _status = "";
+    bool? _awaitingInput;
+    string? _transcriptFormat;
+
+    void RefreshActivityNote() =>
+        ActivityNote = ActivityNoteFor(Phase, _status, _awaitingInput, _transcriptFormat, _items.Count > 0, HasPendingCards, VendorLabel);
+
+    /// The working line is offered only for the daemon's own journal: there the awaiting flag flips
+    /// on every turn end, whereas a PTY vendor's comes from hooks that may never fire, and a note
+    /// that never clears is worse than none. It also needs a row: a running agent nobody has
+    /// prompted yet has nothing in flight.
+    internal static string ActivityNoteFor(
+            ChatTabPhase phase, string status, bool? awaitingInput, string? transcriptFormat,
+            bool hasRows, bool hasPendingCards, string vendorLabel) {
+        if (phase != ChatTabPhase.Reading) return "";
+        if (status == "Starting") return vendorLabel.Length > 0 ? $"Starting {vendorLabel}…" : "Starting…";
+        var working = status == "Running" && transcriptFormat == TranscriptFormats.Envelopes
+                   && awaitingInput == false && hasRows && !hasPendingCards;
+        if (!working) return "";
+        return vendorLabel.Length > 0 ? $"{vendorLabel} is working…" : "Working…";
+    }
 
     bool _isReadOnlyParticipant;
     /// True for a flow participant (any kind other than "agent"): the view swaps the composer
@@ -218,6 +246,10 @@ public sealed class ChatTabViewModel : ReactiveObject {
                 h => notifications.CollectionChanged += h, h => notifications.CollectionChanged -= h)
             .Select(_ => pendingCards.Count > 0)
             .ToProperty(this, x => x.HasPendingCards, initialValue: pendingCards.Count > 0)
+            .DisposeWith(_disposables);
+
+        this.WhenAnyValue(x => x.HasPendingCards)
+            .Subscribe(_ => RefreshActivityNote())
             .DisposeWith(_disposables);
 
         cards.Subscribe().DisposeWith(_disposables);
@@ -318,7 +350,11 @@ public sealed class ChatTabViewModel : ReactiveObject {
         ModelLabel = HostedHarnessCatalog.ModelLabelFor(dto.Vendor, dto.Model ?? "");
         StatusText = SessionStatusDots.Label(dto);
         StatusDot = SessionStatusDots.For(dto.Status);
+        _status = dto.Status;
+        _awaitingInput = dto.AwaitingInput;
+        _transcriptFormat = dto.TranscriptFormat;
         if (_projection is not null && dto.TranscriptPath is { } path && path != _path) SwitchPath(path);
+        RefreshActivityNote();
     }
 
     void SwitchPath(string path) {
@@ -390,7 +426,10 @@ public sealed class ChatTabViewModel : ReactiveObject {
         }
 
         Phase = ChatTabPhase.Reading;
-        if (envelopes.Count == 0) return;
+        if (envelopes.Count == 0) {
+            RefreshActivityNote();
+            return;
+        }
 
         var fresh = new List<ChatItemViewModel>();
         foreach (var e in envelopes) {
@@ -428,6 +467,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
         }
         if (fresh.Count > 0) _items.AddRange(fresh);
         Reconcile();
+        RefreshActivityNote();
     }
 
     /// A row is marked iff some pending request targets it: by tool-use id when the request has

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -154,19 +154,23 @@ public sealed class ChatTabViewModel : ReactiveObject {
     string? _transcriptFormat;
 
     void RefreshActivityNote() =>
-        ActivityNote = ActivityNoteFor(Phase, _status, _awaitingInput, _transcriptFormat, _items.Count > 0, HasPendingCards, VendorLabel);
+        ActivityNote = ActivityNoteFor(
+            Phase, _status, _awaitingInput, _transcriptFormat,
+            _items.Count > 0 && _items[^1] is UserTurnItem, HasPendingCards, VendorLabel);
 
     /// The working line is offered only for the daemon's own journal: there the awaiting flag flips
     /// on every turn end, whereas a PTY vendor's comes from hooks that may never fire, and a note
-    /// that never clears is worse than none. It also needs a row: a running agent nobody has
-    /// prompted yet has nothing in flight.
+    /// that never clears is worse than none. It shows only while the tail row is the user's own
+    /// prompt — the agent has been given something and produced nothing yet. The first assistant or
+    /// tool row makes the transcript itself the sign of life, so the note clears rather than sitting
+    /// beside the output.
     internal static string ActivityNoteFor(
             ChatTabPhase phase, string status, bool? awaitingInput, string? transcriptFormat,
-            bool hasRows, bool hasPendingCards, string vendorLabel) {
+            bool awaitingFirstOutput, bool hasPendingCards, string vendorLabel) {
         if (phase != ChatTabPhase.Reading) return "";
         if (status == "Starting") return vendorLabel.Length > 0 ? $"Starting {vendorLabel}…" : "Starting…";
         var working = status == "Running" && transcriptFormat == TranscriptFormats.Envelopes
-                   && awaitingInput == false && hasRows && !hasPendingCards;
+                   && awaitingInput == false && awaitingFirstOutput && !hasPendingCards;
         if (!working) return "";
         return vendorLabel.Length > 0 ? $"{vendorLabel} is working…" : "Working…";
     }

--- a/src/Capacitor.App/Views/ChatTabView.axaml
+++ b/src/Capacitor.App/Views/ChatTabView.axaml
@@ -4,7 +4,7 @@
              xmlns:views="clr-namespace:Capacitor.App.Views"
              x:Class="Capacitor.App.Views.ChatTabView"
              x:DataType="vm:ChatTabViewModel">
-    <Grid RowDefinitions="*,Auto,Auto">
+    <Grid RowDefinitions="*,Auto,Auto,Auto">
         <!-- The template owns the ScrollViewer: that is the shape Avalonia virtualizes. An
              ItemsControl inside an external ScrollViewer is measured at infinite height. -->
         <ItemsControl x:Name="ChatItems" Grid.Row="0" ItemsSource="{Binding Items}">
@@ -131,7 +131,15 @@
                    Foreground="{StaticResource KcapMutedBrush}" FontSize="12.5"
                    HorizontalAlignment="Center" VerticalAlignment="Center" />
 
-        <Border x:Name="NeedsYouRow" Grid.Row="1" Margin="22,0,22,4" IsVisible="{Binding HasPendingCards}">
+        <StackPanel x:Name="ChatActivityNote" Grid.Row="1" Orientation="Horizontal" Spacing="8" Margin="22,0,22,6"
+                    IsVisible="{Binding ActivityNote, Converter={x:Static StringConverters.IsNotNullOrEmpty}}">
+            <Border Classes="toolRunning toolStatus" Width="8" Height="8" CornerRadius="4" VerticalAlignment="Center"
+                    Background="{StaticResource KcapWarningBrush}" />
+            <TextBlock Text="{Binding ActivityNote}" Foreground="{StaticResource KcapMutedBrush}" FontSize="12"
+                       VerticalAlignment="Center" />
+        </StackPanel>
+
+        <Border x:Name="NeedsYouRow" Grid.Row="2" Margin="22,0,22,4" IsVisible="{Binding HasPendingCards}">
             <StackPanel Spacing="6">
                 <TextBlock Text="NEEDS YOU" FontSize="10" FontWeight="SemiBold" Foreground="{StaticResource KcapMutedBrush}" />
                 <ScrollViewer MaxHeight="420" VerticalScrollBarVisibility="Auto">
@@ -352,7 +360,7 @@
             </StackPanel>
         </Border>
 
-        <Border Grid.Row="2" Margin="22,8,22,18"
+        <Border Grid.Row="3" Margin="22,8,22,18"
                 Background="{StaticResource KcapSurfaceBrush}" BorderBrush="{StaticResource KcapBorderBrush}"
                 BorderThickness="1" CornerRadius="10" Padding="13,12">
             <StackPanel Spacing="6">

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -3769,8 +3769,13 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // A quit command typed into chat: a runtime with no TUI has nothing that interprets it, so
         // forwarding would hand the text to the model as an ordinary prompt — at best role-played
         // ("Quitting"), never a stop. PTY runtimes keep receiving the text verbatim: their TUI owns
-        // the command's meaning.
-        if (!agent.Runtime.EmitsTerminalOutput && IsQuitCommand(text)) return InputDeliveryOutcome.QuitRequested;
+        // the command's meaning. The runtime is what journals a delivered prompt, so the one text it
+        // never sees is recorded here: the chat renders the journal alone.
+        if (!agent.Runtime.EmitsTerminalOutput && IsQuitCommand(text)) {
+            agent.Journal?.Record(AcpEventTranslator.BuildUserMessage(seq: 0, DateTimeOffset.UtcNow.ToString("O"), text));
+
+            return InputDeliveryOutcome.QuitRequested;
+        }
 
         // Codex turn diagnostic: whether to run the post-send rollout probe, plus this round's
         // generation and the rollout length sampled just BEFORE delivery. The probe reads a rollout

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -829,7 +829,16 @@ public class ChatTabViewModelTests {
             await h.TickAsync();
             await Assert.That(h.Chat.ActivityNote).IsEqualTo("Pi is working…");
 
+            // The awaiting-input flag hides it (the turn ended and the agent waits on the user)…
             await h.PushAsync(Hosted(path, "Running", awaitingInput: true));
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("");
+            await h.PushAsync(Hosted(path, "Running", awaitingInput: false));
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("Pi is working…");
+
+            // …and so does the agent's first output row, mid-turn: the transcript is now the sign of
+            // life, so the note clears instead of sitting beside the streaming answer.
+            File.AppendAllText(path, EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.AssistantText, Text: "on it")) + "\n");
+            await h.TickAsync();
             await Assert.That(h.Chat.ActivityNote).IsEqualTo("");
             await h.TeardownAsync();
         });

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -800,6 +800,83 @@ public class ChatTabViewModelTests {
         });
     }
 
+    static AgentStatusDto Hosted(string path, string status, bool? awaitingInput) =>
+        Agent("a1", "pi", hasTerminal: false) with {
+            TranscriptPath = path, TranscriptFormat = TranscriptFormats.Envelopes, Status = status, AwaitingInput = awaitingInput,
+        };
+
+    /// The note is the only sign of life before the first envelope: a starting agent, then a turn
+    /// in flight once a prompt row exists, then nothing once the daemon says the agent waits on
+    /// the user. A running agent with no row yet has nothing in flight, so it gets no note either.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Activity_note_reads_starting_then_working_and_clears_when_the_agent_waits() {
+        await RunOnUiAsync(async () => {
+            var path = Tmp.CreateFile("j.jsonl", [
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.SessionStarted, Cwd: "/w")),
+            ]);
+            var h = new Harness(TranscriptChat.Journal);
+
+            await h.PushAsync(Hosted(path, "Starting", awaitingInput: false));
+            await h.TickAsync();
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("Starting Pi…");
+
+            await h.PushAsync(Hosted(path, "Running", awaitingInput: false));
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("");
+
+            File.AppendAllText(path, EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: "hi")) + "\n");
+            await h.TickAsync();
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("Pi is working…");
+
+            await h.PushAsync(Hosted(path, "Running", awaitingInput: true));
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("");
+            await h.TeardownAsync();
+        });
+    }
+
+    /// A pending card means the agent waits on the user, whatever the awaiting flag says: the card
+    /// arrives before the daemon's status pulse does.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_pending_card_suppresses_the_working_note() {
+        await RunOnUiAsync(async () => {
+            var path = Tmp.CreateFile("j.jsonl", [
+                EnvelopeJournalFormat.Write(new AcpEventEnvelope(Kind: AcpEventKind.UserMessage, Text: "hi")),
+            ]);
+            var h = new Harness(TranscriptChat.Journal);
+            await h.PushAsync(Hosted(path, "Running", awaitingInput: false));
+            await h.TickAsync();
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("Pi is working…");
+
+            h.Permissions.Add(PermissionEntries.Entry("r1", "a1"));
+            await WaitUntilAsync(() => h.Chat.HasPendingCards, what: "the card");
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("");
+
+            h.Permissions.Remove("r1");
+            await WaitUntilAsync(() => !h.Chat.HasPendingCards, what: "the card gone");
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("Pi is working…");
+            await h.TeardownAsync();
+        });
+    }
+
+    /// A PTY session's awaiting flag comes from vendor hooks that may never fire, so the working
+    /// note is not offered there: its terminal already shows the activity.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_pty_session_shows_no_working_note() {
+        await RunOnUiAsync(async () => {
+            var h = Claude();
+            var path = Tmp.CreateFile("t.jsonl", [UserLine]);
+            await h.PushAsync(Dto(path) with { Status = "Running", AwaitingInput = false });
+            await h.TickAsync();
+
+            await Assert.That(h.Chat.Phase).IsEqualTo(ChatTabPhase.Reading);
+            await Assert.That(h.Chat.ActivityNote).IsEqualTo("");
+            await h.TeardownAsync();
+        });
+    }
+
     sealed class CountingProjection(ITranscriptProjection inner) : ITranscriptProjection {
         public List<int> LineNumbers { get; } = [];
         public int ContextsCreated { get; private set; }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorHarness.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorHarness.cs
@@ -208,7 +208,8 @@ internal static class AgentOrchestratorHarness {
     /// clock passes one; omitting it keeps every existing caller's real-time default.</summary>
     internal static AgentInstance SeedAcpAgent(
             AgentOrchestrator orch, string agentId, IHostedAgentRuntime runtime, string status = "Running",
-            AgentActivityClock? activityClock = null, LaunchKind kind = LaunchKind.Default, bool isPrivate = false) {
+            AgentActivityClock? activityClock = null, LaunchKind kind = LaunchKind.Default, bool isPrivate = false,
+            TranscriptJournal? journal = null) {
         var agent = new AgentInstance(
             agentId, "review this", "default", null, "/repo", "cursor",
             runtime,
@@ -217,7 +218,8 @@ internal static class AgentOrchestratorHarness {
             Status = status,
             ActivityClock = activityClock ?? new AgentActivityClock(TimeProvider.System),
             Kind = kind,
-            IsPrivate = isPrivate
+            IsPrivate = isPrivate,
+            Journal = journal
         };
 
         orch.RegisterAgentForTest(agent);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/InputDeliveryCoreTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/InputDeliveryCoreTests.cs
@@ -115,6 +115,28 @@ public class InputDeliveryCoreTests {
         await WaitForExit(rt);
     }
 
+    /// <summary>The quit is the user's own message, so the transcript carries it like any other:
+    /// the chat renders only the journal, and a text the runtime never receives would otherwise
+    /// leave the session ending with no row saying why.</summary>
+    [Test]
+    public async Task Quit_on_a_non_pty_runtime_is_journaled_as_the_users_message() {
+        var server = new CaptureServerConnection();
+        await using var orch = Build(server);
+        var journal = TranscriptJournal.ForAgent(
+            orch.PidRecordRootForTest, "acp-quit-row", Microsoft.Extensions.Logging.Abstractions.NullLogger.Instance);
+        await Assert.That(journal.Open("/repo", "default")).IsTrue();
+        var agent = AgentOrchestratorHarness.SeedAcpAgent(orch, "acp-quit-row", new FakeAcpRuntime(), journal: journal);
+
+        var outcome = await orch.DeliverInputAsync(agent, "/quit", null);
+        await journal.CompleteAsync();
+
+        await Assert.That(outcome.Kind).IsEqualTo(InputDeliveryKind.QuitRequested);
+        var userRows = JournalFiles.ReadLines(journal.Path)
+            .Where(l => l.Contains("\"kind\":\"user_message\"", StringComparison.Ordinal)).ToArray();
+        await Assert.That(userRows).Count().IsEqualTo(1);
+        await Assert.That(userRows[0]).Contains("\"text\":\"/quit\"");
+    }
+
     [Test]
     public async Task A_runtime_fault_maps_to_delivery_failed_with_the_runtimes_own_message() {
         var server = new CaptureServerConnection();


### PR DESCRIPTION
Closes #853, closes #854 — AI-2679, AI-2680

## What & why

Two gaps found testing the Chat tab against hosted sessions without a PTY. A `/quit` or `/exit` typed into the composer stopped the agent but never appeared in the chat: the runtime is what journals a delivered prompt, and the quit is the one text a non-PTY runtime never receives, so the daemon now records it as the user's own row before the stop. And the chat showed nothing between the user's prompt and the agent's first output — for a starting agent or a slow first turn the tab looked dead. The tab now carries one line under the rows: "Starting Gemini…" while the daemon reports `Starting`, "Gemini is working…" while a turn is in flight, nothing once the agent waits on the user.

## Where to look

The working line is derived, not signalled: `Running` + `awaiting_input == false` + a row exists + no pending card, and only for `transcript_format: "envelopes"`. A PTY vendor's awaiting flag comes from hooks that may never fire, so a note there could never clear; their terminal already shows activity.

## Verification

- `dotnet run --project test/Capacitor.App.Tests.Unit`: 1640 passed (3 new: starting → idle → working → waits; a pending card suppresses the note; a PTY session gets none).
- Daemon `InputDeliveryCoreTests`, `LocalSendTextTests`, `SendInputQuitCommandTests`, `AgentOrchestratorJournalTests`, `SendInputActivityClockTests`: 37 passed; the new case reads the `/quit` user row back from the journal file.
