### PR TITLE
Complete a failed launch's own journal and skip live agents in the sweep

### DIFF
--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -552,7 +552,8 @@ public static partial class DaemonRunner {
         builder.Services.AddHostedService(sp => sp.GetRequiredService<LocalControlServer>());
 
         builder.Services.AddSingleton(sp => new TranscriptJournalSweep(
-            config.Store.StateDirectory(config.Name), TimeProvider.System, sp.GetRequiredService<ILogger<TranscriptJournalSweep>>()));
+            config.Store.StateDirectory(config.Name), TimeProvider.System, sp.GetRequiredService<ILogger<TranscriptJournalSweep>>(),
+            isLive: sp.GetRequiredService<AgentOrchestrator>().IsLiveJournalStem));
         builder.Services.AddHostedService(sp => sp.GetRequiredService<TranscriptJournalSweep>());
 
         var host   = builder.Build();

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -875,6 +875,11 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
 
     internal int ActiveCount => _agents.Count(a => a.Value.Status is "Starting" or "Running");
 
+    /// <see cref="TranscriptJournalSweep"/>'s live-agent check: a hashed transcript/PID-record file
+    /// stem is live when some agent still in <see cref="_agents"/> hashes to it — true between an
+    /// Antigravity turn's child exiting and the next one starting, when no PID record exists.
+    internal bool IsLiveJournalStem(string stem) => _agents.Keys.Any(id => AgentFileNames.For(id) == stem);
+
     /// Mutation FIRST, Pulse() second — always (a pulse published before its mutation lets a
     /// subscriber read the new version, snapshot the OLD state, and wait forever). These
     /// helpers are the only writers of agent status and registry membership, so the ordering
@@ -2019,6 +2024,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         // be able to complete it, and remove a file no other incarnation has written to.
         TranscriptJournal? journal = null;
 
+        // Set the instant PublishAgent makes _agents[agentId] THIS launch's own instance. Without
+        // it, the catch below can't tell "_agents already holds agentId" apart from "a different,
+        // already-live incarnation holds it" — a pre-publish failure on the latter would route
+        // through CleanupAgentAsync for the WRONG agent and leave this launch's own journal parked.
+        var published = false;
+
         // Created here, ahead of the reviewer-token mint and the AgentInstance that will own it, so the
         // SAME instance reaches the permission-bridge grant, the ACP runtime and the AgentInstance —
         // one clock per launch, never three.
@@ -2410,6 +2421,7 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
                 InactivityBoundSeconds = cmd.InactivityBoundSeconds
             };
             PublishAgent(agent);
+            published = true;
 
             // Phase B (D4 §6.4(2)): capture the start-identity + write the durable PID record
             // immediately after the process exists (before registration) so a daemon crash right after
@@ -2530,10 +2542,12 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         } catch (Exception ex) {
             LogLaunchFailed(ex, agentId);
 
-            // Phase B (D1): a post-insert failure (agent already in _agents — e.g. a throwing
-            // RegisterAgentAsync) routes teardown through the single-flight CleanupAgentAsync so it
-            // can't strand a live child; a pre-insert failure falls through to the transient cleanup below.
-            if (_agents.ContainsKey(agentId)) {
+            // Phase B (D1): a post-insert failure (this launch's own agent already in _agents — e.g. a
+            // throwing RegisterAgentAsync) routes teardown through the single-flight CleanupAgentAsync
+            // so it can't strand a live child. `published`, not ContainsKey: a pre-publish failure can
+            // find agentId already occupied by a DIFFERENT, live incarnation, and CleanupAgentAsync
+            // would then tear down that unrelated agent while leaking this launch's own journal.
+            if (published) {
                 await CleanupAgentAsync(agentId);
                 // §3.5: never forward a null/whitespace ex.Message raw.
                 await _server.LaunchFailedAsync(agentId, AcpHostedAgentRuntimeFactory.DescribeLaunchFailure(ex));

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2542,8 +2542,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         } catch (Exception ex) {
             LogLaunchFailed(ex, agentId);
 
-            // Phase B (D1): a post-insert failure (this launch's own agent already in _agents — e.g. a
-            // throwing RegisterAgentAsync) routes teardown through the single-flight CleanupAgentAsync
+            // A post-insert failure (this launch's own agent already in _agents — e.g. a throwing
+            // RegisterAgentAsync) routes teardown through the single-flight CleanupAgentAsync
             // so it can't strand a live child. `published`, not ContainsKey: a pre-publish failure can
             // find agentId already occupied by a DIFFERENT, live incarnation, and CleanupAgentAsync
             // would then tear down that unrelated agent while leaking this launch's own journal.

--- a/src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs
+++ b/src/Capacitor.Cli.Daemon/Services/TranscriptJournalSweep.cs
@@ -6,7 +6,15 @@ namespace Capacitor.Cli.Daemon.Services;
 /// Reaps envelope journals kcap owns: older than the retention and with no PID record under the
 /// same name. Runs once after the startup orphan reap (which removes a prior epoch's records) and
 /// then every 24 hours. Never throws — a sweep fault must not block the daemon's connect.
-internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time, ILogger<TranscriptJournalSweep> logger, JournalPathLocks? locks = null) : BackgroundService {
+internal sealed class TranscriptJournalSweep(
+        string                          stateDir,
+        TimeProvider                    time,
+        ILogger<TranscriptJournalSweep> logger,
+        JournalPathLocks?               locks  = null,
+        // A runtime that spawns one child per turn (Antigravity) has no PID record BETWEEN turns —
+        // that gap alone must never look like "no live owner" to a 30-day-old idle session, or the
+        // sweep deletes the journal and the runtime's next append latches the writer off.
+        Func<string, bool>?             isLive = null) : BackgroundService {
     public static readonly TimeSpan Retention = TimeSpan.FromDays(30);
     public static readonly TimeSpan Interval  = TimeSpan.FromHours(24);
 
@@ -57,7 +65,9 @@ internal sealed class TranscriptJournalSweep(string stateDir, TimeProvider time,
             // on is read after it is held: a check made while waiting would be about a stale file.
             if (!File.Exists(path)) return;
             if (File.GetLastWriteTimeUtc(path) >= cutoff.UtcDateTime) return;
-            var record = Path.Combine(stateDir, "agents", Path.GetFileNameWithoutExtension(path) + ".json");
+            var stem = Path.GetFileNameWithoutExtension(path);
+            if (isLive?.Invoke(stem) == true) return;
+            var record = Path.Combine(stateDir, "agents", stem + ".json");
             if (File.Exists(record)) return;
             File.Delete(path);
         } catch (OperationCanceledException) when (ct.IsCancellationRequested) {

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AgentOrchestratorJournalTests.cs
@@ -85,8 +85,8 @@ public class AgentOrchestratorJournalTests {
         await Assert.That(JournalFiles.ReadLines(existing.Path).Length).IsEqualTo(2); // its header plus the failed launch's header
     }
 
-    sealed class FailingAfterOpenFactory : IHostedAgentRuntimeFactory {
-        public string CliPath => "x"; public string Vendor => "cursor"; public bool SupportsUnattended => false;
+    sealed class FailingAfterOpenFactory(string vendor = "cursor") : IHostedAgentRuntimeFactory {
+        public string CliPath => "x"; public string Vendor => vendor; public bool SupportsUnattended => false;
         public TranscriptJournal? LastJournal { get; private set; }
         public bool IsAvailable() => true;
         public Task<HostedRuntimeStart> StartAsync(RuntimeStartContext ctx, CancellationToken ct) {
@@ -94,6 +94,30 @@ public class AgentOrchestratorJournalTests {
             ctx.Journal?.Open(ctx.Worktree.Path, ctx.Model);
             throw new InvalidOperationException("boom");
         }
+    }
+
+    [Test]
+    public async Task Failed_launch_completes_its_own_journal_when_the_id_collides_with_a_live_agent() {
+        using var repoPath = GitRepo.CreateWithCommit();
+        var server = new CaptureServerConnection();
+        var liveFactory = new OpeningAcpFactory();
+        var failingFactory = new FailingAfterOpenFactory("cursor-collide");
+        // No allowedRepoPath: BorrowAuthorizer compares the CANONICAL cwd against it, and the
+        // macOS temp root (/var, a symlink into /private) would fail that match against the raw path.
+        await using var orch = AgentOrchestratorHarness.BuildOrchestrator(server, new SpyPtyProcessFactory(), new Dictionary<string, IHostedAgentLauncher>(),
+            extraRuntimeFactories: [liveFactory, failingFactory]);
+
+        // A live agent already holds "agent-collide" when the second, doomed launch for the SAME
+        // id starts — the pre-publish failure below must not route through the live agent's
+        // CleanupAgentAsync teardown.
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-collide", repoPath));
+
+        await orch.HandleLaunchAgentForTest(AgentOrchestratorHarness.NewCursorLaunch("agent-collide", repoPath) with {
+            Vendor = failingFactory.Vendor, Borrowed = true, BorrowCwd = repoPath
+        });
+
+        await Assert.That(failingFactory.LastJournal!.Drained).IsTrue();
+        await Assert.That(orch.SnapshotAgentsForStatus().Single(a => a.Id == "agent-collide").Vendor).IsEqualTo("cursor");
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/TranscriptJournalSweepTests.cs
@@ -16,8 +16,8 @@ public class TranscriptJournalSweepTests {
     static void PidRecord(TempDir tmp, string agentId) =>
         tmp.CreateFile(["agents", AgentFileNames.For(agentId) + ".json"], "{}");
 
-    static TranscriptJournalSweep Sweep(TempDir tmp, TimeProvider time, JournalPathLocks? locks = null) =>
-        new(tmp.Path, time, NullLogger<TranscriptJournalSweep>.Instance, locks);
+    static TranscriptJournalSweep Sweep(TempDir tmp, TimeProvider time, JournalPathLocks? locks = null, Func<string, bool>? isLive = null) =>
+        new(tmp.Path, time, NullLogger<TranscriptJournalSweep>.Instance, locks, isLive);
 
     /// A fake clock only fires the timers that exist when it advances, and StartAsync returns before
     /// the hosted service has necessarily armed its own: advancing first drops the tick for a whole
@@ -51,6 +51,21 @@ public class TranscriptJournalSweepTests {
         await Assert.That(File.Exists(fresh)).IsTrue();
         await Assert.That(File.Exists(oldButLive)).IsTrue();
         await Assert.That(File.Exists(other)).IsTrue();
+    }
+
+    /// Antigravity spawns one child per turn, so its PID record can be absent BETWEEN turns while
+    /// the runtime + journal are still live — the id-live check must save the journal even with no
+    /// PID record on disk, not just alongside one.
+    [Test]
+    public async Task Skips_a_journal_whose_id_is_a_live_agent_even_without_a_pid_record() {
+        using var tmp = new TempDir();
+        var time = new FakeTimeProvider(Now);
+        var old  = Journal(tmp, "old-live", TimeSpan.FromDays(31));
+        var stem = AgentFileNames.For("old-live");
+
+        await Sweep(tmp, time, isLive: s => s == stem).RunOnceAsync(CancellationToken.None);
+
+        await Assert.That(File.Exists(old)).IsTrue();
     }
 
     [Test]


### PR DESCRIPTION
Closes #849 — AI-2674

## What & why

Two lifecycle edges in the daemon's envelope journal, each a leak rather than data loss but each breaking "completed exactly once per journal".

A pre-publish launch failure decided its cleanup on `_agents.ContainsKey(agentId)`, which only proves *some* agent holds that id. When a different, already-live incarnation held it, the failure routed through `CleanupAgentAsync` for that agent and left the failed launch's own journal parked (writer task and CTS alive for the daemon's lifetime). Cleanup now keys on a `published` flag set the instant the launch publishes its own agent, so a pre-publish failure always discards its own journal and never touches the live incarnation.

The 30-day sweep deleted a journal whenever the file was old and no PID record existed. Antigravity runs one child per turn, so its PID record is legitimately absent between turns while the runtime and journal are live; an idle month would delete the journal and fault the next append. The sweep now skips any stem a live agent hashes to, via a predicate the orchestrator supplies.

## Verification

- New tests: a failed launch colliding with a live same-id agent drains its own journal and leaves the live one untouched (failed pre-fix with the leak); the sweep keeps a 31-day-old journal with no PID record when its id is a live agent, and still deletes an old orphan when it is not.
- Targeted journal/sweep/orchestrator-journal suites green; daemon AOT publish clean.
