### PR TITLE
Drain the version probe's pipes while waiting so a chatty --version cannot deadlock startup

### DIFF
--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1560,14 +1560,31 @@ public static partial class DaemonRunner {
                 RedirectStandardError = true,
                 ArgumentList = { "--version" }
             });
-            if (process is null || !process.WaitForExit(timeoutMs)) {
-                try { if (process is not null) ProcessTree.Kill(process); } catch { }
+            if (process is null) return null;
+
+            // Drain both pipes WHILE the child runs. A --version that writes more than the OS pipe
+            // buffer — some vendor CLIs emit a banner or an "update available" notice — blocks on
+            // write until the parent reads, so reading only after WaitForExit deadlocks: the child
+            // parks on a full pipe, the wait never returns, and the probe hangs until the timeout
+            // kills it. The drains never fault (they swallow to ""), so the abandoned timeout path
+            // leaves no unobserved task exception.
+            var stdout = DrainToEndAsync(process.StandardOutput);
+            var stderr = DrainToEndAsync(process.StandardError);
+
+            if (!process.WaitForExit(timeoutMs)) {
+                try { ProcessTree.Kill(process); } catch { }
                 return null;
             }
-            var output = process.StandardOutput.ReadToEnd().Trim();
-            if (output.Length == 0) output = process.StandardError.ReadToEnd().Trim();
+
+            var output = stdout.GetAwaiter().GetResult().Trim();
+            if (output.Length == 0) output = stderr.GetAwaiter().GetResult().Trim();
             return ParseProbedVersion(output);
         } catch { return null; }
+    }
+
+    static async Task<string> DrainToEndAsync(System.IO.StreamReader reader) {
+        try { return await reader.ReadToEndAsync().ConfigureAwait(false); }
+        catch { return ""; }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1582,9 +1582,23 @@ public static partial class DaemonRunner {
         } catch { return null; }
     }
 
+    /// Enough for any real vendor <c>--version</c> (a line or two); a version that needed more would
+    /// fail the parser anyway. Past the cap the stream is still read to EOF so the child never blocks
+    /// on a full pipe, but nothing more is retained — a noisy or runaway CLI cannot grow this buffer
+    /// for the whole probe budget.
+    const int ProbeOutputCap = 8 * 1024;
+
     static async Task<string> DrainToEndAsync(System.IO.StreamReader reader) {
-        try { return await reader.ReadToEndAsync().ConfigureAwait(false); }
-        catch { return ""; }
+        try {
+            var buffer = new char[4096];
+            var kept   = new System.Text.StringBuilder();
+            int read;
+            while ((read = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0) {
+                var room = ProbeOutputCap - kept.Length;
+                if (room > 0) kept.Append(buffer, 0, Math.Min(read, room));
+            }
+            return kept.ToString();
+        } catch { return ""; }
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerVersionProbeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerVersionProbeTests.cs
@@ -50,4 +50,23 @@ public class DaemonRunnerVersionProbeTests {
     public async Task Output_with_no_version_token_resolves_to_null(string observed) {
         await Assert.That(DaemonRunner.ParseProbedVersion(observed)).IsNull();
     }
+
+    /// <summary>A vendor whose <c>--version</c> writes more than the OS pipe buffer — some print a
+    /// banner or an "update available" notice — must not deadlock the probe. Its redirected streams
+    /// are drained while it runs, so it can finish writing and exit and the version is read; reading
+    /// only after the wait would park the child on a full pipe and hang the probe until its timeout
+    /// killed it, the silent multi-minute daemon startup this guards against. POSIX stub, so Windows
+    /// is skipped like the other real-binary probe checks.</summary>
+    [Test]
+    public async Task A_version_whose_output_exceeds_the_pipe_buffer_is_drained_not_deadlocked() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary is a POSIX shell script.");
+        using var tmp = new TempDir();
+        // ~500 KB to stderr — past every platform's pipe buffer — before the version line on stdout.
+        var cli = tmp.CreateFile(
+            "faketool", "#!/bin/sh\nyes 0123456789ABCDEFGHIJ | head -c 500000 1>&2\necho 'faketool 9.9.9'\n");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(cli, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        await Assert.That(DaemonRunner.ProbeCliVersionForLaunch(cli)).IsEqualTo("9.9.9");
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerVersionProbeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerVersionProbeTests.cs
@@ -69,4 +69,20 @@ public class DaemonRunnerVersionProbeTests {
 
         await Assert.That(DaemonRunner.ProbeCliVersionForLaunch(cli)).IsEqualTo("9.9.9");
     }
+
+    /// <summary>The version sits at the front and a flood follows on the same stream: the probe keeps
+    /// only a bounded prefix (so a noisy CLI cannot grow the buffer without limit) yet must keep
+    /// draining past the cap, or the child blocks on the full pipe and the probe stalls to its
+    /// timeout. Guards both halves — a drain that stopped at the cap would fail this.</summary>
+    [Test]
+    public async Task A_version_at_the_front_survives_a_trailing_flood_on_the_same_stream() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary is a POSIX shell script.");
+        using var tmp = new TempDir();
+        var cli = tmp.CreateFile(
+            "faketool", "#!/bin/sh\necho 'faketool 9.9.9'\nyes 0123456789ABCDEFGHIJ | head -c 500000\n");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(cli, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        await Assert.That(DaemonRunner.ProbeCliVersionForLaunch(cli)).IsEqualTo("9.9.9");
+    }
 }


### PR DESCRIPTION
Refs #859 — AI-2684

## What & why

The daemon's startup vendor `--version` probe deadlocks on any CLI that prints more than the OS pipe buffer. `ProbeCliVersionOnce` redirected both stdout and stderr but called `WaitForExit(timeout)` before reading either, so a child that writes ~16-64 KB+ (some vendor CLIs emit a banner or an "update available" notice) blocks on the full pipe while the parent blocks in the wait — neither side moves until the per-attempt timeout kills the child, then it retries three times, across several probe sites. That is the multi-minute silent daemon startup: observed live as `agy --version` alive 75+ seconds as a daemon child though it returns in ~1 s standalone. The probe now drains both streams while the child runs, so it exits promptly and the version is read.

This is the pipe-deadlock cause only. The other AI-2684 items — moving the probes off the startup critical path so a genuinely hung CLI cannot delay the socket bind, a startup phase trace for the pre-host window, and `kcap daemon status` distinguishing pid-alive from serving — stay open on the issue.

## Where to look

`DrainToEndAsync` swallows read faults to `""`, so the abandoned timeout path (kill then return) leaves no unobserved task exception behind the two in-flight reads.

## Verification

- New `DaemonRunnerVersionProbeTests.A_version_whose_output_exceeds_the_pipe_buffer_is_drained_not_deadlocked`: a POSIX stub floods 500 KB to stderr before its version line. Before the fix the probe hit its 3 s timeout and returned null; after, it returns `9.9.9`. Red-then-green confirmed.
- Full `Capacitor.Cli.Daemon.Tests.Unit` suite green; daemon AOT publish clean.
