### PR TITLE
Derive the Antigravity ADC trio for every daemon spawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -1108,22 +1108,27 @@ reasons, and can never deliver its result. The grant admits those named tools an
 **Give the daemon durable credentials.** An unattended reviewer's stdin is closed, so it cannot complete an
 interactive login — an unauthenticated `agy` fails the launch with a coded
 `antigravity_reviewer_auth_unavailable` rather than hanging. Application Default Credentials are the
-supported setup, and the service install completes them for you:
+supported setup, and every CLI-driven daemon start completes them for you — `daemon start`, `-d`, and
+`service install` alike:
 
 ```bash
 gcloud auth application-default login
-kcap daemon service install --name "$(whoami)"   # captures/derives the trio into the unit
+kcap daemon start -d --name "$(whoami)"          # or: kcap daemon service install --name "$(whoami)"
 ```
 
 The daemon needs all three of `GOOGLE_CLOUD_PROJECT`, `AGY_ADC_AUTH=1` and
-`GOOGLE_APPLICATION_CREDENTIALS`. The install captures any you exported and silently derives the rest:
+`GOOGLE_APPLICATION_CREDENTIALS`. The CLI captures any you exported and silently derives the rest:
 the credential path from ADC's well-known location (only when the file is actually there), `AGY_ADC_AUTH=1`
 alongside it, and the project from your environment or gcloud's own active configuration. Exported values
 always win. Only the canonical `GOOGLE_CLOUD_PROJECT` counts here — `GOOGLE_CLOUD_PROJECT_ID` is carried
 for Gemini, which honours both, and does not satisfy agy's project leg. The explicit path looks redundant — ADC has a well-known default location — but a reviewer
 launch redirects `HOME` to a per-launch state directory, so the default location is not visible to the
-child. Derivation happens in the installer, at your command; the daemon itself still never reads a
-credential location of its own accord — it only forwards what the unit carries.
+child. Derivation happens in the CLI, at your command; the daemon itself still never reads a credential
+location of its own accord — it only forwards what it was started with.
+
+A daemon already running from before you logged in needs a fresh start to pick the trio up — `kcap daemon
+stop` then `kcap daemon start`/`-d` (or re-run `service install`). `kcap daemon restart` reuses the running
+process's own environment rather than re-deriving, so it will not.
 
 Deliberately unit-only: do **not** export `AGY_ADC_AUTH=1` in your interactive shell — under ADC auth agy
 fires no hooks, so that export would stop kcap capturing your own interactive Antigravity sessions. The

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
@@ -413,24 +413,19 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
 
     /// <summary>
     /// Turns a failed handshake into a reason an operator can act on. The auth arm is
-    /// <b>non-retryable and names the ADC remedy</b> — a generic launch failure would send an operator
-    /// looking at the daemon, the flow or the network, when the actual fix is three environment
-    /// variables.
+    /// <b>non-retryable and names the kcap command that fixes it</b>, not the three environment
+    /// variables it sets — every CLI-driven daemon start (<c>daemon start</c>, <c>-d</c>,
+    /// <c>service install</c>) now derives them the same way, so the fix is a restart, not manual
+    /// export.
     ///
-    /// <para><b>GOOGLE_APPLICATION_CREDENTIALS is one of the three, and naming it is load-bearing.</b>
-    /// ADC's default location is <c>$HOME/.config/gcloud/application_default_credentials.json</c>, and
-    /// this launch redirects <c>HOME</c> to a per-launch state directory — so the credential
-    /// <c>gcloud auth application-default login</c> just wrote is invisible to the child, and neither
-    /// <c>AGY_ADC_AUTH</c> nor <c>GOOGLE_CLOUD_PROJECT</c> carries a path that would find it. An earlier
-    /// revision of this message named only those two; measured, an operator following it exactly still
-    /// gets <c>authentication required. Run 'agy' to log in.</c> The remedy text has to be sufficient on
-    /// its own — a remedy that leaves the operator where they started reads as a broken feature.</para>
+    /// <para><b>Naming GOOGLE_APPLICATION_CREDENTIALS is still load-bearing.</b> ADC's default
+    /// location is <c>$HOME/.config/gcloud/application_default_credentials.json</c>, and this launch
+    /// redirects <c>HOME</c> to a per-launch state directory, so the credential <c>gcloud auth
+    /// application-default login</c> wrote is invisible to the child unless the path is explicit.</para>
     ///
     /// <para>The daemon deliberately does NOT synthesize the path from its own <c>HOME</c>. Per the
     /// borrowed-review auth design it never goes <i>looking</i> for a credential — it forwards what the
-    /// operator exported and nothing else — and reading a well-known credential location is exactly
-    /// that. <c>ServiceEnvironment</c> already carries this key into a supervised unit off-Windows, so
-    /// the export survives a service install without the daemon ever reading the file.</para>
+    /// CLI derived at spawn time and nothing else.</para>
     /// </summary>
     static InvalidOperationException DescribeLaunchFailure(
             Exception cause, IAgyTurnProcess? firstTurn, CancellationToken callerToken, CancellationToken launchToken) {
@@ -438,13 +433,12 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
             return new InvalidOperationException(
                 "antigravity_reviewer_auth_unavailable: agy could not authenticate, and a daemon-hosted "
               + "agy has no way to complete an interactive login (its stdin is closed). Give the "
-              + "daemon durable credentials: `gcloud auth application-default login`, then set ALL THREE "
-              + "of GOOGLE_CLOUD_PROJECT=<project>, AGY_ADC_AUTH=1 and "
-              + "GOOGLE_APPLICATION_CREDENTIALS=<absolute path to "
-              + "application_default_credentials.json> in the daemon's environment. The path is required "
-              + "even though ADC has a default location: a reviewer launch redirects HOME, so the "
-              + "default location is not visible to it. A supervised daemon installed before these were "
-              + "exported must be reinstalled to capture them.",
+              + "daemon durable credentials: `gcloud auth application-default login`, then stop and "
+              + "start it (`kcap daemon stop` then `kcap daemon start` or `-d`) — or re-run `kcap "
+              + "daemon service install` for a supervised daemon. That now derives all three of "
+              + "GOOGLE_CLOUD_PROJECT, AGY_ADC_AUTH=1 and GOOGLE_APPLICATION_CREDENTIALS for you; the "
+              + "explicit credentials path matters even though ADC has a default location, because a "
+              + "reviewer launch redirects HOME and that default location is not visible to it.",
                 cause);
 
         if (launchToken.IsCancellationRequested && !callerToken.IsCancellationRequested)

--- a/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Harness/Antigravity/AntigravityHostedAgentRuntimeFactory.cs
@@ -415,7 +415,7 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
     /// Turns a failed handshake into a reason an operator can act on. The auth arm is
     /// <b>non-retryable and names the kcap command that fixes it</b>, not the three environment
     /// variables it sets — every CLI-driven daemon start (<c>daemon start</c>, <c>-d</c>,
-    /// <c>service install</c>) now derives them the same way, so the fix is a restart, not manual
+    /// <c>service install</c>) derives them the same way, so the fix is a restart, not manual
     /// export.
     ///
     /// <para><b>Naming GOOGLE_APPLICATION_CREDENTIALS is still load-bearing.</b> ADC's default
@@ -435,10 +435,12 @@ internal sealed partial class AntigravityHostedAgentRuntimeFactory(
               + "agy has no way to complete an interactive login (its stdin is closed). Give the "
               + "daemon durable credentials: `gcloud auth application-default login`, then stop and "
               + "start it (`kcap daemon stop` then `kcap daemon start` or `-d`) — or re-run `kcap "
-              + "daemon service install` for a supervised daemon. That now derives all three of "
-              + "GOOGLE_CLOUD_PROJECT, AGY_ADC_AUTH=1 and GOOGLE_APPLICATION_CREDENTIALS for you; the "
-              + "explicit credentials path matters even though ADC has a default location, because a "
-              + "reviewer launch redirects HOME and that default location is not visible to it.",
+              + "daemon service install` for a supervised daemon. That derives AGY_ADC_AUTH=1 and "
+              + "GOOGLE_APPLICATION_CREDENTIALS from the credential you just wrote, and "
+              + "GOOGLE_CLOUD_PROJECT from your active gcloud project — so set one first if you have "
+              + "not (`gcloud config set project <id>`). The explicit credentials path matters even "
+              + "though ADC has a default location, because a reviewer launch redirects HOME and that "
+              + "default location is not visible to it.",
                 cause);
 
         if (launchToken.IsCancellationRequested && !callerToken.IsCancellationRequested)

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -275,30 +275,43 @@ public sealed class DaemonCommands(
     /// </summary>
     void ApplyEnvironment(IDictionary<string, string?> env) {
         var isWindows = OperatingSystem.IsWindows();
-        var overlay   = new Dictionary<string, string>();
 
         ApplySpawnEnvironment(
-            overlay, store.Directory, config.Directory, isWindows,
+            env, store.Directory, config.Directory, isWindows,
             adcCredentialsPath: isWindows ? null : Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.ExistingCredentialsPath(home),
             gcloudProject:      isWindows ? null : GcloudConfig.DefaultProject(home));
-
-        foreach (var (k, v) in overlay) env[k] = v;
     }
 
     /// <summary>Pure half of <see cref="ApplyEnvironment"/>: the daemon/config roots are written, not
     /// left to the child to derive (a derived root is one HOME change away from a different one, and
     /// the sandboxes that do rewrite HOME name their own root anyway), and off Windows the trio is
-    /// completed via <see cref="Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.Complete"/> —
-    /// never re-derived here, so a future change to that derivation cannot drift between the two
-    /// callers.</summary>
+    /// completed via <see cref="Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.Complete"/>.
+    /// <c>Complete</c> is seeded from what the environment already carries, so a trio member the
+    /// operator exported wins over the derived default — it only fills what is absent, and handing it
+    /// an empty view would let the derived default overwrite the exported value on the copy back.
+    /// A present-but-EMPTY export is dropped from the seed so the derivation still runs — matching how
+    /// <c>ServiceEnvironment.Capture</c> treats an empty capture as unset — except an empty
+    /// <c>AGY_ADC_AUTH</c>, which is a deliberate refusal of ADC auth and is kept. Without that drop an
+    /// empty credentials path both blocks derivation and manufactures <c>AGY_ADC_AUTH=1</c> for a path
+    /// agy cannot read.</summary>
     internal static void ApplySpawnEnvironment(
-            IDictionary<string, string> env, string daemonsDir, string configDir, bool isWindows,
+            IDictionary<string, string?> env, string daemonsDir, string configDir, bool isWindows,
             string? adcCredentialsPath, string? gcloudProject) {
         env[DaemonStore.DaemonsDirEnvVar] = daemonsDir;
         env[ConfigRoot.ConfigDirEnvVar]   = configDir;
 
-        if (!isWindows)
-            Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.Complete(env, adcCredentialsPath, gcloudProject);
+        if (isWindows) return;
+
+        var trio = new Dictionary<string, string>();
+        foreach (var (k, v) in env) {
+            if (v is null) continue;
+            if (v.Length > 0 || k == Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.FlagKey)
+                trio[k] = v;
+        }
+
+        Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.Complete(trio, adcCredentialsPath, gcloudProject);
+
+        foreach (var (k, v) in trio) env[k] = v;
     }
 
     /// <summary><c>DaemonRunner.BootCarriers.Seed</c>'s twin: the daemon project defines the

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -117,10 +117,7 @@ public sealed class DaemonCommands(
             CreateNoWindow  = true
         };
 
-        // Written, not left to the child to derive: a derived root is one HOME change away from a
-        // different one, and the sandboxes that do rewrite HOME name their own root anyway.
-        psi.Environment[DaemonStore.DaemonsDirEnvVar] = store.Directory;
-        psi.Environment[ConfigRoot.ConfigDirEnvVar]   = config.Directory;
+        ApplyEnvironment(psi.Environment);
 
         foreach (var arg in args) {
             psi.ArgumentList.Add(arg);
@@ -206,10 +203,7 @@ public sealed class DaemonCommands(
         psi.ArgumentList.Add("--log-file");
         psi.ArgumentList.Add(LogPath);
 
-        // Written, not left to the child to derive: a derived root is one HOME change away from a
-        // different one, and the sandboxes that do rewrite HOME name their own root anyway.
-        psi.Environment[DaemonStore.DaemonsDirEnvVar] = store.Directory;
-        psi.Environment[ConfigRoot.ConfigDirEnvVar]   = config.Directory;
+        ApplyEnvironment(psi.Environment);
 
         // we close the daemon's std pipes just below (anti-hang), which
         // means a runtime/native fatal message written straight to fd 2 would be
@@ -270,6 +264,41 @@ public sealed class DaemonCommands(
         Console.Out.WriteLine($"  Status:    kcap daemon status --name {name}");
 
         return 0;
+    }
+
+    /// <summary>
+    /// Overlays the daemon/config roots plus the Antigravity ADC trio onto a CLI-spawned daemon's
+    /// <see cref="ProcessStartInfo.Environment"/> — the same derivation
+    /// <c>ServiceEnvironment.Capture</c> runs at <c>daemon service install</c>, reused here so
+    /// `daemon start` and `start -d` (and the desktop app, which shells out to the latter) do not
+    /// leave hosted Antigravity without it just because the daemon didn't come from a service install.
+    /// </summary>
+    void ApplyEnvironment(IDictionary<string, string?> env) {
+        var isWindows = OperatingSystem.IsWindows();
+        var overlay   = new Dictionary<string, string>();
+
+        ApplySpawnEnvironment(
+            overlay, store.Directory, config.Directory, isWindows,
+            adcCredentialsPath: isWindows ? null : Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.ExistingCredentialsPath(home),
+            gcloudProject:      isWindows ? null : GcloudConfig.DefaultProject(home));
+
+        foreach (var (k, v) in overlay) env[k] = v;
+    }
+
+    /// <summary>Pure half of <see cref="ApplyEnvironment"/>: the daemon/config roots are written, not
+    /// left to the child to derive (a derived root is one HOME change away from a different one, and
+    /// the sandboxes that do rewrite HOME name their own root anyway), and off Windows the trio is
+    /// completed via <see cref="Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.Complete"/> —
+    /// never re-derived here, so a future change to that derivation cannot drift between the two
+    /// callers.</summary>
+    internal static void ApplySpawnEnvironment(
+            IDictionary<string, string> env, string daemonsDir, string configDir, bool isWindows,
+            string? adcCredentialsPath, string? gcloudProject) {
+        env[DaemonStore.DaemonsDirEnvVar] = daemonsDir;
+        env[ConfigRoot.ConfigDirEnvVar]   = configDir;
+
+        if (!isWindows)
+            Capacitor.Cli.Harness.Antigravity.AntigravityAdcTrio.Complete(env, adcCredentialsPath, gcloudProject);
     }
 
     /// <summary><c>DaemonRunner.BootCarriers.Seed</c>'s twin: the daemon project defines the

--- a/src/Capacitor.Cli/Harness/Antigravity/AntigravityAdcTrio.cs
+++ b/src/Capacitor.Cli/Harness/Antigravity/AntigravityAdcTrio.cs
@@ -1,14 +1,15 @@
 namespace Capacitor.Cli.Harness.Antigravity;
 
 /// <summary>
-/// The three environment variables a daemon-hosted agy needs, and how a service install completes
-/// them. A hosted launch redirects HOME, so ADC's well-known location is invisible to the child and
-/// the credential path has to be explicit; the flag selects the auth mode, without which agy demands
-/// an interactive login it has no stdin for.
+/// The three environment variables a daemon-hosted agy needs, and how the CLI completes them when it
+/// stamps a daemon spawn's environment — a <c>daemon service install</c> unit and a direct
+/// <c>daemon start</c> / <c>-d</c> alike. A hosted launch redirects HOME, so ADC's well-known location
+/// is invisible to the child and the credential path has to be explicit; the flag selects the auth
+/// mode, without which agy demands an interactive login it has no stdin for.
 ///
-/// <para>Deriving belongs to the installer the operator is running, never to the daemon, which goes
-/// looking for a credential nowhere. And it lands in the unit only: <c>AGY_ADC_AUTH=1</c> exported
-/// in an interactive shell disables agy's own hook capture.</para>
+/// <para>Deriving belongs to whichever CLI the operator runs, never to the daemon, which goes looking
+/// for a credential nowhere. It is stamped only onto a daemon the CLI spawns, never exported into the
+/// operator's interactive shell: <c>AGY_ADC_AUTH=1</c> there disables agy's own hook capture.</para>
 /// </summary>
 static class AntigravityAdcTrio {
     internal const string ProjectKey     = "GOOGLE_CLOUD_PROJECT";

--- a/src/Capacitor.Cli/Services/GcloudConfig.cs
+++ b/src/Capacitor.Cli/Services/GcloudConfig.cs
@@ -2,8 +2,9 @@ namespace Capacitor.Cli.Services;
 
 /// <summary>
 /// Reads gcloud's own on-disk configuration for the active default project — no process spawn, no
-/// network. Used only by the service-install capture (<see cref="ServiceEnvironment.Capture"/>);
-/// the daemon itself never reads this.
+/// network. Read by the CLI as it stamps a daemon spawn's environment — the <c>daemon service
+/// install</c> capture and a direct <c>daemon start</c> / <c>-d</c> alike; the daemon process itself
+/// never reads it.
 /// </summary>
 static class GcloudConfig {
     /// <summary>The active configuration's <c>[core] project</c>, or null when gcloud is not set

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityReviewerLaunchTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Harness/Antigravity/AntigravityReviewerLaunchTests.cs
@@ -1136,6 +1136,10 @@ public class AntigravityReviewerLaunchTests {
         // And it must say WHY the path is needed despite ADC having a default — without that an
         // operator reasonably deletes it as redundant.
         await Assert.That(ex.Message).Contains("HOME");
+
+        // The actionable step is a kcap command, not "go set three env vars yourself" — every
+        // CLI-driven daemon start now derives the trio the same way `service install` does.
+        await Assert.That(ex.Message).Contains("kcap daemon start");
     }
 
     /// <summary>

--- a/test/Capacitor.Cli.Tests.Unit/Commands/DaemonSpawnEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/DaemonSpawnEnvironmentTests.cs
@@ -1,0 +1,76 @@
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>
+/// <c>DaemonCommands.ApplySpawnEnvironment</c> is what <c>kcap daemon start</c> (foreground and
+/// <c>-d</c>) overlays onto the spawned daemon's <c>ProcessStartInfo.Environment</c> — the daemon/config
+/// roots, plus the same Antigravity ADC trio derivation <c>ServiceEnvironment.Capture</c> runs at
+/// service install, so a daemon started any other way is not left without it.
+/// </summary>
+public class DaemonSpawnEnvironmentTests {
+    [Test]
+    public async Task Includes_the_trio_when_adc_and_project_exist() {
+        var env = new Dictionary<string, string>();
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: false,
+            adcCredentialsPath: "/h/.config/gcloud/application_default_credentials.json",
+            gcloudProject: "gcloud-proj");
+
+        await Assert.That(env["GOOGLE_APPLICATION_CREDENTIALS"])
+            .IsEqualTo("/h/.config/gcloud/application_default_credentials.json");
+        await Assert.That(env["AGY_ADC_AUTH"]).IsEqualTo("1");
+        await Assert.That(env["GOOGLE_CLOUD_PROJECT"]).IsEqualTo("gcloud-proj");
+    }
+
+    [Test]
+    public async Task Omits_the_trio_without_adc_or_project() {
+        var env = new Dictionary<string, string>();
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: false,
+            adcCredentialsPath: null, gcloudProject: null);
+
+        await Assert.That(env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS")).IsFalse();
+        await Assert.That(env.ContainsKey("AGY_ADC_AUTH")).IsFalse();
+        await Assert.That(env.ContainsKey("GOOGLE_CLOUD_PROJECT")).IsFalse();
+    }
+
+    [Test]
+    public async Task Never_derives_on_windows_even_when_adc_and_project_are_given() {
+        var env = new Dictionary<string, string>();
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: true,
+            adcCredentialsPath: "/derived/adc.json", gcloudProject: "gcloud-proj");
+
+        await Assert.That(env.ContainsKey("GOOGLE_APPLICATION_CREDENTIALS")).IsFalse();
+        await Assert.That(env.ContainsKey("AGY_ADC_AUTH")).IsFalse();
+        await Assert.That(env.ContainsKey("GOOGLE_CLOUD_PROJECT")).IsFalse();
+    }
+
+    [Test]
+    public async Task Keeps_an_already_exported_credentials_path() {
+        var env = new Dictionary<string, string> { ["GOOGLE_APPLICATION_CREDENTIALS"] = "/custom/adc.json" };
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: false,
+            adcCredentialsPath: "/derived/adc.json", gcloudProject: null);
+
+        await Assert.That(env["GOOGLE_APPLICATION_CREDENTIALS"]).IsEqualTo("/custom/adc.json");
+    }
+
+    [Test]
+    public async Task Always_carries_the_daemon_and_config_roots() {
+        var env = new Dictionary<string, string>();
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: false,
+            adcCredentialsPath: null, gcloudProject: null);
+
+        await Assert.That(env[DaemonStore.DaemonsDirEnvVar]).IsEqualTo("/daemons");
+        await Assert.That(env[ConfigRoot.ConfigDirEnvVar]).IsEqualTo("/config");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/DaemonSpawnEnvironmentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/DaemonSpawnEnvironmentTests.cs
@@ -12,7 +12,7 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 public class DaemonSpawnEnvironmentTests {
     [Test]
     public async Task Includes_the_trio_when_adc_and_project_exist() {
-        var env = new Dictionary<string, string>();
+        var env = new Dictionary<string, string?>();
 
         DaemonCommands.ApplySpawnEnvironment(
             env, "/daemons", "/config", isWindows: false,
@@ -27,7 +27,7 @@ public class DaemonSpawnEnvironmentTests {
 
     [Test]
     public async Task Omits_the_trio_without_adc_or_project() {
-        var env = new Dictionary<string, string>();
+        var env = new Dictionary<string, string?>();
 
         DaemonCommands.ApplySpawnEnvironment(
             env, "/daemons", "/config", isWindows: false,
@@ -40,7 +40,7 @@ public class DaemonSpawnEnvironmentTests {
 
     [Test]
     public async Task Never_derives_on_windows_even_when_adc_and_project_are_given() {
-        var env = new Dictionary<string, string>();
+        var env = new Dictionary<string, string?>();
 
         DaemonCommands.ApplySpawnEnvironment(
             env, "/daemons", "/config", isWindows: true,
@@ -53,7 +53,7 @@ public class DaemonSpawnEnvironmentTests {
 
     [Test]
     public async Task Keeps_an_already_exported_credentials_path() {
-        var env = new Dictionary<string, string> { ["GOOGLE_APPLICATION_CREDENTIALS"] = "/custom/adc.json" };
+        var env = new Dictionary<string, string?> { ["GOOGLE_APPLICATION_CREDENTIALS"] = "/custom/adc.json" };
 
         DaemonCommands.ApplySpawnEnvironment(
             env, "/daemons", "/config", isWindows: false,
@@ -63,8 +63,66 @@ public class DaemonSpawnEnvironmentTests {
     }
 
     [Test]
+    public async Task Keeps_an_already_exported_project() {
+        var env = new Dictionary<string, string?> { ["GOOGLE_CLOUD_PROJECT"] = "operator-proj" };
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: false,
+            adcCredentialsPath: null, gcloudProject: "gcloud-proj");
+
+        await Assert.That(env["GOOGLE_CLOUD_PROJECT"]).IsEqualTo("operator-proj");
+    }
+
+    [Test]
+    public async Task Derives_over_an_empty_exported_credentials_path() {
+        var env = new Dictionary<string, string?> { ["GOOGLE_APPLICATION_CREDENTIALS"] = "" };
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: false,
+            adcCredentialsPath: "/derived/adc.json", gcloudProject: null);
+
+        await Assert.That(env["GOOGLE_APPLICATION_CREDENTIALS"]).IsEqualTo("/derived/adc.json");
+        await Assert.That(env["AGY_ADC_AUTH"]).IsEqualTo("1");
+    }
+
+    [Test]
+    public async Task Never_manufactures_the_auth_flag_for_an_empty_path_without_adc() {
+        var env = new Dictionary<string, string?> { ["GOOGLE_APPLICATION_CREDENTIALS"] = "" };
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: false,
+            adcCredentialsPath: null, gcloudProject: null);
+
+        await Assert.That(env.ContainsKey("AGY_ADC_AUTH")).IsFalse();
+    }
+
+    [Test]
+    public async Task Derives_over_an_empty_exported_project() {
+        var env = new Dictionary<string, string?> { ["GOOGLE_CLOUD_PROJECT"] = "" };
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: false,
+            adcCredentialsPath: null, gcloudProject: "gcloud-proj");
+
+        await Assert.That(env["GOOGLE_CLOUD_PROJECT"]).IsEqualTo("gcloud-proj");
+    }
+
+    [Test]
+    public async Task Keeps_an_empty_exported_auth_flag_as_a_refusal() {
+        var env = new Dictionary<string, string?> {
+            ["AGY_ADC_AUTH"] = "", ["GOOGLE_APPLICATION_CREDENTIALS"] = "/custom/adc.json",
+        };
+
+        DaemonCommands.ApplySpawnEnvironment(
+            env, "/daemons", "/config", isWindows: false,
+            adcCredentialsPath: "/derived/adc.json", gcloudProject: null);
+
+        await Assert.That(env["AGY_ADC_AUTH"]).IsEqualTo("");
+    }
+
+    [Test]
     public async Task Always_carries_the_daemon_and_config_roots() {
-        var env = new Dictionary<string, string>();
+        var env = new Dictionary<string, string?>();
 
         DaemonCommands.ApplySpawnEnvironment(
             env, "/daemons", "/config", isWindows: false,


### PR DESCRIPTION
Closes #852 — AI-2678

## What & why

Hosted Antigravity failed with `antigravity_reviewer_auth_unavailable` unless the daemon came from `kcap daemon service install` — the only path that captured the ADC trio (`GOOGLE_CLOUD_PROJECT`, `AGY_ADC_AUTH=1`, `GOOGLE_APPLICATION_CREDENTIALS`). A daemon started by `kcap daemon start`, `-d`, or the desktop app (which shells out to `kcap daemon start -d`) got none of it. The CLI's two foreground/detached spawn paths now derive the trio into the child daemon's environment the same way the installer does — `AntigravityAdcTrio.Complete`, off Windows, guarded by its own checks so the trio is added only when the machine has ADC and a gcloud project. The daemon still never looks for a credential; the derivation stays in the CLI, the operator's installer.

## Where to look

`ApplySpawnEnvironment` is the pure, tested half — daemon/config roots plus, off Windows, the trio via the installer's own method. The error message now names the kcap command that fixes it instead of three environment variables.

Not in scope (follow-up): `kcap daemon restart` reuses the running daemon's own environment and won't pick up a freshly created ADC file — closing that needs the trio threaded through the local-control restart frame or a stop+start. Documented in the README.

## Verification

- New `DaemonSpawnEnvironmentTests`: the trio is present when ADC and a project exist, absent without them, never derived on Windows, an already-exported credentials path is kept, and the daemon/config roots are always carried. Tests operate on a plain dictionary, so they assert what the code contributes rather than an env var's absence from a real ProcessStartInfo. The reviewer error-message test asserts the new remedy.
- Full Cli suite and daemon suite green apart from known env flakes; both AOT publishes clean; README updated.
