### PR TITLE
Send the WorkOS refresh once and stop re-sending a refused token

### DIFF
--- a/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
+++ b/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
@@ -304,7 +304,8 @@ public sealed class OnboardingFacade(
                     ct: ct, progress: progress, keys: KeyWatcher),
             orgSwitch: (refreshToken, organizationId) =>
                 workos.SwitchOrganizationAsync(clientId, refreshToken, organizationId, ct),
-            orglessRefresh: (refreshToken, refreshCt) => workos.RefreshAsync(clientId, refreshToken, refreshCt),
+            orglessRefresh: async (refreshToken, refreshCt) =>
+                (await workos.RefreshAsync(clientId, refreshToken, refreshCt)).Response,
             provisioner: provisioner,
             ct: ct,
             progress: progress,

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -683,11 +683,13 @@ public sealed class TokenStore(ConfigRoot config, ProfileOverrides env, IHttpCli
         RefreshWorkOSAsync(tokens, CancellationToken.None);
 
     async Task<StoredTokens?> RefreshWorkOSAsync(StoredTokens tokens, CancellationToken ct) {
-        var json = await workos.RefreshAsync(tokens.ClientId!, tokens.RefreshToken!, ct);
+        var result = await workos.RefreshAsync(tokens.ClientId!, tokens.RefreshToken!, ct);
 
-        if (json is null) {
+        if (result.Outcome is not WorkOSRefreshOutcome.Rotated) {
             return null;
         }
+
+        var json = result.Response!;
 
         // Persistence is the caller's responsibility (RefreshWithCrossProcessLockAsync saves under the
         // locked profile) — see RefreshGitHubAsync. WorkOS rotates the refresh token on use, so writing

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -698,7 +698,7 @@ public sealed class TokenStore(ConfigRoot config, ProfileOverrides env, IHttpCli
 
     // `onOutcome` reports the raw WorkOS classification so a caller (the proactive tick) can tell a
     // refused refresh token — terminal, `kcap login` repairs it — from a transport failure it may
-    // retry. The non-Rotated → null mapping is unchanged: every other caller ignores the outcome.
+    // retry. A non-Rotated outcome maps to null; only the proactive tick reads onOutcome.
     async Task<StoredTokens?> RefreshWorkOSAsync(
             StoredTokens tokens, CancellationToken ct, Action<WorkOSRefreshOutcome>? onOutcome = null) {
         var result = await workos.RefreshAsync(tokens.ClientId!, tokens.RefreshToken!, ct);

--- a/src/Capacitor.Cli.Core/Auth/TokenStore.cs
+++ b/src/Capacitor.Cli.Core/Auth/TokenStore.cs
@@ -52,12 +52,15 @@ public sealed record TokenResolution(
 // Outcome of a proactive-refresh tick (<see cref="TokenStore.RefreshIfExpiringAsync"/>).
 // NotDue = no-op (no tokens, the None provider, or the token still comfortably valid);
 // Refreshed = a valid token is now persisted (we refreshed, a peer did, or it was already
-// fresh under the lock); Failed = a refresh was attempted but failed (network / 4xx) and the
-// token is unchanged; Contended = we couldn't acquire the cross-process lock before its
+// fresh under the lock); Failed = a refresh was attempted but the endpoint never answered
+// (transport failure) — the refresh credential may still be live, so a later retry can succeed;
+// Rejected = WorkOS refused the refresh token (a non-success response, a 400 invalid_grant the
+// usual case — the token is consumed or revoked), which only a fresh `kcap login` repairs, so
+// re-sending it is pointless; Contended = we couldn't acquire the cross-process lock before its
 // deadline (a peer holds it, presumably refreshing) — no endpoint call was made, so it is NOT a
-// failure. The daemon loop rate-limits on Refreshed and Failed (to bound endpoint traffic) but
+// failure. The daemon loop rate-limits on Refreshed and Failed, backs off hard on Rejected, and
 // treats Contended quietly — no warning, no backoff.
-public enum ProactiveRefreshOutcome { NotDue, Refreshed, Failed, Contended }
+public enum ProactiveRefreshOutcome { NotDue, Refreshed, Failed, Contended, Rejected }
 
 public sealed class TokenStore(ConfigRoot config, ProfileOverrides env, IHttpClientFactory httpFactory, WorkOSClient workos) {
     string LegacyTokenPath { get; } = config.Path("tokens.json");
@@ -483,8 +486,14 @@ public sealed class TokenStore(ConfigRoot config, ProfileOverrides env, IHttpCli
         // between our read here and our acquiring the lock, leaving the re-read token fresh.
         bool ExpiringWithinWindow(StoredTokens t) => DateTimeOffset.UtcNow >= t.ExpiresAt - window;
 
+        // Capture the raw WorkOS classification the same way `contended` captures lock contention:
+        // the delegate records it, the code after the lock reads it. Only set when the WorkOS
+        // refresh delegate actually runs (a peer-refresh or still-fresh re-read returns non-null
+        // without calling it), so a null result plus a Rejected outcome is a genuine refusal.
+        WorkOSRefreshOutcome? workosOutcome = null;
+
         var refresh = decision == RefreshDecision.RefreshWorkOS
-            ? (Func<StoredTokens, Task<StoredTokens?>>)RefreshWorkOSAsync
+            ? (Func<StoredTokens, Task<StoredTokens?>>)(t => RefreshWorkOSAsync(t, CancellationToken.None, o => workosOutcome = o))
             : t => RefreshGitHubAsync(profile, t, CancellationToken.None);
 
         var contended = false;
@@ -495,8 +504,13 @@ public sealed class TokenStore(ConfigRoot config, ProfileOverrides env, IHttpCli
         // don't let the daemon warn/back off as though the endpoint rejected us. Otherwise:
         // non-null = a valid token is now persisted; null = the refresh call actually failed.
         if (contended) return ProactiveRefreshOutcome.Contended;
+        if (result is not null) return ProactiveRefreshOutcome.Refreshed;
 
-        return result is not null ? ProactiveRefreshOutcome.Refreshed : ProactiveRefreshOutcome.Failed;
+        // A refused WorkOS refresh token is terminal — re-sending it is pointless, so the daemon
+        // backs off hard on Rejected rather than the ordinary Failed retry cadence.
+        return workosOutcome is WorkOSRefreshOutcome.Rejected
+            ? ProactiveRefreshOutcome.Rejected
+            : ProactiveRefreshOutcome.Failed;
     }
 
     // Profile-scoped cross-process lock. Acquire it, re-read the token under it (a peer
@@ -682,8 +696,14 @@ public sealed class TokenStore(ConfigRoot config, ProfileOverrides env, IHttpCli
     Task<StoredTokens?> RefreshWorkOSAsync(StoredTokens tokens) =>
         RefreshWorkOSAsync(tokens, CancellationToken.None);
 
-    async Task<StoredTokens?> RefreshWorkOSAsync(StoredTokens tokens, CancellationToken ct) {
+    // `onOutcome` reports the raw WorkOS classification so a caller (the proactive tick) can tell a
+    // refused refresh token — terminal, `kcap login` repairs it — from a transport failure it may
+    // retry. The non-Rotated → null mapping is unchanged: every other caller ignores the outcome.
+    async Task<StoredTokens?> RefreshWorkOSAsync(
+            StoredTokens tokens, CancellationToken ct, Action<WorkOSRefreshOutcome>? onOutcome = null) {
         var result = await workos.RefreshAsync(tokens.ClientId!, tokens.RefreshToken!, ct);
+
+        onOutcome?.Invoke(result.Outcome);
 
         if (result.Outcome is not WorkOSRefreshOutcome.Rotated) {
             return null;

--- a/src/Capacitor.Cli.Core/Auth/WorkOSClient.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSClient.cs
@@ -20,36 +20,38 @@ public sealed class WorkOSClient(IHttpClientFactory httpFactory) {
     /// <summary>AuthKit's API host. The machine mint posts elsewhere — see <see cref="MachineAuth.DefaultTokenUrl"/>.</summary>
     public const string ApiBase = "https://api.workos.com";
 
-    // Short, so a hook never blocks for the default budget when WorkOS is unreachable.
-    static readonly TimeSpan RetryBudget = TimeSpan.FromSeconds(5);
-
     /// <summary>
-    /// Exchanges a rotating refresh token for a fresh access token, or null when WorkOS refused it or
-    /// answered unreadably — the repair is a fresh login either way.
+    /// Exchanges a rotating refresh token for a fresh access token, classifying the outcome so a caller
+    /// can tell a token WorkOS refused apart from a request that never landed.
     ///
-    /// <para>The retry covers transport failures only, never a non-success response. WorkOS rotates the
-    /// refresh token on every successful use, so a retry after a response was lost in transit does
-    /// re-send a token WorkOS already consumed — but that window exists without the retry too, since
-    /// the next refresh re-reads the same unrotated token from disk. What it buys is the common case:
-    /// a request that never arrived.</para>
+    /// <para>Sent once — never retried. WorkOS consumes the refresh token on every use, so re-sending
+    /// one after a lost response presents a token it has already spent, which trips reuse detection and
+    /// revokes the whole family. A <see cref="WorkOSRefreshOutcome.Rejected"/> is any non-success status
+    /// (an <c>invalid_grant</c> among them); <see cref="WorkOSRefreshOutcome.TransportFailed"/> is an
+    /// exception or an unreadable body, where the token was not spent. Reports rather than throws,
+    /// cancellation aside.</para>
     /// </summary>
-    public async Task<WorkOSAuthResponse?> RefreshAsync(
+    public async Task<WorkOSRefreshResult> RefreshAsync(
             string clientId, string refreshToken, CancellationToken ct) {
         try {
-            using var http = httpFactory.CreateClient(CapacitorClients.WorkOS);
-            using var form = new FormUrlEncodedContent(new Dictionary<string, string> {
+            using var response = await PostFormAsync(AuthenticateUrl, new() {
                 ["grant_type"]    = "refresh_token",
                 ["client_id"]     = clientId,
                 ["refresh_token"] = refreshToken
-            });
+            }, ct);
 
-            using var response = await http.PostWithRetryAsync(AuthenticateUrl, form, RetryBudget, ct);
+            if (!response.IsSuccessStatusCode) {
+                return new(WorkOSRefreshOutcome.Rejected, null);
+            }
 
-            return response.IsSuccessStatusCode
-                ? await response.Content.ReadFromJsonAsync(CapacitorJsonContext.Default.WorkOSAuthResponse, ct)
-                : null;
-        } catch {
-            return null;
+            var body = await response.Content.ReadFromJsonAsync(
+                CapacitorJsonContext.Default.WorkOSAuthResponse, ct);
+
+            return body is null
+                ? new(WorkOSRefreshOutcome.TransportFailed, null)
+                : new(WorkOSRefreshOutcome.Rotated, body);
+        } catch when (!ct.IsCancellationRequested) {
+            return new(WorkOSRefreshOutcome.TransportFailed, null);
         }
     }
 

--- a/src/Capacitor.Cli.Core/Auth/WorkOSClient.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSClient.cs
@@ -41,7 +41,13 @@ public sealed class WorkOSClient(IHttpClientFactory httpFactory) {
             }, ct);
 
             if (!response.IsSuccessStatusCode) {
-                return new(WorkOSRefreshOutcome.Rejected, null);
+                // A 4xx means WorkOS understood and refused the refresh token (a 400 invalid_grant on
+                // a consumed/revoked token is the usual one) — terminal, only `kcap login` repairs it.
+                // A 5xx/408/429 is the server faltering, not the token being bad, so it reads as a
+                // transport failure the caller may retry with the same still-live token.
+                return IsTransientStatus((int)response.StatusCode)
+                    ? new(WorkOSRefreshOutcome.TransportFailed, null)
+                    : new(WorkOSRefreshOutcome.Rejected, null);
             }
 
             var body = await response.Content.ReadFromJsonAsync(
@@ -54,6 +60,8 @@ public sealed class WorkOSClient(IHttpClientFactory httpFactory) {
             return new(WorkOSRefreshOutcome.TransportFailed, null);
         }
     }
+
+    static bool IsTransientStatus(int status) => status >= 500 || status is 408 or 429;
 
     /// <summary>
     /// Opens a device grant. It takes no organization: the human picks one at the AuthKit screen, so

--- a/src/Capacitor.Cli.Core/Auth/WorkOSClient.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSClient.cs
@@ -16,9 +16,14 @@ namespace Capacitor.Cli.Core.Auth;
 /// authenticate exits quietly rather than stack-tracing into a transcript. The sign-in legs do not,
 /// because a sign-in is interactive and a transport failure there is worth saying out loud.</para>
 /// </summary>
-public sealed class WorkOSClient(IHttpClientFactory httpFactory) {
+public sealed class WorkOSClient(IHttpClientFactory httpFactory, TimeSpan? refreshTimeout = null) {
     /// <summary>AuthKit's API host. The machine mint posts elsewhere — see <see cref="MachineAuth.DefaultTokenUrl"/>.</summary>
     public const string ApiBase = "https://api.workos.com";
+
+    // A hard deadline on the single refresh attempt: the shared HttpClient carries the 100 s default,
+    // and a refresh runs under the cross-process lock, so a stalled WorkOS would otherwise hold auth
+    // and every peer's refresh for that long. Short — a hook must not block on an unreachable WorkOS.
+    readonly TimeSpan _refreshTimeout = refreshTimeout ?? TimeSpan.FromSeconds(5);
 
     /// <summary>
     /// Exchanges a rotating refresh token for a fresh access token, classifying the outcome so a caller
@@ -33,12 +38,17 @@ public sealed class WorkOSClient(IHttpClientFactory httpFactory) {
     /// </summary>
     public async Task<WorkOSRefreshResult> RefreshAsync(
             string clientId, string refreshToken, CancellationToken ct) {
+        // The deadline cancels only the linked token, not the caller's ct, so a timeout is caught below
+        // as a TransportFailed (the token was not spent — retry is safe) while a real caller cancel
+        // still propagates.
+        using var deadline = CancellationTokenSource.CreateLinkedTokenSource(ct);
+        deadline.CancelAfter(_refreshTimeout);
         try {
             using var response = await PostFormAsync(AuthenticateUrl, new() {
                 ["grant_type"]    = "refresh_token",
                 ["client_id"]     = clientId,
                 ["refresh_token"] = refreshToken
-            }, ct);
+            }, deadline.Token);
 
             if (!response.IsSuccessStatusCode) {
                 // A 4xx means WorkOS understood and refused the refresh token (a 400 invalid_grant on
@@ -51,7 +61,7 @@ public sealed class WorkOSClient(IHttpClientFactory httpFactory) {
             }
 
             var body = await response.Content.ReadFromJsonAsync(
-                CapacitorJsonContext.Default.WorkOSAuthResponse, ct);
+                CapacitorJsonContext.Default.WorkOSAuthResponse, deadline.Token);
 
             return body is null
                 ? new(WorkOSRefreshOutcome.TransportFailed, null)

--- a/src/Capacitor.Cli.Core/Auth/WorkOSClient.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSClient.cs
@@ -43,13 +43,24 @@ public sealed class WorkOSClient(IHttpClientFactory httpFactory, TimeSpan? refre
         // still propagates.
         using var deadline = CancellationTokenSource.CreateLinkedTokenSource(ct);
         deadline.CancelAfter(_refreshTimeout);
+
+        HttpResponseMessage response;
         try {
-            using var response = await PostFormAsync(AuthenticateUrl, new() {
+            response = await PostFormAsync(AuthenticateUrl, new() {
                 ["grant_type"]    = "refresh_token",
                 ["client_id"]     = clientId,
                 ["refresh_token"] = refreshToken
             }, deadline.Token);
+        } catch when (!ct.IsCancellationRequested) {
+            // No response headers arrived — the request may never have reached WorkOS, so the token is
+            // most likely still live and a later attempt re-reads the same on-disk one. The residual
+            // ambiguity (a reply lost after WorkOS processed it) needs a durable "attempted" marker to
+            // close fully — a deliberate follow-up, since marking every transient blip terminal would
+            // force a re-login far more often than a lost reply actually occurs.
+            return new(WorkOSRefreshOutcome.TransportFailed, null);
+        }
 
+        using (response) {
             if (!response.IsSuccessStatusCode) {
                 // A 4xx means WorkOS understood and refused the refresh token (a 400 invalid_grant on
                 // a consumed/revoked token is the usual one) — terminal, only `kcap login` repairs it.
@@ -60,14 +71,20 @@ public sealed class WorkOSClient(IHttpClientFactory httpFactory, TimeSpan? refre
                     : new(WorkOSRefreshOutcome.Rejected, null);
             }
 
-            var body = await response.Content.ReadFromJsonAsync(
-                CapacitorJsonContext.Default.WorkOSAuthResponse, deadline.Token);
+            // A success status means WorkOS has consumed the old token and rotated. If the new one is
+            // unreadable it is lost and the old token is spent — Rejected (re-login), never a
+            // retryable failure that would re-send the consumed token.
+            WorkOSAuthResponse? body;
+            try {
+                body = await response.Content.ReadFromJsonAsync(
+                    CapacitorJsonContext.Default.WorkOSAuthResponse, deadline.Token);
+            } catch when (!ct.IsCancellationRequested) {
+                return new(WorkOSRefreshOutcome.Rejected, null);
+            }
 
             return body is null
-                ? new(WorkOSRefreshOutcome.TransportFailed, null)
+                ? new(WorkOSRefreshOutcome.Rejected, null)
                 : new(WorkOSRefreshOutcome.Rotated, body);
-        } catch when (!ct.IsCancellationRequested) {
-            return new(WorkOSRefreshOutcome.TransportFailed, null);
         }
     }
 

--- a/src/Capacitor.Cli.Core/Auth/WorkOSRefreshResult.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSRefreshResult.cs
@@ -1,0 +1,15 @@
+namespace Capacitor.Cli.Core.Auth;
+
+/// <summary>
+/// How a WorkOS refresh resolved. WorkOS rotates the refresh token single-use, so the outcome must
+/// separate a token it <see cref="Rejected"/> — consumed or refused, repair is a fresh login — from a
+/// <see cref="TransportFailed"/> that never reached it, where the same token is still live to try again.
+/// </summary>
+public enum WorkOSRefreshOutcome {
+    Rotated,
+    Rejected,
+    TransportFailed
+}
+
+/// <summary>The result of <see cref="WorkOSClient.RefreshAsync"/>; <see cref="Response"/> is set only when <see cref="WorkOSRefreshOutcome.Rotated"/>.</summary>
+public readonly record struct WorkOSRefreshResult(WorkOSRefreshOutcome Outcome, WorkOSAuthResponse? Response);

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -598,9 +598,10 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
     // scan) or explicitly rate-limited by TitleResolveLoop itself.
     readonly PeriodicTimer _titleResolve = new(TimeSpan.FromSeconds(60));
 
-    // Refresh once the token is within this much of its expiry. Comfortably above the 60 s tick
-    // so the window is never stepped over.
-    static readonly TimeSpan ProactiveRefreshWindow = TimeSpan.FromMinutes(5);
+    // Refresh once the token is within this much of its expiry. Kept above the 60 s tick plus the
+    // reactive 30 s IsExpired margin, so proactive refresh still fires before a hook would hit the
+    // margin — but no wider, so a token minted seconds ago at login isn't refreshed on the spot.
+    static readonly TimeSpan ProactiveRefreshWindow = TimeSpan.FromMinutes(2);
 
     // Hit the refresh endpoint at most once per this interval (see TokenRefreshLoop). Small
     // enough that a healthy token issued with a short lifetime is still renewed before it

--- a/src/Capacitor.Cli.Daemon/Services/TokenRefreshLoop.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TokenRefreshLoop.cs
@@ -47,6 +47,12 @@ internal sealed class TokenStoreRefreshPort(TokenStore store, string profile, Ti
 /// the moment it enters the window.</para>
 /// </summary>
 internal sealed class TokenRefreshLoop {
+    // A rejected refresh means the refresh token itself is dead — WorkOS refused it, and only
+    // `kcap login` mints a new one. Backing off this far (rather than the ordinary
+    // minAttemptInterval) stops the loop re-sending a doomed token every few minutes, while still
+    // picking a re-login up eventually without a daemon restart.
+    static readonly TimeSpan RejectedBackoff = TimeSpan.FromHours(1);
+
     readonly IProactiveTokenRefreshPort _port;
     readonly ILogger                    _logger;
     readonly TimeSpan                   _minAttemptInterval;
@@ -92,6 +98,14 @@ internal sealed class TokenRefreshLoop {
                     _logger.LogWarning(
                         "Proactive token refresh failed — backing off for {BackoffSeconds:F0}s; run `kcap login` if this persists",
                         _minAttemptInterval.TotalSeconds
+                    );
+
+                    break;
+
+                case ProactiveRefreshOutcome.Rejected:
+                    _nextAttemptAllowedAt = _utcNow() + RejectedBackoff;
+                    _logger.LogWarning(
+                        "Proactive token refresh was rejected — the stored credential is no longer valid; run `kcap login` to re-authenticate"
                     );
 
                     break;

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/OAuthFlowTests.cs
@@ -144,8 +144,8 @@ public class OAuthFlowTests {
                 """{"user":{"id":"user_x"},"access_token":"acc","refresh_token":"rt2"}"""));
         using var stub = new StubHost(server.Urls[0]);
 
-        var auth = await new WorkOSClient(new PlainHttpClientFactory(stub))
-            .RefreshAsync("client_d", "rt1", CancellationToken.None);
+        var auth = (await new WorkOSClient(new PlainHttpClientFactory(stub))
+            .RefreshAsync("client_d", "rt1", CancellationToken.None)).Response;
 
         await Assert.That(auth!.AccessToken).IsEqualTo("acc");
         await Assert.That(auth.RefreshToken).IsEqualTo("rt2");
@@ -165,8 +165,8 @@ public class OAuthFlowTests {
 
         using var stub = new StubHost(url);
 
-        var auth = await new WorkOSClient(new PlainHttpClientFactory(stub))
-            .RefreshAsync("client_d", "rt1", CancellationToken.None);
+        var auth = (await new WorkOSClient(new PlainHttpClientFactory(stub))
+            .RefreshAsync("client_d", "rt1", CancellationToken.None)).Response;
 
         await Assert.That(auth).IsNull();
     }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/ProactiveTokenRefreshDecisionTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/ProactiveTokenRefreshDecisionTests.cs
@@ -64,6 +64,28 @@ public class ProactiveTokenRefreshDecisionTests {
     }
 
     [Test]
+    public async Task Two_minute_window_leaves_a_token_beyond_it_not_due() {
+        // The daemon's shrunk 2-minute window: a token 2m30s out is still comfortably valid, so a
+        // freshly-issued token is not refreshed the instant after login.
+        var window   = TimeSpan.FromMinutes(2);
+        var tokens   = Tokens(AuthProvider.WorkOS, Now.AddSeconds(150));
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.NotDueYet);
+    }
+
+    [Test]
+    public async Task Two_minute_window_refreshes_a_token_inside_it() {
+        // 1m30s out is inside the 2-minute window — proactive refresh fires before the reactive
+        // 30s IsExpired margin, keeping the window above the 60s tick plus that margin.
+        var window   = TimeSpan.FromMinutes(2);
+        var tokens   = Tokens(AuthProvider.WorkOS, Now.AddSeconds(90));
+        var decision = TokenStore.DecideProactiveRefresh(tokens, Now, window);
+
+        await Assert.That(decision).IsEqualTo(TokenStore.RefreshDecision.RefreshWorkOS);
+    }
+
+    [Test]
     public async Task Already_expired_workos_token_still_refreshes() {
         var tokens   = Tokens(AuthProvider.WorkOS, Now.AddMinutes(-10));
         var decision = TokenStore.DecideProactiveRefresh(tokens, Now, Window);

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/ProactiveTokenRefreshDecisionTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/ProactiveTokenRefreshDecisionTests.cs
@@ -65,7 +65,7 @@ public class ProactiveTokenRefreshDecisionTests {
 
     [Test]
     public async Task Two_minute_window_leaves_a_token_beyond_it_not_due() {
-        // The daemon's shrunk 2-minute window: a token 2m30s out is still comfortably valid, so a
+        // The daemon's 2-minute window: a token 2m30s out is still comfortably valid, so a
         // freshly-issued token is not refreshed the instant after login.
         var window   = TimeSpan.FromMinutes(2);
         var tokens   = Tokens(AuthProvider.WorkOS, Now.AddSeconds(150));

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/RefreshIfExpiringTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/RefreshIfExpiringTests.cs
@@ -1,15 +1,20 @@
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
 
 namespace Capacitor.Cli.Core.Tests.Unit.Auth;
 
 /// <summary>
-/// No-op behaviour of <see cref="TokenStore.RefreshIfExpiringAsync"/> — the paths that
-/// must NOT touch the network. These are the daemon acceptance criteria: proactive refresh
-/// is a no-op when no tokens are stored, for the None provider, and while the token is still
-/// comfortably valid (refresh only inside the expiry window). The provider paths that DO hit
-/// the WorkOS / server refresh endpoints are exercised by DecideProactiveRefresh's unit tests
-/// and integration coverage, never here, so this suite stays offline and fast.
+/// Behaviour of <see cref="TokenStore.RefreshIfExpiringAsync"/> the daemon relies on. Most cases
+/// are the no-op paths that must NOT touch the network — proactive refresh is a no-op when no
+/// tokens are stored, for the None provider, and while the token is still comfortably valid
+/// (refresh only inside the expiry window). The remaining case pins the classification the daemon
+/// loop keys its hard backoff on: a WorkOS refresh the endpoint refuses reads as
+/// <see cref="ProactiveRefreshOutcome.Rejected"/>, not <see cref="ProactiveRefreshOutcome.Failed"/>,
+/// so the daemon stops re-sending a dead token. It reaches WorkOS through a local stub, never the
+/// real host.
 /// </summary>
 public class RefreshIfExpiringTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
@@ -51,5 +56,28 @@ public class RefreshIfExpiringTests {
         });
 
         await Assert.That(await AuthFixtures.NewTokenStore(Config.Root).RefreshIfExpiringAsync(ProfileConfig.DefaultName, Window)).IsEqualTo(ProactiveRefreshOutcome.NotDue);
+    }
+
+    [Test]
+    public async Task Rejected_when_workos_refuses_the_refresh_token() {
+        // A refused refresh (400 invalid_grant) is terminal — the token is spent, only `kcap login`
+        // repairs it — so the tick reports Rejected, distinct from a Failed transport blip.
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(400).WithBody("""{"error":"invalid_grant"}"""));
+
+        await AuthFixtures.NewTokenStore(Config.Root).SaveAsync("default", new StoredTokens {
+            AccessToken    = "at",
+            RefreshToken   = "rt",
+            ClientId       = "cid",
+            ExpiresAt      = DateTimeOffset.UtcNow.AddMinutes(1), // inside the window
+            GitHubUsername = "alice",
+            Provider       = AuthProvider.WorkOS
+        });
+
+        var outcome = await AuthFixtures.NewTokenStore(Config.Root, new StubHost(server.Urls[0]))
+            .RefreshIfExpiringAsync(ProfileConfig.DefaultName, Window);
+
+        await Assert.That(outcome).IsEqualTo(ProactiveRefreshOutcome.Rejected);
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSClientTests.cs
@@ -114,4 +114,23 @@ public class WorkOSClientTests : IDisposable {
         await Assert.That(result.Outcome).IsEqualTo(WorkOSRefreshOutcome.TransportFailed);
         await Assert.That(result.Response).IsNull();
     }
+
+    /// <summary>A WorkOS that accepts the connection but stalls must not hold auth — and every peer's
+    /// refresh, since a refresh runs under the cross-process lock — for the client's 100 s default.
+    /// The single attempt has its own short deadline, and a stall reads as a transport failure (the
+    /// token was not spent), never a rejection.</summary>
+    [Test]
+    public async Task A_stalled_refresh_times_out_as_a_transport_failure() {
+        _server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithBody("""{"access_token":"acc","refresh_token":"rt2"}""")
+                .WithDelay(TimeSpan.FromSeconds(3)));
+
+        var client = new WorkOSClient(
+            new PlainHttpClientFactory(new StubHost(_server.Urls[0])), refreshTimeout: TimeSpan.FromMilliseconds(200));
+
+        var result = await client.RefreshAsync("client_d", "rt1", CancellationToken.None);
+
+        await Assert.That(result.Outcome).IsEqualTo(WorkOSRefreshOutcome.TransportFailed);
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSClientTests.cs
@@ -63,4 +63,40 @@ public class WorkOSClientTests : IDisposable {
         await Assert.That(result.Problem!).Contains("403");
         await Assert.That(result.Problem!).DoesNotContain("sekrit");
     }
+
+    /// <summary>A refresh that WorkOS honours rotates and carries the parsed tokens back to the caller.</summary>
+    [Test]
+    public async Task A_honoured_refresh_rotates_and_carries_the_response() {
+        _server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody(
+                """{"user":{"id":"user_x"},"access_token":"acc","refresh_token":"rt2"}"""));
+
+        var result = await new WorkOSClient(new PlainHttpClientFactory(new StubHost(_server.Urls[0])))
+            .RefreshAsync("client_d", "rt1", CancellationToken.None);
+
+        await Assert.That(result.Outcome).IsEqualTo(WorkOSRefreshOutcome.Rotated);
+        await Assert.That(result.Response!.AccessToken).IsEqualTo("acc");
+        await Assert.That(result.Response!.RefreshToken).IsEqualTo("rt2");
+    }
+
+    /// <summary>
+    /// A refused refresh reads as Rejected with no response — the token WorkOS declined must not be
+    /// mistaken for a live one — and the refresh is sent once, never retried onto a consumed token.
+    /// </summary>
+    [Test]
+    public async Task A_refused_refresh_is_rejected_and_sent_exactly_once() {
+        _server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(400).WithBody(
+                """{"error":"invalid_grant"}"""));
+
+        var result = await new WorkOSClient(new PlainHttpClientFactory(new StubHost(_server.Urls[0])))
+            .RefreshAsync("client_d", "rt1", CancellationToken.None);
+
+        await Assert.That(result.Outcome).IsEqualTo(WorkOSRefreshOutcome.Rejected);
+        await Assert.That(result.Response).IsNull();
+
+        var posts = _server.FindLogEntries(
+            Request.Create().WithPath("/user_management/authenticate").UsingPost());
+        await Assert.That(posts.Count).IsEqualTo(1);
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSClientTests.cs
@@ -99,4 +99,19 @@ public class WorkOSClientTests : IDisposable {
             Request.Create().WithPath("/user_management/authenticate").UsingPost());
         await Assert.That(posts.Count).IsEqualTo(1);
     }
+
+    /// <summary>A 5xx is the server faltering, not the token being refused: it must read as a
+    /// transport failure (retry with the same live token), not Rejected (which would strand the
+    /// daemon on the hour-long re-login backoff over a transient blip).</summary>
+    [Test]
+    public async Task A_server_error_is_a_transport_failure_not_a_rejection() {
+        _server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(503));
+
+        var result = await new WorkOSClient(new PlainHttpClientFactory(new StubHost(_server.Urls[0])))
+            .RefreshAsync("client_d", "rt1", CancellationToken.None);
+
+        await Assert.That(result.Outcome).IsEqualTo(WorkOSRefreshOutcome.TransportFailed);
+        await Assert.That(result.Response).IsNull();
+    }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSClientTests.cs
@@ -133,4 +133,19 @@ public class WorkOSClientTests : IDisposable {
 
         await Assert.That(result.Outcome).IsEqualTo(WorkOSRefreshOutcome.TransportFailed);
     }
+
+    /// <summary>A success status means WorkOS already consumed the old token and rotated; an unreadable
+    /// body loses the new token, so the outcome is Rejected (re-login) — never a retryable failure that
+    /// would re-send the spent token and trip reuse detection.</summary>
+    [Test]
+    public async Task An_unreadable_success_body_is_rejected_not_retried() {
+        _server.Given(Request.Create().WithPath("/user_management/authenticate").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200).WithBody("not-json"));
+
+        var result = await new WorkOSClient(new PlainHttpClientFactory(new StubHost(_server.Urls[0])))
+            .RefreshAsync("client_d", "rt1", CancellationToken.None);
+
+        await Assert.That(result.Outcome).IsEqualTo(WorkOSRefreshOutcome.Rejected);
+        await Assert.That(result.Response).IsNull();
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TokenRefreshLoopTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TokenRefreshLoopTests.cs
@@ -81,6 +81,26 @@ public class TokenRefreshLoopTests {
     }
 
     [Test]
+    public async Task Tick_Rejected_LogsOnceNamingLoginAndBacksOffHard() {
+        // A rejected refresh means the refresh token itself is dead (WorkOS refused it). The loop
+        // must warn once, point at `kcap login`, and stop re-sending the dead token every interval
+        // — a much longer backoff than a transient Failed, so a tick 30 minutes later is skipped.
+        var now    = new DateTimeOffset(2026, 1, 1, 12, 0, 0, TimeSpan.Zero);
+        var logger = new CaptureLogger();
+        var port   = new FakePort { Handler = () => Task.FromResult(ProactiveRefreshOutcome.Rejected) };
+        var loop   = new TokenRefreshLoop(port, logger, Interval, () => now);
+
+        await loop.TickAsync(CancellationToken.None);
+        await Assert.That(port.Calls).IsEqualTo(1);
+        await Assert.That(logger.Entries.Count(e => e.Level == LogLevel.Warning)).IsEqualTo(1);
+        await Assert.That(logger.Entries).Contains(e => e.Level == LogLevel.Warning && e.Message.Contains("kcap login"));
+
+        now = now.AddMinutes(30);                           // far past the 5-minute interval, well inside the hard backoff
+        await loop.TickAsync(CancellationToken.None);
+        await Assert.That(port.Calls).IsEqualTo(1);         // suppressed — the dead token isn't re-sent
+    }
+
+    [Test]
     public async Task Tick_PortThrows_DoesNotRethrowAndLogsWarning() {
         // The unobserved background loop must survive a faulting refresh (e.g. a genuine IO
         // fault reading the token file that TokenStore lets propagate).


### PR DESCRIPTION
Closes #867 — AI-2691

## What & why

The shared single-use WorkOS refresh token was being re-sent after WorkOS had already consumed it, which trips AuthKit reuse-detection and revokes the whole token family — the "I have to run `kcap login` every few minutes" bug. The per-profile file lock already serialized concurrent refreshers correctly; the gap was re-sending a consumed token. Two changes close it: the refresh POST is now single-shot (a single-use token must be at-most-once on the wire — a retry re-presents a token a lost/timed-out first attempt may already have consumed), and its outcome is classified so a refusal is distinguishable from a blip. A refused refresh token (4xx) is terminal: the daemon's proactive loop logs one clear "run `kcap login`" and backs off an hour instead of re-sending the dead token every few minutes; a transient 5xx/408/429 stays a retryable transport failure. The proactive window drops from 5 minutes to 2 so a token minted seconds ago at login is not refreshed on the spot.

## Where to look

`WorkOSClient.RefreshAsync` returns a typed `WorkOSRefreshResult` (Rotated / Rejected / TransportFailed); the login-flow callers keep their old behavior by reading `.Response`. `RefreshIfExpiringAsync` threads the WorkOS classification through a captured-outcome callback, mirroring the existing `onLockContended` pattern, so a null result plus a Rejected outcome is a genuine refusal (a peer-refresh or still-fresh re-read returns non-null without calling the delegate).

Not in scope (follow-ups, AI-2691's analysis Fix 4/5): a cross-process "auth broken" marker so hooks/app also stop on a refusal, and making the daemon the sole refresher. This PR closes the primary re-send and the daemon-loop escalation.

## Verification

- Core Auth suite green incl. new tests: refused refresh → Rejected and sent exactly once (no retry); a 200 → Rotated; a 503 → TransportFailed; `RefreshIfExpiringAsync` 400 → `ProactiveRefreshOutcome.Rejected`; the 2-minute window boundary.
- Daemon `TokenRefreshLoopTests`: a Rejected tick logs once and arms the hour-long backoff.
- Both AOT publishes (CLI and daemon) clean.
