### PR TITLE
Add Window, Help and About menus to the desktop app

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,21 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## The desktop app has Window, Help and About menus
+
+Every window carries its own Window and Help menus rather than the app carrying one set. On macOS
+Avalonia makes the key window's menu the menu bar, and with no key window it shows the
+Application's menu with the app menu item appended last, so top-level menus set on the Application
+would lose their order. The cost is that the bar shows only the app menu while no window of ours is
+key, as when the main window is hidden to the tray. Avalonia also never hands its menus to AppKit's
+`windowsMenu` and `helpMenu` slots, and only a registered Window menu gets Move to a display, the
+tiling items and the window list, only a registered Help menu the search field; `AppKitMenus`
+registers the key window's copies each time it activates. The full-screen item keeps one label,
+because renaming an exported item rebuilds the native menu and drops that registration until the
+window next activates. The app menu is our own, set in `Initialize` before Avalonia exports it, so
+its fallback "About Avalonia" never appears. About opens the standard macOS panel, which reads the
+bundle's `Info.plist`, so a build run outside the bundle shows no version.
+
 ## A hosted agent's teardown cannot hang up the daemon
 
 Stopping a Pi agent that outlived its grace period took the whole daemon down: the log showed

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -186,7 +186,12 @@ public partial class App : Application {
         }
     }
 
-    public override void Initialize() => AvaloniaXamlLoader.Load(this);
+    public override void Initialize() {
+        AvaloniaXamlLoader.Load(this);
+        // Here, not later: Avalonia exports the app menu right after Initialize, substituting its own
+        // "About Avalonia" when there is none.
+        NativeMenu.SetMenu(this, AppMenuBar.BuildAppMenu(AppKitMenus.ShowAboutPanel));
+    }
 
     public override void OnFrameworkInitializationCompleted() {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
@@ -197,6 +202,8 @@ public partial class App : Application {
             // comment explains the exit-code bug that pin fixes).
             desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
             desktop.ShutdownRequested += OnShutdownRequested;
+            // Before StartAsync: it shows its first window (the install guard or the wizard) synchronously.
+            new AppMenuBar(new ShellUrlOpener(), () => desktop.Windows, () => _coordinator is { } c ? c.ShowMainWindow : null).Install();
             _ = StartAsync(desktop);
         }
 

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -203,12 +203,17 @@ public partial class App : Application {
             desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
             desktop.ShutdownRequested += OnShutdownRequested;
             // Before StartAsync: it shows its first window (the install guard or the wizard) synchronously.
-            new AppMenuBar(new ShellUrlOpener(), () => desktop.Windows, () => _coordinator is { } c ? c.ShowMainWindow : null).Install();
+            new AppMenuBar(new ShellUrlOpener(), () => desktop.Windows, () => MainWindowAction(_coordinator)).Install();
             _ = StartAsync(desktop);
         }
 
         base.OnFrameworkInitializationCompleted();
     }
+
+    // A failed startup latches the coordinator but keeps it, and a quit latches it too: showing a
+    // window from either would run the window factory over a graph that is being torn down.
+    internal static Action? MainWindowAction(MainWindowCoordinator? coordinator) =>
+        coordinator is { QuitInProgress: false } c ? c.ShowMainWindow : null;
 
     // This continuation is the ONLY path to a visible window: OnFrameworkInitializationCompleted
     // fires it fire-and-forget and returns immediately, so an exception escaping here would

--- a/src/Capacitor.App/Views/AppKitMenus.cs
+++ b/src/Capacitor.App/Views/AppKitMenus.cs
@@ -1,0 +1,57 @@
+using System.Runtime.InteropServices;
+
+namespace Capacitor.App.Views;
+
+/// The AppKit menu calls Avalonia does not make. It never hands its menus to the windowsMenu and
+/// helpMenu slots, and only a registered Window menu gets Move to a display, the tiling items and
+/// the window list, and only a registered Help menu gets the search field.
+public static partial class AppKitMenus {
+    const string ObjC = "/usr/lib/libobjc.A.dylib";
+
+    /// Registers the current main menu's submenus with these titles; one that is missing is skipped.
+    public static void Adopt(string windowTitle, string helpTitle) {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        var app = SharedApplication();
+        var mainMenu = Send(app, Selector("mainMenu"));
+        if (mainMenu == 0) return;
+
+        var windowMenu = Submenu(mainMenu, windowTitle);
+        if (windowMenu != 0) SendVoid(app, Selector("setWindowsMenu:"), windowMenu);
+
+        var helpMenu = Submenu(mainMenu, helpTitle);
+        if (helpMenu != 0) SendVoid(app, Selector("setHelpMenu:"), helpMenu);
+    }
+
+    /// Filled from the bundle's Info.plist, so a build run outside a bundle shows no version.
+    public static void ShowAboutPanel() {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        SendVoid(SharedApplication(), Selector("orderFrontStandardAboutPanel:"), 0);
+    }
+
+    static nint SharedApplication() => Send(GetClass("NSApplication"), Selector("sharedApplication"));
+
+    static nint Submenu(nint menu, string title) {
+        var item = Send(menu, Selector("itemWithTitle:"), Send(GetClass("NSString"), Selector("stringWithUTF8String:"), title));
+        return item == 0 ? 0 : Send(item, Selector("submenu"));
+    }
+
+    [LibraryImport(ObjC, EntryPoint = "objc_getClass", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint GetClass(string name);
+
+    [LibraryImport(ObjC, EntryPoint = "sel_registerName", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint Selector(string name);
+
+    [LibraryImport(ObjC, EntryPoint = "objc_msgSend")]
+    private static partial nint Send(nint receiver, nint selector);
+
+    [LibraryImport(ObjC, EntryPoint = "objc_msgSend")]
+    private static partial nint Send(nint receiver, nint selector, nint argument);
+
+    [LibraryImport(ObjC, EntryPoint = "objc_msgSend", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint Send(nint receiver, nint selector, string argument);
+
+    [LibraryImport(ObjC, EntryPoint = "objc_msgSend")]
+    private static partial void SendVoid(nint receiver, nint selector, nint argument);
+}

--- a/src/Capacitor.App/Views/AppMenuBar.cs
+++ b/src/Capacitor.App/Views/AppMenuBar.cs
@@ -1,0 +1,78 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Views;
+
+/// The Window and Help menus. Every window carries its own copy: on macOS Avalonia makes the key
+/// window's menu the menu bar, and a menu set only on the Application loses its order there.
+public sealed class AppMenuBar(IUrlOpener opener, Func<IReadOnlyList<Window>> windows, Func<Action?> showMainWindow) {
+    public const string DocsUrl = "https://www.kurrent.io/docs/capacitor/";
+    public const string ChangelogUrl = "https://github.com/kurrent-io/kcap-cli/releases";
+
+    const string WindowMenuTitle = "Window";
+    const string HelpMenuTitle = "Help";
+
+    /// The app menu's own items; Avalonia appends Services, Hide and Quit after them.
+    public static NativeMenu BuildAppMenu(Action showAbout) => new() { Item("About Kurrent Capacitor", showAbout) };
+
+    /// Once per process: the class handler cannot be removed.
+    public void Install() => Window.WindowOpenedEvent.AddClassHandler<Window>((window, _) => Attach(window));
+
+    public void Attach(Window window) {
+        // Opened fires again each time a hidden window is shown, as the main window is from the tray.
+        if (NativeMenu.GetMenu(window) is not null) return;
+
+        NativeMenu.SetMenu(window, Build(window));
+        // Avalonia swaps the main menu to the key window's own, so AppKit has to be pointed at this
+        // window's copies again every time it becomes key.
+        window.Activated += (_, _) => AppKitMenus.Adopt(WindowMenuTitle, HelpMenuTitle);
+    }
+
+    public NativeMenu Build(Window window) => new() {
+        new NativeMenuItem(WindowMenuTitle) { Menu = BuildWindowMenu(window) },
+        new NativeMenuItem(HelpMenuTitle) { Menu = BuildHelpMenu() },
+    };
+
+    NativeMenu BuildWindowMenu(Window window) {
+        var menu = new NativeMenu {
+            Item("Minimize", () => window.WindowState = WindowState.Minimized, new KeyGesture(Key.M, KeyModifiers.Meta)),
+            Item("Zoom", () => Toggle(window, WindowState.Maximized), enabled: window.CanResize),
+            // A fixed label: renaming an exported item makes Avalonia rebuild the native menu, which
+            // would drop the AppKit registration until the window next becomes key.
+            Item("Toggle Full Screen", () => Toggle(window, WindowState.FullScreen),
+                new KeyGesture(Key.F, KeyModifiers.Control | KeyModifiers.Meta), window.CanResize),
+            new NativeMenuItemSeparator(),
+        };
+
+        if (showMainWindow() is { } show) {
+            menu.Add(Item("Kurrent Capacitor", show, new KeyGesture(Key.D0, KeyModifiers.Meta)));
+            menu.Add(new NativeMenuItemSeparator());
+        }
+
+        menu.Add(Item("Bring All to Front", () => BringAllToFront(window)));
+        return menu;
+    }
+
+    NativeMenu BuildHelpMenu() => new() {
+        Item("Kurrent Capacitor Documentation", () => LinkPolicy.Open(opener, DocsUrl)),
+        Item("Changelog", () => LinkPolicy.Open(opener, ChangelogUrl)),
+    };
+
+    static void Toggle(Window window, WindowState state) =>
+        window.WindowState = window.WindowState == state ? WindowState.Normal : state;
+
+    void BringAllToFront(Window invoking) {
+        foreach (var window in windows()) {
+            if (window != invoking && window.IsVisible && window.WindowState != WindowState.Minimized) window.Activate();
+        }
+
+        invoking.Activate();
+    }
+
+    static NativeMenuItem Item(string header, Action action, KeyGesture? gesture = null, bool enabled = true) {
+        var item = new NativeMenuItem(header) { Gesture = gesture, IsEnabled = enabled };
+        item.Click += (_, _) => action();
+        return item;
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/AppMenuBarTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMenuBarTests.cs
@@ -1,12 +1,11 @@
 using Avalonia.Controls;
 using Avalonia.Input;
 using Avalonia.Threading;
+using Capacitor.App.Services;
 using Capacitor.App.Views;
 
 namespace Capacitor.App.Tests.Unit;
 
-/// The Window and Help menus every window carries: their layout, what each item does to the
-/// window it was built for, and the exact pages Help opens.
 public class AppMenuBarTests {
     static AppMenuBar NewBar(RecordingOpener? opener = null, Action? showMainWindow = null, IReadOnlyList<Window>? windows = null) =>
         new(opener ?? new RecordingOpener(), () => windows ?? [], () => showMainWindow);
@@ -123,6 +122,18 @@ public class AppMenuBarTests {
             Click(Item(Submenu(NewBar(showMainWindow: () => shown++).Build(new Window()), "Window"), "Kurrent Capacitor")));
 
         await Assert.That(shown).IsEqualTo(1);
+    }
+
+    /// A failed startup latches the coordinator but keeps it, and then opens its error window: that
+    /// window must not get an item that re-runs the window factory over the torn-down graph.
+    [Test]
+    public async Task Only_a_coordinator_no_failure_or_quit_has_latched_supplies_the_main_window_item() {
+        var live = new MainWindowCoordinator(() => throw new InvalidOperationException("factory"));
+        var latched = new MainWindowCoordinator(() => throw new InvalidOperationException("factory")) { QuitInProgress = true };
+
+        await Assert.That(Capacitor.App.App.MainWindowAction(live) is not null).IsTrue();
+        await Assert.That(Capacitor.App.App.MainWindowAction(latched) is null).IsTrue();
+        await Assert.That(Capacitor.App.App.MainWindowAction(null) is null).IsTrue();
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/AppMenuBarTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AppMenuBarTests.cs
@@ -1,0 +1,219 @@
+using Avalonia.Controls;
+using Avalonia.Input;
+using Avalonia.Threading;
+using Capacitor.App.Views;
+
+namespace Capacitor.App.Tests.Unit;
+
+/// The Window and Help menus every window carries: their layout, what each item does to the
+/// window it was built for, and the exact pages Help opens.
+public class AppMenuBarTests {
+    static AppMenuBar NewBar(RecordingOpener? opener = null, Action? showMainWindow = null, IReadOnlyList<Window>? windows = null) =>
+        new(opener ?? new RecordingOpener(), () => windows ?? [], () => showMainWindow);
+
+    static NativeMenu Submenu(NativeMenu bar, string header) => Item(bar, header).Menu!;
+
+    static NativeMenuItem Item(NativeMenu menu, string header) =>
+        menu.Items.OfType<NativeMenuItem>().Single(i => i.Header == header);
+
+    static string Layout(NativeMenu menu) =>
+        string.Join("|", menu.Items.Select(i => i is NativeMenuItem item ? item.Header : "-"));
+
+    static void Click(NativeMenuItem item) => ((INativeMenuItemExporterEventsImplBridge)item).RaiseClicked();
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Build_puts_Window_before_Help() {
+        var layout = await AvaloniaSession.DispatchAsync(() => Layout(NewBar().Build(new Window())));
+
+        await Assert.That(layout).IsEqualTo("Window|Help");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Window_menu_offers_the_main_window_when_one_can_be_shown() {
+        var layout = await AvaloniaSession.DispatchAsync(() =>
+            Layout(Submenu(NewBar(showMainWindow: () => { }).Build(new Window()), "Window")));
+
+        await Assert.That(layout).IsEqualTo("Minimize|Zoom|Toggle Full Screen|-|Kurrent Capacitor|-|Bring All to Front");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Window_menu_leaves_out_the_main_window_before_one_exists() {
+        var layout = await AvaloniaSession.DispatchAsync(() => Layout(Submenu(NewBar().Build(new Window()), "Window")));
+
+        await Assert.That(layout).IsEqualTo("Minimize|Zoom|Toggle Full Screen|-|Bring All to Front");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Window_menu_carries_the_standard_macOS_shortcuts() {
+        var (minimize, fullScreen, main) = await AvaloniaSession.DispatchAsync(() => {
+            var menu = Submenu(NewBar(showMainWindow: () => { }).Build(new Window()), "Window");
+            return (Item(menu, "Minimize").Gesture, Item(menu, "Toggle Full Screen").Gesture, Item(menu, "Kurrent Capacitor").Gesture);
+        });
+
+        await Assert.That(minimize).IsEqualTo(new KeyGesture(Key.M, KeyModifiers.Meta));
+        await Assert.That(fullScreen).IsEqualTo(new KeyGesture(Key.F, KeyModifiers.Control | KeyModifiers.Meta));
+        await Assert.That(main).IsEqualTo(new KeyGesture(Key.D0, KeyModifiers.Meta));
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Minimize_minimizes_the_window_the_menu_was_built_for() {
+        var state = await AvaloniaSession.DispatchAsync(() => {
+            var window = new Window();
+            Click(Item(Submenu(NewBar().Build(window), "Window"), "Minimize"));
+            return window.WindowState;
+        });
+
+        await Assert.That(state).IsEqualTo(WindowState.Minimized);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Zoom_toggles_between_maximized_and_normal() {
+        var (first, second) = await AvaloniaSession.DispatchAsync(() => {
+            var window = new Window();
+            var zoom = Item(Submenu(NewBar().Build(window), "Window"), "Zoom");
+            Click(zoom);
+            var afterFirst = window.WindowState;
+            Click(zoom);
+            return (afterFirst, window.WindowState);
+        });
+
+        await Assert.That(first).IsEqualTo(WindowState.Maximized);
+        await Assert.That(second).IsEqualTo(WindowState.Normal);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Toggle_Full_Screen_enters_and_leaves_full_screen() {
+        var (first, second) = await AvaloniaSession.DispatchAsync(() => {
+            var window = new Window();
+            var fullScreen = Item(Submenu(NewBar().Build(window), "Window"), "Toggle Full Screen");
+            Click(fullScreen);
+            var afterFirst = window.WindowState;
+            Click(fullScreen);
+            return (afterFirst, window.WindowState);
+        });
+
+        await Assert.That(first).IsEqualTo(WindowState.FullScreen);
+        await Assert.That(second).IsEqualTo(WindowState.Normal);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_fixed_size_window_cannot_be_zoomed_or_made_full_screen() {
+        var (zoom, fullScreen) = await AvaloniaSession.DispatchAsync(() => {
+            var menu = Submenu(NewBar().Build(new Window { CanResize = false }), "Window");
+            return (Item(menu, "Zoom").IsEnabled, Item(menu, "Toggle Full Screen").IsEnabled);
+        });
+
+        await Assert.That(zoom).IsFalse();
+        await Assert.That(fullScreen).IsFalse();
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_main_window_item_shows_the_main_window() {
+        var shown = 0;
+        await AvaloniaSession.DispatchAsync(() =>
+            Click(Item(Submenu(NewBar(showMainWindow: () => shown++).Build(new Window()), "Window"), "Kurrent Capacitor")));
+
+        await Assert.That(shown).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Bring_All_to_Front_activates_every_visible_window_and_leaves_the_invoking_one_key() {
+        var order = await AvaloniaSession.DispatchAsync(() => {
+            var invoking = new Window { Title = "invoking" };
+            var other = new Window { Title = "other" };
+            var hidden = new Window { Title = "hidden" };
+            try {
+                invoking.Show();
+                other.Show();
+                // Headless windows post Activated to the dispatcher: drain what Show queued before
+                // listening, then what the click queued before reading.
+                Dispatcher.UIThread.RunJobs();
+                var activated = new List<string>();
+                foreach (var w in new[] { invoking, other, hidden }) w.Activated += (_, _) => activated.Add(w.Title!);
+
+                Click(Item(Submenu(NewBar(windows: [invoking, other, hidden]).Build(invoking), "Window"), "Bring All to Front"));
+                Dispatcher.UIThread.RunJobs();
+                return string.Join("|", activated);
+            } finally {
+                invoking.Close();
+                other.Close();
+                hidden.Close();
+            }
+        });
+
+        await Assert.That(order).IsEqualTo("other|invoking");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Help_opens_the_docs_and_the_GitHub_releases() {
+        var opener = new RecordingOpener();
+        var layout = await AvaloniaSession.DispatchAsync(() => {
+            var help = Submenu(NewBar(opener).Build(new Window()), "Help");
+            Click(Item(help, "Kurrent Capacitor Documentation"));
+            Click(Item(help, "Changelog"));
+            return Layout(help);
+        });
+
+        await Assert.That(layout).IsEqualTo("Kurrent Capacitor Documentation|Changelog");
+        await Assert.That(string.Join("|", opener.Opened))
+            .IsEqualTo("https://www.kurrent.io/docs/capacitor/|https://github.com/kurrent-io/kcap-cli/releases");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task A_help_link_that_fails_to_open_does_not_throw() {
+        var opener = new RecordingOpener { ThrowOnOpen = new InvalidOperationException("no browser") };
+        await AvaloniaSession.DispatchAsync(() => Click(Item(Submenu(NewBar(opener).Build(new Window()), "Help"), "Changelog")));
+
+        await Assert.That(opener.Opened.Count).IsEqualTo(1);
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_app_menu_opens_About() {
+        var opened = 0;
+        var layout = await AvaloniaSession.DispatchAsync(() => {
+            var menu = AppMenuBar.BuildAppMenu(() => opened++);
+            Click(Item(menu, "About Kurrent Capacitor"));
+            return Layout(menu);
+        });
+
+        await Assert.That(layout).IsEqualTo("About Kurrent Capacitor");
+        await Assert.That(opened).IsEqualTo(1);
+    }
+
+    /// Without an app menu of its own, Avalonia substitutes one whose only item is "About Avalonia".
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_app_brings_its_own_app_menu() {
+        var layout = await AvaloniaSession.DispatchAsync(() => Layout(NativeMenu.GetMenu(Avalonia.Application.Current!)!));
+
+        await Assert.That(layout).IsEqualTo("About Kurrent Capacitor");
+    }
+
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Attach_keeps_the_menu_a_window_already_has() {
+        var same = await AvaloniaSession.DispatchAsync(() => {
+            var window = new Window();
+            var bar = NewBar();
+            bar.Attach(window);
+            var first = NativeMenu.GetMenu(window);
+            bar.Attach(window);
+            return first is not null && ReferenceEquals(first, NativeMenu.GetMenu(window));
+        });
+
+        await Assert.That(same).IsTrue();
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/PauseControllerTests.cs
+++ b/test/Capacitor.App.Tests.Unit/PauseControllerTests.cs
@@ -145,8 +145,11 @@ public class PauseControllerTests {
         ops.QueueAck(true, null);
         ops.QueueGet(new ConsentPolicyDto("prompt", 45, [PauseRule, narrower]));
 
+        var beforeToggle = states.Count;
         controller.RequestToggle(true);
-        await Assert.That(states[^1].Busy).IsTrue(); // pushed synchronously before RequestToggle returns
+        // Read at the index RequestToggle pushed under its own lock, not at the end: every op here is
+        // queued in advance, so the toggle can settle before this line and leave a non-busy state last.
+        await Assert.That(states[beforeToggle].Busy).IsTrue();
         await WaitUntilAsync(() => states.Count >= 3, what: "toggle to settle");
 
         await Assert.That(ops.PutCalls).IsEqualTo(1);


### PR DESCRIPTION
Closes #861 — AI-2687

## What & why

The desktop app's menu bar is Avalonia's fallback app menu alone, and its About opens "About Avalonia". This adds a Window menu (Minimize, Zoom, Toggle Full Screen, Bring All to Front, and Kurrent Capacitor ⌘0 to show the main window), a Help menu (the docs, and GitHub releases as the changelog), and About Kurrent Capacitor opening the standard macOS panel. Each window carries its own Window and Help menus, and `AppKitMenus` registers them with AppKit whenever a window becomes key, which is what makes macOS add Move to a display, the tiling items, the window list and the Help search field.

## Where to look

While no window of ours is key (the main window hidden to the tray, or minimized), Avalonia shows only the app menu, so Window and Help are gone until a window is focused again.

## Verification

- `dotnet run --project test/Capacitor.App.Tests.Unit`: 1652 passed, 0 failed.
- `dotnet build src/Capacitor.App --no-incremental`: 0 warnings.
- Dev build on macOS: the Window menu showed Fill, Center, Move & Resize, Full Screen Tile and the window list; Help showed the search field; About opened the macOS panel.
