### PR TITLE
Diagnose and surface silently refused ACP permissions

### DIFF
--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -322,9 +322,11 @@ internal sealed partial class AcpInteractionBridge(
 
         AcpInteractionDecision decision;
 
-        // Payload-free lifecycle logging — kind + eventual decision ONLY, never the tool
-        // name/args/options content already captured above in interactionRequest.
+        // The lifecycle log stays payload-free (kind only); the options log is deliberately
+        // narrower than the full offer — ids/kinds only, never labels or tool name/args — so a
+        // server-side optionId echo mismatch is diagnosable from the daemon log alone.
         LogInteractionIssued(agentId, "permission");
+        LogPermissionOptionsOffered(agentId, FormatOptions(options));
         AcpMetrics.RecordBlockingRequest("permission");
 
         try {
@@ -353,7 +355,9 @@ internal sealed partial class AcpInteractionBridge(
             return CancelledResult();
         }
 
-        var mapped = MapPermissionDecision(decision, options);
+        var mapped  = MapPermissionDecision(decision, options);
+        var matched = decision.SelectedOptionId is { } sid && options.Any(o => o.OptionId == sid);
+        LogPermissionDecisionReceived(agentId, decision.Outcome, decision.SelectedOptionId ?? "(none)", matched);
         LogInteractionResolved(agentId, "permission", OutcomeLabel(mapped));
 
         return mapped;
@@ -820,15 +824,30 @@ internal sealed partial class AcpInteractionBridge(
     /// only <c>{toolCallId, title}</c> — therefore never matches a preset and keeps prompting.</summary>
     static string? TryGetToolKind(JsonElement toolCall)   => toolCall.Str("kind");
 
+    /// <summary>The offered options as <c>optionId:kind</c> pairs, e.g. <c>[allow-once:allow_once,
+    /// deny:reject_once]</c> — never <see cref="PermissionOptionDto.Name"/>, which is an
+    /// agent-supplied label, not a stable identifier.</summary>
+    static string FormatOptions(IReadOnlyList<PermissionOptionDto> options) =>
+        "[" + string.Join(", ", options.Select(o => $"{o.OptionId}:{o.Kind ?? "?"}")) + "]";
+
     // ── LoggerMessage source-generated methods ──────────────────────────────────────────────────
-    // Payload-free by construction: kind ("permission"/"elicitation") and decision
-    // ("selected"/"cancelled") ONLY — never tool name/args, prompt text, or option content.
+    // The lifecycle pair stays payload-free: kind ("permission"/"elicitation") and decision
+    // ("selected"/"cancelled") ONLY — never tool name/args, prompt text, or option content. The
+    // permission-only pair below is the deliberate exception: offered/received option identifiers
+    // ARE the diagnostic this exists for — a mismatched optionId fails safe to cancelled with
+    // nothing in the log to show why — so they're logged narrowly (ids/kinds, never labels).
 
     [LoggerMessage(Level = LogLevel.Information, Message = "ACP blocking request issued: agentId={AgentId} kind={Kind}")]
     partial void LogInteractionIssued(string agentId, string kind);
 
     [LoggerMessage(Level = LogLevel.Information, Message = "ACP blocking request resolved: agentId={AgentId} kind={Kind} decision={Decision}")]
     partial void LogInteractionResolved(string agentId, string kind, string decision);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP permission options offered: agentId={AgentId} options={Options}")]
+    partial void LogPermissionOptionsOffered(string agentId, string options);
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "ACP permission decision received: agentId={AgentId} outcome={Outcome} selectedOptionId={SelectedOptionId} matchedOfferedOption={Matched}")]
+    partial void LogPermissionDecisionReceived(string agentId, string outcome, string selectedOptionId, bool matched);
 
     // ── Unattended review-flow auto-approve audit ───────────────────────────────────────────────
     // Pinned fields only: agentId + the selected allow Kind, plus the tool title as EXPLICITLY

--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -828,7 +828,15 @@ internal sealed partial class AcpInteractionBridge(
     /// deny:reject_once]</c> — never <see cref="PermissionOptionDto.Name"/>, which is an
     /// agent-supplied label, not a stable identifier.</summary>
     static string FormatOptions(IReadOnlyList<PermissionOptionDto> options) =>
-        "[" + string.Join(", ", options.Select(o => $"{o.OptionId}:{o.Kind ?? "?"}")) + "]";
+        "[" + string.Join(", ", options.Select(o => $"{Clip(o.OptionId)}:{Clip(o.Kind ?? "?")}")) + "]";
+
+    /// The id and kind are agent-controlled, and the file logger writes a value verbatim: strip
+    /// control characters so a newline cannot inject a forged log line, and cap the length so a
+    /// hostile or buggy agent cannot flood the log.
+    static string Clip(string value) {
+        var stripped = new string(value.Where(c => !char.IsControl(c)).ToArray());
+        return stripped.Length <= 64 ? stripped : stripped[..64] + "…";
+    }
 
     // ── LoggerMessage source-generated methods ──────────────────────────────────────────────────
     // The lifecycle pair stays payload-free: kind ("permission"/"elicitation") and decision

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -1318,6 +1318,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 connection          = _installed.Connection;
             }
 
+            // Reset THIS turn's silent-permission-refusal signal (see the finally block below) —
+            // a prior turn's cancelled permission or assistant text must never leak into this one.
+            Volatile.Write(ref _turnHadAssistantOutput, 0);
+            Volatile.Write(ref _turnPermissionCancelled, 0);
+
             // Liveness-supervision spec §0/§1: the turn gate is genuinely held from here — a parked
             // (not-yet-entered) turn above never reaches this line, so TurnInFlight never flips true
             // for a turn that isn't really in flight yet.
@@ -1346,6 +1351,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 // skip-whole-replay nothing is ever re-emitted from replay, so the flushed partial
                 // run cannot be duplicated; it is the only copy of what the agent said before dying.
                 FlushOpenRun();
+
+                // A permission cancelled mid-turn with nothing else said leaves the chat looking
+                // idle rather than refused — say so once the turn is otherwise silent.
+                if (Volatile.Read(ref _turnPermissionCancelled) == 1 && Volatile.Read(ref _turnHadAssistantOutput) == 0)
+                    EmitSilentPermissionRefusalNote();
 
                 // However this turn ended — stopReason, fault, cancellation — it is settled, which
                 // disarms the first-output watchdog. Without this a turn that legitimately produced
@@ -1838,6 +1848,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         if (envelope.Kind is AcpEventKind.AssistantText or AcpEventKind.AssistantThinking
                           or AcpEventKind.ToolCall or AcpEventKind.ToolResult or AcpEventKind.Plan)
             Interlocked.Increment(ref _turnOutputEnvelopes);
+
+        // Narrower than the counter above (tool activity doesn't count): whether the AGENT SAID
+        // ANYTHING this turn, read by the turn-end silent-refusal check.
+        if (envelope.Kind is AcpEventKind.AssistantText or AcpEventKind.AssistantThinking)
+            Volatile.Write(ref _turnHadAssistantOutput, 1);
 
         lock (_aggregationLock) {
             if (_transcript.Reader.Count >= _transcriptCapacity) {
@@ -2465,6 +2480,17 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// difference across a silence window — the absolute value means nothing.</summary>
     long _turnOutputEnvelopes;
 
+    /// <summary>Set once THIS turn emits an assistant text/thinking envelope; reset per turn in
+    /// <see cref="ProcessAdmittedTurnAsync"/>. 0/1, not <see langword="bool"/>, so it can be
+    /// written from the connection's read loop and read from the turn worker without a lock.</summary>
+    int _turnHadAssistantOutput;
+
+    /// <summary>Set once a <c>session/request_permission</c> THIS turn resolves to the ACP
+    /// <c>cancelled</c> outcome — see <see cref="NotePermissionOutcome"/>. Paired with
+    /// <see cref="_turnHadAssistantOutput"/> at turn end to decide whether the refusal left the
+    /// chat with nothing to show.</summary>
+    int _turnPermissionCancelled;
+
     /// <summary>How long an interactive turn may produce nothing before the user is told. Long enough
     /// that an ordinary slow first token stays quiet (a rate-limited gemini backs off ~70s per
     /// attempt, so a shorter window would fire mid-wave on a turn that recovers).</summary>
@@ -2558,6 +2584,17 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             Seq: 0,
             Kind: AcpEventKind.SystemNote,
             Text: $"approval policy degraded: {firstDegradation}",
+            TimestampIso: NowIso()));
+
+    /// <summary>Tells the user why a turn ended with nothing to look at: its permission was
+    /// cancelled (see <see cref="NotePermissionOutcome"/>) and the agent never said anything
+    /// afterward — e.g. a vendor whose tool reports a rejection to itself but never turns that
+    /// into assistant text.</summary>
+    void EmitSilentPermissionRefusalNote() =>
+        EmitEnvelope(new AcpEventEnvelope(
+            Seq: 0,
+            Kind: AcpEventKind.SystemNote,
+            Text: "The tool call was not permitted; the turn ended.",
             TimestampIso: NowIso()));
 
     /// <summary>The §8 surfacing envelope — emitted after commit and settlement, before reopen,
@@ -2719,16 +2756,28 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     /// <summary>
     /// The state-derived interaction router — one per incarnation, installed at spawn, never
-    /// swapped. Phase one, under the reconnect lock: (installed ∧ Running) or immediate decline,
-    /// and — when admitted — atomic registration in the pending registry. Phase two, outside the
-    /// lock: a lock-acquired may-start re-check (a filter, not an atomicity claim — the
-    /// post-check/pre-invoke window's contract is surfaced-then-cancelled), then the real bridge
-    /// under the entry's token, RACED against the sweep's bookkeeping signal so a blocked foreign
-    /// cancellation callback can never strand the response or the entry's removal (r5–r8).
-    /// Exactly one response per request is the connection layer's own guarantee; the entry's claim
-    /// decides real-vs-cancelled.
+    /// swapped. Wraps <see cref="RouteServerRequestCoreAsync"/> to also observe the response this
+    /// runtime writes back for a <c>session/request_permission</c> (see
+    /// <see cref="NotePermissionOutcome"/>) — every return path (declined or bridged) funnels
+    /// through here, so nothing that answers the agent goes unobserved.
     /// </summary>
     async Task<JsonElement?> RouteServerRequestAsync(long incarnationId, AcpRequest request, CancellationToken ct) {
+        var response = await RouteServerRequestCoreAsync(incarnationId, request, ct).ConfigureAwait(false);
+        NotePermissionOutcome(request.Method, response);
+
+        return response;
+    }
+
+    /// <summary>
+    /// Phase one, under the reconnect lock: (installed ∧ Running) or immediate decline, and — when
+    /// admitted — atomic registration in the pending registry. Phase two, outside the lock: a
+    /// lock-acquired may-start re-check (a filter, not an atomicity claim — the post-check/pre-invoke
+    /// window's contract is surfaced-then-cancelled), then the real bridge under the entry's token,
+    /// RACED against the sweep's bookkeeping signal so a blocked foreign cancellation callback can
+    /// never strand the response or the entry's removal (r5–r8). Exactly one response per request is
+    /// the connection layer's own guarantee; the entry's claim decides real-vs-cancelled.
+    /// </summary>
+    async Task<JsonElement?> RouteServerRequestCoreAsync(long incarnationId, AcpRequest request, CancellationToken ct) {
         PendingInteraction entry;
 
         lock (_reconnectLock) {
@@ -2771,6 +2820,25 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             // left to the GC is the documented cost of never severing that path.
             lock (_reconnectLock) _pendingInteractions.Remove(entry);
         }
+    }
+
+    /// <summary>Marks THIS turn's <see cref="_turnPermissionCancelled"/> from the ACP response this
+    /// runtime is about to write back for a <c>session/request_permission</c> — whether it came from
+    /// the real bridge or <see cref="DeclineFor"/>, both answer in the same
+    /// <c>{"outcome":{"outcome":...}}</c> shape. Keyed on the wire outcome, not
+    /// <see cref="AcpInteractionDecision"/>: a <c>cancelled</c> response is what the bridge produces
+    /// BOTH for a genuine cancellation and for its own fail-closed case (an affirmative decision whose
+    /// <c>optionId</c> matched no offered option) — either way the agent was told no, which is the
+    /// fact this note exists to surface. A <c>selected</c> reject is not counted
+    /// here: the agent already knows, from the option it offered, that this call was refused.</summary>
+    void NotePermissionOutcome(string method, JsonElement? response) {
+        if (method != "session/request_permission" || response is not { } result)
+            return;
+
+        if (result.TryGetProperty("outcome", out var wrapped)
+         && wrapped.TryGetProperty("outcome", out var label)
+         && label.GetString() == "cancelled")
+            Volatile.Write(ref _turnPermissionCancelled, 1);
     }
 
     /// <summary>Each method declines in ITS OWN protocol's result shape — the stabilized

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -1337,8 +1337,15 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
             using var silenceNotice = ArmTurnSilenceNotice(turn);
 
+            // Only a turn that reaches its stopReason emits the silent-refusal note below. A fault
+            // (caught) or a cancellation (propagates past the catch) leaves this false, so a transport
+            // drop — whose reconnect sweep answers the pending permission with a cancelled decline —
+            // never renders as a user-facing "not permitted" note.
+            var completedNormally = false;
+
             try {
                 await SendPromptAsync(connection, turn, ct).ConfigureAwait(false);
+                completedNormally = true;
             } catch (Exception ex) when (ex is not OperationCanceledException) {
                 // Only reachable once write entry succeeded: faulting the ack is correct for
                 // `entered` and a structural no-op for `written` (the TCS already resolved at
@@ -1352,9 +1359,12 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 // run cannot be duplicated; it is the only copy of what the agent said before dying.
                 FlushOpenRun();
 
-                // A permission cancelled mid-turn with nothing else said leaves the chat looking
-                // idle rather than refused — say so once the turn is otherwise silent.
-                if (Volatile.Read(ref _turnPermissionCancelled) == 1 && Volatile.Read(ref _turnHadAssistantOutput) == 0)
+                // A permission refused mid-turn with nothing else said leaves the chat looking idle
+                // rather than refused — say so, but only for a turn that ran to its stopReason, so a
+                // teardown/transport-drop cancellation cannot forge a refusal the user never made.
+                if (completedNormally
+                    && Volatile.Read(ref _turnPermissionCancelled) == 1
+                    && Volatile.Read(ref _turnHadAssistantOutput) == 0)
                     EmitSilentPermissionRefusalNote();
 
                 // However this turn ended — stopReason, fault, cancellation — it is settled, which
@@ -2769,13 +2779,13 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     }
 
     /// <summary>
-    /// Phase one, under the reconnect lock: (installed ∧ Running) or immediate decline, and — when
-    /// admitted — atomic registration in the pending registry. Phase two, outside the lock: a
-    /// lock-acquired may-start re-check (a filter, not an atomicity claim — the post-check/pre-invoke
-    /// window's contract is surfaced-then-cancelled), then the real bridge under the entry's token,
-    /// RACED against the sweep's bookkeeping signal so a blocked foreign cancellation callback can
-    /// never strand the response or the entry's removal (r5–r8). Exactly one response per request is
-    /// the connection layer's own guarantee; the entry's claim decides real-vs-cancelled.
+    /// Under the reconnect lock: admit only while (installed ∧ Running), else decline immediately,
+    /// and on admission register the request atomically in the pending registry. Then, outside the
+    /// lock: a may-start re-check (a filter, not an atomicity claim — the post-check/pre-invoke window
+    /// resolves to surfaced-then-cancelled), then the real bridge under the entry's token, raced
+    /// against the sweep's bookkeeping signal so a blocked foreign cancellation callback can never
+    /// strand the response or the entry's removal. Exactly one response per request is the connection
+    /// layer's own guarantee; the entry's claim decides real-vs-cancelled.
     /// </summary>
     async Task<JsonElement?> RouteServerRequestCoreAsync(long incarnationId, AcpRequest request, CancellationToken ct) {
         PendingInteraction entry;

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -703,11 +703,8 @@ public class AcpInteractionBridgeTests {
         var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
         var result  = await bridge.HandleAsync(request, CancellationToken.None);
 
-        // The mapped ACP result still fails closed to cancelled...
         await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
 
-        // ...but the daemon log now shows exactly why: the raw decision that arrived, and that it
-        // didn't match anything this request offered.
         var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
         await Assert.That(infoEntries).Contains(e =>
             e.Message.Contains("decision received")

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -663,10 +663,73 @@ public class AcpInteractionBridgeTests {
         await Assert.That(infoEntries).Contains(e => e.Message.Contains("issued") && e.Message.Contains("permission"));
         await Assert.That(infoEntries).Contains(e => e.Message.Contains("resolved") && e.Message.Contains("permission") && e.Message.Contains("selected"));
 
-        // Payload-free: the tool title ("Run ls") and the chosen optionId ("allow-once") must never
-        // leak into these Info logs, even though "allow-once" happens to also be a log-safe kind
-        // token elsewhere — check the actual tool content, not option ids.
+        // The tool title ("Run ls") must never leak into these Info logs — option ids/kinds ARE
+        // deliberately logged elsewhere (see the "offered options"/"decision received" tests below),
+        // but tool identity/content never is.
         await Assert.That(infoEntries).DoesNotContain(e => e.Message.Contains("Run ls"));
+    }
+
+    [Test]
+    public async Task RequestPermission_Issued_LogsOfferedOptionIdsAndKinds() {
+        var logger = new CaptureLogger();
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", "allow-once", "Allow", null, null, null)),
+            agentId: AgentId,
+            logger: logger);
+
+        var request = new AcpRequest(1, "session/request_permission", KindedPermissionParams(("allow-once", "allow_once"), ("deny", "reject_once")));
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).Contains(e =>
+            e.Message.Contains("options offered") && e.Message.Contains("allow-once:allow_once") && e.Message.Contains("deny:reject_once"));
+    }
+
+    /// <summary>
+    /// The undiagnosable case: the server resolves an AFFIRMATIVE decision (the human really did
+    /// approve it) but with a <see cref="AcpInteractionDecision.SelectedOptionId"/> that matches none
+    /// of the options THIS request offered — <c>MapPermissionDecision</c> fails closed to
+    /// `cancelled`. The resolve log must carry the raw outcome/selectedOptionId and say plainly that
+    /// it did not match, so this exact mismatch is diagnosable from the daemon log alone.
+    /// </summary>
+    [Test]
+    public async Task RequestPermission_ResolvedOptionIdDoesNotMatchOffered_LogsOutcomeAndMismatch() {
+        var logger = new CaptureLogger();
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", "some-other-id", "Allow", null, null, null)),
+            agentId: AgentId,
+            logger: logger);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+        var result  = await bridge.HandleAsync(request, CancellationToken.None);
+
+        // The mapped ACP result still fails closed to cancelled...
+        await Assert.That(result!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("cancelled");
+
+        // ...but the daemon log now shows exactly why: the raw decision that arrived, and that it
+        // didn't match anything this request offered.
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).Contains(e =>
+            e.Message.Contains("decision received")
+         && e.Message.Contains("outcome=allow")
+         && e.Message.Contains("selectedOptionId=some-other-id")
+         && e.Message.Contains("matchedOfferedOption=False"));
+    }
+
+    [Test]
+    public async Task RequestPermission_ResolvedOptionIdMatchesOffered_LogsMatchedTrue() {
+        var logger = new CaptureLogger();
+        var bridge = new AcpInteractionBridge(
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", "allow-once", "Allow", null, null, null)),
+            agentId: AgentId,
+            logger: logger);
+
+        var request = new AcpRequest(1, "session/request_permission", PermissionRequestParams(["allow-once", "deny"]));
+        await bridge.HandleAsync(request, CancellationToken.None);
+
+        var infoEntries = logger.Entries.Where(e => e.Level == LogLevel.Information).ToList();
+        await Assert.That(infoEntries).Contains(e =>
+            e.Message.Contains("decision received") && e.Message.Contains("matchedOfferedOption=True"));
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimePermissionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimePermissionTests.cs
@@ -291,8 +291,6 @@ public class AcpHostedAgentRuntimePermissionTests {
         await fake.DisposeAsync();
     }
 
-    // ── No blank chat after a cancelled permission with no assistant output ─────────────────────
-
     static async Task<AcpEventEnvelope?> WaitForEnvelopeAsync(
             AcpHostedAgentRuntime runtime, Func<AcpEventEnvelope, bool> predicate,
             List<AcpEventEnvelope>? seen = null, TimeSpan? timeout = null) {
@@ -352,6 +350,46 @@ public class AcpHostedAgentRuntimePermissionTests {
         await Assert.That(note!.Value.Text).IsEqualTo("The tool call was not permitted; the turn ended.");
 
         cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Negative control: a cancelled permission whose turn never reaches its stopReason —
+    /// the transport drops and its reconnect sweep declines the pending request. The note is only for
+    /// a turn that ended normally, so a teardown-driven cancellation must not forge a refusal.</summary>
+    [Test]
+    public async Task PermissionCancelled_ButTransportDropsBeforeStopReason_EmitsNoSystemNote() {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+
+        var runtime = new AcpHostedAgentRuntime(
+            conn,
+            process,
+            NullLogger.Instance,
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("cancel", null, null, null, null, null)));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run rm -rf /"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]""");
+        // No stopReason enqueued: after the permission is declined the prompt never completes, so the
+        // turn ends only when the transport below drops it — the exact case that must not emit a note.
+
+        _ = runtime.SendUserInputAsync("do it");
+
+        var seen = new List<AcpEventEnvelope>();
+        await Task.Delay(300); // let the permission be issued and declined so the cancelled flag is set
+        cts.Cancel();          // drop the fake agent → transport ends → the pending turn is cancelled
+        await WaitForEnvelopeAsync(runtime, _ => false, seen, timeout: TimeSpan.FromMilliseconds(600));
+
+        await Assert.That(seen).DoesNotContain(e => e.Kind == AcpEventKind.SystemNote);
+
         try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
         await runtime.DisposeAsync();
         await fake.DisposeAsync();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimePermissionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimePermissionTests.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
@@ -283,6 +284,158 @@ public class AcpHostedAgentRuntimePermissionTests {
         await Assert.That(captured).IsNotNull();
         await Assert.That(captured!.Value.AcpSessionId).IsEqualTo(FakeAcpAgent.FixedSessionId);
         await Assert.That(captured.Value.AcpSessionId).IsNotEmpty();
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    // ── No blank chat after a cancelled permission with no assistant output ─────────────────────
+
+    static async Task<AcpEventEnvelope?> WaitForEnvelopeAsync(
+            AcpHostedAgentRuntime runtime, Func<AcpEventEnvelope, bool> predicate,
+            List<AcpEventEnvelope>? seen = null, TimeSpan? timeout = null) {
+        var deadline = DateTime.UtcNow + (timeout ?? HangGuard);
+
+        while (DateTime.UtcNow < deadline) {
+            while (runtime.Envelopes.TryRead(out var envelope)) {
+                seen?.Add(envelope);
+                if (predicate(envelope))
+                    return envelope;
+            }
+
+            await Task.Delay(10);
+        }
+
+        return null;
+    }
+
+    /// <summary>
+    /// The reported failure end-to-end: a turn's permission request resolves to the ACP `cancelled`
+    /// outcome (exactly what a mismatched server-side optionId echo fails closed to — see
+    /// <c>AcpInteractionBridgeTests.RequestPermission_ResolvedOptionIdDoesNotMatchOffered_LogsOutcomeAndMismatch</c>),
+    /// and the turn's scripted response carries no agent_message_chunk at all — the "Copilot's tool
+    /// returned a rejection but the turn just ends" shape. The runtime must emit a system_note so the
+    /// transcript says why, instead of leaving the chat looking idle.
+    /// </summary>
+    [Test]
+    public async Task PermissionCancelled_NoAssistantOutput_TurnEndEmitsSystemNote() {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+
+        var runtime = new AcpHostedAgentRuntime(
+            conn,
+            process,
+            NullLogger.Instance,
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("cancel", null, null, null, null, null)));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run rm -rf /"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]""");
+
+        // No updates at all — the turn ends on stopReason alone, exactly like a vendor that reports
+        // the rejection to itself but never turns it into assistant text.
+        fake.EnqueuePromptScript([], JsonDocument.Parse("""{"stopReason":"end_turn"}""").RootElement.Clone());
+
+        await runtime.SendUserInputAsync("do it").WaitAsync(HangGuard);
+
+        var note = await WaitForEnvelopeAsync(runtime, e => e.Kind == AcpEventKind.SystemNote);
+
+        await Assert.That(note).IsNotNull();
+        await Assert.That(note!.Value.Text).IsEqualTo("The tool call was not permitted; the turn ended.");
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Negative control: the SAME cancelled permission, but the agent goes on to say
+    /// something before ending the turn. No system_note — the chat already shows why the turn
+    /// ended, so a second, daemon-synthesized note would be redundant noise.</summary>
+    [Test]
+    public async Task PermissionCancelled_WithAssistantOutput_TurnEndEmitsNoSystemNote() {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+
+        var runtime = new AcpHostedAgentRuntime(
+            conn,
+            process,
+            NullLogger.Instance,
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("cancel", null, null, null, null, null)));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run rm -rf /"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"},{"optionId":"deny","name":"Deny","kind":"reject_once"}]""");
+
+        fake.EnqueuePromptScript(
+            [FakeAcpAgent.DefaultAgentMessageChunkUpdate(FakeAcpAgent.FixedSessionId, "I can't run that.")],
+            JsonDocument.Parse("""{"stopReason":"end_turn"}""").RootElement.Clone());
+
+        await runtime.SendUserInputAsync("do it").WaitAsync(HangGuard);
+
+        var seen = new List<AcpEventEnvelope>();
+        var text = await WaitForEnvelopeAsync(runtime, e => e.Kind == AcpEventKind.AssistantText, seen);
+
+        await Assert.That(text).IsNotNull();
+        await Assert.That(seen).DoesNotContain(e => e.Kind == AcpEventKind.SystemNote);
+
+        cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>Negative control: an ALLOWED permission with no assistant output must not be
+    /// mistaken for a refusal — the note is keyed on the cancelled outcome, never on silence
+    /// alone.</summary>
+    [Test]
+    public async Task PermissionAllowed_NoAssistantOutput_TurnEndEmitsNoSystemNote() {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+
+        var runtime = new AcpHostedAgentRuntime(
+            conn,
+            process,
+            NullLogger.Instance,
+            requestInteraction: (req, ct) => Task.FromResult(new AcpInteractionDecision("allow", "allow-once", "Allow", null, null, null)));
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run ls"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]""");
+
+        fake.EnqueuePromptScript([], JsonDocument.Parse("""{"stopReason":"end_turn"}""").RootElement.Clone());
+
+        await runtime.SendUserInputAsync("run ls").WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (fake.LastServerRequestResponse is null && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(fake.LastServerRequestResponse!.Value.GetProperty("outcome").GetProperty("outcome").GetString()).IsEqualTo("selected");
+
+        var seen = new List<AcpEventEnvelope>();
+        await WaitForEnvelopeAsync(runtime, _ => false, seen, timeout: TimeSpan.FromMilliseconds(500));
+
+        await Assert.That(seen).DoesNotContain(e => e.Kind == AcpEventKind.SystemNote);
 
         cts.Cancel();
         try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }


### PR DESCRIPTION
Closes #851 — AI-2677

## What & why

Launching Copilot from the desktop app, a permission approved in the web UI resolved as `cancelled`, the tool returned "The user rejected this tool call", and the turn ended with nothing in the chat. `AcpInteractionBridge.MapPermissionDecision` is fail-closed: an affirmative outcome maps to allow only when its `SelectedOptionId` matches an option the agent offered; anything else is `cancelled`. The daemon logged neither the offered ids nor the received decision, so the mismatch was invisible, and a refused turn left the chat blank.

Two kcap-cli changes: the bridge now logs the offered options as `optionId:kind` pairs when a request is issued and the received `(outcome, selectedOptionId, matched)` when it resolves, so an id echoed back that matches nothing offered shows `matched=false` in the daemon log. And an ACP turn that ends after a permission is cancelled with no assistant output emits a system note ("The tool call was not permitted; the turn ended.") so the chat shows why it stopped.

Not in scope (cross-repo): the actual root cause is the kcap-server web UI permission card echoing back a different `optionId` than Copilot offered. This PR makes that failure diagnosable and stops the blank chat; the card itself is a separate kcap-server fix.

## Where to look

The offered/received option ids are the one deliberately non-payload-free permission log — they are the diagnostic this exists for — logged narrowly (ids and kinds, never labels or tool args). The turn-end note keys on the ACP `cancelled` response shape, which covers both a genuine cancel and the fail-closed mismatch.

## Verification

- New bridge tests (offered ids logged; a non-matching selectedOptionId logs `matched=false`, reproducing the Copilot shape; a matching id logs `matched=true`) and runtime tests (cancelled + no assistant output emits the note; with assistant output or an allow, no note). TDD sanity check confirmed the runtime test fails without the emission.
- ACP bridge + runtime suites green; daemon AOT publish clean.
