### PR TITLE
[AI-2696] Let the app-server runtime answer approvals in an envelope-sourced session

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/PendingAcpInteractionRegistry.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PendingAcpInteractionRegistry.cs
@@ -23,14 +23,14 @@ internal sealed class PendingAcpInteractionRegistry {
     // cancel this side asked for — and that answer must be dropped, not buffered: request ids are a
     // per-server sequence, so a buffered stale decision could be handed to a later request that reuses
     // the id after a server restart. A new wait on the id supersedes the mark.
-    readonly HashSet<string>                                                   _abandoned      = new();
-    readonly Queue<string>                                                     _abandonedOrder = new();
+    readonly Dictionary<string, LinkedListNode<string>>                        _abandoned      = new();
+    readonly LinkedList<string>                                                _abandonedOrder = new();
 
     public Task<AcpInteractionDecision> AwaitDecisionAsync(string requestId, CancellationToken ct) {
         TaskCompletionSource<AcpInteractionDecision> tcs;
 
         lock (_gate) {
-            _abandoned.Remove(requestId);
+            ClearAbandoned(requestId);
             if (_early.Remove(requestId, out var early))
                 return Task.FromResult(early);
 
@@ -57,17 +57,30 @@ internal sealed class PendingAcpInteractionRegistry {
         return await tcs.Task.ConfigureAwait(false);
     }
 
+    // Age-ordered by the CURRENT mark: re-marking an id moves it to the back, and clearing it removes
+    // its order entry, so the bound evicts the genuinely oldest mark and the list cannot grow past it.
     void MarkAbandoned(string requestId) {
-        if (_abandoned.Add(requestId)) _abandonedOrder.Enqueue(requestId);
-        while (_abandoned.Count > MaxBufferedDecisions && _abandonedOrder.Count > 0)
-            _abandoned.Remove(_abandonedOrder.Dequeue());
+        if (_abandoned.TryGetValue(requestId, out var existing))
+            _abandonedOrder.Remove(existing);
+        _abandoned[requestId] = _abandonedOrder.AddLast(requestId);
+        while (_abandoned.Count > MaxBufferedDecisions) {
+            var oldest = _abandonedOrder.First!;
+            _abandonedOrder.RemoveFirst();
+            _abandoned.Remove(oldest.Value);
+        }
+    }
+
+    bool ClearAbandoned(string requestId) {
+        if (!_abandoned.Remove(requestId, out var node)) return false;
+        _abandonedOrder.Remove(node);
+        return true;
     }
 
     public void Resolve(string requestId, AcpInteractionDecision decision) {
         TaskCompletionSource<AcpInteractionDecision>? tcs;
 
         lock (_gate) {
-            if (_abandoned.Remove(requestId))
+            if (ClearAbandoned(requestId))
                 return;
 
             if (!_pending.Remove(requestId, out tcs)) {

--- a/src/Capacitor.Cli.Daemon/Services/PendingAcpInteractionRegistry.cs
+++ b/src/Capacitor.Cli.Daemon/Services/PendingAcpInteractionRegistry.cs
@@ -19,11 +19,18 @@ internal sealed class PendingAcpInteractionRegistry {
     readonly Dictionary<string, TaskCompletionSource<AcpInteractionDecision>>  _pending    = new();
     readonly Dictionary<string, AcpInteractionDecision>                        _early      = new();
     readonly Queue<string>                                                     _earlyOrder = new();
+    // Request ids this side stopped waiting on. The server still answers them — at least with the
+    // cancel this side asked for — and that answer must be dropped, not buffered: request ids are a
+    // per-server sequence, so a buffered stale decision could be handed to a later request that reuses
+    // the id after a server restart. A new wait on the id supersedes the mark.
+    readonly HashSet<string>                                                   _abandoned      = new();
+    readonly Queue<string>                                                     _abandonedOrder = new();
 
     public Task<AcpInteractionDecision> AwaitDecisionAsync(string requestId, CancellationToken ct) {
         TaskCompletionSource<AcpInteractionDecision> tcs;
 
         lock (_gate) {
+            _abandoned.Remove(requestId);
             if (_early.Remove(requestId, out var early))
                 return Task.FromResult(early);
 
@@ -40,7 +47,9 @@ internal sealed class PendingAcpInteractionRegistry {
             CancellationToken                              ct
         ) {
         await using var _ = ct.Register(() => {
-            lock (_gate) _pending.Remove(requestId);
+            lock (_gate) {
+                if (_pending.Remove(requestId)) MarkAbandoned(requestId);
+            }
 
             tcs.TrySetCanceled(ct);
         }).ConfigureAwait(false);
@@ -48,10 +57,19 @@ internal sealed class PendingAcpInteractionRegistry {
         return await tcs.Task.ConfigureAwait(false);
     }
 
+    void MarkAbandoned(string requestId) {
+        if (_abandoned.Add(requestId)) _abandonedOrder.Enqueue(requestId);
+        while (_abandoned.Count > MaxBufferedDecisions && _abandonedOrder.Count > 0)
+            _abandoned.Remove(_abandonedOrder.Dequeue());
+    }
+
     public void Resolve(string requestId, AcpInteractionDecision decision) {
         TaskCompletionSource<AcpInteractionDecision>? tcs;
 
         lock (_gate) {
+            if (_abandoned.Remove(requestId))
+                return;
+
             if (!_pending.Remove(requestId, out tcs)) {
                 if (_early.TryAdd(requestId, decision))
                     _earlyOrder.Enqueue(requestId);

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1115,16 +1115,18 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         return await AwaitInteractionDecisionAsync(request, requestId, ct);
     }
 
-    /// <summary>Awaits the user's decision for <paramref name="requestId"/>. The server holds an
-    /// interaction open until it is answered — it has no deadline of its own — so when this side stops
-    /// waiting (the caller's deadline, or teardown) the entry is resolved as cancelled here, best-effort,
-    /// before the cancellation propagates; otherwise the pending card outlives the request.</summary>
+    /// <summary>Awaits the user's decision for <paramref name="requestId"/>. The server keeps an
+    /// interaction open far longer than any caller here waits, so when this side stops waiting on a live
+    /// connection the entry is resolved as cancelled, best-effort, before the cancellation propagates —
+    /// otherwise the pending card outlives the request. A wait cancelled by daemon shutdown is left to
+    /// the server's session-end cleanup: the hub is already stopping and the send could not land.</summary>
     internal async Task<AcpInteractionDecision> AwaitInteractionDecisionAsync(
             AcpInteractionRequest request, string requestId, CancellationToken ct) {
         try {
             return await _pendingAcpInteractions.AwaitDecisionAsync(requestId, ct);
         } catch (OperationCanceledException) {
-            _ = ResolveAbandonedInteractionAsync(request, requestId);
+            if (!_ct.IsCancellationRequested)
+                _ = ResolveAbandonedInteractionAsync(request, requestId);
             throw;
         }
     }

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1112,7 +1112,36 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             maxServerErrorRetries: OwnershipNotReadyMaxRetries
         );
 
-        return await _pendingAcpInteractions.AwaitDecisionAsync(requestId, ct);
+        return await AwaitInteractionDecisionAsync(request, requestId, ct);
+    }
+
+    /// <summary>Awaits the user's decision for <paramref name="requestId"/>. The server holds an
+    /// interaction open until it is answered — it has no deadline of its own — so when this side stops
+    /// waiting (the caller's deadline, or teardown) the entry is resolved as cancelled here, best-effort,
+    /// before the cancellation propagates; otherwise the pending card outlives the request.</summary>
+    internal async Task<AcpInteractionDecision> AwaitInteractionDecisionAsync(
+            AcpInteractionRequest request, string requestId, CancellationToken ct) {
+        try {
+            return await _pendingAcpInteractions.AwaitDecisionAsync(requestId, ct);
+        } catch (OperationCanceledException) {
+            _ = ResolveAbandonedInteractionAsync(request, requestId);
+            throw;
+        }
+    }
+
+    /// <summary>The outcome the server records for an interaction this side stopped waiting on — its own
+    /// token for an interaction nobody answered (InterruptOutcomes.Cancel), distinct from a user deny.</summary>
+    internal const string AbandonedInteractionOutcome = "cancel";
+
+    async Task ResolveAbandonedInteractionAsync(AcpInteractionRequest request, string requestId) {
+        try {
+            var sessionId = SessionIds.Canonical(request.AcpSessionId) ?? request.AcpSessionId;
+            var outcome   = await RespondToPermissionAsync(sessionId, requestId, new PermissionDecision(AbandonedInteractionOutcome, null, null));
+            if (outcome.Kind == RespondOutcomeKind.Failed)
+                _logger.LogDebug("ACP interaction {RequestId} abandoned locally but not resolved on the server: {Reason}", requestId, outcome.Reason);
+        } catch (Exception ex) {
+            _logger.LogDebug(ex, "ACP interaction {RequestId} abandoned locally but not resolved on the server", requestId);
+        }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
@@ -27,11 +27,12 @@ namespace Capacitor.Cli.Commands.Harness;
 ///                       emit the idle-wait marker that clears the chat
 ///                       "working" indicator. HandleStop also refreshes watcher
 ///                       liveness and emits {"continue":true} for Codex's parser.
-///   PermissionRequest → in a daemon-launched hosted agent (a loopback bridge named), bounce
-///                       through the daemon's LocalPermissionBridge and wait for the dashboard's
-///                       decision (fail-closed on bridge errors: deny + exit nonzero). Otherwise:
-///                       POST /hooks/permission-record (fire-and-forget; CLI emits no decision so
-///                       Codex's normal in-CLI approval prompt takes over).
+///   PermissionRequest → in an envelope-sourced hosted session (KCAP_HOSTED_APPSERVER), yield: the
+///                       app-server runtime owns approvals there. Otherwise in a daemon-launched
+///                       hosted agent (a loopback bridge named), bounce through the daemon's
+///                       LocalPermissionBridge and wait for the dashboard's decision (fail-closed on
+///                       bridge errors: deny + exit nonzero). Otherwise: POST /hooks/permission-record
+///                       (fire-and-forget; CLI emits no decision so Codex's own prompt takes over).
 ///   UserPromptSubmit  → swallowed (v1 — neither vendor consumes them)
 ///   PreToolUse        → swallowed
 ///   PostToolUse       → swallowed
@@ -486,12 +487,27 @@ sealed class CodexHookCommand(
         return 0;
     }
 
-    async Task<int> HandlePermissionRequest(JsonNode node) =>
-        hosted.Bridge switch {
+    async Task<int> HandlePermissionRequest(JsonNode node) {
+        // An envelope-sourced hosted session answers approvals over the app-server protocol itself:
+        // Codex's requestApproval reaches the daemon's CodexApprovalBridge, which surfaces it to the
+        // user and fails closed on its own deadline. Bouncing this hook to the daemon bridge would
+        // answer first, through a channel with no deadline, and that decline would never come.
+        if (IsEnvelopeSourcedHostedSession())
+            return YieldToCodex();
+
+        return hosted.Bridge switch {
             DaemonBridge.Loopback bridge => await HandlePermissionRequestViaBridge(bridge.BaseUrl, node),
             DaemonBridge.NotLoopback bad => RefuseBridge(bad.Value),
             _                            => await HandlePermissionRequestStub(node),
         };
+    }
+
+    /// <summary>Empty hookSpecificOutput — Codex reads it as "no decision" and runs its own approval
+    /// flow (codex-rs/hooks/src/events/permission_request.rs).</summary>
+    static int YieldToCodex() {
+        Console.Write("{}");
+        return 0;
+    }
 
     /// A named bridge this hook may not post to is a misconfiguration, not a terminal session: the
     /// stub's silent fallback to Codex's own prompt would hide it, and this hook fails closed.
@@ -523,11 +539,7 @@ sealed class CodexHookCommand(
         // PostBestEffortAsync for the shared swallow-all/cap behavior.
         await PostBestEffortAsync("permission-record", node, TimeSpan.FromSeconds(2));
 
-        // Empty hookSpecificOutput → Codex treats it as "no decision" and runs
-        // its normal approval flow. See
-        // codex-rs/hooks/src/events/permission_request.rs in openai/codex.
-        Console.Write("{}");
-        return 0;
+        return YieldToCodex();
     }
 
     async Task<int> HandlePermissionRequestViaBridge(string bridgeBase, JsonNode node) {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexApprovalTimeoutChainTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Codex/CodexApprovalTimeoutChainTests.cs
@@ -1,0 +1,36 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Acp;
+using Capacitor.Cli.Daemon.Harness.Codex;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Harness.Codex;
+
+/// <summary>Composes the bridge with the REAL pieces its production delegate is made of — the connection
+/// retry helper and the pending-interaction registry — instead of a fake that honours the token by
+/// construction. A decision that never arrives must still become a decline at the bridge's timeout.</summary>
+public class CodexApprovalTimeoutChainTests {
+    static AcpRequest Approval() {
+        using var doc = JsonDocument.Parse("""{"threadId":"t-1","itemId":"i-1","command":"pwd"}""");
+        return new AcpRequest(0, "item/commandExecution/requestApproval", doc.RootElement.Clone());
+    }
+
+    [Test]
+    public async Task An_unanswered_interaction_declines_at_the_timeout_through_the_real_registry_and_retry() {
+        var registry = new PendingAcpInteractionRegistry();
+
+        // Mirrors ServerConnection.RequestAcpInteractionAsync: invoke (returns the request id) then await the decision.
+        async Task<AcpInteractionDecision> RequestInteraction(AcpInteractionRequest request, CancellationToken ct) {
+            var requestId = await ConnectionRetry.InvokeWithConnectionRetryAsync(
+                () => Task.FromResult("req-1"), () => true, TimeSpan.FromMilliseconds(50), _ => { }, ct);
+            return await registry.AwaitDecisionAsync(requestId, ct);
+        }
+
+        var bridge = new CodexApprovalBridge(RequestInteraction, "agent-1", NullLogger.Instance, TimeSpan.FromMilliseconds(300));
+
+        var result = await bridge.HandleAsync(Approval(), CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(5));
+
+        await Assert.That(result?.GetProperty("decision").GetString()).IsEqualTo("decline");
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/PendingAcpInteractionRegistryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/PendingAcpInteractionRegistryTests.cs
@@ -68,4 +68,30 @@ public class PendingAcpInteractionRegistryTests {
         registry.Resolve("req-4", new AcpInteractionDecision("allow", null, null, null, null, null));
         await Assert.That((await reused.WaitAsync(HangGuard)).Outcome).IsEqualTo("allow");
     }
+
+    /// <summary>The abandoned set is bounded by age of the CURRENT mark: an id abandoned, answered and
+    /// abandoned again must not be evicted by the age of its first mark when the set fills up.</summary>
+    [Test]
+    public async Task Re_abandoning_an_id_keeps_its_mark_until_it_is_the_oldest_current_mark() {
+        var registry = new PendingAcpInteractionRegistry();
+        async Task AbandonAsync(string id) {
+            using var cts = new CancellationTokenSource();
+            var wait = registry.AwaitDecisionAsync(id, cts.Token);
+            await cts.CancelAsync();
+            await Assert.ThrowsAsync<OperationCanceledException>(async () => await wait.WaitAsync(HangGuard));
+        }
+        var cancel = new AcpInteractionDecision("cancel", null, null, null, null, null);
+
+        await AbandonAsync("req-a");
+        registry.Resolve("req-a", cancel);                                    // consumes the first mark
+        for (var i = 0; i < 1000; i++) await AbandonAsync($"filler-{i}");     // older than the re-mark below
+        await AbandonAsync("req-a");                                          // marked again — newer than those
+        for (var i = 1000; i < 1024; i++) await AbandonAsync($"filler-{i}");  // pushes the set past its bound: the oldest fillers go, not req-a
+
+        registry.Resolve("req-a", cancel);          // the echo for the second abandonment must still be dropped
+        var reused = registry.AwaitDecisionAsync("req-a", CancellationToken.None);
+
+        await Assert.That(await Task.WhenAny(reused, Task.Delay(200)) == reused).IsFalse()
+            .Because("an evicted mark would have buffered the stale cancel and resolved the reused id with it");
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/PendingAcpInteractionRegistryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/PendingAcpInteractionRegistryTests.cs
@@ -46,4 +46,26 @@ public class PendingAcpInteractionRegistryTests {
 
         await Assert.ThrowsAsync<OperationCanceledException>(async () => await awaitTask.WaitAsync(HangGuard));
     }
+
+    /// <summary>A decision arriving for a request this side stopped waiting on is dropped, not
+    /// buffered: the server echoes the cancel this side asked for, and request ids are a per-server
+    /// sequence, so a buffered stale decision would be handed to whichever later request reuses the id.
+    /// The reused id must still receive its own decision.</summary>
+    [Test]
+    public async Task A_resolution_for_an_abandoned_request_is_discarded_and_a_reused_id_still_pends() {
+        var registry = new PendingAcpInteractionRegistry();
+        using var cts = new CancellationTokenSource();
+        var abandoned = registry.AwaitDecisionAsync("req-4", cts.Token);
+        await cts.CancelAsync();
+        await Assert.ThrowsAsync<OperationCanceledException>(async () => await abandoned.WaitAsync(HangGuard));
+
+        registry.Resolve("req-4", new AcpInteractionDecision("cancel", null, null, null, null, null)); // the server's echo
+
+        var reused = registry.AwaitDecisionAsync("req-4", CancellationToken.None);
+        await Assert.That(await Task.WhenAny(reused, Task.Delay(200)) == reused).IsFalse()
+            .Because("the stale cancel must not resolve a later request that reuses the id");
+
+        registry.Resolve("req-4", new AcpInteractionDecision("allow", null, null, null, null, null));
+        await Assert.That((await reused.WaitAsync(HangGuard)).Outcome).IsEqualTo("allow");
+    }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionAbandonedInteractionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/ServerConnectionAbandonedInteractionTests.cs
@@ -1,0 +1,46 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>The server keeps an ACP interaction open until something answers it. When this side stops
+/// waiting, the entry has to be resolved from here or the pending card outlives the request.</summary>
+public class ServerConnectionAbandonedInteractionTests {
+    sealed class CapturingServerConnection() : ServerConnection(
+            new() { Name = "test", ServerUrl = "http://127.0.0.1:1" },
+            UnusedTokenStore.Create(),
+            NullLoggerFactory.Instance,
+            NullLogger<ServerConnection>.Instance) {
+        public readonly List<(string SessionId, string RequestId, string Behavior)> Responded = [];
+        public readonly TaskCompletionSource RespondedOnce = new(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        public override Task<RespondOutcome> RespondToPermissionAsync(string sessionId, string serverRequestId, PermissionDecision decision) {
+            Responded.Add((sessionId, serverRequestId, decision.Behavior));
+            RespondedOnce.TrySetResult();
+            return Task.FromResult(new RespondOutcome(RespondOutcomeKind.Applied, null));
+        }
+    }
+
+    static AcpInteractionRequest Interaction(string threadId) =>
+        new(AgentId: "agent-1", AcpSessionId: threadId, Kind: "permission", ToolName: "commandExecution",
+            ToolInput: null, ToolCallId: "item-1", Prompt: null, Options: [], IsMultiSelect: false);
+
+    [Test]
+    public async Task A_wait_that_is_cancelled_resolves_the_server_side_interaction_as_cancelled() {
+        await using var connection = new CapturingServerConnection();
+        using var cts = new CancellationTokenSource(TimeSpan.FromMilliseconds(100));
+
+        await Assert.That(async () => await connection.AwaitInteractionDecisionAsync(
+                Interaction("01a08e07-957d-7b13-a935-093cb48cb814"), "sid:4", cts.Token))
+            .Throws<OperationCanceledException>();
+
+        await connection.RespondedOnce.Task.WaitAsync(TimeSpan.FromSeconds(5));
+        await Assert.That(connection.Responded).HasSingleItem();
+        var (sessionId, requestId, behavior) = connection.Responded[0];
+        // The thread id travels in UUID form; the server keys interactions by the canonical 32-hex id.
+        await Assert.That(sessionId).IsEqualTo("01a08e07957d7b13a935093cb48cb814");
+        await Assert.That(requestId).IsEqualTo("sid:4");
+        await Assert.That(behavior).IsEqualTo(ServerConnection.AbandonedInteractionOutcome);
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CodexHookCommandTests.cs
@@ -585,7 +585,8 @@ public class CodexHookCommandTests : IDisposable {
 
     /// <summary>In an envelope-sourced hosted session the app-server runtime answers approvals over
     /// Codex's own requestApproval, with a deadline. The hook must step aside — a bridge round-trip
-    /// here would answer first through a channel with no deadline. Same marker guard-1 uses.</summary>
+    /// here would answer first through a channel with no deadline. Keyed on the same marker that
+    /// suppresses the hook's transcript watcher for such sessions.</summary>
     [Test, NotInParallel]
     public async Task PermissionRequest_in_an_envelope_sourced_hosted_session_yields_to_codex_without_posting_to_the_bridge() {
         using var bridge = WireMockServer.Start();
@@ -594,20 +595,15 @@ public class CodexHookCommandTests : IDisposable {
             .RespondWith(Response.Create().WithStatusCode(200)
                 .WithBody("""{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"""));
         var hosted = new HostedAgent(null, IsRendered: true, DaemonBridge.Parse($"http://127.0.0.1:{bridge.Ports[0]}/{token}"));
-        var previousMarker = Environment.GetEnvironmentVariable("KCAP_HOSTED_APPSERVER");
+        using var marker  = EnvScope.Exclusive("KCAP_HOSTED_APPSERVER", "1");
         using var capture = ConsoleOutput.StartCapture();
-        try {
-            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", "1");
 
-            var exit = await new CodexHookCommand(Config.Root, Resolutions.At("http://server.example", Config.Root), new HookClock(TimeProvider.System), Home, TestHarnesses.Under(Home), hosted, new FixedCapacitorHttpClient())
-                .Handle(new StringReader("""{"hook_event_name":"PermissionRequest","session_id":"s1","tool_name":"shell","tool_input":{"command":"ls"}}"""));
+        var exit = await new CodexHookCommand(Config.Root, Resolutions.At("http://server.example", Config.Root), new HookClock(TimeProvider.System), Home, TestHarnesses.Under(Home), hosted, new FixedCapacitorHttpClient())
+            .Handle(new StringReader("""{"hook_event_name":"PermissionRequest","session_id":"s1","tool_name":"shell","tool_input":{"command":"ls"}}"""));
 
-            await Assert.That(exit).IsEqualTo(0);
-            await Assert.That(capture.GetCapturedOutput().Trim()).IsEqualTo("{}");
-            await Assert.That(bridge.LogEntries.Count).IsEqualTo(0);
-        } finally {
-            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", previousMarker);
-        }
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(capture.GetCapturedOutput().Trim()).IsEqualTo("{}");
+        await Assert.That(bridge.LogEntries.Count).IsEqualTo(0);
     }
 
     [Test, NotInParallel]

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CodexHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/CodexHookCommandTests.cs
@@ -583,6 +583,33 @@ public class CodexHookCommandTests : IDisposable {
         await Assert.That(capture.GetCapturedOutput()).Contains("\"behavior\":\"allow\"");
     }
 
+    /// <summary>In an envelope-sourced hosted session the app-server runtime answers approvals over
+    /// Codex's own requestApproval, with a deadline. The hook must step aside — a bridge round-trip
+    /// here would answer first through a channel with no deadline. Same marker guard-1 uses.</summary>
+    [Test, NotInParallel]
+    public async Task PermissionRequest_in_an_envelope_sourced_hosted_session_yields_to_codex_without_posting_to_the_bridge() {
+        using var bridge = WireMockServer.Start();
+        var       token  = "abc123";
+        bridge.Given(Request.Create().WithPath($"/{token}/codex/permission-request").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithBody("""{"hookSpecificOutput":{"hookEventName":"PermissionRequest","decision":{"behavior":"allow"}}}"""));
+        var hosted = new HostedAgent(null, IsRendered: true, DaemonBridge.Parse($"http://127.0.0.1:{bridge.Ports[0]}/{token}"));
+        var previousMarker = Environment.GetEnvironmentVariable("KCAP_HOSTED_APPSERVER");
+        using var capture = ConsoleOutput.StartCapture();
+        try {
+            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", "1");
+
+            var exit = await new CodexHookCommand(Config.Root, Resolutions.At("http://server.example", Config.Root), new HookClock(TimeProvider.System), Home, TestHarnesses.Under(Home), hosted, new FixedCapacitorHttpClient())
+                .Handle(new StringReader("""{"hook_event_name":"PermissionRequest","session_id":"s1","tool_name":"shell","tool_input":{"command":"ls"}}"""));
+
+            await Assert.That(exit).IsEqualTo(0);
+            await Assert.That(capture.GetCapturedOutput().Trim()).IsEqualTo("{}");
+            await Assert.That(bridge.LogEntries.Count).IsEqualTo(0);
+        } finally {
+            Environment.SetEnvironmentVariable("KCAP_HOSTED_APPSERVER", previousMarker);
+        }
+    }
+
     [Test, NotInParallel]
     public async Task PermissionRequest_with_daemon_url_emits_deny_and_exits_nonzero_on_500() {
         using var bridge = WireMockServer.Start();


### PR DESCRIPTION
No GitHub issue — AI-2696

## What & why

In a hosted app-server Codex session, an approval never failed closed: Codex runs the user's `PermissionRequest` hook before it asks its client, and that hook bounced the request through the daemon's `LocalPermissionBridge` — the Claude channel, deliberately built with no deadline — so the runtime's `requestApproval` (and `CodexApprovalBridge`'s 45 s decline) never happened. The hook now yields in an envelope-sourced session, keyed on the same `KCAP_HOSTED_APPSERVER` marker that already suppresses its transcript watcher there. Separately, the server keeps an interaction open until something answers it and nothing told it when the daemon stopped waiting, so a timed-out request stayed a pending card for the rest of the session; the cancelled wait now resolves the entry as `cancel` before the cancellation propagates.

## Where to look

The hook change is one guard at the top of `HandlePermissionRequest`; everything hangs on the marker being set only for envelope-sourced launches (`CodexHostedAgentRuntimeFactory.BuildEnv`). `ResolveAbandonedInteractionAsync` reuses the existing `RespondToPermission` hub call — the hub already routes an ACP request id to `acpTracker.TryComplete` — with the canonical 32-hex thread id, because the hub does not normalise that argument.

## Verification

- Live (v1.0.1, daemon with `KCAP_ACP_DEBUG_FRAMES=1`, approval timeout 15 s): a full approval cycle showed **no** `requestApproval` JSON-RPC frame at all — only `hook/started` frames and `LocalPermissionBridge → RequestPermissionAsync → PendingPermissionRegistry` stacks; Codex's rollout shows the exec cell blocked until the dashboard answered (`:2` ran 80 ms after a late allow, 150 s in).
- `CodexHookCommandTests` 32/32 incl. the new yield test; mutant (marker never matches) fails it plus the two guard-1 tests that share the check. `ServerConnectionAbandonedInteractionTests` 1/1; mutant (resolve never reaches the server) fails with a 5 s timeout. `CodexApprovalTimeoutChainTests` pins that bridge + real registry + real retry decline at the deadline (they did; the bridge was simply never asked).
