### PR TITLE
Emit a queued ACP prompt's user_message row at enqueue

### DIFF
--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -116,7 +116,6 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     bool         _incidentResendSentence;
     InFlightTurn? _inFlight;
     PendingTurn?  _heldTurn;
-    bool          _heldTurnSkipEnvelope;
     CancellationTokenSource? _ownerCts;
     Task          _ownerTask = Task.CompletedTask;
 
@@ -1201,7 +1200,14 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
             var closed = new InputNotAdmittedException("ACP runtime is terminal; this input was not queued.");
             if (written is null) throw closed;
             written.TrySetException(closed);
+            return written.Task;
         }
+
+        // Emit the user's message the moment the turn is accepted onto the queue, so a prompt queued
+        // behind an in-flight turn shows in send order immediately instead of only when the worker
+        // dequeues it. A held turn re-admitted after a reconnect is re-processed without
+        // re-enqueueing, so this is the single emit per turn — the worker's admission path emits none.
+        EmitEnvelope(AcpEventTranslator.BuildUserMessage(seq: 0, NowIso(), text));
         return written?.Task ?? Task.CompletedTask;
     }
 
@@ -1218,16 +1224,13 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         try {
             while (true) {
                 PendingTurn turn;
-                var skipEnvelope = false;
 
-                // The held-turn slot outranks the queue (reconnect spec §6.4 ordering: held turn
-                // first, then queued turns). At most one turn can be held: the worker is
-                // single-flight, so only one turn is ever past dequeue.
+                // The held-turn slot outranks the queue: a turn parked during reconnect is
+                // re-admitted before any newer queued turn. At most one turn is ever held — the
+                // worker is single-flight, so only one turn is past dequeue at a time.
                 if (_heldTurn is { } held) {
-                    turn                  = held;
-                    skipEnvelope          = _heldTurnSkipEnvelope;
-                    _heldTurn             = null;
-                    _heldTurnSkipEnvelope = false;
+                    turn      = held;
+                    _heldTurn = null;
                 } else {
                     if (!await _pendingTurns.Reader.WaitToReadAsync(ct).ConfigureAwait(false))
                         break; // channel completed — shutdown
@@ -1236,12 +1239,10 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                         continue;
                 }
 
-                // Pre-gate admission (reconnect spec §5.3): the park-or-register decision and —
-                // when admitted — the UserMessage envelope emission share ONE critical section
-                // under the reconnect lock (the aggregation lock nests inside, §5.1), so a crash
-                // snapshot can never observe a registered turn with indeterminate envelope state,
-                // and a turn dequeued after the gate closed parks instead of being sent at a dead
-                // incarnation. Parking holds no gate.
+                // Pre-gate admission: decide park-or-register under the reconnect lock. This turn's
+                // UserMessage row was already emitted at accept time (EnqueueTurn), so admission only
+                // registers the in-flight turn or parks it — a turn dequeued after the gate closed
+                // parks instead of being sent at a dead incarnation. Parking holds no gate.
                 Task? reopen   = null;
                 var   terminal = false;
 
@@ -1249,13 +1250,10 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                     if (Phase == RuntimePhase.Terminal) {
                         terminal = true;
                     } else if (Phase == RuntimePhase.Reconnecting) {
-                        _heldTurn             = turn;
-                        _heldTurnSkipEnvelope = skipEnvelope;
-                        reopen                = _gateOpen.Task;
+                        _heldTurn = turn;
+                        reopen    = _gateOpen.Task;
                     } else {
                         _inFlight = new InFlightTurn(turn, _installed.Id);
-                        if (!skipEnvelope)
-                            EmitEnvelope(AcpEventTranslator.BuildUserMessage(seq: 0, NowIso(), turn.Text));
                     }
                 }
 
@@ -1283,7 +1281,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
 
     /// <summary>
     /// Processes exactly one ADMITTED prompt turn (its <c>UserMessage</c> envelope was already
-    /// emitted inside the pre-gate admission critical section — reconnect spec §5.3): (a) performs
+    /// emitted at accept time in <see cref="EnqueueTurn"/>): (a) performs
     /// the write-entry transition (or parks on refusal); (b) sends <c>session/prompt</c> and awaits
     /// its <c>stopReason</c> response (reusing <see cref="SendPromptAsync"/>); (c) performs this
     /// turn's end-of-turn flush of the aggregation buffer in a <c>finally</c> — this runs whether
@@ -1296,21 +1294,21 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     async Task ProcessAdmittedTurnAsync(PendingTurn turn, CancellationToken ct) {
         await _turnExecutionGate.WaitAsync(ct).ConfigureAwait(false);
         try {
-            // Write entry (reconnect spec §5.3, `TryEnterWrite`): re-check `Reconnecting` and
-            // advance `not-started → entered` atomically, INSIDE the turn-execution gate,
-            // immediately before the send. A refusal parks the turn with its envelope already in
-            // the transcript (skip-user-envelope) and NEVER faults the ack — the failed write
-            // entry is what guarantees this turn's bytes never reached any incarnation, the race
-            // an installed-id check alone cannot close because no swap has happened yet. The park
-            // path returns through this method's finally, releasing the gate BEFORE the worker
-            // awaits reopen, which is what keeps the owner's settlement wait deadlock-free.
+            // Write entry (`TryEnterWrite`): re-check `Reconnecting` and advance
+            // `not-started → entered` atomically, INSIDE the turn-execution gate, immediately before
+            // the send. A refusal parks the turn — its UserMessage row is already in the transcript
+            // (emitted at accept time) and its re-admission never re-enqueues, so the row is not
+            // duplicated — and NEVER faults the ack: the failed write entry is what guarantees this
+            // turn's bytes never reached any incarnation, the race an installed-id check alone cannot
+            // close because no swap has happened yet. The park path returns through this method's
+            // finally, releasing the gate BEFORE the worker awaits reopen, which is what keeps the
+            // owner's settlement wait deadlock-free.
             AcpConnection connection;
 
             lock (_reconnectLock) {
                 if (Phase != RuntimePhase.Running || _inFlight is not { } inFlight || !ReferenceEquals(inFlight.Turn, turn)) {
-                    _heldTurn             = turn;
-                    _heldTurnSkipEnvelope = true;
-                    _inFlight             = null;
+                    _heldTurn = turn;
+                    _inFlight = null;
                     return;
                 }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -267,6 +267,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// </summary>
     readonly object _aggregationLock = new();
 
+    /// Serializes <see cref="EnqueueTurn"/> so a turn's user-message emit, its capacity check, and its
+    /// write to <see cref="_pendingTurns"/> are one atomic step: concurrent senders cannot both pass a
+    /// stale count and have one write silently dropped, and the emit always precedes the write.
+    readonly object _enqueueLock = new();
+
     AcpUpdateKind?  _openRunKind;
     StringBuilder?  _openRunText;
 
@@ -1183,31 +1188,40 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         var written = acknowledgeWrite
             ? new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously)
             : null;
-        if (_pendingTurns.Reader.Count >= _pendingTurnsCapacity) {
-            var dropped = Interlocked.Increment(ref _droppedPendingTurns);
-            _logger.LogWarning(
-                "ACP: pending-turns queue full (capacity={Capacity}) — dropping this input; {DroppedCount} dropped this session so far (the turn worker is likely stuck on a stalled turn).",
-                _pendingTurnsCapacity, dropped);
+        // The capacity check, the user-message emit, and the write are one critical section. The
+        // emit precedes the write, so the worker — which cannot see the turn until it is written —
+        // never sends a prompt whose user row is not yet recorded (the row shows in send order the
+        // moment the turn is accepted, even queued behind an in-flight one). And because no
+        // concurrent sender can fill the queue between the check and the write under this lock, the
+        // write cannot be DropWrite-dropped, so a row is never left for a turn that never queued. A
+        // held turn re-admitted after a reconnect is re-processed without re-enqueueing, so this is
+        // the single emit per turn — the worker's admission path emits none.
+        lock (_enqueueLock) {
+            if (_pendingTurns.Reader.Count >= _pendingTurnsCapacity) {
+                var dropped = Interlocked.Increment(ref _droppedPendingTurns);
+                _logger.LogWarning(
+                    "ACP: pending-turns queue full (capacity={Capacity}) — dropping this input; {DroppedCount} dropped this session so far (the turn worker is likely stuck on a stalled turn).",
+                    _pendingTurnsCapacity, dropped);
 
-            var full = new InputNotAdmittedException("ACP pending-turns queue is full.");
-            if (written is null) throw full;
-            written.TrySetException(full);
-            return written.Task;
+                var full = new InputNotAdmittedException("ACP pending-turns queue is full.");
+                if (written is null) throw full;
+                written.TrySetException(full);
+                return written.Task;
+            }
+
+            EmitEnvelope(AcpEventTranslator.BuildUserMessage(seq: 0, NowIso(), text));
+
+            if (!_pendingTurns.Writer.TryWrite(new PendingTurn(text, written))) {
+                // The channel was completed (the runtime went terminal) — the only way a not-full
+                // write fails. Rare, and the row above is harmless on a transcript that is ending;
+                // fault the caller so it is not left awaiting a turn that will never run.
+                _logger.LogDebug("ACP: dropped a prompt turn — pending-turns channel already completed.");
+                var closed = new InputNotAdmittedException("ACP runtime is terminal; this input was not queued.");
+                if (written is null) throw closed;
+                written.TrySetException(closed);
+            }
         }
 
-        if (!_pendingTurns.Writer.TryWrite(new PendingTurn(text, written))) {
-            _logger.LogDebug("ACP: dropped a prompt turn — pending-turns channel already completed.");
-            var closed = new InputNotAdmittedException("ACP runtime is terminal; this input was not queued.");
-            if (written is null) throw closed;
-            written.TrySetException(closed);
-            return written.Task;
-        }
-
-        // Emit the user's message the moment the turn is accepted onto the queue, so a prompt queued
-        // behind an in-flight turn shows in send order immediately instead of only when the worker
-        // dequeues it. A held turn re-admitted after a reconnect is re-processed without
-        // re-enqueueing, so this is the single emit per turn — the worker's admission path emits none.
-        EmitEnvelope(AcpEventTranslator.BuildUserMessage(seq: 0, NowIso(), text));
         return written?.Task ?? Task.CompletedTask;
     }
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntime.cs
@@ -1209,7 +1209,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
                 return written.Task;
             }
 
-            EmitEnvelope(AcpEventTranslator.BuildUserMessage(seq: 0, NowIso(), text));
+            EmitEnvelope(AcpEventTranslator.BuildUserMessage(seq: 0, NowIso(), text), advanceActivity: false);
 
             if (!_pendingTurns.Writer.TryWrite(new PendingTurn(text, written))) {
                 // The channel was completed (the runtime went terminal) — the only way a not-full
@@ -1828,7 +1828,7 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
     /// relying on <c>TryWrite</c>'s return value, which is <see langword="true"/> for BOTH a normal
     /// write and a drop-and-evict write under this FullMode — it cannot distinguish the two.
     /// </summary>
-    void EmitEnvelope(AcpEventEnvelope envelope) {
+    void EmitEnvelope(AcpEventEnvelope envelope, bool advanceActivity = true) {
         // Liveness-supervision spec §1: advance BEFORE the channel write below, never after — a
         // reader blocked on Envelopes.ReadAsync can wake and run the instant TryWrite makes the item
         // visible, on another thread, with no ordering relationship to whatever this thread does
@@ -1841,8 +1841,11 @@ internal sealed partial class AcpHostedAgentRuntime : IHostedAgentRuntime, IAcpT
         // admitted — session_info_update/usage_update reach here with no turn in flight at all (see
         // AggregateUpdate's standalone-emit case). Advance even on the dropped-because-completed path
         // below: the content was genuinely produced, and by the time the channel is completed nothing
-        // downstream is reading idle state for this agent anyway.
-        ActivityClock?.Advance();
+        // downstream is reading idle state for this agent anyway. The one exception is the accept-time
+        // user row (advanceActivity: false): a prompt queued behind an in-flight turn is the person's
+        // input, not that turn's progress, so advancing here would reset a stalled turn's idle timer
+        // every time the user queues another prompt and let a wedged reviewer dodge the turn-wedge reap.
+        if (advanceActivity) ActivityClock?.Advance();
 
         // Named positively, so a metadata kind added later cannot count as the agent speaking by
         // accident: usage and session-info envelopes reach here with no turn in flight at all, and a

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpTranscriptAggregationTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpTranscriptAggregationTests.cs
@@ -285,14 +285,17 @@ public class AcpTranscriptAggregationTests {
         var e3 = await ReadEnvelopeAsync(h.Runtime);
         var e4 = await ReadEnvelopeAsync(h.Runtime);
 
+        // Both user rows are emitted at accept time, so the queued turn's row lands the moment it is
+        // sent — while turn 1 is still held — ahead of turn 1's flushed reply. Each turn's assistant
+        // run still flushes as its own uncontaminated envelope, in turn order.
         await Assert.That(e1.Kind).IsEqualTo(AcpEventKind.UserMessage);
         await Assert.That(e1.Text).IsEqualTo("first");
 
-        await Assert.That(e2.Kind).IsEqualTo(AcpEventKind.AssistantText);
-        await Assert.That(e2.Text).IsEqualTo("turn one reply"); // NOT contaminated with turn 2's text
+        await Assert.That(e2.Kind).IsEqualTo(AcpEventKind.UserMessage);
+        await Assert.That(e2.Text).IsEqualTo("second");
 
-        await Assert.That(e3.Kind).IsEqualTo(AcpEventKind.UserMessage);
-        await Assert.That(e3.Text).IsEqualTo("second");
+        await Assert.That(e3.Kind).IsEqualTo(AcpEventKind.AssistantText);
+        await Assert.That(e3.Text).IsEqualTo("turn one reply"); // NOT contaminated with turn 2's text
 
         await Assert.That(e4.Kind).IsEqualTo(AcpEventKind.AssistantText);
         await Assert.That(e4.Text).IsEqualTo("turn two reply"); // NOT contaminated with turn 1's text

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimePermissionTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimePermissionTests.cs
@@ -3,6 +3,7 @@ using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Capacitor.Cli.Daemon.Tests.Unit.Acp;
 using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
@@ -118,6 +119,51 @@ public class AcpHostedAgentRuntimePermissionTests {
         await Assert.That(fake.LastServerRequestError!.Value.GetProperty("code").GetInt32()).IsEqualTo(-32601);
 
         cts.Cancel();
+        try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
+        await runtime.DisposeAsync();
+        await fake.DisposeAsync();
+    }
+
+    /// <summary>A prompt queued behind an in-flight turn records its user row at accept time (that is
+    /// the point of showing queued input immediately), but that row is the person's input, not the
+    /// active turn's progress — so it must not advance the activity clock, or queuing input while a
+    /// turn is wedged would keep resetting its idle timer and let it dodge the turn-wedge reap.</summary>
+    [Test]
+    public async Task Queued_prompt_records_its_row_without_advancing_the_activity_clock() {
+        var fake    = new FakeAcpAgent();
+        var conn    = new AcpConnection(fake.ClientWriteStream, fake.ClientReadStream, NullLogger.Instance);
+        var process = new FakeAcpProcess();
+        var gate    = new TaskCompletionSource<AcpInteractionDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        var runtime = new AcpHostedAgentRuntime(
+            conn, process, NullLogger.Instance, requestInteraction: (req, ct) => gate.Task) {
+            ActivityClock = new AgentActivityClock(new FakeTimeProvider())
+        };
+
+        using var cts = new CancellationTokenSource();
+        var fakeRunTask = fake.RunAsync(cts.Token);
+        await runtime.StartAsync("/abs/worktree", "", cts.Token).WaitAsync(HangGuard);
+
+        // Turn 1 stalls on a permission that never resolves: it stays in flight and produces no output.
+        fake.EnqueuePermissionRequestDuringNextPrompt(
+            toolCallJson: """{"toolCallId":"call-1","title":"Run ls"}""",
+            optionsJson: """[{"optionId":"allow-once","name":"Allow","kind":"allow_once"}]""");
+        await runtime.SendUserInputAsync("first").WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (!fake.SentServerRequests.Any(r => r.Method == "session/request_permission") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+
+        var seqBefore = runtime.ActivityClock!.ActivitySeq;
+
+        // SendUserInputAsync emits the accept-time row synchronously before its task completes, so the
+        // clock is settled by the time this await returns — no envelope poll needed.
+        await runtime.SendUserInputAsync("second").WaitAsync(HangGuard);
+
+        await Assert.That(runtime.ActivityClock!.ActivitySeq).IsEqualTo(seqBefore);
+
+        cts.Cancel();
+        gate.TrySetCanceled();
         try { await fakeRunTask.WaitAsync(HangGuard); } catch (OperationCanceledException) { }
         await runtime.DisposeAsync();
         await fake.DisposeAsync();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeReconnectTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeReconnectTests.cs
@@ -3,6 +3,7 @@ using Capacitor.Cli.Daemon.Acp;
 using Capacitor.Cli.Daemon.Services;
 using Capacitor.Cli.Daemon.Tests.Unit.Acp;
 using Microsoft.Extensions.Logging.Abstractions;
+using TUnit.Assertions.Enums;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
@@ -271,14 +272,21 @@ public class AcpHostedAgentRuntimeReconnectTests {
             c.Params!.Value.GetProperty("prompt")[0].GetProperty("text").GetString() == "in-flight-turn")).IsFalse();
 
         // …the note carries the resend sentence (a turn was in flight)…
+        await Harness.PollUntilAsync(() => {
+            var e = h.EnvelopeSnapshot();
+            return e.Any(x => x.Kind == AcpEventKind.SystemNote)
+                && e.Count(x => x.Kind == AcpEventKind.UserMessage) == 2;
+        });
+
         var envelopes = h.EnvelopeSnapshot();
         var note = envelopes.Single(e => e.Kind == AcpEventKind.SystemNote);
         await Assert.That(note.Text!).Contains("resend");
 
-        // …and ordering held: the note precedes the queued turn's UserMessage envelope.
-        var noteIndex   = envelopes.ToList().FindIndex(e => e.Kind == AcpEventKind.SystemNote);
-        var queuedIndex = envelopes.ToList().FindIndex(e => e.Kind == AcpEventKind.UserMessage && e.Text == "queued-turn");
-        await Assert.That(queuedIndex).IsGreaterThan(noteIndex);
+        // …and each turn's UserMessage row was emitted exactly once, at accept time, in send order:
+        // parking the queued turn during reconnect neither loses its row nor lets its later
+        // re-admission duplicate it.
+        var userMessages = envelopes.Where(e => e.Kind == AcpEventKind.UserMessage).Select(e => e.Text!).ToList();
+        await Assert.That(userMessages).IsEquivalentTo(new[] { "in-flight-turn", "queued-turn" }, CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeTests.cs
@@ -518,6 +518,42 @@ public class AcpHostedAgentRuntimeTests {
         h.Fake.HoldPromptResponses.TrySetResult();
     }
 
+    [Test]
+    public async Task Second_prompt_queued_behind_an_in_flight_turn_emits_its_user_message_immediately_in_send_order() {
+        await using var h = new Harness();
+        h.StartFakeAgentLoop();
+
+        // Hold every session/prompt response so the first turn stays genuinely in flight while the
+        // second is queued behind it.
+        h.Fake.HoldPromptResponses = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+
+        await h.Runtime.StartAsync("/abs/worktree", "prompt-A", h.Cts.Token).WaitAsync(HangGuard);
+
+        var deadline = DateTime.UtcNow + HangGuard;
+        while (h.Fake.ReceivedCalls.All(c => c.Method != "session/prompt") && DateTime.UtcNow < deadline)
+            await Task.Delay(10);
+        await Assert.That(h.Fake.ReceivedCalls.Any(c => c.Method == "session/prompt")).IsTrue();
+
+        // The queued prompt's row must appear the moment it is accepted — while the first turn is
+        // still held open, not only once the worker dequeues it — and after the first prompt's.
+        await h.Runtime.SendUserInputAsync("prompt-B").WaitAsync(HangGuard);
+
+        var userMessages = new List<AcpEventEnvelope>();
+        while (userMessages.Count < 2) {
+            var env = await h.Runtime.Envelopes.ReadAsync(h.Cts.Token).AsTask().WaitAsync(HangGuard);
+            if (env.Kind == AcpEventKind.UserMessage) userMessages.Add(env);
+        }
+
+        await Assert.That(userMessages.Select(e => e.Text!))
+            .IsEquivalentTo(new[] { "prompt-A", "prompt-B" }, CollectionOrdering.Matching);
+
+        // The second row did not wait on the first turn: only prompt-A's session/prompt was ever
+        // sent, and its response is still held.
+        await Assert.That(h.Fake.ReceivedCalls.Count(c => c.Method == "session/prompt")).IsEqualTo(1);
+
+        h.Fake.HoldPromptResponses.TrySetResult();
+    }
+
     // ── Test plan item 9: cancellation propagates out of StartAsync ───────────────────
 
     /// <summary>


### PR DESCRIPTION
Closes #864 — AI-2679-adjacent, AI-2688

## What & why

In an ACP-hosted session, a prompt sent while a turn is still running was queued but its `user_message` row was only emitted when the worker dequeued it, after the running turn ended. So the chat showed nothing for the queued prompt until then, and a `/quit` journaled at admission could order ahead of it. The runtime now emits the `user_message` envelope the moment a turn is accepted onto the queue (`EnqueueTurn`), so queued prompts appear immediately in send order, and the worker's admission path emits none.

## Where to look

The emit sits on the successful-enqueue path only — the queue-full and channel-closed paths return before it, so a dropped turn produces no row. A turn parked during a reconnect is re-admitted without re-enqueueing, so the accept-time emit is still exactly one row per turn; the `_heldTurnSkipEnvelope` plumbing that guarded the old dequeue-time emit is gone. A turn later parked or dropped keeps its already-emitted row — the row is the user's message, not the turn's outcome.

## Verification

- New test: a second prompt sent while a first turn is in flight has its `user_message` emitted immediately, in order (A then B), before the first turn completes (RED→GREEN). Two reconnect/aggregation tests adjusted to the accept-time emit.
- ACP runtime, reconnect, aggregation and Antigravity user-turn suites green (69); daemon AOT publish clean.
