### PR TITLE
Inject the machine credential and pin each vendor's config slot

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,22 +17,29 @@ on:
     tags:
       - 'v*'
 
+# A new commit supersedes an older run for the same PR. Pushes to main and tag builds key on their
+# own ref and are never cancelled, so a release build always finishes.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build-and-test:
     name: Build and test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # Roughly 2.5x the longest observed leg (17m); this only has to catch a wedge, and GitHub's
+    # kill takes the uploaded reports with it.
+    timeout-minutes: 40
     strategy:
       fail-fast: false
       matrix:
-        # linux-x64 + windows-x64. macOS is NOT in this matrix: the unit suite has
-        # a known cluster of macOS-local temp-path/parallel-load flakes that would
-        # make a macOS leg permanently red. macOS arm64 is covered by maintainer
-        # runs; macOS x64 is intentionally untested. Platform-sensitive daemon
-        # behavior that must hold everywhere (e.g. the borrowed-review capability
-        # advertisement, which no longer carries any OS/arch precondition) is
-        # additionally pinned by host-independent source guards in the unit suite —
-        # see DaemonRunnerCursorAvailabilityTests' platform coverage matrix.
-        os: [ubuntu-latest, windows-latest]
+        include:
+          - { os: ubuntu-latest,  modules: 3, tests: 4 }
+          - { os: macos-latest,   modules: 3, tests: 4 }
+          # Narrower, because this is the leg that loses the wall-clock budgets inside the code under
+          # test: at three-by-four it spent a 20s service-readiness budget and a 1s memory-fetch
+          # budget with nothing actually slow, and each one reads as a product failure.
+          - { os: windows-latest, modules: 2, tests: 2 }
 
     steps:
       - uses: actions/checkout@v7
@@ -55,7 +62,7 @@ jobs:
       - name: Run npm wrapper tests
         # Plain-Node assertion scripts for the npm launcher/refresh/resolve
         # modules (no test framework, no npm install). `shell: bash` gives
-        # fail-fast -e semantics on both matrix legs.
+        # fail-fast -e semantics on every matrix leg.
         shell: bash
         run: |
           node npm/kcap/bin/kcap.test.js
@@ -67,19 +74,38 @@ jobs:
         run: bash scripts/run-shell-tests.sh
 
       - name: Run tests
-        # --max-parallel-test-modules 1 runs one assembly at a time. Two things block lifting it,
-        # both measured with it off: five concurrent assemblies starve the tests that assert a
-        # wall-clock budget on the two-core Windows runner (a 1s cap measured 1.004s), and an
-        # Integration test's temp working directory vanished mid-test on Linux — a cross-assembly
-        # sharing point no in-assembly [NotInParallel] key can serialise. It halves CI wall-clock,
-        # so it is worth another attempt once budget assertions take an injected clock.
-        # --maximum-parallel-tests caps only TUnit's unkeyed bucket — keyed
-        # [NotInParallel] tests still run concurrently with disjoint-key classes, so
-        # anything touching process-global state must hold the SAME key as every other
-        # toucher. A cap of 1 narrows race windows rather than closing them, so it hides
-        # a missing key instead of failing on it; 4 is wide enough to surface one.
-        # Local dev runs stay parallel; both flags live only in CI.
-        run: dotnet test --solution Capacitor.slnx --no-build --max-parallel-test-modules 1 -- --maximum-parallel-tests 4
+        # Assemblies and per-assembly width are per-leg, above: the ceiling is what the runner can
+        # carry without the wall-clock budgets inside the code under test expiring. Five modules was
+        # measured to starve those and to vanish an Integration test's temp working directory on
+        # Linux — a cross-assembly sharing point no in-assembly [NotInParallel] key can serialise.
+        # A keyed [NotInParallel] test still runs concurrently with every disjoint-key class, so
+        # anything touching process-global state must hold the SAME key as every other toucher. A
+        # width this narrow surfaces a missing key less readily than a dev machine does, where the
+        # default is four times the core count.
+        run: >
+          dotnet test --solution Capacitor.slnx --no-build
+          --max-parallel-test-modules ${{ matrix.modules }}
+          -- --maximum-parallel-tests ${{ matrix.tests }}
+
+      # Kept on success too: the console prints nothing between banner and summary, so these are the
+      # only per-test timing record. File kinds and not the directory — upload-artifact roots the
+      # archive at the common ancestor of its paths — which also excludes the TRX attachment folder,
+      # a second copy of the HTML report.
+      #
+      # continue-on-error: a diagnostic must never decide whether the tests passed. An artifact-service
+      # 403 is classed non-retryable, so without this it reddens a run that reported `failed: 0`.
+      - name: Upload test reports
+        if: always()
+        continue-on-error: true
+        uses: actions/upload-artifact@v7
+        with:
+          name: test-reports-${{ matrix.os }}-attempt-${{ github.run_attempt }}
+          path: |
+            TestResults/*.html
+            TestResults/*.trx
+            TestResults/*.tunit-report.json
+          retention-days: 3
+          if-no-files-found: ignore
 
   lint-linear-ids:
     name: No Linear issue IDs in C# source

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,9 +126,9 @@ A single suite still runs directly as an executable, which is the faster loop wh
 dotnet run --project test/Capacitor.Cli.Core.Tests.Unit/Capacitor.Cli.Core.Tests.Unit.csproj
 ```
 
-Every suite, the daemon one included, runs green at full parallelism — no flag needed. CI's
-`--maximum-parallel-tests 1` caps only the unconstrained bucket, so it narrows race windows rather
-than closing them; a test that needs exclusion carries the constraint itself.
+Every suite, the daemon one included, runs green at full parallelism — no flag needed, and CI runs
+each assembly at that same width. A test that needs exclusion carries the constraint itself; a
+narrower width would only narrow the race window, not close it.
 
 ## Publishing
 

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -31,6 +31,9 @@
     <PackageVersion Include="Spectre.Console" Version="0.57.2" />
     <PackageVersion Include="SvcSystems.UI.Terminal" Version="1.1.4" />
     <PackageVersion Include="Tomlyn" Version="2.10.1" />
+    <!-- Must stay on the Microsoft.Testing.Platform version TUnit.Engine resolves (2.4.0):
+         an MTP extension only loads against its own platform version. -->
+    <PackageVersion Include="Microsoft.Testing.Extensions.GitHubActionsReport" Version="2.4.0" />
     <PackageVersion Include="TUnit" Version="1.66.27" />
     <PackageVersion Include="TUnit.Core" Version="1.66.27" />
     <PackageVersion Include="Velopack" Version="1.2.0" />

--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -48,7 +48,8 @@ public partial class App : Application {
     readonly ConfigRoot _config = ConfigRoot.FromEnvironment();
 
     // And its one read of KCAP_URL / KCAP_PROFILE.
-    readonly ProfileOverrides _serverEnv = ProfileOverrides.FromEnvironment();
+    readonly ProfileOverrides _serverEnv  = ProfileOverrides.FromEnvironment();
+    readonly MachineAuth      _machineEnv = MachineAuth.FromEnvironment();
     readonly UserHome   _userHome = UserHome.FromEnvironment();
 
     /// Process-lifetime rather than per wizard run — a provisioning poll can outlive the window that
@@ -70,7 +71,7 @@ public partial class App : Application {
             .AddSingleton(_config)
             .AddSingleton(profiles)
             .AddSingleton(new CapacitorServer(url, _config, profiles))
-            .AddCapacitorHttp(_serverEnv)
+            .AddCapacitorHttp(_serverEnv, _machineEnv)
             .BuildValidated();
 
         return _serverHttp.GetRequiredService<ICapacitorHttpClient>();
@@ -498,8 +499,8 @@ public partial class App : Application {
         // disposed at teardown.
         var serverLane = new ServerConnectionService(profiles, _foreignHttp.GetRequiredService<TokenStore>());
         serverLane.Start();
-        var workContext = new ServerWorkContextSource(_config, profiles, _serverEnv);
-        var pullRequests = new ServerPullRequestSource(_config, profiles, _serverEnv);
+        var workContext = new ServerWorkContextSource(_config, profiles, _serverEnv, _machineEnv);
+        var pullRequests = new ServerPullRequestSource(_config, profiles, _serverEnv, _machineEnv);
         var ghRunner = new ProcessRunner();
         var gh = new GitHubCliRunner(ghRunner, OperatingSystem.IsWindows() ? null : new LoginShellProbe(ghRunner, Environment.GetEnvironmentVariable), Environment.GetEnvironmentVariable);
         // Registration order is precedence: local CLI readers before the server.

--- a/src/Capacitor.App/Services/AuthenticatedServerReads.cs
+++ b/src/Capacitor.App/Services/AuthenticatedServerReads.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
@@ -25,17 +26,19 @@ public sealed class AuthenticatedServerReads<TChannel> : IAsyncDisposable where 
     readonly List<Task> _active = [];
     Lease? _lease;
     readonly ProfileOverrides _env;
+    readonly MachineAuth      _machine;
     ServiceProvider? _lane;
     readonly bool _allowAutoRedirect;
     long _generation;
     bool _disposed;
 
     public AuthenticatedServerReads(ConfigRoot config, ProfileContext? profiles, ProfileOverrides env,
-        Func<HttpClient, string, TChannel> channelFactory,
+        MachineAuth machine, Func<HttpClient, string, TChannel> channelFactory,
         ClientFactory? factory = null, bool allowAutoRedirect = true) {
         _config = config;
         _profiles = profiles;
         _env = env;
+        _machine = machine;
         _channelFactory = channelFactory;
         _allowAutoRedirect = allowAutoRedirect;
         _factory = factory ?? RegisteredLaneAsync;
@@ -46,7 +49,7 @@ public sealed class AuthenticatedServerReads<TChannel> : IAsyncDisposable where 
             .AddSingleton(config)
             .AddSingleton(profiles)
             .AddSingleton(new CapacitorServer(url, config, profiles))
-            .AddCapacitorHttp(_env)
+            .AddCapacitorHttp(_env, _machine)
             .BuildValidated();
         var clients = _lane.GetRequiredService<ICapacitorHttpClient>();
         var attempt = _allowAutoRedirect

--- a/src/Capacitor.App/Services/ServerPullRequestSource.cs
+++ b/src/Capacitor.App/Services/ServerPullRequestSource.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.PullRequests;
@@ -10,8 +11,9 @@ public sealed class ServerPullRequestSource : IPullRequestSource, IAsyncDisposab
     readonly Dictionary<string, int> _missing = new(StringComparer.Ordinal);
     long _generation;
     public ServerPullRequestSource(ConfigRoot config, ProfileContext? profiles, ProfileOverrides env,
-        AuthenticatedServerReads<PullRequestClient>.ClientFactory? factory = null, TimeProvider? time = null) {
-        _reads = new(config, profiles, env, (http, url) => new PullRequestClient(http, url, time), factory, allowAutoRedirect: false);
+        MachineAuth machine, AuthenticatedServerReads<PullRequestClient>.ClientFactory? factory = null,
+        TimeProvider? time = null) {
+        _reads = new(config, profiles, env, machine, (http, url) => new PullRequestClient(http, url, time), factory, allowAutoRedirect: false);
     }
     public Task<PullRequestCapability> DiscoverAsync(bool refresh, CancellationToken ct) => _reads.ReadAsync((channel, token) => channel.DiscoverAsync(refresh, token),
         read => read.Kind == PullRequestCapabilityKind.SignedOut, new PullRequestCapability(PullRequestCapabilityKind.SignedOut),

--- a/src/Capacitor.App/Services/ServerWorkContextSource.cs
+++ b/src/Capacitor.App/Services/ServerWorkContextSource.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.WorkItems;
@@ -8,8 +9,9 @@ public sealed class ServerWorkContextSource : IWorkContextSource, IAsyncDisposab
     public delegate Task<(HttpClient Client, AuthStatus Status)> ClientFactory(ConfigRoot config, ProfileContext profiles, string serverUrl, CancellationToken ct);
     readonly AuthenticatedServerReads<WorkContextClient> _reads;
 
-    public ServerWorkContextSource(ConfigRoot config, ProfileContext? profiles, ProfileOverrides env, ClientFactory? factory = null) {
-        _reads = new(config, profiles, env, (http, url) => new WorkContextClient(http, url),
+    public ServerWorkContextSource(ConfigRoot config, ProfileContext? profiles, ProfileOverrides env,
+            MachineAuth machine, ClientFactory? factory = null) {
+        _reads = new(config, profiles, env, machine, (http, url) => new WorkContextClient(http, url),
             factory is null ? null : (c, p, url, ct) => factory(c, p, url, ct));
     }
     public Task<WorkContextRead> ReadAsync(string sessionId, CancellationToken ct) => _reads.ReadAsync(

--- a/src/Capacitor.Cli.Core/Auth/MachineAuth.cs
+++ b/src/Capacitor.Cli.Core/Auth/MachineAuth.cs
@@ -6,15 +6,21 @@ namespace Capacitor.Cli.Core.Auth;
 public sealed record MachineCredential(string ClientId, string ClientSecret);
 
 /// <summary>
-/// Reads the machine credential a headless runner carries, and resolves where to exchange it.
+/// The machine credential a headless runner carries, resolved once at the composition root, plus
+/// where to exchange it.
 ///
 /// <para>A runner has no profile and no token store — it is a fresh container with two environment
 /// variables. Everything else it needs it already has: the server comes from <c>KCAP_URL</c>, and
 /// provider discovery over <c>/auth/config</c> needs no credential.</para>
+///
+/// <para>A value rather than a reader, so the process that resolves the credential and the process
+/// that explains the resolution to the operator cannot answer differently — <c>kcap status</c>
+/// describes the same instance the credential lane picked from.</para>
 /// </summary>
-public static class MachineAuth {
+public sealed record MachineAuth(string? ClientId, string? ClientSecret, string? TokenUrlOverride) {
     public const string ClientIdVar     = "KCAP_CLIENT_ID";
     public const string ClientSecretVar = "KCAP_CLIENT_SECRET";
+    public const string TokenUrlVar     = "KCAP_WORKOS_TOKEN_URL";
 
     /// <summary>
     /// WorkOS AuthKit's OAuth2 token endpoint.
@@ -30,18 +36,27 @@ public static class MachineAuth {
     /// </summary>
     public const string DefaultTokenUrl = "https://signin.kcap.ai/oauth2/token";
 
-    /// <summary>KCAP_WORKOS_TOKEN_URL is an internal dev/test override; not documented for end users.</summary>
-    public static string TokenUrl =>
-        (Environment.GetEnvironmentVariable("KCAP_WORKOS_TOKEN_URL") ?? DefaultTokenUrl).Trim();
+    /// <summary>No machine credential — the process authenticates as whoever is signed in.</summary>
+    public static readonly MachineAuth None = new(null, null, null);
+
+    /// <summary>This process's machine credential. Call once, in <c>Main</c> or the composition
+    /// root.</summary>
+    public static MachineAuth FromEnvironment() => new(
+        Environment.GetEnvironmentVariable(ClientIdVar),
+        Environment.GetEnvironmentVariable(ClientSecretVar),
+        Environment.GetEnvironmentVariable(TokenUrlVar));
+
+    /// <summary><c>KCAP_WORKOS_TOKEN_URL</c> is an internal dev/test override; not documented for
+    /// end users.</summary>
+    public string TokenUrl => (TokenUrlOverride ?? DefaultTokenUrl).Trim();
 
     /// <summary>
     /// The token URL, refusing any override that could exfiltrate the credential.
     ///
-    /// <para>Review raised that <c>KCAP_WORKOS_TOKEN_URL</c> is a redirect primitive: the request
-    /// direction carries the secret, so an attacker who can set one environment variable — a k8s
-    /// ConfigMap rather than a Secret, a CI "variable" rather than a "secret" — could point the mint at
-    /// a host they control and harvest it. The no-echo rule protects the RESPONSE direction; this
-    /// protects the request.</para>
+    /// <para><c>KCAP_WORKOS_TOKEN_URL</c> is a redirect primitive: the request direction carries the
+    /// secret, so anyone who can set one environment variable — a k8s ConfigMap rather than a Secret,
+    /// a CI "variable" rather than a "secret" — could point the mint at a host they control and
+    /// harvest it. The no-echo rule protects the RESPONSE direction; this protects the request.</para>
     ///
     /// <para><b>https, except loopback.</b> A bare https requirement would be untestable without
     /// trusting a stub's certificate, and loopback is the same carve-out OAuth redirect-URI rules make
@@ -50,9 +65,9 @@ public static class MachineAuth {
     /// the real credential to the real endpoint while the developer believed they were pointed at a stub.</para>
     ///
     /// <para>Reports rather than throws: this whole path's contract is to return an auth outcome, and a
-    /// property that throws would surface as an unhandled exception inside a hook.</para>
+    /// member that throws would surface as an unhandled exception inside a hook.</para>
     /// </summary>
-    public static string? TryResolveTokenUrl(out string? problem) {
+    public string? TryResolveTokenUrl(out string? problem) {
         var raw = TokenUrl;
 
         if (!Uri.TryCreate(raw, UriKind.Absolute, out var uri)) {
@@ -61,11 +76,11 @@ public static class MachineAuth {
             return null;
         }
 
-        // https anywhere, or http on loopback. `IsLoopback` is HOST-only, so it must be paired with the
-        // http scheme — otherwise ftp://127.0.0.1 or ws://localhost would pass, being loopback but not a
-        // credential-safe POST target. (Review round 2.)
-        var httpsAnywhere   = uri.Scheme == Uri.UriSchemeHttps;
-        var httpOnLoopback  = uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback;
+        // `IsLoopback` is HOST-only, so it must be paired with the http scheme — otherwise
+        // ftp://127.0.0.1 or ws://localhost would pass, being loopback but not a credential-safe
+        // POST target.
+        var httpsAnywhere  = uri.Scheme == Uri.UriSchemeHttps;
+        var httpOnLoopback = uri.Scheme == Uri.UriSchemeHttp && uri.IsLoopback;
 
         if (httpsAnywhere || httpOnLoopback) {
             problem = null;
@@ -79,10 +94,21 @@ public static class MachineAuth {
         return null;
     }
 
-    public const string TokenUrlVar = "KCAP_WORKOS_TOKEN_URL";
+    bool HasId     => !string.IsNullOrWhiteSpace(ClientId);
+    bool HasSecret => !string.IsNullOrWhiteSpace(ClientSecret);
+
+    /// <summary>Presence, never values. A record's synthesized <c>ToString</c> prints every property,
+    /// so one interpolation or one structured-log field would put the client secret in a transcript —
+    /// and this is a container singleton every lane can reach.</summary>
+    public override string ToString() =>
+        $"{nameof(MachineAuth)} {{ {nameof(ClientId)} = {Presence(ClientId)}, "
+      + $"{nameof(ClientSecret)} = {Presence(ClientSecret)}, "
+      + $"{nameof(TokenUrlOverride)} = {Presence(TokenUrlOverride)} }}";
+
+    static string Presence(string? value) => string.IsNullOrWhiteSpace(value) ? "unset" : "set";
 
     /// <summary>
-    /// True when EITHER variable is present — i.e. someone intended machine auth. Deliberately not
+    /// True when EITHER half is present — i.e. someone intended machine auth. Deliberately not
     /// "both", so a half-configured runner is diagnosed rather than silently falling back to a token
     /// store it does not have and being told to run <c>kcap login</c>, which it cannot do.
     ///
@@ -92,28 +118,20 @@ public static class MachineAuth {
     /// failure is loud (they are told which variable is missing) — neither of which would hold for a
     /// looser gate like a bare <c>CLIENT_ID</c> or a "looks like a machine" heuristic.</para>
     /// </summary>
-    public static bool Intended =>
-        !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ClientIdVar))
-        || !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(ClientSecretVar));
+    public bool Intended => HasId || HasSecret;
 
     /// <summary>
-    /// Reads both halves. Returns null with a <paramref name="problem"/> naming the missing variable
-    /// when only one is set.
+    /// Both halves. Returns null with a <paramref name="problem"/> naming the missing variable when
+    /// only one is set.
     /// </summary>
-    public static MachineCredential? TryRead(out string? problem) {
-        var id     = Environment.GetEnvironmentVariable(ClientIdVar);
-        var secret = Environment.GetEnvironmentVariable(ClientSecretVar);
-
-        var haveId     = !string.IsNullOrWhiteSpace(id);
-        var haveSecret = !string.IsNullOrWhiteSpace(secret);
-
-        if (haveId && haveSecret) {
+    public MachineCredential? TryRead(out string? problem) {
+        if (HasId && HasSecret) {
             problem = null;
 
-            return new(id!.Trim(), secret!.Trim());
+            return new(ClientId!.Trim(), ClientSecret!.Trim());
         }
 
-        problem = (haveId, haveSecret) switch {
+        problem = (HasId, HasSecret) switch {
             (true, false) => $"{ClientIdVar} is set but {ClientSecretVar} is not — a machine needs both.",
             (false, true) => $"{ClientSecretVar} is set but {ClientIdVar} is not — a machine needs both.",
             _             => null
@@ -124,9 +142,9 @@ public static class MachineAuth {
 
     /// <summary>
     /// The one-line <c>kcap status</c> explanation of the auth diversion <see cref="Intended"/>
-    /// causes. Returns null when machine auth is not in play (caller prints nothing).
+    /// causes. Null when machine auth is not in play (caller prints nothing).
     ///
-    /// <para>Distinguishes the two states <see cref="Intended"/> (either-var) collapses, because they
+    /// <para>Distinguishes the two states <see cref="Intended"/> (either-half) collapses, because they
     /// are not the same to a reader: with BOTH variables present the CLI genuinely records as the
     /// machine instead of the signed-in user; with only ONE the credential is incomplete, so
     /// <see cref="TryRead"/> refuses it and NOTHING records — the diversion still happens (the token
@@ -135,7 +153,7 @@ public static class MachineAuth {
     /// would both be false. Names exactly which variable(s) are present so the message is truthful in
     /// every case.</para>
     /// </summary>
-    public static string? DescribeDiversion(bool idSet, bool secretSet) => (idSet, secretSet) switch {
+    public string? Diversion => (HasId, HasSecret) switch {
         (false, false) => null,
         (true,  true)  => $"machine credential ({ClientIdVar} and {ClientSecretVar} set) — kcap records as the machine, not as your login.",
         (true,  false) => $"machine credential incomplete — {ClientIdVar} is set but {ClientSecretVar} is not. Auth is diverted off your login and will fail until both are set.",

--- a/src/Capacitor.Cli.Core/Auth/MachineTokenProvider.cs
+++ b/src/Capacitor.Cli.Core/Auth/MachineTokenProvider.cs
@@ -34,7 +34,7 @@ public readonly record struct MachineTokenResult(string? Token, string? Problem)
 /// explicitly: a <c>SemaphoreSlim</c> release is not a barrier, so a field written inside the gate is
 /// not guaranteed visible to a reader outside it.</para>
 /// </summary>
-public sealed class MachineTokenProvider : IDisposable {
+public sealed class MachineTokenProvider(MachineAuth machine) : IDisposable {
     /// <summary>
     /// Re-mint this long before nominal expiry. A token that expires mid-flight surfaces as a 401 the
     /// caller must interpret; spending a few seconds of a 3600s lifetime avoids that entirely.
@@ -76,7 +76,7 @@ public sealed class MachineTokenProvider : IDisposable {
             string?           rejectedToken,
             CancellationToken ct
         ) {
-        var tokenUrl = MachineAuth.TryResolveTokenUrl(out var urlProblem);
+        var tokenUrl = machine.TryResolveTokenUrl(out var urlProblem);
 
         if (tokenUrl is null) return new(null, urlProblem);
 

--- a/src/Capacitor.Cli.Core/Auth/ResolvingCredentialSource.cs
+++ b/src/Capacitor.Cli.Core/Auth/ResolvingCredentialSource.cs
@@ -12,7 +12,8 @@ internal sealed class ResolvingCredentialSource(
         TokenStore           tokens,
         WorkOSClient         workos,
         AuthProviderDiscovery discovery,
-        MachineTokenProvider  minter) : ICredentialSource {
+        MachineTokenProvider  minter,
+        MachineAuth           machine) : ICredentialSource {
     ICredentialSource? _chosen;
 
     public async Task<CredentialState> ResolveAsync(CancellationToken ct) =>
@@ -45,8 +46,8 @@ internal sealed class ResolvingCredentialSource(
         // Before the token store: a runner has no profile, so that path would find nothing and advise
         // `kcap login`, which a runner cannot do. Gated on Intended, not on both variables, so a
         // half-configured one is told which is missing.
-        if (MachineAuth.Intended)
-            return MachineAuth.TryRead(out var problem) is { } credential
+        if (machine.Intended)
+            return machine.TryRead(out var problem) is { } credential
                 ? new MachineCredentials(minter, workos, credential)
                 : new Unusable(problem!);
 

--- a/src/Capacitor.Cli.Core/Http/CapacitorHttpServices.cs
+++ b/src/Capacitor.Cli.Core/Http/CapacitorHttpServices.cs
@@ -11,9 +11,11 @@ public static class CapacitorHttpServices {
     /// so it records the response finally returned rather than a discarded 401, and the observation
     /// headers so a resend carries one copy of each rather than two.
     /// </summary>
-    public static IServiceCollection AddCapacitorHttp(this IServiceCollection services, ProfileOverrides env) {
+    public static IServiceCollection AddCapacitorHttp(
+            this IServiceCollection services, ProfileOverrides env, MachineAuth machine) {
         services.AddCapacitorForeignClients();
         services.AddSingleton(env);
+        services.AddSingleton(machine);
         // Here rather than beside ConfigRoot: the refreshes need the anonymous and WorkOS lanes, so a
         // host that never stands up HTTP is never handed a store that can reach the network.
         services.AddSingleton<TokenStore>();

--- a/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpVendorDescriptor.cs
@@ -1,4 +1,5 @@
 using System.Collections.Immutable;
+using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Daemon.Harness.Kiro;
 using Capacitor.Cli.Daemon.Harness.OpenCode;
 
@@ -108,9 +109,14 @@ internal enum AcpBorrowedReviewContainment {
 /// defensive — no observable behavior change.
 /// </summary>
 internal sealed record AcpVendorDescriptor {
-    public string                      Vendor                 { get; }
-    public Func<DaemonConfig, string>  ResolveBinaryPath     { get; }
-    public Func<DaemonConfig, string?> ResolveDefaultModel   { get; }
+    /// <summary>Which harness this row hosts. Everything a launch needs to find in
+    /// <see cref="DaemonConfig"/> — the binary, the default model — is keyed on it, so a row cannot
+    /// read one vendor's slot while the boot binder writes another's.</summary>
+    public HarnessId                   Harness                { get; }
+
+    /// <summary>How this vendor is spelled outside this build. Derived, so the descriptor holds no
+    /// second spelling that could drift from the one our payloads and ledgers carry.</summary>
+    public string                      Vendor                 => Harness.VendorId;
     public ImmutableArray<string>      Argv                   { get; }
     public ImmutableArray<string>      UnattendedTrustArgv    { get; }
 
@@ -148,9 +154,7 @@ internal sealed record AcpVendorDescriptor {
     public bool                        SupportsReconnectResume { get; }
 
     public AcpVendorDescriptor(
-            string                      Vendor,
-            Func<DaemonConfig, string>  ResolveBinaryPath,
-            Func<DaemonConfig, string?> ResolveDefaultModel,
+            HarnessId                   Harness,
             ImmutableArray<string>      Argv,
             ImmutableArray<string>      UnattendedTrustArgv,
             bool                        SupportsUnattended,
@@ -164,6 +168,11 @@ internal sealed record AcpVendorDescriptor {
             Func<IReadOnlyList<Core.Acp.AcpMcpServerSpec>, LaunchIdentity, ImmutableArray<string>>?
                                         UnattendedTrustArgvBuilder = null
         ) {
+        // Before the checks below, every one of which names {Vendor} in its message: that is derived
+        // from this, so reporting a malformed descriptor would otherwise accuse whichever vendor the
+        // enum's default happens to be.
+        this.Harness = Harness;
+
         var normalizedUnattendedTrustArgv = UnattendedTrustArgv.IsDefault ? ImmutableArray<string>.Empty : UnattendedTrustArgv;
 
         if (!SupportsUnattended && !normalizedUnattendedTrustArgv.IsEmpty)
@@ -203,9 +212,6 @@ internal sealed record AcpVendorDescriptor {
                 $"{nameof(UnattendedInteractionPolicy)} must be explicit when {nameof(SupportsUnattended)} is true (vendor: {Vendor}).",
                 nameof(UnattendedInteractionPolicy));
 
-        this.Vendor              = Vendor;
-        this.ResolveBinaryPath   = ResolveBinaryPath;
-        this.ResolveDefaultModel = ResolveDefaultModel;
         this.Argv                = Argv.IsDefault ? ImmutableArray<string>.Empty : Argv;
         this.UnattendedTrustArgv = normalizedUnattendedTrustArgv;
         this.UnattendedTrustArgvBuilder = UnattendedTrustArgvBuilder;
@@ -236,9 +242,7 @@ internal static class AcpVendorDescriptors {
     /// trust. kcap does not auto-approve a fallback frame: any permission, elicitation, or unknown
     /// interaction request is a contract violation and reaps the reviewer.</summary>
     public static readonly AcpVendorDescriptor Cursor = new(
-        Vendor:              "cursor",
-        ResolveBinaryPath:   cfg => cfg.CursorPath,
-        ResolveDefaultModel: cfg => cfg.CursorModel,
+        Harness:             HarnessId.Cursor,
         Argv:                ["acp"],
         UnattendedTrustArgv: ["--force", "--approve-mcps", "--trust"],
         SupportsUnattended:  true,
@@ -275,9 +279,7 @@ internal static class AcpVendorDescriptors {
     /// <para>Review flows therefore preload their validated stdio servers through Copilot's
     /// <c>--additional-mcp-config</c> process argument and clamp the visible tool surface.</para></summary>
     public static readonly AcpVendorDescriptor Copilot = new(
-        Vendor:              "copilot",
-        ResolveBinaryPath:   cfg => cfg.CopilotPath,
-        ResolveDefaultModel: _ => null,
+        Harness:             HarnessId.Copilot,
         Argv:                ["--acp", "--stdio"],
         UnattendedTrustArgv: ["--allow-all-tools", "--no-ask-user", "--no-custom-instructions", "--disable-builtin-mcps"],
         SupportsUnattended:  true,
@@ -334,7 +336,7 @@ internal static class AcpVendorDescriptors {
     /// <c>session/set_config_option</c> with <c>-32601 Method not found</c> but honours
     /// <c>session/set_model</c> at effect level — the evidence the earlier
     /// <see cref="NoOpModelSelector"/> deferral was waiting for (detail on
-    /// <see cref="SetModelSelector"/> and in the probe record). <c>ResolveDefaultModel</c> reads
+    /// <see cref="SetModelSelector"/> and in the probe record). The model slot reads
     /// <c>DaemonConfig.KiroModel</c> (<c>KCAP_KIRO_MODEL</c>), default NULL: a zero-configuration
     /// launch keeps Kiro's own default model with none reported; a per-launch
     /// <c>RuntimeStartContext.Model</c> takes precedence as for Cursor.</para>
@@ -343,9 +345,7 @@ internal static class AcpVendorDescriptors {
     /// diverges the hosted session from what the user gets interactively and buys an upgrade
     /// treadmill. Revisit only if a measured behavioural difference forces it.</para></summary>
     public static readonly AcpVendorDescriptor Kiro = new(
-        Vendor:              "kiro",
-        ResolveBinaryPath:   cfg => cfg.KiroPath,
-        ResolveDefaultModel: cfg => cfg.KiroModel,
+        Harness:             HarnessId.Kiro,
         Argv:                ["acp"],
         // Built PER LAUNCH from the same injected MCP specs and the same LaunchIdentity session/new
         // gets: a fixed list would omit the review's allowlist servers, and under the Fail policy
@@ -406,7 +406,7 @@ internal static class AcpVendorDescriptors {
     /// previous one. <c>session/set_model</c> also exists here (it answers <c>{}</c>, so not
     /// <c>-32601</c>) but is redundant — only the config-option surface has a matching read half.</para>
     ///
-    /// <para><b><c>ResolveDefaultModel</c> reads <c>DaemonConfig.OpenCodeModel</c></b>
+    /// <para><b>The model slot reads <c>DaemonConfig.OpenCodeModel</c></b>
     /// (<c>KCAP_OPENCODE_MODEL</c>), default NULL: a zero-configuration launch keeps OpenCode's own
     /// default with none reported, exactly as for Kiro.</para>
     ///
@@ -447,9 +447,7 @@ internal static class AcpVendorDescriptors {
     /// response-after-replay barrier. Flipping it requires a passing run of
     /// <c>docs/probes/2026-08-04-acp-reconnect-c0/</c>, not the advertisement.</para></summary>
     public static readonly AcpVendorDescriptor OpenCode = new(
-        Vendor:              "opencode",
-        ResolveBinaryPath:   cfg => cfg.OpenCodePath,
-        ResolveDefaultModel: cfg => cfg.OpenCodeModel,
+        Harness:             HarnessId.OpenCode,
         Argv:                ["acp"],
         // Empty, and not an oversight: OpenCode's trust vector is OPENCODE_PERMISSION, an env variable.
         // `opencode acp` accepts none of the global flags, so there is no argv form of it at all.
@@ -517,8 +515,8 @@ internal static class AcpVendorDescriptors {
     /// <para><see cref="NoOpModelSelector"/> because Gemini's model-selection WRITE half is
     /// unverified: <c>session/new</c> does return a <c>models</c> object, so a live selector's read
     /// half would fit, but both wire selectors fail SILENTLY when the write does not take — a
-    /// session that reports the requested model while running another. <c>ResolveDefaultModel:
-    /// null</c> alone is not enough, because <c>ResolveRequestedModel</c> prioritises a per-launch
+    /// session that reports the requested model while running another. A null model slot alone is
+    /// not enough, because <c>ResolveRequestedModel</c> prioritises a per-launch
     /// model and would reach a live selector anyway. Kiro's probe
     /// (<c>docs/probes/2026-08-05-kiro-model-override/</c>) is the template for flipping this: it
     /// found Kiro rejects <c>session/set_config_option</c> outright but honours
@@ -531,9 +529,7 @@ internal static class AcpVendorDescriptors {
     /// <c>DiagnosticBinary</c> needs no branch — the vendor key and the binary name are both
     /// <c>gemini</c>.</para></summary>
     public static readonly AcpVendorDescriptor Gemini = new(
-        Vendor:              "gemini",
-        ResolveBinaryPath:   cfg => cfg.GeminiPath,
-        ResolveDefaultModel: _ => null,
+        Harness:             HarnessId.Gemini,
         Argv:                ["--experimental-acp", "--skip-trust",
                               "--allowed-mcp-server-names", UnmatchableMcpNamePlaceholder],
         // --approval-mode yolo is REQUIRED for a reviewer, not a convenience: without it Gemini emits

--- a/src/Capacitor.Cli.Daemon/ConfigSlot.cs
+++ b/src/Capacitor.Cli.Daemon/ConfigSlot.cs
@@ -1,0 +1,9 @@
+namespace Capacitor.Cli.Daemon;
+
+/// <summary>
+/// One place in <see cref="DaemonConfig"/>, named once and handed to both directions: the boot
+/// binder writes an operator's override through it, the launch reads back whatever ended up there.
+/// Naming the property twice is what lets an override land in one place while the launcher reads
+/// another, with both spellings valid and nothing failing.
+/// </summary>
+internal sealed record ConfigSlot<T>(Func<T> Read, Action<T> Write);

--- a/src/Capacitor.Cli.Daemon/DaemonHttpServices.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonHttpServices.cs
@@ -1,4 +1,5 @@
 using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -12,9 +13,10 @@ public static class DaemonHttpServices {
     /// headers to drift out of step.
     /// </summary>
     public static IServiceCollection AddDaemonHttp(
-            this IServiceCollection services, ConfigRoot configRoot, DaemonConfig config, ProfileOverrides env) {
+            this IServiceCollection services, ConfigRoot configRoot, DaemonConfig config,
+            ProfileOverrides env, MachineAuth machine) {
         services.AddSingleton(_ => new CapacitorServer(config.ServerUrl, configRoot, config.Profiles));
-        services.AddCapacitorHttp(env);
+        services.AddCapacitorHttp(env, machine);
 
         return services;
     }

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -95,8 +95,9 @@ public static partial class DaemonRunner {
         // Program.cs, but the daemon is a separate process so its statics start
         // empty. Skips repo discovery (the daemon isn't bound to a working dir);
         // honors --server-url, KCAP_URL, KCAP_PROFILE.
-        var serverEnv = ProfileOverrides.FromEnvironment();
-        var profiles  = await AppConfig.ResolveActiveProfile(args, configRoot, serverEnv);
+        var serverEnv  = ProfileOverrides.FromEnvironment();
+        var machineEnv = MachineAuth.FromEnvironment();
+        var profiles   = await AppConfig.ResolveActiveProfile(args, configRoot, serverEnv);
         config.Profiles  = profiles;
         config.ServerUrl = profiles.Resolution.ServerUrl ?? "";
 
@@ -337,7 +338,7 @@ public static partial class DaemonRunner {
         builder.Services.AddSingleton(config);
         builder.Services.AddSingleton(harnesses);
         builder.Services.AddSingleton(daemonLock);
-        builder.Services.AddDaemonHttp(configRoot, config, serverEnv);
+        builder.Services.AddDaemonHttp(configRoot, config, serverEnv, machineEnv);
         builder.Services.AddSingleton<ServerConnection>();
 
         // The owner consent gate — policy store + append-only decision log share the
@@ -1173,52 +1174,24 @@ public static partial class DaemonRunner {
     /// Applies every vendor's path and model override, over whatever the profile and the harness
     /// defaults have already put in <paramref name="config"/>.
     ///
-    /// <para>Ranges over the vendors rather than naming each variable, so a vendor cannot arrive with
-    /// an override <see cref="HarnessOverrides"/> declares and nothing applies: the
-    /// appliers below switch over the same closed set, and a new member of it fails the build
-    /// here.</para>
+    /// <para>Ranges over the vendors rather than naming each variable, so a vendor cannot arrive
+    /// with an override <see cref="HarnessOverrides"/> declares and nothing applies: the slots it
+    /// writes through switch over the same closed set, and a new member of it fails the build in
+    /// both places.</para>
     /// </summary>
     internal static void BindVendorOverrides(
             DaemonConfig config, IEnumerable<HarnessId> vendors, Func<string, string?> read) {
         foreach (var vendor in vendors) {
             if (read(vendor.PathEnvVar) is { Length: > 0 } path)
-                PathApplier(config, vendor)(path);
+                config.PathSlot(vendor).Write(path);
 
             if (vendor.ModelEnvVar is { } modelVar && read(modelVar) is { Length: > 0 } model)
-                ModelApplier(config, vendor)(model);
+                (config.ModelSlot(vendor)
+              ?? throw new NotSupportedException(
+                     $"{vendor} declares a model override variable but DaemonConfig holds no model "
+                   + "for it, so setting it would silently do nothing. Add the slot.")).Write(model);
         }
     }
-
-    internal static Action<string> PathApplier(DaemonConfig config, HarnessId vendor) => vendor switch {
-        HarnessId.Claude      => v => config.ClaudePath      = v,
-        HarnessId.Codex       => v => config.CodexPath       = v,
-        HarnessId.Cursor      => v => config.CursorPath      = v,
-        HarnessId.Copilot     => v => config.CopilotPath     = v,
-        HarnessId.Gemini      => v => config.GeminiPath      = v,
-        HarnessId.Kiro        => v => config.KiroPath        = v,
-        HarnessId.Pi          => v => config.PiPath          = v,
-        HarnessId.OpenCode    => v => config.OpenCodePath    = v,
-        HarnessId.Antigravity => v => config.AntigravityPath = v,
-    };
-
-    /// <summary>
-    /// The four vendors that pick their own model throw rather than being absent: the binder reaches
-    /// one only once <see cref="HarnessOverrides"/> names a variable for it, so arriving
-    /// here means a knob was declared without an accessor to receive it.
-    /// </summary>
-    internal static Action<string> ModelApplier(DaemonConfig config, HarnessId vendor) => vendor switch {
-        HarnessId.Cursor      => v => config.CursorModel      = v,
-        HarnessId.Kiro        => v => config.KiroModel        = v,
-        HarnessId.Pi          => v => config.PiModel          = v,
-        HarnessId.OpenCode    => v => config.OpenCodeModel    = v,
-        HarnessId.Antigravity => v => config.AntigravityModel = v,
-
-        HarnessId.Claude or HarnessId.Codex
-            or HarnessId.Copilot or HarnessId.Gemini =>
-            throw new NotSupportedException(
-                $"{vendor} declares a model override variable but no DaemonConfig accessor is wired to "
-              + "it, so setting it would silently do nothing. Add the accessor here."),
-    };
 
     /// <summary>
     /// Where a gated reviewer's opt-out lands on <see cref="DaemonConfig"/>.

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -4,6 +4,7 @@ using System.Text.Json.Nodes;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
 using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Harness.Cursor;
@@ -16,7 +17,7 @@ namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
 /// <see cref="IHostedAgentRuntimeFactory"/> for ACP-speaking vendors, parameterized over an
-/// <see cref="AcpVendorDescriptor"/> — spawns <c>{descriptor.ResolveBinaryPath(config)}
+/// <see cref="AcpVendorDescriptor"/> — spawns <c>{config.PathSlot(descriptor.Harness).Read()}
 /// {descriptor.Argv}</c> as a child process, wraps its stdio in an <see cref="AcpConnection"/> +
 /// <see cref="AcpChildProcess"/>, and drives the ACP handshake via
 /// <see cref="AcpHostedAgentRuntime.StartAsync"/>. Cursor and Copilot descriptors share this path;
@@ -62,7 +63,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// this, never the static descriptor — see <see cref="ResolvedBorrowedReviewPolicy"/> for why
     /// splitting them is how advertisement and spawn drift apart.</summary>
     internal static ResolvedBorrowedReviewPolicy PolicyFor(AcpVendorDescriptor descriptor) =>
-        descriptor.Vendor == AcpVendorDescriptors.Copilot.Vendor
+        descriptor.Harness is HarnessId.Copilot
             ? CopilotBorrowedReviewPolicy.Current
             : ResolvedBorrowedReviewPolicy.FromDescriptor(descriptor);
 
@@ -116,7 +117,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// implementation, or a test double, is equally valid and would defeat one.</summary>
     public bool SupportsModelSelection => descriptor.ModelSelector.CanSelectModel;
 
-    public string CliPath => descriptor.ResolveBinaryPath(config);
+    public string CliPath => config.PathSlot(descriptor.Harness).Read();
 
     public bool IsAvailable() => config.Binaries.Finds(CliPath);
 
@@ -543,10 +544,10 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             AcpVendorDescriptor descriptor, DaemonConfig config, RuntimeStartContext ctx) {
         if (!ctx.IsReviewFlow) return null;
 
-        if (descriptor.Vendor == AcpVendorDescriptors.Kiro.Vendor)
+        if (descriptor.Harness is HarnessId.Kiro)
             return config.KiroReviewerLaunchTimeoutSeconds;
 
-        if (descriptor.Vendor == AcpVendorDescriptors.OpenCode.Vendor)
+        if (descriptor.Harness is HarnessId.OpenCode)
             return config.OpenCodeReviewerLaunchTimeoutSeconds;
 
         return null;
@@ -569,7 +570,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// an interactive login instead of failing — so the shape is the same and only the binary
     /// differs.</summary>
     static string ReviewerLaunchTimeoutHint(AcpVendorDescriptor descriptor) =>
-        descriptor.Vendor == AcpVendorDescriptors.OpenCode.Vendor
+        descriptor.Harness is HarnessId.OpenCode
             ? "An opencode whose credential has expired can wait on an interactive login rather than "
             + "failing, which is the shape this bound exists for — check that the daemon user's "
             + "opencode is still authenticated (`opencode auth login`)."
@@ -590,7 +591,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         var stateDir = ReviewerStateDir(config);
         var epoch    = config.DaemonEpoch ?? "unpinned";
 
-        if (descriptor.Vendor == AcpVendorDescriptors.Kiro.Vendor) {
+        if (descriptor.Harness is HarnessId.Kiro) {
             KiroReviewerHome.Delete(
                 Path.Combine(KiroReviewerHome.RootFor(stateDir),
                              KiroReviewerHome.NameFor(epoch, ctx.AgentId)),
@@ -598,7 +599,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             return;
         }
 
-        if (descriptor.Vendor == AcpVendorDescriptors.OpenCode.Vendor) {
+        if (descriptor.Harness is HarnessId.OpenCode) {
             OpenCodeReviewerConfigDir.Delete(
                 Path.Combine(OpenCodeReviewerConfigDir.RootFor(stateDir),
                              OpenCodeReviewerConfigDir.NameFor(epoch, ctx.AgentId)),
@@ -697,8 +698,8 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// produce — aliasing is what makes that comparison close to an identity check rather than a
     /// string match.</para></summary>
     internal static bool AliasesResultChannel(AcpVendorDescriptor descriptor) =>
-        descriptor.Vendor == AcpVendorDescriptors.Gemini.Vendor
-     || descriptor.Vendor == AcpVendorDescriptors.Kiro.Vendor;
+        descriptor.Harness is HarnessId.Gemini
+     || descriptor.Harness is HarnessId.Kiro;
 
     /// <summary>Vendors whose ARGV carries an exact-name MCP allowlist a review launch must widen to
     /// exactly its injected set — Gemini alone.
@@ -708,7 +709,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// the placeholder substitution or the canonical-argv assertion for it would assert against
     /// machinery it does not have, and route it through Gemini's capability gate.</para></summary>
     internal static bool UsesMcpNameAllowlistArgv(AcpVendorDescriptor descriptor) =>
-        descriptor.Vendor == AcpVendorDescriptors.Gemini.Vendor;
+        descriptor.Harness is HarnessId.Gemini;
 
     /// <summary>Whether the model reaching the runtime is the launch's own pick rather than the
     /// daemon-wide default. The UI dispatches the literal string <c>"default"</c>, not an empty one,
@@ -731,7 +732,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// against the session's <c>availableModels</c> happens in <see cref="AcpHostedAgentRuntime"/>
     /// via <see cref="Capacitor.Cli.Core.Acp.AcpModelResolver"/>.</summary>
     static string? ResolveRequestedModel(AcpVendorDescriptor descriptor, DaemonConfig config, RuntimeStartContext ctx) =>
-        LaunchPickedTheModel(ctx) ? ctx.Model : descriptor.ResolveDefaultModel(config);
+        LaunchPickedTheModel(ctx) ? ctx.Model : config.ModelSlot(descriptor.Harness)?.Read();
 
     /// <summary>
     /// PURE builder for a real launch's spawn shape — no process side effects. StartRealProcess is
@@ -856,7 +857,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         // Resolving a borrowed reviewer through an exact-build record instead made a vendor
         // auto-update hard-fail the launch. See
         // docs/superpowers/specs/2026-07-27-ai1528-trust-by-default-borrowed-review-design.md.
-        var binaryPath = descriptor.ResolveBinaryPath(config);
+        var binaryPath = config.PathSlot(descriptor.Harness).Read();
 
         // The read boundary. Only a borrowed snapshot is wrapped: every other launch either has no
         // borrowed content to protect or is already confined by the owned worktree it runs in.
@@ -928,7 +929,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         // left to the vendor: it must exist, and be owner-only, before the child writes the first
         // transcript line into it. Review launches only; an interactive hosted Kiro must behave as the
         // user's own session does, global servers included.
-        if (ctx.IsReviewFlow && descriptor.Vendor == AcpVendorDescriptors.Kiro.Vendor) {
+        if (ctx.IsReviewFlow && descriptor.Harness is HarnessId.Kiro) {
             psi.Environment["KIRO_HOME"] = KiroReviewerHome.Create(
                 ReviewerStateDir(config), config.DaemonEpoch ?? "unpinned", ctx.AgentId);
         }
@@ -937,7 +938,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         // none of the global flags), so its whole posture lives here. Unlike Kiro's branch above this
         // is NOT review-only: the plugin suppression it applies is what keeps an INTERACTIVE hosted
         // session from being captured twice.
-        if (descriptor.Vendor == AcpVendorDescriptors.OpenCode.Vendor) {
+        if (descriptor.Harness is HarnessId.OpenCode) {
             OpenCodeLaunchEnvironment.Apply(psi.Environment);
 
             // A review launch additionally gets the isolated config dir, project-config suppression and
@@ -959,7 +960,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
             }
         }
 
-        if (stateRoot is not null && descriptor.Vendor == AcpVendorDescriptors.Copilot.Vendor)
+        if (stateRoot is not null && descriptor.Harness is HarnessId.Copilot)
             // COPILOT_HOME relocates Copilot's whole tree, so an inherited one points the reviewer
             // outside the sandbox home below — at a path this deny-default profile never grants.
             psi.Environment.Remove("COPILOT_HOME");
@@ -1099,7 +1100,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         if (!enabled) return new(false, null, null);
 
         var installed = (resolveVersion ?? new VendorVersionResolver(config.Binaries).Resolve)(
-            descriptor.ResolveBinaryPath(config));
+            config.PathSlot(descriptor.Harness).Read());
 
         return new(true, installed, VersionStoreFor(config, descriptor.Vendor).Affirmed);
     }
@@ -1117,7 +1118,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
     /// </summary>
     internal static string? ReviewerRefusal(
             AcpVendorDescriptor descriptor, DaemonConfig config, Func<string, string?>? resolveVersion) {
-        if (descriptor.Vendor == AcpVendorDescriptors.Kiro.Vendor) {
+        if (descriptor.Harness is HarnessId.Kiro) {
             var g    = GateInputsFor(descriptor, config, config.KiroUnattendedReviewerEnabled, resolveVersion);
             var kiro = KiroReviewerCapability.Decide(g.Enabled, g.Installed, g.Affirmed);
 
@@ -1126,7 +1127,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
                 : KiroReviewerCapability.DenialReason(kiro, g.Installed, g.Affirmed);
         }
 
-        if (descriptor.Vendor == AcpVendorDescriptors.OpenCode.Vendor) {
+        if (descriptor.Harness is HarnessId.OpenCode) {
             var g   = GateInputsFor(descriptor, config, config.OpenCodeUnattendedReviewerEnabled, resolveVersion);
             var oc  = OpenCodeReviewerCapability.Decide(g.Enabled, g.Installed, g.Affirmed);
 

--- a/src/Capacitor.Cli.Daemon/VendorConfigSlots.cs
+++ b/src/Capacitor.Cli.Daemon/VendorConfigSlots.cs
@@ -1,0 +1,40 @@
+using Capacitor.Cli.Core.Harness;
+
+namespace Capacitor.Cli.Daemon;
+
+/// <summary>
+/// Where each vendor's binary and model live in <see cref="DaemonConfig"/>.
+///
+/// <para>Switches over the closed harness set rather than a table, so a new vendor fails the build
+/// here instead of arriving with an override <see cref="HarnessOverrides"/> declares and no place
+/// to put it.</para>
+/// </summary>
+internal static class VendorConfigSlots {
+    extension(DaemonConfig config) {
+        /// <summary>Every vendor has one — a launch needs a command to spawn.</summary>
+        public ConfigSlot<string> PathSlot(HarnessId vendor) => vendor switch {
+            HarnessId.Claude      => new(() => config.ClaudePath,      v => config.ClaudePath      = v),
+            HarnessId.Codex       => new(() => config.CodexPath,       v => config.CodexPath       = v),
+            HarnessId.Cursor      => new(() => config.CursorPath,      v => config.CursorPath      = v),
+            HarnessId.Copilot     => new(() => config.CopilotPath,     v => config.CopilotPath     = v),
+            HarnessId.Gemini      => new(() => config.GeminiPath,      v => config.GeminiPath      = v),
+            HarnessId.Kiro        => new(() => config.KiroPath,        v => config.KiroPath        = v),
+            HarnessId.Pi          => new(() => config.PiPath,          v => config.PiPath          = v),
+            HarnessId.OpenCode    => new(() => config.OpenCodePath,    v => config.OpenCodePath    = v),
+            HarnessId.Antigravity => new(() => config.AntigravityPath, v => config.AntigravityPath = v),
+        };
+
+        /// <summary>Null for the vendors we hand no model at all, which then pick their own. Exactly
+        /// the set <see cref="HarnessOverrides"/> names no model variable for — a vendor with
+        /// one but not the other is a knob that does nothing, or a knob nobody can turn.</summary>
+        public ConfigSlot<string?>? ModelSlot(HarnessId vendor) => vendor switch {
+            HarnessId.Cursor      => new(() => config.CursorModel,      v => config.CursorModel      = v!),
+            HarnessId.Kiro        => new(() => config.KiroModel,        v => config.KiroModel        = v),
+            HarnessId.Pi          => new(() => config.PiModel,          v => config.PiModel          = v),
+            HarnessId.OpenCode    => new(() => config.OpenCodeModel,    v => config.OpenCodeModel    = v),
+            HarnessId.Antigravity => new(() => config.AntigravityModel, v => config.AntigravityModel = v),
+
+            HarnessId.Claude or HarnessId.Codex or HarnessId.Copilot or HarnessId.Gemini => null,
+        };
+    }
+}

--- a/src/Capacitor.Cli/Commands/CommandServices.cs
+++ b/src/Capacitor.Cli/Commands/CommandServices.cs
@@ -18,7 +18,8 @@ public static class CommandServices {
     /// </summary>
     public static IServiceCollection AddCapacitorCli(
             this IServiceCollection services, ConfigRoot config, UserHome home, DaemonStore daemons,
-            ProfileContext profiles, ProfileOverrides env, HookClock clock, string? baseUrl) {
+            ProfileContext profiles, ProfileOverrides env, MachineAuth machine, HookClock clock,
+            string? baseUrl) {
         services
             .AddCapacitorContext(config, home, daemons, profiles)
             .AddCapacitorCommands();
@@ -38,7 +39,7 @@ public static class CommandServices {
                 sp.GetRequiredService<HarnessRegistry>()));
 
         services.AddSingleton(_ => new CapacitorServer(baseUrl, config, profiles));
-        services.AddCapacitorHttp(env);
+        services.AddCapacitorHttp(env, machine);
 
         return services;
     }

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -414,7 +414,8 @@ sealed class SetupMachineActions : IFirstRunMachineActions {
 }
 
 public sealed class SetupCommand(
-        ConfigRoot config, ProfileContext profiles, ProfileOverrides env, TokenStore store, IHttpClientFactory httpFactory,
+        ConfigRoot config, ProfileContext profiles, ProfileOverrides env, MachineAuth machine,
+        TokenStore store, IHttpClientFactory httpFactory,
         IAuthProxyClient proxy, WorkOSClient workos, GitHubOAuthClient github, IBrowserLauncher browser,
         UserHome home, HarnessRegistry harnesses, AgentsPaths agents, ICapacitorHttpClient http,
         TenantProvisioningClient provisioning, AuthProviderDiscovery discovery) {
@@ -1268,7 +1269,7 @@ public sealed class SetupCommand(
             .AddSingleton(config)
             .AddSingleton(context)
             .AddSingleton(new CapacitorServer(serverUrl, config, context))
-            .AddCapacitorHttp(env)
+            .AddCapacitorHttp(env, machine)
             .BuildValidated();
     }
 

--- a/src/Capacitor.Cli/Commands/StatusCommand.cs
+++ b/src/Capacitor.Cli/Commands/StatusCommand.cs
@@ -8,7 +8,7 @@ namespace Capacitor.Cli.Commands;
 
 public sealed class StatusCommand(
         DaemonStore store, ProfileContext profiles, ConfigRoot config, TokenStore tokenStore, HarnessRegistry harnesses,
-        ICapacitorHttpClient http, NpmRegistryClient npm, bool? appBundled = null) {
+        ICapacitorHttpClient http, NpmRegistryClient npm, MachineAuth machine, bool? appBundled = null) {
 
     readonly bool _appBundled = appBundled ?? InstallProvenance.IsAppBundled();
 
@@ -44,9 +44,7 @@ public sealed class StatusCommand(
         // the token store entirely, so its state is not what this CLI authenticates with — printing
         // both would show a headless runner as "records as the machine" AND "not authenticated (run:
         // kcap login)", contradictory and with irrelevant remediation.
-        var machineLine = MachineAuth.DescribeDiversion(
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(MachineAuth.ClientIdVar)),
-            !string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable(MachineAuth.ClientSecretVar)));
+        var machineLine = machine.Diversion;
 
         if (machineLine is not null) {
             Console.WriteLine($"  Auth:    {machineLine}");

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -95,6 +95,7 @@ if (isHook && args.Contains("--claude")) {
 var daemonPaths = DaemonStore.FromEnvironment();
 
 var serverEnv = ProfileOverrides.FromEnvironment();
+var machineEnv = MachineAuth.FromEnvironment();
 
 var profiles = await AppConfig.ResolveForRepo(args, config, serverEnv, gitTimeoutMs: isHook ? 1000 : 5000);
 var baseUrl  = profiles.Resolution.ServerUrl;
@@ -102,7 +103,7 @@ var baseUrl  = profiles.Resolution.ServerUrl;
 // Composition root. Every context resolved above is registered once here; the dispatch switch below
 // asks for a command rather than handing each one its arguments.
 var services = new ServiceCollection()
-    .AddCapacitorCli(config, home, daemonPaths, profiles, serverEnv, clock, baseUrl);
+    .AddCapacitorCli(config, home, daemonPaths, profiles, serverEnv, machineEnv, clock, baseUrl);
 
 await using var sp = services.BuildValidated();
 

--- a/test/Capacitor.App.Tests.Unit/ServerPullRequestSourceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerPullRequestSourceTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using System.Net;
 using System.Text;
 using Capacitor.App.Services;
@@ -13,7 +14,7 @@ public class ServerPullRequestSourceTests {
     [Test]
     public async Task Three_missing_reads_stop_only_that_session_and_retry_resets_it() {
         using var handler = new Handler();
-        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None,
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None, MachineAuth.None,
             (_, _, _, _) => Task.FromResult((new HttpClient(handler), AuthStatus.Ok)));
         for (var i = 0; i < 4; i++) await source.ListAsync("missing", default);
         await Assert.That(handler.Lists).IsEqualTo(3);
@@ -28,7 +29,7 @@ public class ServerPullRequestSourceTests {
         using var handler = new Handler();
         var gate = new TaskCompletionSource<(HttpClient, AuthStatus)>();
         var calls = 0;
-        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None, (_, _, _, _) => {
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None, MachineAuth.None, (_, _, _, _) => {
             calls++;
             return calls == 1 ? gate.Task : Task.FromResult((new HttpClient(new Handler()), AuthStatus.Ok));
         });

--- a/test/Capacitor.App.Tests.Unit/ServerReaderProviderTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerReaderProviderTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using System.Net;
 using System.Text;
 using Capacitor.App.Services;
@@ -16,7 +17,7 @@ public class ServerReaderProviderTests {
     [Test]
     public async Task Probe_maps_the_server_capability_and_serves_github_com_only_while_supported() {
         using var handler = new Handler { Versions = "[1]" };
-        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None,
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None, MachineAuth.None,
             (_, _, _, _) => Task.FromResult((new HttpClient(handler), AuthStatus.Ok)));
         var provider = new ServerReaderProvider(source);
         await Assert.That(provider.Name).IsEqualTo("server");
@@ -36,7 +37,7 @@ public class ServerReaderProviderTests {
     [Test]
     public async Task An_older_server_probes_as_failed_with_its_capability_named() {
         using var handler = new Handler { Versions = null };
-        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None,
+        await using var source = new ServerPullRequestSource(Config.Root, Resolutions.At("https://server.test", Config.Root), ProfileOverrides.None, MachineAuth.None,
             (_, _, _, _) => Task.FromResult((new HttpClient(handler), AuthStatus.Ok)));
         var provider = new ServerReaderProvider(source);
         var status = await provider.ProbeAsync(false, default);

--- a/test/Capacitor.App.Tests.Unit/ServerWorkContextSourceLaneTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerWorkContextSourceLaneTests.cs
@@ -33,7 +33,7 @@ public class ServerWorkContextSourceLaneTests {
             ServerUrl      = Url,
         });
 
-        await using var source = new ServerWorkContextSource(Config.Root, profiles, ProfileOverrides.None);
+        await using var source = new ServerWorkContextSource(Config.Root, profiles, ProfileOverrides.None, MachineAuth.None);
 
         var read = await source.ReadAsync(Session, CancellationToken.None);
 

--- a/test/Capacitor.App.Tests.Unit/ServerWorkContextSourceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ServerWorkContextSourceTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using System.Net;
 using System.Text;
 using Capacitor.App.Services;
@@ -43,7 +44,7 @@ public class ServerWorkContextSourceTests {
     static (ServerWorkContextSource Source, List<ScriptedHandler> Handlers) Build(
             ConfigRoot config, ProfileContext? profiles, Func<AuthStatus>? status = null) {
         var handlers = new List<ScriptedHandler>();
-        var source = new ServerWorkContextSource(config, profiles, ProfileOverrides.None, (_, _, _, _) => {
+        var source = new ServerWorkContextSource(config, profiles, ProfileOverrides.None, MachineAuth.None, (_, _, _, _) => {
             var handler = new ScriptedHandler();
             handlers.Add(handler);
             return Task.FromResult((new HttpClient(handler), status?.Invoke() ?? AuthStatus.Ok));

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/MachineAuthStatusLineTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/MachineAuthStatusLineTests.cs
@@ -3,7 +3,7 @@ using Capacitor.Cli.Core.Auth;
 namespace Capacitor.Cli.Core.Tests.Unit.Auth;
 
 /// <summary>
-/// `kcap status` warns when machine-credential environment variables are diverting this CLI's auth
+/// `kcap status` warns when a machine credential is diverting this CLI's auth
 /// off the profile token store. Because <see cref="MachineAuth.Intended"/> triggers on EITHER
 /// variable but <see cref="MachineAuth.TryRead"/> needs BOTH, the message distinguishes the two:
 /// both set means the CLI records as the machine; one set means the credential is incomplete and
@@ -11,9 +11,14 @@ namespace Capacitor.Cli.Core.Tests.Unit.Auth;
 /// It names exactly the variable(s) present and says nothing when neither is set.
 /// </summary>
 public class MachineAuthStatusLineTests {
+    /// <summary>The line reads the credential's own halves, so a blank-but-exported variable must
+    /// count as absent here exactly as it does for <see cref="MachineAuth.Intended"/>.</summary>
+    static MachineAuth Machine(bool idSet, bool secretSet) =>
+        new(idSet ? "client_01ABC" : null, secretSet ? "sekrit" : null, null);
+
     [Test]
     public async Task Both_variables_present_says_it_records_as_the_machine() {
-        var line = MachineAuth.DescribeDiversion(idSet: true, secretSet: true);
+        var line = Machine(idSet: true, secretSet: true).Diversion;
         await Assert.That(line).IsNotNull();
         await Assert.That(line!).Contains("KCAP_CLIENT_ID and KCAP_CLIENT_SECRET set");
         await Assert.That(line!).Contains("records as the machine, not as your login");
@@ -23,7 +28,7 @@ public class MachineAuthStatusLineTests {
     [Arguments(true,  false, "KCAP_CLIENT_ID is set but KCAP_CLIENT_SECRET is not")]
     [Arguments(false, true,  "KCAP_CLIENT_SECRET is set but KCAP_CLIENT_ID is not")]
     public async Task One_variable_present_reports_an_incomplete_credential(bool id, bool secret, string expectedFragment) {
-        var line = MachineAuth.DescribeDiversion(id, secret);
+        var line = Machine(id, secret).Diversion;
         await Assert.That(line).IsNotNull();
         await Assert.That(line!).Contains("incomplete");
         await Assert.That(line!).Contains(expectedFragment);
@@ -34,6 +39,6 @@ public class MachineAuthStatusLineTests {
 
     [Test]
     public async Task Silent_when_neither_variable_is_present() {
-        await Assert.That(MachineAuth.DescribeDiversion(false, false)).IsNull();
+        await Assert.That(Machine(idSet: false, secretSet: false).Diversion).IsNull();
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/MachineAuthTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/MachineAuthTests.cs
@@ -13,17 +13,13 @@ namespace Capacitor.Cli.Core.Tests.Unit.Auth;
 /// <summary>
 /// Machine-credential authentication for headless runners.
 ///
-/// <para>These tests deliberately go through the REAL HTTP exchange against a stub server rather than
-/// asserting shapes around it. The immediately preceding work on this feature shipped a `kcap machine`
-/// whose every subcommand threw before a request left the process, with a clean build, sixteen green
-/// tests and a clean review — because every test exercised help text. The thing that has to work here is
-/// the exchange, so the exchange is what is tested, including the wire format, which is precisely what
-/// would be silently wrong.</para>
+/// <para>These go through the REAL HTTP exchange against a stub server rather than asserting shapes
+/// around it: the thing that has to work is the exchange, including the wire format, which is
+/// precisely what would be silently wrong while everything around it looked healthy.</para>
 ///
-/// <para><c>[NotInParallel]</c> throughout: these manipulate process-wide environment variables and the
-/// provider/token caches are process-wide statics.</para>
+/// <para>The credential is a value handed in, the way a composition root hands production one, so
+/// nothing here touches the environment and none of it needs exclusion.</para>
 /// </summary>
-[NotInParallel]
 public class MachineAuthTests : IDisposable {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
@@ -33,19 +29,14 @@ public class MachineAuthTests : IDisposable {
     // against a stub: no credential of ours, no observation headers.
     static readonly WorkOSClient Workos = new(new PlainHttpClientFactory());
 
-    public void Dispose() {
-        _server.Stop();
-        Clear();
-    }
+    public void Dispose() => _server.Stop();
 
-    static void Clear() {
-        Environment.SetEnvironmentVariable(MachineAuth.ClientIdVar, null);
-        Environment.SetEnvironmentVariable(MachineAuth.ClientSecretVar, null);
-        Environment.SetEnvironmentVariable(MachineAuth.TokenUrlVar, null);
-    }
+    /// <summary>Pointed at the stub's token endpoint, carrying no credential — enough to mint with
+    /// one passed to <c>GetTokenAsync</c> directly.</summary>
+    MachineAuth StubEndpoint => new(null, null, $"{_server.Urls[0]}/oauth2/token");
 
-    void UseStubTokenEndpoint() =>
-        Environment.SetEnvironmentVariable(MachineAuth.TokenUrlVar, $"{_server.Urls[0]}/oauth2/token");
+    /// <summary>What a headless runner exports: both halves, against the stub.</summary>
+    MachineAuth Runner => StubEndpoint with { ClientId = "client_01ABC", ClientSecret = "sekrit" };
 
     void StubToken(string token, int expiresIn = 3600) =>
         _server.Given(Request.Create().WithPath("/oauth2/token").UsingPost())
@@ -56,14 +47,14 @@ public class MachineAuthTests : IDisposable {
     /// <summary>A container wired the same way production resolves a client, for the sites that go
     /// through <see cref="ICapacitorHttpClient"/> rather than calling the minter directly. Profiles
     /// resolve to none, matching a runner with no profile present.</summary>
-    ServiceProvider Container() {
+    ServiceProvider Container(MachineAuth machine) {
         var services = new ServiceCollection();
         var profiles = Resolutions.None(Config.Root);
 
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(_server.Urls[0], Config.Root, profiles));
-        services.AddCapacitorHttp(ProfileOverrides.None);
+        services.AddCapacitorHttp(ProfileOverrides.None, machine);
 
         return services.BuildServiceProvider();
     }
@@ -77,8 +68,6 @@ public class MachineAuthTests : IDisposable {
     /// </summary>
     [Test]
     public async Task A_redirect_before_the_token_is_followed_and_still_mints() {
-        Clear();
-        UseStubTokenEndpoint();
 
         _server.Given(Request.Create().WithPath("/oauth2/token").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(307)
@@ -89,8 +78,8 @@ public class MachineAuthTests : IDisposable {
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("""{"access_token":"tok_after_hop","expires_in":3600}"""));
 
-        using var sp     = Container();
-        using var minter = new MachineTokenProvider();
+        using var sp     = Container(Runner);
+        using var minter = new MachineTokenProvider(StubEndpoint);
 
         var result = await minter.GetTokenAsync(
             sp.GetRequiredService<WorkOSClient>(), new MachineCredential("client_01ABC", "sekrit"),
@@ -103,13 +92,11 @@ public class MachineAuthTests : IDisposable {
 
     [Test]
     public async Task Both_variables_present_reads_the_credential() {
-        Clear();
-        Environment.SetEnvironmentVariable(MachineAuth.ClientIdVar, "client_01ABC");
-        Environment.SetEnvironmentVariable(MachineAuth.ClientSecretVar, "sekrit");
+        var machine = new MachineAuth("client_01ABC", "sekrit", null);
 
-        await Assert.That(MachineAuth.Intended).IsTrue();
+        await Assert.That(machine.Intended).IsTrue();
 
-        var credential = MachineAuth.TryRead(out var problem);
+        var credential = machine.TryRead(out var problem);
 
         await Assert.That(problem).IsNull();
         await Assert.That(credential!.ClientId).IsEqualTo("client_01ABC");
@@ -125,14 +112,12 @@ public class MachineAuthTests : IDisposable {
     [Arguments(null, "sekrit", "KCAP_CLIENT_ID")]
     public async Task One_variable_present_is_reported_as_a_problem_naming_the_missing_one(
             string? id, string? secret, string expectedInProblem) {
-        Clear();
-        Environment.SetEnvironmentVariable(MachineAuth.ClientIdVar, id);
-        Environment.SetEnvironmentVariable(MachineAuth.ClientSecretVar, secret);
+        var machine = new MachineAuth(id, secret, null);
 
-        await Assert.That(MachineAuth.Intended).IsTrue()
+        await Assert.That(machine.Intended).IsTrue()
             .Because("machine auth was clearly intended, so it must be diagnosed rather than skipped");
 
-        var credential = MachineAuth.TryRead(out var problem);
+        var credential = machine.TryRead(out var problem);
 
         await Assert.That(credential).IsNull();
         await Assert.That(problem).IsNotNull();
@@ -141,28 +126,37 @@ public class MachineAuthTests : IDisposable {
 
     [Test]
     public async Task Neither_variable_present_is_not_machine_auth_at_all() {
-        Clear();
-
-        await Assert.That(MachineAuth.Intended).IsFalse();
-        await Assert.That(MachineAuth.TryRead(out var problem)).IsNull();
+        await Assert.That(MachineAuth.None.Intended).IsFalse();
+        await Assert.That(MachineAuth.None.TryRead(out var problem)).IsNull();
         await Assert.That(problem).IsNull()
             .Because("an ordinary interactive user is not a misconfigured machine");
+    }
+
+    /// <summary>The credential must not be printable. The guard belongs on the type, not on the
+    /// discipline of every caller that could interpolate it or hand it to a structured log.</summary>
+    [Test]
+    public async Task Formatting_the_credential_reports_presence_and_never_the_secret() {
+        var printed = $"{new MachineAuth("client_01ABC", "sekrit", "https://idp.test/oauth2/token")}";
+
+        await Assert.That(printed).DoesNotContain("sekrit");
+        await Assert.That(printed).DoesNotContain("client_01ABC");
+        await Assert.That(printed).DoesNotContain("idp.test");
+        await Assert.That(printed).Contains("set");
+        await Assert.That($"{MachineAuth.None}").Contains("unset");
     }
 
     // ── The exchange itself ────────────────────────────────────────────────────────────────────
 
     /// <summary>
-    /// The load-bearing test: a real POST, and the WIRE FORMAT asserted. Verified against the live
+    /// The load-bearing test: a real POST, and the WIRE FORMAT asserted. Measured against the live
     /// WorkOS endpoint too, which answers this exact form with a credential rejection rather than
     /// `unsupported_grant_type`.
     /// </summary>
     [Test]
     public async Task Minting_posts_client_credentials_form_and_returns_the_token() {
-        Clear();
-        UseStubTokenEndpoint();
         StubToken("tok_minted");
 
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(StubEndpoint);
         var       result = await minter.GetTokenAsync(
             Workos, new MachineCredential("client_01ABC", "sekrit"), rejectedToken: null, CancellationToken.None);
 
@@ -178,7 +172,7 @@ public class MachineAuthTests : IDisposable {
         await Assert.That(body).Contains("client_id=client_01ABC");
         await Assert.That(body).Contains("client_secret=sekrit");
 
-        // Review: some token endpoints reject other content types with misleading errors, so pin it.
+        // Some token endpoints reject other content types with misleading errors, so pin it.
         var contentType = requests[0].RequestMessage.Headers!["Content-Type"].First();
 
         await Assert.That(contentType).Contains("application/x-www-form-urlencoded");
@@ -187,13 +181,11 @@ public class MachineAuthTests : IDisposable {
     /// <summary>Second call reuses the cached token — no second mint.</summary>
     [Test]
     public async Task A_cached_token_is_reused_without_a_second_request() {
-        Clear();
-        UseStubTokenEndpoint();
         StubToken("tok_cached");
 
         var credential = new MachineCredential("client_01ABC", "sekrit");
 
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(StubEndpoint);
 
         await minter.GetTokenAsync(Workos, credential, null, CancellationToken.None);
         var second = await minter.GetTokenAsync(Workos, credential, null, CancellationToken.None);
@@ -210,15 +202,13 @@ public class MachineAuthTests : IDisposable {
     /// </summary>
     [Test]
     public async Task A_cache_hit_does_not_wait_for_an_in_flight_mint() {
-        Clear();
-        UseStubTokenEndpoint();
         StubToken("tok_A");
 
         var warm = new MachineCredential("client_A", "s");
 
         // Shared across every call below: the cache and the gate this test exercises are both
         // per-instance, so a fresh minter per call would prove nothing about either.
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(StubEndpoint);
 
         await minter.GetTokenAsync(Workos, warm, null, CancellationToken.None);
 
@@ -253,13 +243,11 @@ public class MachineAuthTests : IDisposable {
     /// </summary>
     [Test]
     public async Task A_rejected_token_forces_a_fresh_mint() {
-        Clear();
-        UseStubTokenEndpoint();
         StubToken("tok_first");
 
         var credential = new MachineCredential("client_01ABC", "sekrit");
 
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(StubEndpoint);
         var       first  = await minter.GetTokenAsync(Workos, credential, null, CancellationToken.None);
 
         await Assert.That(first.Token).IsEqualTo("tok_first");
@@ -277,15 +265,13 @@ public class MachineAuthTests : IDisposable {
     /// </summary>
     [Test]
     public async Task A_rejected_credential_reports_a_problem_without_leaking_the_secret() {
-        Clear();
-        UseStubTokenEndpoint();
         _server.Given(Request.Create().WithPath("/oauth2/token").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(401)
                 .WithHeader("Content-Type", "application/json")
                 // A hostile/naive endpoint reflecting the request back at us.
                 .WithBody("{\"error\":\"unauthorized\",\"echo\":\"client_secret=hunter2-the-secret\"}"));
 
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(StubEndpoint);
         var       result = await minter.GetTokenAsync(
             Workos, new MachineCredential("client_01ABC", "hunter2-the-secret"), null, CancellationToken.None);
 
@@ -299,13 +285,11 @@ public class MachineAuthTests : IDisposable {
     /// <summary>Success with no access_token must fail, not hand back an empty bearer.</summary>
     [Test]
     public async Task A_success_response_with_no_token_is_a_failure() {
-        Clear();
-        UseStubTokenEndpoint();
         _server.Given(Request.Create().WithPath("/oauth2/token").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json").WithBody("{\"expires_in\":3600}"));
 
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(StubEndpoint);
         var       result = await minter.GetTokenAsync(
             Workos, new MachineCredential("client_01ABC", "sekrit"), null, CancellationToken.None);
 
@@ -316,14 +300,12 @@ public class MachineAuthTests : IDisposable {
     // ── The wiring: does an authenticated client actually carry the bearer? ─────────────────────
 
     /// <summary>
-    /// End-to-end through the client-construction choke point every authenticated CLI call uses. This is
-    /// the test whose absence let the last iteration of this feature ship completely non-functional: it
-    /// is the only one that proves the branch is REACHED and the header attached.
+    /// End-to-end through the client-construction choke point every authenticated CLI call uses: the
+    /// only test that proves the machine branch is REACHED and the header actually attached, rather
+    /// than that the pieces around it have the right shape.
     /// </summary>
     [Test]
     public async Task An_authenticated_client_carries_the_minted_bearer_with_no_profile_present() {
-        Clear();
-        UseStubTokenEndpoint();
         StubToken("tok_wired");
 
         // A runner's server is discovered over unauthenticated /auth/config — no profile, no token store.
@@ -334,10 +316,7 @@ public class MachineAuthTests : IDisposable {
         _server.Given(Request.Create().WithPath("/ping").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200));
 
-        Environment.SetEnvironmentVariable(MachineAuth.ClientIdVar, "client_01ABC");
-        Environment.SetEnvironmentVariable(MachineAuth.ClientSecretVar, "sekrit");
-
-        using var sp      = Container();
+        using var sp      = Container(Runner);
         var       attempt = await sp.GetRequiredService<ICapacitorHttpClient>().ForHookAsync();
         using var client  = attempt.Client;
 
@@ -351,8 +330,8 @@ public class MachineAuthTests : IDisposable {
 
         await Assert.That(sent.Headers!["Authorization"].Single()).IsEqualTo("Bearer tok_wired");
 
-        // Review: without this the test would still pass if the branch moved ahead of provider
-        // discovery — it would only be checking the final header, not that a mint actually happened.
+        // Without this the test would still pass if the branch moved ahead of provider discovery: it
+        // would be checking the final header, not that a mint actually happened.
         var mints = _server.LogEntries.Count(e => e.RequestMessage.Path.Contains("/oauth2/token"));
 
         await Assert.That(mints).IsEqualTo(1);
@@ -364,17 +343,13 @@ public class MachineAuthTests : IDisposable {
     /// </summary>
     [Test]
     public async Task A_half_configured_runner_reports_not_authenticated() {
-        Clear();
-        UseStubTokenEndpoint();
 
         _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200)
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("{\"provider\":\"workos\",\"client_id\":\"client_01TENANT\",\"authkit_domain\":\"\",\"organization_id\":\"org_01T\"}"));
 
-        Environment.SetEnvironmentVariable(MachineAuth.ClientIdVar, "client_01ABC"); // secret missing
-
-        using var sp      = Container();
+        using var sp      = Container(StubEndpoint with { ClientId = "client_01ABC" }); // secret missing
         var       attempt = await sp.GetRequiredService<ICapacitorHttpClient>().ForHookAsync();
         using var client  = attempt.Client;
 
@@ -384,17 +359,15 @@ public class MachineAuthTests : IDisposable {
     // ── The token-URL override is a redirect primitive ─────────────────────────────────────────
 
     /// <summary>
-    /// Review found that KCAP_WORKOS_TOKEN_URL can point the mint at an attacker-chosen host, and the
-    /// REQUEST carries the secret. Plaintext non-loopback must be refused — and refused rather than
-    /// silently falling back to the default, which would send the real credential to the real endpoint
-    /// while the developer believed they were pointed at a stub.
+    /// The token URL points the mint at a host of the operator's choosing, and the REQUEST carries the
+    /// secret. Plaintext non-loopback must be refused — and refused rather than silently falling back
+    /// to the default, which would send the real credential to the real endpoint while the developer
+    /// believed they were pointed at a stub.
     /// </summary>
     [Test]
     public async Task A_plaintext_non_loopback_token_url_is_refused_without_sending_the_credential() {
-        Clear();
-        Environment.SetEnvironmentVariable(MachineAuth.TokenUrlVar, "http://evil.example.com/oauth2/token");
-
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(
+            new MachineAuth(null, null, "http://evil.example.com/oauth2/token"));
         var       result = await minter.GetTokenAsync(
             Workos, new MachineCredential("client_01ABC", "sekrit"), null, CancellationToken.None);
 
@@ -406,18 +379,15 @@ public class MachineAuthTests : IDisposable {
     }
 
     /// <summary>
-    /// Review round 2: the loopback carve-out is for http ONLY. `Uri.IsLoopback` is host-only, so an
-    /// odd-scheme loopback URL (ftp/ws/file) must NOT be admitted just for being loopback — it is not a
+    /// The loopback carve-out is for http ONLY. `Uri.IsLoopback` is host-only, so an odd-scheme
+    /// loopback URL (ftp/ws/file) must NOT be admitted just for being loopback — it is not a
     /// credential-safe POST target.
     /// </summary>
     [Test]
     [Arguments("ftp://127.0.0.1/oauth2/token")]
     [Arguments("ws://localhost/oauth2/token")]
     public async Task An_odd_scheme_loopback_token_url_is_refused(string url) {
-        Clear();
-        Environment.SetEnvironmentVariable(MachineAuth.TokenUrlVar, url);
-
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(new MachineAuth(null, null, url));
         var       result = await minter.GetTokenAsync(
             Workos, new MachineCredential("client_01ABC", "sekrit"), null, CancellationToken.None);
 
@@ -429,11 +399,9 @@ public class MachineAuthTests : IDisposable {
     /// <summary>Loopback over http is the deliberate carve-out — a credential cannot leave the machine.</summary>
     [Test]
     public async Task A_loopback_http_token_url_is_allowed_so_stubs_stay_testable() {
-        Clear();
-        UseStubTokenEndpoint();
         StubToken("tok_loopback");
 
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(StubEndpoint);
         var       result = await minter.GetTokenAsync(
             Workos, new MachineCredential("client_01ABC", "sekrit"), null, CancellationToken.None);
 
@@ -442,10 +410,7 @@ public class MachineAuthTests : IDisposable {
 
     [Test]
     public async Task A_malformed_token_url_is_refused() {
-        Clear();
-        Environment.SetEnvironmentVariable(MachineAuth.TokenUrlVar, "not-a-url");
-
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(new MachineAuth(null, null, "not-a-url"));
         var       result = await minter.GetTokenAsync(
             Workos, new MachineCredential("client_01ABC", "sekrit"), null, CancellationToken.None);
 
@@ -454,16 +419,14 @@ public class MachineAuthTests : IDisposable {
     }
 
     /// <summary>
-    /// Review #3: the cache is keyed on client id AND token URL, so a second credential does not receive
-    /// the first one's token.
+    /// The cache is keyed on client id AND token URL, so a second credential does not receive the
+    /// first one's token.
     /// </summary>
     [Test]
     public async Task A_different_credential_does_not_receive_the_cached_token() {
-        Clear();
-        UseStubTokenEndpoint();
         StubToken("tok_for_A");
 
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(StubEndpoint);
         var       a      = await minter.GetTokenAsync(Workos, new MachineCredential("client_A", "s"), null, CancellationToken.None);
 
         await Assert.That(a.Token).IsEqualTo("tok_for_A");
@@ -475,18 +438,15 @@ public class MachineAuthTests : IDisposable {
         await Assert.That(b.Token).IsNotNull();
     }
 
-    // ── Automatic 401 recovery on the constructed client (Qodo finding 1) ───────────────────────
+    // ── Automatic 401 recovery on the constructed client ───────────────────────────────────────
 
     /// <summary>
-    /// The gap the previous revision had: an authenticated machine client got NO 401-retry handler, so
-    /// a token revoked mid-life produced repeated 401s. This drives a real request through the
-    /// constructed client: the token endpoint issues tok_A, the API 401s it once, and the client must
-    /// re-mint (tok_B) and resend WITHOUT the caller threading anything back.
+    /// A token revoked mid-life must not produce repeated 401s. This drives a real request through the
+    /// constructed client: the token endpoint issues one token, the API 401s it once, and the client
+    /// must re-mint and resend WITHOUT the caller threading anything back.
     /// </summary>
     [Test]
     public async Task An_authenticated_client_automatically_re_mints_on_a_401() {
-        Clear();
-        UseStubTokenEndpoint();
 
         _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
             .RespondWith(Response.Create().WithStatusCode(200)
@@ -511,10 +471,7 @@ public class MachineAuthTests : IDisposable {
         _server.Given(Request.Create().WithPath("/api/ping").UsingGet().WithHeader("Authorization", "Bearer tok_2"))
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("ok"));
 
-        Environment.SetEnvironmentVariable(MachineAuth.ClientIdVar, "client_01ABC");
-        Environment.SetEnvironmentVariable(MachineAuth.ClientSecretVar, "sekrit");
-
-        using var sp = Container();
+        using var sp = Container(Runner);
 
         // The interactive lane is the one that installs the retry handler.
         using var client = await sp.GetRequiredService<ICapacitorHttpClient>().ForCommandAsync();
@@ -529,7 +486,7 @@ public class MachineAuthTests : IDisposable {
             .Because("exactly one re-mint: the initial token plus one recovery");
     }
 
-    // ── Error hygiene: no userinfo, no control chars in the Problem (Qodo finding 2) ────────────
+    // ── Error hygiene: no userinfo, no control chars in the Problem ─────────────────────────────
 
     /// <summary>
     /// A KCAP_WORKOS_TOKEN_URL carrying userinfo must not print the secret half in the Problem string.
@@ -537,12 +494,10 @@ public class MachineAuthTests : IDisposable {
     /// </summary>
     [Test]
     public async Task A_token_url_with_userinfo_does_not_leak_it_into_the_problem() {
-        Clear();
         // Loopback so the scheme check admits it and we reach the mint, which then fails (nothing
         // listening on that path) and builds the Problem string containing the URL.
-        Environment.SetEnvironmentVariable(MachineAuth.TokenUrlVar, "http://id:supersecret@127.0.0.1:1/oauth2/token");
-
-        using var minter = new MachineTokenProvider();
+        using var minter = new MachineTokenProvider(
+            new MachineAuth(null, null, "http://id:supersecret@127.0.0.1:1/oauth2/token"));
         var       result = await minter.GetTokenAsync(
             Workos, new MachineCredential("client_01ABC", "sekrit"), null, CancellationToken.None);
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/Http/CapacitorHttpContainerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Http/CapacitorHttpContainerTests.cs
@@ -14,35 +14,23 @@ namespace Capacitor.Cli.Core.Tests.Unit.Http;
 /// server. <c>AddHttpMessageHandler</c> resolves each handler on the FIRST REQUEST, not at container
 /// build, so a missing registration cannot be caught by anything short of a real call.
 ///
-/// <para><c>[NotInParallel]</c>: the machine-credential variables are process-wide environment. The
-/// discovery memo and the machine-token cache are not — each container owns its own.</para>
+/// <para>Each container owns its own discovery memo and machine-token cache, and the credential it
+/// resolves against is the one handed in — only the two tests that capture stderr touch anything
+/// process-global, and they carry the exclusion themselves.</para>
 /// </summary>
-[NotInParallel]
 public class CapacitorHttpContainerTests : IDisposable {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
     readonly WireMockServer _server = WireMockServer.Start();
 
-    EnvScope? _clientId;
-    EnvScope? _clientSecret;
-    string    _profile = "";
+    string _profile = "";
 
     string Url => _server.Urls[0];
 
     [Before(Test)]
-    public void Isolate() {
-        // Cleared so the credential source picks the token store: a runner's machine credential would
-        // otherwise win over it and mint against an endpoint no test here stubs.
-        _clientId     = EnvScope.Exclusive(MachineAuth.ClientIdVar, null);
-        _clientSecret = EnvScope.Exclusive(MachineAuth.ClientSecretVar, null);
-        _profile      = Resolutions.At(Url, Config.Root).Name;
-    }
+    public void Isolate() => _profile = Resolutions.At(Url, Config.Root).Name;
 
-    public void Dispose() {
-        _clientId?.Dispose();
-        _clientSecret?.Dispose();
-        _server.Stop();
-    }
+    public void Dispose() => _server.Stop();
 
     ServiceProvider Container(string? serverUrl = null) {
         var target   = serverUrl ?? Url;
@@ -53,7 +41,9 @@ public class CapacitorHttpContainerTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(target, Config.Root, profiles));
-        services.AddCapacitorHttp(ProfileOverrides.None);
+        // None so the credential source picks the token store — a machine credential wins over it,
+        // and would mint against an endpoint no test here stubs.
+        services.AddCapacitorHttp(ProfileOverrides.None, MachineAuth.None);
 
         return services.BuildServiceProvider();
     }
@@ -267,7 +257,9 @@ public class CapacitorHttpContainerTests : IDisposable {
     /// actionable line. One hint per flush on a stderr nobody reads is what the background verb
     /// exists to avoid.
     /// </summary>
+    // Console is process-global, so a capture cannot overlap another.
     [Test]
+    [NotInParallel]
     public async Task The_background_lane_is_silent_where_an_interactive_command_prints_the_hint() {
         StubProvider(AuthProvider.GitHubApp);
 
@@ -290,7 +282,9 @@ public class CapacitorHttpContainerTests : IDisposable {
     /// A vendor reads hook stderr as the hook's own result, so the lapse must reach the caller as a
     /// value and never as a line: the status is what lets a hook skip a send it would only lose.
     /// </summary>
+    /// <inheritdoc cref="The_background_lane_is_silent_where_an_interactive_command_prints_the_hint"/>
     [Test]
+    [NotInParallel]
     public async Task The_hook_lane_reports_a_lapse_as_a_status_and_never_on_stderr() {
         StubProvider(AuthProvider.GitHubApp);
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpVendorDescriptorTests.cs
@@ -1,17 +1,13 @@
+using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Acp;
 
 /// <summary>
-/// Test plan item 7 (Round 2 Finding 2 drops the throwing-construction cases from an
-/// earlier revision of this design): pins <see cref="AcpVendorDescriptors.Cursor"/>'s literal
-/// field values against today's hard-coded constants — a lightweight guard against an accidental
-/// edit to the shared descriptor silently changing Cursor's behavior. There is no
-/// <c>SupportsModelSelection</c> flag/invariant left to test — <see cref="AcpVendorDescriptor"/>
-/// accepts any <see cref="IAcpModelSelector"/> for <see cref="AcpVendorDescriptor.ModelSelector"/>
-/// unconditionally, so the one thing worth asserting is that Cursor's real descriptor constructs
-/// successfully and round-trips through equality as expected.
+/// Pins each shipped descriptor's literal field values, so an edit to the shared descriptor cannot
+/// silently change one vendor's launch, and the construction-time invariants that reject an
+/// incoherent row.
 /// </summary>
 public class AcpVendorDescriptorTests {
     [Test]
@@ -55,13 +51,6 @@ public class AcpVendorDescriptorTests {
         await Assert.That(descriptor.BorrowedReviewContainment)
             .IsEqualTo(AcpBorrowedReviewContainment.None);
         await Assert.That(descriptor.ModelSelector).IsEqualTo(ConfigOptionModelSelector.Instance);
-    }
-
-    [Test]
-    public async Task Copilot_ResolveBinaryPath_ReadsConfigCopilotPath() {
-        var config = new DaemonConfig { CopilotPath = "/opt/copilot/copilot" };
-
-        await Assert.That(AcpVendorDescriptors.Copilot.ResolveBinaryPath(config)).IsEqualTo("/opt/copilot/copilot");
     }
 
     [Test]
@@ -114,13 +103,6 @@ public class AcpVendorDescriptorTests {
         await Assert.That(descriptor.ModelSelector).IsEqualTo(SetModelSelector.Instance);
     }
 
-    [Test]
-    public async Task Kiro_ResolveBinaryPath_ReadsConfigKiroPath() {
-        var config = new DaemonConfig { KiroPath = "/opt/kiro/kiro-cli" };
-
-        await Assert.That(AcpVendorDescriptors.Kiro.ResolveBinaryPath(config)).IsEqualTo("/opt/kiro/kiro-cli");
-    }
-
     /// <summary>
     /// The zero-configuration case, and the one an env-precedence test cannot cover: with nothing set,
     /// the descriptor must resolve the name a standard install actually puts on PATH.
@@ -135,47 +117,27 @@ public class AcpVendorDescriptorTests {
     /// </summary>
     [Test]
     public async Task Kiro_ZeroConfiguration_ResolvesTheShippedBinaryName() {
-        await Assert.That(AcpVendorDescriptors.Kiro.ResolveBinaryPath(new DaemonConfig()))
+        await Assert.That(new DaemonConfig().PathSlot(AcpVendorDescriptors.Kiro.Harness).Read())
             .IsEqualTo("kiro-cli");
     }
 
-    /// <summary>Zero-configuration behaviour is unchanged from the no-override era: with no
-    /// <c>KiroModel</c> configured the descriptor offers no daemon-wide default — Kiro runs its own
-    /// default model and none is reported — and ANOTHER vendor's model field must never leak in.
-    /// When <c>KiroModel</c> IS configured it is the daemon-wide default, resolved against
+    /// <summary>With no <c>KiroModel</c> configured the daemon offers no default — Kiro runs its own
+    /// and none is reported. When one IS configured it is the daemon-wide default, resolved against
     /// <c>session/new</c>'s <c>availableModels</c> at launch like Cursor's.</summary>
     [Test]
-    public async Task Kiro_ResolveDefaultModel_ReadsConfigKiroModel_NullByDefault() {
-        await Assert.That(AcpVendorDescriptors.Kiro.ResolveDefaultModel(new DaemonConfig())).IsNull();
-        await Assert.That(AcpVendorDescriptors.Kiro.ResolveDefaultModel(
-            new DaemonConfig { CursorModel = "claude-opus-4-8" })).IsNull();
-        await Assert.That(AcpVendorDescriptors.Kiro.ResolveDefaultModel(
-            new DaemonConfig { KiroModel = "claude-haiku-4.5" })).IsEqualTo("claude-haiku-4.5");
-    }
-
-    [Test]
-    public async Task Cursor_ResolveBinaryPath_ReadsConfigCursorPath() {
-        var config = new DaemonConfig { CursorPath = "/opt/cursor/cursor-agent" };
-
-        await Assert.That(AcpVendorDescriptors.Cursor.ResolveBinaryPath(config)).IsEqualTo("/opt/cursor/cursor-agent");
-    }
-
-    [Test]
-    public async Task Cursor_ResolveDefaultModel_ReadsConfigCursorModel() {
-        var config = new DaemonConfig { CursorModel = "claude-opus-4-8" };
-
-        await Assert.That(AcpVendorDescriptors.Cursor.ResolveDefaultModel(config)).IsEqualTo("claude-opus-4-8");
+    public async Task Kiro_offers_no_daemon_wide_model_until_one_is_configured() {
+        await Assert.That(new DaemonConfig().ModelSlot(HarnessId.Kiro)!.Read()).IsNull();
+        await Assert.That(new DaemonConfig { KiroModel = "claude-haiku-4.5" }
+            .ModelSlot(HarnessId.Kiro)!.Read()).IsEqualTo("claude-haiku-4.5");
     }
 
     /// <summary>Any <see cref="IAcpModelSelector"/> — including a NoOp one, even though the real
-    /// Cursor descriptor never uses it — constructs a valid descriptor. There is no invariant left
-    /// to reject this combination (Round 2 Finding 2).</summary>
+    /// Cursor descriptor never uses it — constructs a valid descriptor: no invariant rejects the
+    /// combination.</summary>
     [Test]
     public async Task Descriptor_ConstructsSuccessfully_WithAnyModelSelector() {
         var descriptor = new AcpVendorDescriptor(
-            Vendor:              "test-vendor",
-            ResolveBinaryPath:   _ => "test-vendor-cli",
-            ResolveDefaultModel: _ => null,
+            Harness:             HarnessId.Pi,
             Argv:                ["acp"],
             UnattendedTrustArgv: [],
             SupportsUnattended:  false,
@@ -188,15 +150,13 @@ public class AcpVendorDescriptorTests {
         await Assert.That(descriptor.SupportsBorrowedReviewFlow).IsFalse();
     }
 
-    /// <summary>Qodo finding 3: a vendor that doesn't support unattended launches must not carry
-    /// any <see cref="AcpVendorDescriptor.UnattendedTrustArgv"/> — the constructor enforces this
-    /// invariant rather than relying solely on the orchestrator's external gate.</summary>
+    /// <summary>A vendor that does not support unattended launches must not carry any
+    /// <see cref="AcpVendorDescriptor.UnattendedTrustArgv"/>: the constructor enforces it rather
+    /// than relying solely on the orchestrator's external gate.</summary>
     [Test]
     public async Task Constructor_Throws_WhenUnattendedTrustArgvNonEmpty_AndSupportsUnattendedFalse() {
         await Assert.That(() => new AcpVendorDescriptor(
-            Vendor:              "test-vendor",
-            ResolveBinaryPath:   _ => "test-vendor-cli",
-            ResolveDefaultModel: _ => null,
+            Harness:             HarnessId.Pi,
             Argv:                ["acp"],
             UnattendedTrustArgv: ["--trust"],
             SupportsUnattended:  false,
@@ -205,12 +165,29 @@ public class AcpVendorDescriptorTests {
         )).Throws<ArgumentException>();
     }
 
+    /// <summary>A rejection names the vendor it rejected. The name is derived from the harness, so a
+    /// descriptor that fails validation before the harness is recorded would accuse whichever vendor
+    /// the enum's default happens to be — and the message exists to point at the malformed row.</summary>
+    [Test]
+    public async Task A_rejected_descriptor_names_the_vendor_it_rejected() {
+        var thrown = await Assert.That(() => new AcpVendorDescriptor(
+            Harness:             HarnessId.Pi,
+            Argv:                ["acp"],
+            UnattendedTrustArgv: ["--trust"],
+            SupportsUnattended:  false,
+            ModelSelector:       NoOpModelSelector.Instance,
+            SupportsMcpServers:  false
+        )).Throws<ArgumentException>();
+
+        await Assert.That(thrown!.Message).Contains(HarnessId.Pi.VendorId);
+        await Assert.That(thrown!.Message).DoesNotContain(HarnessId.Claude.VendorId)
+            .Because("naming the default harness would send a reader to the wrong descriptor");
+    }
+
     [Test]
     public async Task Constructor_Throws_WhenSessionNewTransportLacksMcpServerSupport() {
         await Assert.That(() => new AcpVendorDescriptor(
-            Vendor:                 "test-vendor",
-            ResolveBinaryPath:      _ => "test-vendor-cli",
-            ResolveDefaultModel:    _ => null,
+            Harness:                HarnessId.Pi,
             Argv:                   ["acp"],
             UnattendedTrustArgv:    ["--trust"],
             SupportsUnattended:     true,
@@ -227,15 +204,8 @@ public class AcpVendorDescriptorTests {
     /// notice if it stopped being.</summary>
     [Test]
     public async Task Gemini_ZeroConfiguration_ResolvesTheShippedBinaryName() {
-        await Assert.That(AcpVendorDescriptors.Gemini.ResolveBinaryPath(new DaemonConfig()))
+        await Assert.That(new DaemonConfig().PathSlot(AcpVendorDescriptors.Gemini.Harness).Read())
             .IsEqualTo("gemini");
-    }
-
-    [Test]
-    public async Task Gemini_ResolveBinaryPath_ReadsConfigGeminiPath() {
-        var config = new DaemonConfig { GeminiPath = "/opt/gemini/gemini" };
-
-        await Assert.That(AcpVendorDescriptors.Gemini.ResolveBinaryPath(config)).IsEqualTo("/opt/gemini/gemini");
     }
 
     [Test]
@@ -375,9 +345,7 @@ public class AcpVendorDescriptorTests {
     [Test]
     public async Task Constructor_Throws_WhenBorrowedReviewSupportLacksUnattendedSupport() {
         await Assert.That(() => new AcpVendorDescriptor(
-            Vendor:                      "test-vendor",
-            ResolveBinaryPath:           _ => "test-vendor-cli",
-            ResolveDefaultModel:         _ => null,
+            Harness:                     HarnessId.Pi,
             Argv:                        [],
             UnattendedTrustArgv:         [],
             SupportsUnattended:          false,

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonHttpServicesTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonHttpServicesTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Microsoft.Extensions.DependencyInjection;
@@ -19,7 +20,7 @@ public class DaemonHttpServicesTests {
         return new ServiceCollection()
             .AddSingleton(Config.Root)
             .AddSingleton(profiles)
-            .AddDaemonHttp(Config.Root, new DaemonConfig { ServerUrl = serverUrl, Profiles = profiles }, ProfileOverrides.None)
+            .AddDaemonHttp(Config.Root, new DaemonConfig { ServerUrl = serverUrl, Profiles = profiles }, ProfileOverrides.None, MachineAuth.None)
             .BuildServiceProvider();
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityUserTurnTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityUserTurnTests.cs
@@ -62,18 +62,24 @@ public class AntigravityUserTurnTests {
     [Test]
     public async Task Journal_matches_channel_order_under_worker_and_queue_full_notice_writers() {
         using var tmp = new TempDir();
-        var journal = TranscriptJournal.ForAgent(tmp.Path, "agent-1", NullLogger.Instance);
+        // The stock completion grace bounds the writer against a hung disk, which turns an assertion
+        // over fifty fsynced appends into a throughput race the suite's own load can lose.
+        var journal = new TranscriptJournal(
+            tmp.PathTo("journal.jsonl"), NullLogger.Instance, completeGrace: TimeSpan.FromMinutes(1));
         journal.Open("/w", null);
         await using var rt = AntigravityRuntimeFakes.FakeRuntime(FakeTurn.NeverEnds, queueCap: 1, time: Time, journal: journal);
         await rt.SendUserInputAsync("first");
         await rt.WaitForConversationIdAsync(CancellationToken.None);
         await rt.SendUserInputAsync("queued");
-        var refusals = Task.Run(async () => { for (var i = 0; i < 50; i++) { try { await rt.SendUserInputAsync($"r{i}"); } catch { } } });
+        const int refused = 50;
+        var refusals = Task.Run(async () => { for (var i = 0; i < refused; i++) { try { await rt.SendUserInputAsync($"r{i}"); } catch { } } });
         await refusals;
-        await Task.Delay(200);
-        var drained = new List<AcpEventEnvelope>();
-        while (rt.Envelopes.TryRead(out var e)) drained.Add(e);
-        await journal.CompleteAsync();
+
+        // user("first"), session_started, then one note per refusal. Counted, not waited for: a loaded
+        // runner emits the tail of the notes past any fixed delay this test could pick.
+        var drained = await Drain(rt, 2 + refused);
+        await Assert.That(await journal.CompleteAsync()).IsTrue()
+            .Because("an abandoned writer would surface below as a whole-journal diff instead");
 
         var journaled = JournalFiles.ReadLines(journal.Path).Skip(1).Select(l => { EnvelopeJournalFormat.TryRead(l, out var e); return (e.Kind, e.Text); });
         await Assert.That(journaled).IsEquivalentTo(drained.Select(e => (e.Kind, e.Text)), CollectionOrdering.Matching);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Gemini/GeminiReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Gemini/GeminiReviewerLaunchTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
@@ -357,9 +358,7 @@ public class GeminiReviewerLaunchTests {
     // carrying an extra argv token is exactly what a fourth contributor would produce.
 
     static AcpVendorDescriptor GeminiWithExtraArgv(params string[] extra) => new(
-        Vendor:              AcpVendorDescriptors.Gemini.Vendor,
-        ResolveBinaryPath:   _ => "gemini",
-        ResolveDefaultModel: _ => null,
+        Harness:             HarnessId.Gemini,
         Argv:                [.. AcpVendorDescriptors.Gemini.Argv, .. extra],
         UnattendedTrustArgv: AcpVendorDescriptors.Gemini.UnattendedTrustArgv,
         SupportsUnattended:  true,

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Pi/PiRpcHostedAgentRuntimeTests.cs
@@ -538,8 +538,9 @@ public class PiRpcHostedAgentRuntimeTests {
     public async Task Journal_matches_channel_order_under_concurrent_pump_and_send_time_writers() {
         using var tmp = new TempDir();
         // The stock completion grace bounds the writer against a hung disk, which turns an assertion
-        // over 400 fsynced appends into a throughput race the suite's own load can lose.
-        var journal = new TranscriptJournal(tmp.PathTo("journal.jsonl"), NullLogger.Instance, completeGrace: TimeSpan.FromMinutes(1));
+        // over 400 fsynced appends into a throughput race the suite's own load can lose. A minute is
+        // not enough of one: a two-core runner has spent longer than that on these appends alone.
+        var journal = new TranscriptJournal(tmp.PathTo("journal.jsonl"), NullLogger.Instance, completeGrace: TimeSpan.FromMinutes(3));
         journal.Open("/w", null);
         var (runtime, process) = NewRuntime(journal: journal);
         await using var _ = runtime;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Harness;
 using System.Runtime.InteropServices;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Acp;
@@ -741,9 +742,7 @@ public class AcpHostedAgentRuntimeFactoryTests : IDisposable {
             bool borrowedReview = false,
             AcpBorrowedReviewContainment containment = AcpBorrowedReviewContainment.None,
             IAcpModelSelector? modelSelector = null) => new(
-        Vendor:              "test-acp-vendor",
-        ResolveBinaryPath:   _ => "test-acp-vendor-cli",
-        ResolveDefaultModel: _ => null,
+        Harness:             HarnessId.Pi,
         Argv:                ["acp", "--flag-a"],
         UnattendedTrustArgv: ["--trust"],
         SupportsUnattended:  true,
@@ -755,9 +754,7 @@ public class AcpHostedAgentRuntimeFactoryTests : IDisposable {
     );
 
     static AcpVendorDescriptor NonUnattendedDescriptor() => new(
-        Vendor:              "interactive-only",
-        ResolveBinaryPath:   _ => "interactive-only",
-        ResolveDefaultModel: _ => null,
+        Harness:             HarnessId.Pi,
         Argv:                ["acp"],
         UnattendedTrustArgv: [],
         SupportsUnattended:  false,
@@ -2453,9 +2450,7 @@ public class AcpHostedAgentRuntimeFactoryTests : IDisposable {
         // Built explicitly rather than cloned from a shipped descriptor: SupportsUnattended carries
         // construction-time invariants that must be re-run against this argv pairing.
         var neverUnattended = new AcpVendorDescriptor(
-            Vendor:              "probe-vendor",
-            ResolveBinaryPath:   _ => "probe-vendor",
-            ResolveDefaultModel: _ => null,
+            Harness:             HarnessId.Pi,
             Argv:                ["acp"],
             UnattendedTrustArgv: [],
             SupportsUnattended:  false,

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalTests.cs
@@ -193,7 +193,9 @@ public class TranscriptJournalTests {
 
         await Assert.That(drained).IsFalse();
         await Assert.That(journal.Drained).IsFalse();
-        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+        // 5s against a 200ms grace: headroom for a starved pool delivering the Task.Delay
+        // continuation late, which a two-core runner does by ~1s.
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
         await Assert.That(log.Warnings.Single()).Contains("assistant_text").And.Contains("1 queued").And.Contains("1 unrecorded");
         journal.Record(Text("after")); // latched: silently ignored
         sink.Release.Release(10);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/WaitHarness.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/WaitHarness.cs
@@ -5,11 +5,16 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 /// deadline, so a regression fails by name instead of hanging the run.
 /// </summary>
 internal static class WaitHarness {
-    internal static readonly TimeSpan PollBound = TimeSpan.FromSeconds(5);
+    /// <summary>Deadlines, not budgets: each turns a hang into a named failure, so it only has to
+    /// outlast the slowest honest run. A loaded two-core runner overruns anything tighter while the
+    /// code under test is working perfectly.</summary>
+    internal static readonly TimeSpan PollBound = TimeSpan.FromSeconds(30);
 
+    /// <inheritdoc cref="PollBound"/>
     internal static readonly TimeSpan Bounded = TimeSpan.FromSeconds(30);
 
-    internal static readonly TimeSpan AcpHangGuard = TimeSpan.FromSeconds(5);
+    /// <inheritdoc cref="PollBound"/>
+    internal static readonly TimeSpan AcpHangGuard = TimeSpan.FromSeconds(30);
 
     internal static async Task PollUntilAsync(Func<bool> condition) {
         var deadline = DateTime.UtcNow + PollBound;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/VendorConfigSlotsTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/VendorConfigSlotsTests.cs
@@ -1,0 +1,108 @@
+using Capacitor.Cli.Core.Harness;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit;
+
+/// <summary>
+/// <see cref="VendorConfigSlots"/> is the one place naming where a vendor's binary and model live in
+/// <see cref="DaemonConfig"/>. Both directions go through it — the boot binder writes, a launch
+/// reads — so a row pointed at the wrong property would send an operator's override to one vendor
+/// and spawn it for another, with nothing in between to disagree.
+/// </summary>
+public class VendorConfigSlotsTests {
+    /// <summary>The mapping stated a SECOND time, independently of the slots under test: a table
+    /// derived from them could not detect a mis-pointed row. The bare command is what the vendor's
+    /// harness ships, which is also <see cref="DaemonConfig"/>'s default.</summary>
+    static (HarnessId Vendor, Func<DaemonConfig, string> Read, string Bare)[] Paths() => [
+        (HarnessId.Claude,      c => c.ClaudePath,      "claude"),
+        (HarnessId.Codex,       c => c.CodexPath,       "codex"),
+        (HarnessId.Cursor,      c => c.CursorPath,      "cursor-agent"),
+        (HarnessId.Copilot,     c => c.CopilotPath,     "copilot"),
+        (HarnessId.Gemini,      c => c.GeminiPath,      "gemini"),
+        (HarnessId.Kiro,        c => c.KiroPath,        "kiro-cli"),
+        (HarnessId.Pi,          c => c.PiPath,          "pi"),
+        (HarnessId.OpenCode,    c => c.OpenCodePath,    "opencode"),
+        (HarnessId.Antigravity, c => c.AntigravityPath, "agy")
+    ];
+
+    /// <inheritdoc cref="Paths"/>
+    static (HarnessId Vendor, Func<DaemonConfig, string?> Read)[] Models() => [
+        (HarnessId.Cursor,      c => c.CursorModel),
+        (HarnessId.Kiro,        c => c.KiroModel),
+        (HarnessId.Pi,          c => c.PiModel),
+        (HarnessId.OpenCode,    c => c.OpenCodeModel),
+        (HarnessId.Antigravity, c => c.AntigravityModel)
+    ];
+
+    static HarnessId[] EveryVendor => Enum.GetValues<HarnessId>();
+
+    /// <summary>
+    /// A slot's write lands on the property the slot's own read observes, and on no other vendor's.
+    ///
+    /// <para>Asserting the untouched siblings is the half that matters: a row aliasing two vendors
+    /// onto one property still round-trips through itself, so a read-back-what-you-wrote assertion
+    /// passes while one vendor's override silently redirects another's launches.</para>
+    /// </summary>
+    [Test]
+    public async Task A_path_slot_reads_back_the_property_it_writes_and_no_other() {
+        foreach (var (vendor, read, _) in Paths()) {
+            var config    = new DaemonConfig();
+            var untouched = new DaemonConfig();
+
+            config.PathSlot(vendor).Write($"/opt/{vendor}/bin");
+
+            await Assert.That(read(config)).IsEqualTo($"/opt/{vendor}/bin")
+                .Because($"{vendor}'s slot must name {vendor}'s own binary property");
+            await Assert.That(config.PathSlot(vendor).Read()).IsEqualTo($"/opt/{vendor}/bin");
+
+            foreach (var (other, readOther, _) in Paths().Where(p => p.Vendor != vendor))
+                await Assert.That(readOther(config)).IsEqualTo(readOther(untouched))
+                    .Because($"writing {vendor}'s slot must leave {other}'s binary at its default");
+        }
+    }
+
+    /// <inheritdoc cref="A_path_slot_reads_back_the_property_it_writes_and_no_other"/>
+    [Test]
+    public async Task A_model_slot_reads_back_the_property_it_writes_and_no_other() {
+        foreach (var (vendor, read) in Models()) {
+            var config    = new DaemonConfig();
+            var untouched = new DaemonConfig();
+
+            config.ModelSlot(vendor)!.Write($"{vendor}-model");
+
+            await Assert.That(read(config)).IsEqualTo($"{vendor}-model")
+                .Because($"{vendor}'s slot must name {vendor}'s own model property");
+            await Assert.That(config.ModelSlot(vendor)!.Read()).IsEqualTo($"{vendor}-model");
+
+            foreach (var (other, readOther) in Models().Where(m => m.Vendor != vendor))
+                await Assert.That(readOther(config)).IsEqualTo(readOther(untouched))
+                    .Because($"writing {vendor}'s slot must leave {other}'s model at its default");
+        }
+    }
+
+    /// <summary>Every vendor has somewhere to put a binary, and it starts at the command that
+    /// vendor's harness ships — a slot is what makes the override reachable, and the default is what
+    /// a machine with no override spawns.</summary>
+    [Test]
+    public async Task Every_vendor_starts_at_the_command_its_harness_ships() {
+        var config = new DaemonConfig();
+
+        foreach (var (vendor, _, bare) in Paths())
+            await Assert.That(config.PathSlot(vendor).Read()).IsEqualTo(bare);
+    }
+
+    /// <summary>
+    /// Exactly the vendors with a model slot declare a model variable.
+    ///
+    /// <para>A variable with no slot fails the daemon's boot; a slot with no variable is a place
+    /// nothing can reach. The binder relies on this equivalence — it looks the slot up only after
+    /// the variable named something — so this is what keeps its refusal unreachable.</para>
+    /// </summary>
+    [Test]
+    public async Task A_vendor_has_a_model_slot_exactly_when_it_names_a_model_variable() {
+        var config = new DaemonConfig();
+
+        foreach (var vendor in EveryVendor)
+            await Assert.That(config.ModelSlot(vendor) is not null).IsEqualTo(vendor.ModelEnvVar is not null)
+                .Because($"{vendor} must either have both a model variable and a slot, or neither");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/VendorOverrideBindingTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/VendorOverrideBindingTests.cs
@@ -84,11 +84,8 @@ public class VendorOverrideBindingTests {
         }
     }
 
-    /// <summary>
-    /// Exactly the vendors with a model accessor declare a model variable. One declared without an
-    /// accessor fails the daemon's boot; an accessor with no variable named is a knob the README
-    /// documents and nothing reads.
-    /// </summary>
+    /// <summary>Exactly the vendors with a model to set declare a model variable — a variable naming
+    /// a vendor that takes no model is a knob the README documents and nothing reads.</summary>
     [Test]
     public async Task Only_the_vendors_with_a_model_accessor_name_a_model_variable() {
         var declared = EveryVendor.Where(v => v.ModelEnvVar is not null).Order();
@@ -123,18 +120,5 @@ public class VendorOverrideBindingTests {
         foreach (var (vendor, _, readPath, bare) in Paths())
             await Assert.That(readPath(config)).IsEqualTo(bare)
                 .Because($"{vendor} keeps the command its harness ships");
-    }
-
-    /// <summary>A model variable with no accessor behind it fails the boot rather than shipping a
-    /// documented switch that does nothing.</summary>
-    [Test]
-    [Arguments(HarnessId.Claude)]
-    [Arguments(HarnessId.Codex)]
-    [Arguments(HarnessId.Copilot)]
-    [Arguments(HarnessId.Gemini)]
-    public async Task A_model_no_accessor_can_receive_is_refused_loudly(HarnessId vendor) {
-        await Assert.That(() => DaemonRunner.ModelApplier(new DaemonConfig(), vendor))
-            .Throws<NotSupportedException>()
-            .Because($"{vendor} takes no model from us, so naming one would silently do nothing");
     }
 }

--- a/test/Capacitor.Cli.Tests.Integration/PermissionRequestRecoveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/PermissionRequestRecoveryTests.cs
@@ -75,7 +75,7 @@ public class PermissionRequestRecoveryTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(Url, Config.Root, profiles));
-        services.AddCapacitorHttp(ProfileOverrides.None);
+        services.AddCapacitorHttp(ProfileOverrides.None, MachineAuth.None);
 
         var sp = services.BuildServiceProvider();
         _containers.Add(sp);

--- a/test/Capacitor.Cli.Tests.Integration/SessionStartMemoryRedirectTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/SessionStartMemoryRedirectTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Commands.Harness;
 using Capacitor.Cli.Core.Config;
@@ -84,7 +85,7 @@ public class SessionStartMemoryRedirectTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(_server.Url!, Config.Root, profiles));
-        services.AddCapacitorHttp(ProfileOverrides.None);
+        services.AddCapacitorHttp(ProfileOverrides.None, MachineAuth.None);
 
         await using var sp = services.BuildServiceProvider();
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/CommandContainerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/CommandContainerTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core.Config;
 using Microsoft.Extensions.DependencyInjection;
@@ -20,7 +21,7 @@ public class CommandContainerTests {
             .AddCapacitorCli(
                 Config.Root, Home, Daemons.Store,
                 baseUrl is null ? Resolutions.None(Config.Root) : Resolutions.At(baseUrl, Config.Root),
-                ProfileOverrides.None, new HookClock(TimeProvider.System), baseUrl)
+                ProfileOverrides.None, MachineAuth.None, new HookClock(TimeProvider.System), baseUrl)
             // What Program.cs builds with, so a registration this rejects is one a run would too.
             .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ImportChainsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ImportChainsTests.cs
@@ -301,16 +301,14 @@ public class ImportChainsTests : IDisposable {
             .ToList();
         await Assert.That(transcriptEntries.Count).IsEqualTo(4);
 
-        // If chains ran in parallel, all 4 transcript requests arrived close together.
-        // The spread between first and last arrival should be under 160ms
-        // (200ms serial gap × 0.8 margin — any overlap proves parallelism).
         var firstArrival = transcriptEntries.First().RequestMessage.DateTime;
         var lastArrival  = transcriptEntries.Last().RequestMessage.DateTime;
         var spreadMs     = (lastArrival - firstArrival).TotalMilliseconds;
 
-        // If serial, spread ≥ 3 × 200ms = 600ms (each chain waits for the previous).
-        // If parallel, spread < 100ms (all chains start simultaneously).
-        await Assert.That(spreadMs).IsLessThan(160);
+        // Serial dispatch spreads the four arrivals over 3 × 200ms, since each chain waits for the
+        // previous; parallel dispatch lands them in one window, which a loaded runner stretches to
+        // 171ms. 400 separates the two outcomes with room either side — a discriminator, not a budget.
+        await Assert.That(spreadMs).IsLessThan(400);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ObservationHeaderTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ObservationHeaderTests.cs
@@ -36,7 +36,7 @@ public class ObservationHeaderTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(_server.Urls[0], Config.Root, profiles));
-        services.AddCapacitorHttp(ProfileOverrides.None);
+        services.AddCapacitorHttp(ProfileOverrides.None, MachineAuth.None);
         _sp = services.BuildServiceProvider();
 
         return new WhoamiCommand(
@@ -53,7 +53,7 @@ public class ObservationHeaderTests : IDisposable {
         services.AddSingleton(Config.Root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(_server.Urls[0], Config.Root, profiles));
-        services.AddCapacitorHttp(ProfileOverrides.None);
+        services.AddCapacitorHttp(ProfileOverrides.None, MachineAuth.None);
         _sp = services.BuildServiceProvider();
 
         return await _sp.GetRequiredService<ICapacitorHttpClient>().ForCommandAsync();

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ReportVersionCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ReportVersionCommandTests.cs
@@ -46,7 +46,7 @@ public class ReportVersionCommandTests : IDisposable {
         // no-base-url case has to exercise, and a placeholder would hand it a reachable one.
         services.AddSingleton(
             new CapacitorServer(profiles.Resolution.ServerUrl ?? "", Config.Root, profiles));
-        services.AddCapacitorHttp(ProfileOverrides.None);
+        services.AddCapacitorHttp(ProfileOverrides.None, MachineAuth.None);
         _sp = services.BuildServiceProvider();
 
         return new ReportVersionCommand(

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupChosenServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupChosenServerTests.cs
@@ -22,7 +22,8 @@ public class SetupChosenServerTests {
         var factory = new PlainHttpClientFactory();
 
         return new SetupCommand(
-            Config.Root, startup, ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), factory,
+            Config.Root, startup, ProfileOverrides.None, MachineAuth.None,
+            AuthFixtures.NewTokenStore(Config.Root), factory,
             new AuthProxyClient(new HttpClient()), new WorkOSClient(factory), new GitHubOAuthClient(factory),
             new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), new TenantProvisioningClient(new HttpClient()),
             new AuthProviderDiscovery(factory));

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupCommandTests.cs
@@ -871,7 +871,7 @@ public class SetupCommandTests {
         var passed = Resolutions.At("https://example.test", Config.Root);
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -902,7 +902,7 @@ public class SetupCommandTests {
         };
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -925,7 +925,7 @@ public class SetupCommandTests {
         try {
             // Completing without an unhandled exception is the assertion: a non-zero exit
             // code must be swallowed (warned about, not propagated) so setup still finishes.
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -946,7 +946,7 @@ public class SetupCommandTests {
         try {
             // Completing without the InvalidOperationException escaping is the assertion —
             // import is best-effort and must never fail setup.
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -965,7 +965,7 @@ public class SetupCommandTests {
         SetupCommand.ImportRunnerOverride = _ => throw new InvalidOperationException("must not run import");
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       null,
                 authSatisfied:     true,
                 skipImport:        false,
@@ -984,7 +984,7 @@ public class SetupCommandTests {
         SetupCommand.ImportRunnerOverride = _ => throw new InvalidOperationException("must not run import");
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        true,
@@ -1049,7 +1049,7 @@ public class SetupCommandTests {
         try {
             var args = BuildArgs("--server-url", server.Url!, "--no-prompt", "--default-visibility", "org_public");
 
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(captured).IsNotNull();
@@ -1085,7 +1085,7 @@ public class SetupCommandTests {
 
             // Completing with exit 0 without the override's exception escaping is the
             // assertion — --skip-import must suppress the Step 6 call entirely.
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
         } finally {
@@ -1113,7 +1113,7 @@ public class SetupCommandTests {
         try {
             var args = BuildArgs("--server-url", schemeLessServerUrl, "--no-prompt");
 
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(captured).IsNotNull();
@@ -1148,7 +1148,7 @@ public class SetupCommandTests {
         try {
             var args = BuildArgs("--server-url", server.Url!, "--no-prompt");
 
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(captured).IsNotNull();
@@ -1335,7 +1335,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_rejects_half_a_pair_before_doing_anything() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme"]);
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme"]);
 
         await Assert.That(exit).IsEqualTo(1);
         await Assert.That(capture.GetCapturedError()).Contains("--slug");
@@ -1346,7 +1346,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_rejects_creating_and_pointing_at_a_server_at_once() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(
             ["setup", "--org", "Acme", "--slug", "acme", "--server-url", "https://other.kcap.ai"]);
 
         await Assert.That(exit).IsEqualTo(1);
@@ -1358,7 +1358,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_rejects_a_provider_that_cannot_create() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme", "--slug", "acme", "--github"]);
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme", "--slug", "acme", "--github"]);
 
         await Assert.That(exit).IsEqualTo(1);
         await Assert.That(capture.GetCapturedError()).Contains("--github");
@@ -1369,7 +1369,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_still_requires_a_server_url_with_no_prompt_and_no_answers() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--no-prompt"]);
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--no-prompt"]);
 
         await Assert.That(exit).IsEqualTo(1);
         await Assert.That(capture.GetCapturedError()).Contains("--server-url is required");

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
@@ -110,7 +110,7 @@ public class SetupFacadeParityTests {
         SetupCommand.FacadeOverride = _ =>
             NewFacade(Config.Root, new RecordingAuthProgress(), handler, PickerReturningFirst());
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNotNull();
         await Assert.That(discovered!.Value.LoginComplete).IsTrue();
@@ -136,7 +136,7 @@ public class SetupFacadeParityTests {
         SetupCommand.FacadeOverride = _ =>
             NewFacade(Config.Root, new RecordingAuthProgress(), handler, PickerReturningFirst());
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNotNull();
         await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
@@ -151,7 +151,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         // Today's setup fires SigninCompleted unconditionally once the token is acquired, and
@@ -171,7 +171,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
@@ -188,7 +188,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
@@ -203,7 +203,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         // Other/Unreachable failures map to nothing beyond SigninOpened — only SigninDenied and
@@ -221,7 +221,7 @@ public class SetupFacadeParityTests {
 
         using var console = ConsoleOutput.StartErrorCapture("\n");
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         await Assert.That(console.GetCapturedError()).Contains(SetupAuthProgress.UnreachableGuidance);
@@ -240,7 +240,7 @@ public class SetupFacadeParityTests {
             return NewFacade(Config.Root, new RecordingAuthProgress(), handler);
         };
 
-        await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery)
+        await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery)
             .RunDiscoveryAsync([], forceDevice: true, new RequestedWorkspace("Acme", "acme"));
 
         await Assert.That(captured).IsTypeOf<SpectreTenantProvisioner>();
@@ -351,7 +351,7 @@ public class SetupFacadeParityTests {
         int exitCode;
 
         try {
-            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
                 loginComplete: true, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
                 forceDevice: false, activeProfile: "acme");
         } finally {
@@ -369,7 +369,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.None, serverUrl: "https://none.example",
             forceDevice: false, activeProfile: "default");
 
@@ -391,7 +391,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.None, serverUrl: "https://none.example",
             forceDevice: false, activeProfile: "default");
 
@@ -404,7 +404,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
             forceDevice: true, activeProfile: "acme");
 
@@ -428,7 +428,7 @@ public class SetupFacadeParityTests {
 
         using var console = ConsoleOutput.StartCapture();
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
             forceDevice: true, activeProfile: "acme");
 
@@ -453,7 +453,7 @@ public class SetupFacadeParityTests {
         int exitCode;
 
         try {
-            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
                 loginComplete: true, provider: provider, serverUrl: "https://acme.kcap.ai",
                 forceDevice: false, activeProfile: "acme");
         } finally {
@@ -472,7 +472,7 @@ public class SetupFacadeParityTests {
 
         // The provider param is Step 1's resolved value; Step 2 re-fetches /auth/config for the
         // actual login, so a server reporting an unrelated/unknown provider by then still fails.
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
             forceDevice: false, activeProfile: "acme");
 

--- a/test/Capacitor.Cli.Tests.Unit/Harness/Claude/ClaudeMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Harness/Claude/ClaudeMemoryIndexLiveCertTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json.Nodes;
@@ -44,7 +45,7 @@ public class ClaudeMemoryIndexLiveCertTests {
         services.AddSingleton(root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(baseUrl, root, profiles));
-        services.AddCapacitorHttp(ProfileOverrides.None);
+        services.AddCapacitorHttp(ProfileOverrides.None, MachineAuth.None);
 
         return services.BuildServiceProvider();
     }

--- a/test/Capacitor.Cli.Tests.Unit/Harness/Cursor/CursorMemoryIndexLiveCertTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Harness/Cursor/CursorMemoryIndexLiveCertTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Auth;
 using System.Diagnostics;
 using System.Net.Http.Json;
 using System.Text.Json.Nodes;
@@ -51,7 +52,7 @@ public class CursorMemoryIndexLiveCertTests {
         services.AddSingleton(root);
         services.AddSingleton(profiles);
         services.AddSingleton(new CapacitorServer(baseUrl, root, profiles));
-        services.AddCapacitorHttp(ProfileOverrides.None);
+        services.AddCapacitorHttp(ProfileOverrides.None, MachineAuth.None);
 
         return services.BuildServiceProvider();
     }

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
@@ -419,7 +419,9 @@ public class SessionStartMemoryFoundationTests {
             IsTopLevel: true, ClassificationAuthoritative: true,
             SessionLifecycleReason.RepeatedTurnCallback, CallbackMayRepeat: true);
 
-    static SessionStartMemoryContextRequest KiroRequest(double seconds = 1) =>
+    // The budget is wall-clock and none of these tests assert on exhausting it, so it only has
+    // to outlast a loaded runner; the callers that do care pass their own.
+    static SessionStartMemoryContextRequest KiroRequest(double seconds = 20) =>
         new("https://example.test", null, false, TimeSpan.FromSeconds(seconds), CancellationToken.None);
 
     // THE Kiro acceptance criterion. Kiro has no once-per-session hook: agentSpawn fires on every
@@ -577,7 +579,9 @@ public class SessionStartMemoryFoundationTests {
             IsTopLevel: true, ClassificationAuthoritative: true,
             SessionLifecycleReason.RepeatedTurnCallback, CallbackMayRepeat: true);
 
-    static SessionStartMemoryContextRequest AntigravityRequest(double seconds = 1) =>
+    // The budget is wall-clock and none of these tests assert on exhausting it, so it only has
+    // to outlast a loaded runner; the callers that do care pass their own.
+    static SessionStartMemoryContextRequest AntigravityRequest(double seconds = 20) =>
         new("https://example.test", null, false, TimeSpan.FromSeconds(seconds), CancellationToken.None);
 
     // THE Antigravity acceptance criterion, mirroring Kiro's: without the lease the index would be

--- a/test/Directory.Build.props
+++ b/test/Directory.Build.props
@@ -18,5 +18,12 @@
                       and '$(MSBuildProjectName)' != 'Capacitor.Cli.Tests.Unit.NativeTestHost'">
         <Compile Include="$(MSBuildThisFileDirectory)Capacitor.Tests.Helpers/Guards/GuardsBootstrap.cs"
                  Link="Guards/GuardsBootstrap.cs" />
+        <!-- An MTP extension contributes its command-line options only where it is referenced, so this
+             belongs on every test host rather than on Helpers. -->
+        <PackageReference Include="Microsoft.Testing.Extensions.GitHubActionsReport" />
+        <!-- MTP reads a testconfig.json only from the project directory; a user-owned item whose target
+             path is <AssemblyName>.testconfig.json is the supported way to share one file. -->
+        <None Include="$(MSBuildThisFileDirectory)testconfig.json"
+              Link="$(MSBuildProjectName).testconfig.json" CopyToOutputDirectory="PreserveNewest" />
     </ItemGroup>
 </Project>

--- a/test/testconfig.json
+++ b/test/testconfig.json
@@ -1,0 +1,13 @@
+{
+  "platformOptions": {
+    "resultDirectory": "TestResults"
+  },
+  "environmentVariables": {
+    "TUNIT_DISABLE_GITHUB_REPORTER": "true"
+  },
+  "commandLineOptions": {
+    "report-trx": true,
+    "report-gh": true,
+    "report-gh-slow-test-threshold": "60s"
+  }
+}


### PR DESCRIPTION
Closes #870 — AI-2693
Closes #871 — AI-2694

## What & why

`MachineAuth` read its three variables off the process through statics, and `kcap status` read two of them a second time — so the line explaining the auth diversion and the lane performing it could disagree. Each composition root now resolves it once and injects it, as `ProfileOverrides` already is.

The ACP descriptors hand-listed which `DaemonConfig` property each vendor's launch reads, while the boot binder wrote those same properties from a separate list; nothing tied a row to its writer. One slot per concern, keyed on `HarnessId`, now serves both directions.

CI gains a macOS arm64 leg, GitHub-native reporting with TRX and HTML kept as artifacts, cancellation of superseded runs, and a job timeout. It runs two assemblies at a time at the runner's own in-assembly width: a cap narrows a race window without closing it, hiding a missing `[NotInParallel]` key rather than failing on one.

## Where to look

`MachineAuth.ToString` is an override, not decoration: a record prints every property, and this one holds a client secret.

`AcpVendorDescriptor` assigns `Harness` before its validation block, because each rejection message interpolates the vendor name derived from it.

## Verification

| Suite | Passed | Failed |
| --- | --: | --- |
| Cli.Core | 3241 | 0 |
| Cli | 4001 | 0 |
| Cli.Daemon | 3133 | 1 — `Installed_codex_schema_matches_the_vendored_pin`, installed codex 0.153.4 against the 0.147.0 pin; fails on main |
| App | 1660 | 0 |
| Models.Transcripts | 142 | 0 |
| Cli.Tests.Integration | 285 | 0 |

Ten mutations against the new and rewritten assertions, each caught:

| Mutation | Caught by |
| --- | --- |
| OpenCode's path slot points at `KiroPath` | `A_path_slot_reads_back_the_property_it_writes_and_no_other` |
| Pi's model slot points at `KiroModel` | `A_model_slot_reads_back_the_property_it_writes_and_no_other` |
| Cursor moved into the no-model arm | `A_vendor_has_a_model_slot_exactly_when_it_names_a_model_variable` |
| Copilot declares a model variable with no slot | `A_vendor_has_a_model_slot_exactly_when_it_names_a_model_variable` |
| Kiro's descriptor keyed to `HarnessId.Cursor` | `Kiro_MatchesTodaysHardCodedConstants` + 2 |
| `Harness` assigned after the validation block | `A_rejected_descriptor_names_the_vendor_it_rejected` |
| `Intended` narrowed to both halves | `One_variable_present_is_reported_as_a_problem_naming_the_missing_one` |
| `TokenUrl` ignores the override | `A_redirect_before_the_token_is_followed_and_still_mints` + 2 |
| `Diversion` names the wrong missing half | `One_variable_present_reports_an_incomplete_credential` |
| The record's synthesized `ToString` restored | `Formatting_the_credential_reports_presence_and_never_the_secret` |

Deleting a slot arm outright does not compile — CS8509 is an error here, so a new vendor fails the build in both switches.
