### PR TITLE
Make daemon startup fast, observable, and honestly reported

### DIFF
--- a/README.md
+++ b/README.md
@@ -841,6 +841,12 @@ Daemon 'laptop': running (PID 12345)
   version: 0.8.12
 ```
 
+A daemon whose process is alive but whose local control socket does not yet answer — it has taken its lock but has not finished binding and connecting — is reported as still starting, so you can tell a fully-up daemon from one that is only part-way through startup:
+
+```
+Daemon 'laptop': running (PID 12345, starting — not yet serving)
+```
+
 **Updating:** after `kcap update`, a running daemon on macOS/Linux detects the new binary and restarts itself once it's **idle** (no running hosted agents and no in-flight eval) — service-managed daemons exit so the supervisor relaunches the new binary; background (`-d`) daemons re-spawn themselves. `kcap daemon status` shows the running version (above) plus any pending restart, so you can tell the update apart from an as-yet-unrestarted daemon; `kcap daemon restart --force` applies it now. On **Windows**, stop the daemon (`kcap daemon stop` / `kcap daemon service stop`) before `kcap update` — a running daemon locks its binary, so the update can't replace it (the launcher detects this and aborts with instructions).
 
 #### Run it as a service (auto-restart)

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1,3 +1,4 @@
+using System.Collections.Frozen;
 using System.Reflection;
 using System.Runtime.InteropServices;
 using System.Diagnostics;
@@ -273,6 +274,7 @@ public static partial class DaemonRunner {
         }
 
         config.InstanceId = daemonLock.InstanceId;
+        StartupPhase("lock acquired");
 
         // Phase B2-b (sequenced-settlement design §4.2.3): the durable per-daemon state root — used by
         // the pre-host boot-check block immediately below AND (further down) by the coverage journal /
@@ -328,6 +330,8 @@ public static partial class DaemonRunner {
         config.RecordlessSurvivorsImpossible = new CoverageJournal(coverageStateDir, NullLogger.Instance)
             .RecordBoot(daemonLock.InstanceId, daemonLock.PriorInstanceId,
                 priorLockReadFailed: daemonLock.PriorLockIndeterminate, thisEpochContained: OperatingSystem.IsWindows());
+
+        StartupPhase("boot checks done");
 
         builder.Services.AddSingleton(paths);
         builder.Services.AddSingleton(configRoot);
@@ -557,6 +561,7 @@ public static partial class DaemonRunner {
 
         var host   = builder.Build();
         var logger = host.Services.GetRequiredService<ILoggerFactory>().CreateLogger("kcap.Daemon");
+        LogStartupPhase(logger, "host built");
 
         // Set by the supervised restart strategy so we exit non-zero for a supervisor relaunch.
         var restartState = host.Services.GetRequiredService<RestartState>();
@@ -602,6 +607,7 @@ public static partial class DaemonRunner {
             FingerprintUnattendedVendors(config.Binaries, runtimeFactories, config.UnattendedVendors);
         config.UnattendedVendorCapabilities =
             ComputeUnattendedVendorCapabilities(runtimeFactories, config, config.UnattendedVendors);
+        LogStartupPhase(logger, "vendors probed");
 
         // Which build of each unattended vendor was installed when this daemon started. Recorded at
         // startup (like the Cursor-unavailable warning below) rather than per launch, and reported
@@ -699,6 +705,7 @@ public static partial class DaemonRunner {
                 // BaseUrl is still null and the spawned Claude falls back to the HTTPS path —
                 // exactly what this bridge is meant to avoid.
                 await host.StartAsync(lifetime.ApplicationStopping);
+                LogStartupPhase(logger, "socket bound");
 
                 // Phase B (D4 §6.4(3)): resolve the orchestrator (which wires OnLaunchAgent +
                 // GetLiveAgents in its ctor) and reap any hosted-agent children that outlived a
@@ -714,6 +721,7 @@ public static partial class DaemonRunner {
 
                 try {
                     await connection.ConnectAsync(lifetime.ApplicationStopping);
+                    LogStartupPhase(logger, "server connected");
                 } catch (Exception ex) when (nameInUse) {
                     // ConnectAsync's initial-connect path threw because of NameInUse. OnNameInUse
                     // already fired and set our flag; the host hasn't started its main loop yet, so
@@ -1373,16 +1381,22 @@ public static partial class DaemonRunner {
     /// testable without spinning up the whole DI host <see cref="RunAsync"/> builds.
     /// </summary>
     internal static IReadOnlyList<UnattendedVendorStatus> ClassifyUnattendedVendors(
-            IEnumerable<IHostedAgentRuntimeFactory> factories) =>
-        factories
-            .Where(f => f.IsAvailable())
-            .Select(f => {
-                var support = f.DescribeUnattendedSupport();
+            IEnumerable<IHostedAgentRuntimeFactory> factories) {
+        var installed = factories.Where(f => f.IsAvailable()).ToArray();
+        var byVendor  = installed.ToDictionary(f => f.Vendor, StringComparer.Ordinal);
 
-                return new UnattendedVendorStatus(f.Vendor, support.Supported, support.WithheldReason);
-            })
+        // The gated reviewers spawn their vendor binary to answer, so classifying N of them
+        // sequentially serializes N bounded `--version` probes before the socket ever binds. Overlap
+        // them: each factory is still asked exactly once, on its own task, under one shared ceiling.
+        var support = ProbeVendorsConcurrently(
+            byVendor.Keys, vendor => byVendor[vendor].DescribeUnattendedSupport(),
+            timedOut: new UnattendedSupport(false, null));
+
+        return installed
+            .Select(f => new UnattendedVendorStatus(f.Vendor, support[f.Vendor].Supported, support[f.Vendor].WithheldReason))
             .OrderBy(s => s.Vendor, StringComparer.Ordinal)
             .ToArray();
+    }
 
     /// <summary>The advertised subset of a <see cref="ClassifyUnattendedVendors"/> result.</summary>
     internal static string[] AdvertisedUnattendedVendors(IEnumerable<UnattendedVendorStatus> statuses) =>
@@ -1422,15 +1436,21 @@ public static partial class DaemonRunner {
             IEnumerable<IHostedAgentRuntimeFactory> factories, DaemonConfig config,
             IEnumerable<string>? advertised = null) {
         var unattended = advertised?.ToArray() ?? ComputeUnattendedVendors(factories, config);
+        var byVendor   = factories.ToDictionary(f => f.Vendor, StringComparer.Ordinal);
+
+        // The `--version` probe is the slowest thing here (attempts × 10s). Run all of them at once,
+        // under one ceiling, rather than blocking startup for the sum across every advertised vendor.
+        // A vendor whose binary is unresolved is not probed at all — its version stays null, exactly as
+        // an inline probe of an empty path would leave it.
+        var probePaths = unattended
+            .Where(v => byVendor.TryGetValue(v, out var f) && !string.IsNullOrEmpty(f.CliPath))
+            .ToDictionary(v => v, v => byVendor[v].CliPath, StringComparer.Ordinal);
+        var probedVersions = ProbeVendorsConcurrently(
+            probePaths.Keys, vendor => ProbeCliVersion(probePaths[vendor]), timedOut: (string?)null);
+
         var capabilities = new List<UnattendedVendorCapability>();
         foreach (var vendor in unattended) {
-            var factory = factories.First(f => string.Equals(f.Vendor, vendor, StringComparison.Ordinal));
-            // The binary comes from the factory that would launch it, never from a vendor-keyed map
-            // here: a map is a second answer about one build, and the vendor it forgets is advertised
-            // as "CLI version unknown" while the admission gate resolves it fine — the wrong answer
-            // reaching the operator's log and the server. Only the policy version is genuinely per
-            // vendor, and a missing arm there is a wrong string rather than a silent nothing.
-            var cliPath = factory.CliPath;
+            var factory = byVendor[vendor];
             var policyVersion = vendor switch {
                 "claude"  => ClaudeLauncherPolicyVersion,
                 "cursor"  => CursorLauncherPolicyVersion,
@@ -1457,7 +1477,7 @@ public static partial class DaemonRunner {
             var modelResolver = factory.ReviewerModelResolver;
             capabilities.Add(new(
                 vendor,
-                string.IsNullOrEmpty(cliPath) ? null : ProbeCliVersion(cliPath),
+                probedVersions.GetValueOrDefault(vendor),
                 policyVersion,
                 borrowedSupported,
                 borrowedSupported ? factory.BorrowedReviewContainment : null,
@@ -1534,6 +1554,40 @@ public static partial class DaemonRunner {
     /// budget — and inheriting it would have tripled the lane stall this change was meant to
     /// improve.</summary>
     const int LaunchVersionProbeTimeoutMs = 3_000;
+
+    /// <summary>One wall-clock ceiling for a whole concurrent probe pass. Strictly above a single
+    /// vendor's own budget (attempts × timeout, plus its backoff), so overlapping the probes only
+    /// removes the N-way serialization — it never cuts short a probe a sequential pass would have let
+    /// finish, which is what keeps the "one transient miss must not durably disable a vendor" contract
+    /// intact. A vendor still unfinished at the ceiling is a miss the capability-refresh path re-probes.</summary>
+    const int ConcurrentProbeCeilingMs = VersionProbeAttempts * VersionProbeTimeoutMs + 5_000;
+
+    /// <summary>
+    /// Applies <paramref name="probe"/> to every vendor CONCURRENTLY under one wall-clock ceiling, so a
+    /// daemon probing N vendor CLIs at startup waits roughly one probe's budget instead of the sum
+    /// across N. Each probe keeps its own per-vendor budget; the ceiling is only a backstop above it.
+    /// A vendor whose probe faults or has not returned by the ceiling maps to <paramref name="timedOut"/>
+    /// — the same value a sequential miss yields, so nothing but the wall-clock changes.
+    /// </summary>
+    internal static IReadOnlyDictionary<string, T> ProbeVendorsConcurrently<T>(
+            IEnumerable<string> vendors, Func<string, T> probe, T timedOut,
+            int ceilingMs = ConcurrentProbeCeilingMs) {
+        var tasks = new Dictionary<string, Task<T>>(StringComparer.Ordinal);
+        foreach (var vendor in vendors)
+            tasks.TryAdd(vendor, Task.Run(() => probe(vendor)));
+
+        if (tasks.Count == 0) return FrozenDictionary<string, T>.Empty;
+
+        try { Task.WaitAll([.. tasks.Values], ceilingMs); } catch { /* per-task faults handled below */ }
+
+        var result = new Dictionary<string, T>(tasks.Count, StringComparer.Ordinal);
+        foreach (var (vendor, task) in tasks) {
+            if (task.IsFaulted) _ = task.Exception;   // observe so a fault is never an unobserved-task exception
+            result[vendor] = task.Status == TaskStatus.RanToCompletion ? task.Result : timedOut;
+        }
+
+        return result;
+    }
 
     internal static string? ProbeCliVersion(string cliPath) =>
         ProbeCliVersion(cliPath, VersionProbeAttempts, VersionProbeTimeoutMs);
@@ -1821,4 +1875,23 @@ public static partial class DaemonRunner {
             // might be gone, etc. Already exiting — nothing useful to do.
         }
     }
+
+    /// <summary>
+    /// Pre-host startup breadcrumb. Between lock acquisition and host construction there is no
+    /// <see cref="ILogger"/> yet, so a stall in that window would leave no record of how far the boot
+    /// got. Each phase writes one timestamped line to <see cref="Console.Error"/> (captured to the
+    /// stderr file on the detached path), so the last line printed names the last phase reached. Once
+    /// the host is built, normal logging takes over via <see cref="LogStartupPhase"/>.
+    /// </summary>
+    internal static void StartupPhase(string phase) {
+        try {
+            Console.Error.WriteLine($"{DateTime.Now:yyyy-MM-dd HH:mm:ss.fff} [startup] {phase}");
+            Console.Error.Flush();
+        } catch {
+            // Same posture as DeathRattle: a redirected/closed stderr must not fault the boot.
+        }
+    }
+
+    [LoggerMessage(Level = LogLevel.Information, Message = "startup phase: {Phase}")]
+    static partial void LogStartupPhase(ILogger logger, string phase);
 }

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1605,7 +1605,13 @@ public static partial class DaemonRunner {
         return null;
     }
 
+    /// <summary>How long the probe waits for the drains to reach EOF on their own after the child has
+    /// been dealt with. On the happy path they are already done; this only bounds the case where a
+    /// descendant that inherited the pipe is holding it open.</summary>
+    const int DrainGraceMs = 1_500;
+
     static string? ProbeCliVersionOnce(string cliPath, int timeoutMs) {
+        using var deadline = new CancellationTokenSource(timeoutMs);
         try {
             using var process = Process.Start(new ProcessStartInfo {
                 FileName = cliPath,
@@ -1620,21 +1626,45 @@ public static partial class DaemonRunner {
             // buffer — some vendor CLIs emit a banner or an "update available" notice — blocks on
             // write until the parent reads, so reading only after WaitForExit deadlocks: the child
             // parks on a full pipe, the wait never returns, and the probe hangs until the timeout
-            // kills it. The drains never fault (they swallow to ""), so the abandoned timeout path
-            // leaves no unobserved task exception.
-            var stdout = DrainToEndAsync(process.StandardOutput);
-            var stderr = DrainToEndAsync(process.StandardError);
+            // kills it. The drains swallow to their buffer, so an abandoned probe leaves no
+            // unobserved task exception.
+            var stdout = DrainToEndAsync(process.StandardOutput, deadline.Token);
+            var stderr = DrainToEndAsync(process.StandardError, deadline.Token);
 
-            if (!process.WaitForExit(timeoutMs)) {
+            var exited = process.WaitForExit(timeoutMs);
+
+            // The drains have read everything buffered; give them a short window to see EOF. They will
+            // not if the child never exited (still writing) or if a descendant that inherited the pipe
+            // is holding it open past the child's exit — the shape that used to block this probe, and
+            // the Task.Run running it, forever.
+            if (!Task.WaitAll([stdout, stderr], DrainGraceMs)) {
+                // Force the tree down (effective while the child is still alive — the timeout path),
+                // then close our own read ends. Closing them is what unblocks a drain a reparented
+                // descendant is holding open: the pending read throws and the drain returns the bytes
+                // it had already buffered, so a version printed before the block is recovered rather
+                // than discarded. A descendant that outlived a cleanly-exited child cannot be reaped
+                // from its parent's pid once it has reparented — closing the pipe detaches it, and its
+                // next write fails rather than wedging us.
+                deadline.Cancel();
                 try { ProcessTree.Kill(process); } catch { }
-                return null;
+                try { process.StandardOutput.Dispose(); } catch { }
+                try { process.StandardError.Dispose(); }  catch { }
+                Task.WaitAll([stdout, stderr], DrainGraceMs);
             }
 
-            var output = stdout.GetAwaiter().GetResult().Trim();
-            if (output.Length == 0) output = stderr.GetAwaiter().GetResult().Trim();
-            return ParseProbedVersion(output);
+            var output = ResultOrEmpty(stdout).Trim();
+            if (output.Length == 0) output = ResultOrEmpty(stderr).Trim();
+
+            // A child we had to kill for overrunning the budget with no usable output is a miss, not a
+            // version; but if it printed one before a descendant wedged the pipe, keep it.
+            return !exited && output.Length == 0 ? null : ParseProbedVersion(output);
         } catch { return null; }
     }
+
+    /// <summary>A finished drain's text, or "" for one still running — never a blocking wait on a
+    /// drain a descendant is holding open.</summary>
+    static string ResultOrEmpty(Task<string> drain) =>
+        drain.Status == TaskStatus.RanToCompletion ? drain.Result : "";
 
     /// Enough for any real vendor <c>--version</c> (a line or two); a version that needed more would
     /// fail the parser anyway. Past the cap the stream is still read to EOF so the child never blocks
@@ -1642,17 +1672,21 @@ public static partial class DaemonRunner {
     /// for the whole probe budget.
     const int ProbeOutputCap = 8 * 1024;
 
-    static async Task<string> DrainToEndAsync(System.IO.StreamReader reader) {
+    static async Task<string> DrainToEndAsync(System.IO.StreamReader reader, CancellationToken ct) {
+        var kept = new System.Text.StringBuilder();
         try {
             var buffer = new char[4096];
-            var kept   = new System.Text.StringBuilder();
             int read;
-            while ((read = await reader.ReadAsync(buffer, 0, buffer.Length).ConfigureAwait(false)) > 0) {
+            while ((read = await reader.ReadAsync(buffer.AsMemory(0, buffer.Length), ct).ConfigureAwait(false)) > 0) {
                 var room = ProbeOutputCap - kept.Length;
                 if (room > 0) kept.Append(buffer, 0, Math.Min(read, room));
             }
-            return kept.ToString();
-        } catch { return ""; }
+        } catch {
+            // Cancelled at the deadline, or the stream was torn down — return whatever was read before
+            // the block. A version printed ahead of a descendant that then held the pipe open is
+            // recovered rather than lost, and the drain always completes rather than parking a task.
+        }
+        return kept.ToString();
     }
 
     /// <summary>

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -16,6 +16,14 @@ public sealed class DaemonCommands(
         HarnessRegistry harnesses, BinaryProbe binaries) {
     string LogPath { get; } = config.Path("daemon.log");
 
+    /// <summary>The sibling capture for the daemon's raw stderr/stdout — where a detached start points
+    /// the child's fds (<c>--stderr-file</c>) and the launchd unit its <c>StandardErrorPath</c>. It
+    /// holds what the primary log cannot: native fatal messages written straight to fd 2, and the
+    /// pre-host startup breadcrumbs <c>DaemonRunner.StartupPhase</c> writes before the logger exists.
+    /// So <c>daemon logs</c> surfaces it too — a startup that never reached the logger still leaves a
+    /// trace here.</summary>
+    string StderrCapturePath => Path.ChangeExtension(LogPath, null) + ".out.log";
+
     public async Task<int> HandleAsync(string[] args) {
         if (args.Length < 2) {
             PrintUsage();
@@ -217,7 +225,7 @@ public sealed class DaemonCommands(
         // daemon's fds at a sibling capture file so those messages survive. Same
         // ".out.log" convention as the launchd unit's StandardErrorPath.
         psi.ArgumentList.Add("--stderr-file");
-        psi.ArgumentList.Add(Path.ChangeExtension(LogPath, null) + ".out.log");
+        psi.ArgumentList.Add(StderrCapturePath);
 
         foreach (var arg in args.Where(a => a is not "-d" and not "--detach")) {
             psi.ArgumentList.Add(arg);
@@ -585,18 +593,19 @@ public sealed class DaemonCommands(
 
     // ── status ──────────────────────────────────────────────────────────────
 
-    /// <summary>How long <c>status</c> waits for a daemon's Hello before reporting it as still
-    /// starting. Short: a bound daemon answers immediately, and an unbound one refuses the connection
-    /// at once — the timeout only bounds the rare mid-bind race.</summary>
+    /// <summary>How long <c>status</c> waits for a daemon's control socket before reporting it as still
+    /// starting. Short: a bound daemon accepts the connection immediately, and an unbound one refuses
+    /// it at once — the timeout only bounds the rare mid-bind race.</summary>
     static readonly TimeSpan ServingProbeTimeout = TimeSpan.FromSeconds(2);
 
     /// <summary>
     /// The running daemon's status line, distinguishing a daemon that is actually serving from one
-    /// whose PID is live but whose local control socket does not yet answer. A validated PID proves
-    /// only that the process exists; a well-formed Hello proves it has bound its socket and can answer.
-    /// A live process that is not yet answering has acquired its lock but has not finished binding its
-    /// listener and connecting — it is starting, not serving — which a PID alone reports as flatly
-    /// "running".
+    /// whose PID is live but whose local control socket does not yet accept a connection. A validated
+    /// PID proves only that the process exists; a reachable control socket proves the daemon has bound
+    /// its listener. A live process whose socket is not yet reachable has acquired its lock but has not
+    /// finished binding — it is starting, not serving — which a PID alone reports as flatly "running".
+    /// Reachability, not a well-formed Hello, is the signal: an older daemon accepts the connection and
+    /// drops the unknown Hello frame, and it is serving all the same.
     /// </summary>
     internal static string DescribeRunningDaemon(int pid, bool serving) =>
         serving
@@ -627,16 +636,28 @@ public sealed class DaemonCommands(
             return 0;
         }
 
-        foreach (var name in names) {
-            if (DaemonPidProbe.ReadPidFile(store, name) is not { } entry) {
+        // Read each name's PID entry once, then probe every validated-live daemon AT ONCE. Each probe
+        // carries its own ServingProbeTimeout, so a status over several daemons whose sockets accept
+        // but stay silent costs one timeout rather than one per daemon; results are rendered below in
+        // the original name order.
+        var entries = names.Select(n => (Name: n, Entry: DaemonPidProbe.ReadPidFile(store, n))).ToList();
+
+        var servingProbes = entries
+            .Where(e => e.Entry is { } pe && DaemonPidProbe.IsOurDaemon(pe.Pid, pe.StartToken))
+            .ToDictionary(e => e.Name, e => HelloProbe.RunAsync(store, e.Name, ServingProbeTimeout));
+
+        await Task.WhenAll(servingProbes.Values);
+
+        foreach (var (name, entry) in entries) {
+            if (entry is not { } pe) {
                 await Console.Out.WriteLineAsync($"Daemon '{name}': not running");
-            } else if (DaemonPidProbe.IsOurDaemon(entry.Pid, entry.StartToken)) {
-                // Socket-bound is the serving signal: a Hello over the local control socket answers
-                // only once the daemon has bound its listener, which happens after the lock and boot
-                // checks it may still be working through. A validated PID alone cannot tell a
-                // still-starting daemon from a serving one.
-                var hello = await HelloProbe.RunAsync(store, name, ServingProbeTimeout);
-                await Console.Out.WriteLineAsync($"Daemon '{name}': {DescribeRunningDaemon(entry.Pid, hello.WellFormed)}");
+            } else if (DaemonPidProbe.IsOurDaemon(pe.Pid, pe.StartToken)) {
+                // Socket-reachable is the serving signal: a daemon that accepts the control-socket
+                // connection has bound its listener, so it is serving even if it is an older build
+                // that cannot answer the Hello frame. Only a refused or timed-out connection —
+                // unreachable — is the still-starting daemon a validated PID alone cannot tell apart.
+                var serving = servingProbes.TryGetValue(name, out var probe) && probe.Result.Reachable;
+                await Console.Out.WriteLineAsync($"Daemon '{name}': {DescribeRunningDaemon(pe.Pid, serving)}");
 
                 // Version of the *running* daemon (from the marker it wrote at
                 // startup), so the user can confirm a self-update took effect.
@@ -877,22 +898,42 @@ public sealed class DaemonCommands(
     }
 
     async Task<int> Logs() {
-        if (!File.Exists(LogPath)) {
+        var shown = await TailAsync(LogPath);
+
+        // The stderr capture holds what the primary log cannot — native fatal messages and the
+        // pre-host startup breadcrumbs — so a startup that never reached the logger still leaves a
+        // trace an operator can find here rather than in an undocumented sibling file. Surfaced only
+        // when it has content: a clean run leaves it empty.
+        shown |= await TailAsync(StderrCapturePath, skipIfEmpty: true);
+
+        if (!shown) {
             await Console.Error.WriteLineAsync("No log file found.");
 
             return 1;
         }
 
-        var lines = await File.ReadAllLinesAsync(LogPath);
-        var start = Math.Max(0, lines.Length - 50);
-
-        for (var i = start; i < lines.Length; i++) {
-            await Console.Out.WriteLineAsync(lines[i]);
-        }
-
-        await Console.Error.WriteLineAsync($"\n--- {LogPath} ({lines.Length} lines total) ---");
-
         return 0;
+    }
+
+    /// <summary>Prints the last 50 lines of <paramref name="path"/> with a trailing banner, or returns
+    /// false if it is absent (or empty, when <paramref name="skipIfEmpty"/>). Read write-sharing: the
+    /// daemon holds both this log and the stderr capture open for its whole life, and a plain read
+    /// denies it Write on Windows.</summary>
+    static async Task<bool> TailAsync(string path, bool skipIfEmpty = false) {
+        if (!File.Exists(path)) return false;
+        if (skipIfEmpty && new FileInfo(path).Length == 0) return false;
+
+        var lines = (await File.ReadAllTextSharedAsync(path)).Split('\n');
+        // A trailing newline yields a final empty element that is not a line.
+        var count = lines.Length > 0 && lines[^1].Length == 0 ? lines.Length - 1 : lines.Length;
+        var start = Math.Max(0, count - 50);
+
+        for (var i = start; i < count; i++)
+            await Console.Out.WriteLineAsync(lines[i].TrimEnd('\r'));
+
+        await Console.Error.WriteLineAsync($"\n--- {path} ({count} lines total) ---");
+
+        return true;
     }
 
     // ── service evidence for status/doctor (the verbs live in DaemonServiceCommands) ──

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -585,6 +585,24 @@ public sealed class DaemonCommands(
 
     // ── status ──────────────────────────────────────────────────────────────
 
+    /// <summary>How long <c>status</c> waits for a daemon's Hello before reporting it as still
+    /// starting. Short: a bound daemon answers immediately, and an unbound one refuses the connection
+    /// at once — the timeout only bounds the rare mid-bind race.</summary>
+    static readonly TimeSpan ServingProbeTimeout = TimeSpan.FromSeconds(2);
+
+    /// <summary>
+    /// The running daemon's status line, distinguishing a daemon that is actually serving from one
+    /// whose PID is live but whose local control socket does not yet answer. A validated PID proves
+    /// only that the process exists; a well-formed Hello proves it has bound its socket and can answer.
+    /// A live process that is not yet answering has acquired its lock but has not finished binding its
+    /// listener and connecting — it is starting, not serving — which a PID alone reports as flatly
+    /// "running".
+    /// </summary>
+    internal static string DescribeRunningDaemon(int pid, bool serving) =>
+        serving
+            ? $"running (PID {pid})"
+            : $"running (PID {pid}, starting — not yet serving)";
+
     async Task<int> Status(string[] args) {
         string? explicitName;
 
@@ -613,7 +631,12 @@ public sealed class DaemonCommands(
             if (DaemonPidProbe.ReadPidFile(store, name) is not { } entry) {
                 await Console.Out.WriteLineAsync($"Daemon '{name}': not running");
             } else if (DaemonPidProbe.IsOurDaemon(entry.Pid, entry.StartToken)) {
-                await Console.Out.WriteLineAsync($"Daemon '{name}': running (PID {entry.Pid})");
+                // Socket-bound is the serving signal: a Hello over the local control socket answers
+                // only once the daemon has bound its listener, which happens after the lock and boot
+                // checks it may still be working through. A validated PID alone cannot tell a
+                // still-starting daemon from a serving one.
+                var hello = await HelloProbe.RunAsync(store, name, ServingProbeTimeout);
+                await Console.Out.WriteLineAsync($"Daemon '{name}': {DescribeRunningDaemon(entry.Pid, hello.WellFormed)}");
 
                 // Version of the *running* daemon (from the marker it wrote at
                 // startup), so the user can confirm a self-update took effect.

--- a/src/Capacitor.Cli/Services/HelloProbe.cs
+++ b/src/Capacitor.Cli/Services/HelloProbe.cs
@@ -5,7 +5,17 @@ using Capacitor.Cli.Core.LocalIpc;
 
 namespace Capacitor.Cli.Services;
 
-public sealed record HelloProbeResult(bool WellFormed, int? ProtocolVersion, string? DaemonVersion, string? DaemonName);
+/// <param name="WellFormed">The daemon answered a parseable HelloReply — the strong signal
+/// install-verify and start-verify gate on.</param>
+public sealed record HelloProbeResult(bool WellFormed, int? ProtocolVersion, string? DaemonVersion, string? DaemonName) {
+    /// <summary>The control socket accepted the connection, whether or not a HelloReply followed. This
+    /// is the SERVING signal: a daemon built before the Hello frame accepts the connection and drops
+    /// the unknown frame without replying, so it is reachable and serving yet not well-formed. Only a
+    /// connection that never opened — refused, timed out, no socket — is unreachable, and only that is
+    /// still starting. Defaults false so a well-formed test fake that never dialed a socket does not
+    /// falsely read as reachable; <see cref="HelloProbe.RunAsync"/> is the only place it is set true.</summary>
+    public bool Reachable { get; init; }
+}
 
 /// <summary>
 /// One-shot dial + Hello + HelloReply against a daemon's local control socket, bounded by
@@ -15,23 +25,36 @@ public sealed record HelloProbeResult(bool WellFormed, int? ProtocolVersion, str
 /// capability-incompatible hello) must not apply.
 /// </summary>
 static class HelloProbe {
-    static readonly HelloProbeResult NotWellFormed = new(false, null, null, null);
+    static readonly HelloProbeResult Unreachable            = new(false, null, null, null);
+    static readonly HelloProbeResult ReachableNotWellFormed = new(false, null, null, null) { Reachable = true };
 
     public static async Task<HelloProbeResult> RunAsync(DaemonStore store, string daemonName, TimeSpan timeout) {
         using var cts = new CancellationTokenSource(timeout);
+
+        NetworkStream stream;
         try {
             var sock = new Socket(AddressFamily.Unix, SocketType.Stream, ProtocolType.Unspecified);
-            await using var stream = await ConnectAsync(sock, store, daemonName, cts.Token);
-
-            await FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.Hello), cts.Token);
-            var reply = await FrameCodec.ReadAsync(stream, cts.Token);
-            if (reply is null || reply.Type != FrameType.HelloReply) return NotWellFormed;
-
-            var dto = JsonSerializer.Deserialize(reply.Text, HelloIpcJsonContext.Default.HelloReplyDto);
-            if (dto is null) return NotWellFormed;
-            return new HelloProbeResult(true, dto.ProtocolVersion, dto.DaemonVersion, dto.DaemonName);
+            stream = await ConnectAsync(sock, store, daemonName, cts.Token);
         } catch {
-            return NotWellFormed;
+            // Never opened: refused, timed out, or no socket at all — the daemon has not bound its
+            // listener, so it is starting, not serving.
+            return Unreachable;
+        }
+
+        // The connection opened, so the daemon is reachable — serving — from here on, even if the
+        // exchange below fails. An older daemon drops the unknown Hello frame without replying.
+        await using (stream) {
+            try {
+                await FrameCodec.WriteAsync(stream, new LocalFrame(FrameType.Hello), cts.Token);
+                var reply = await FrameCodec.ReadAsync(stream, cts.Token);
+                if (reply is null || reply.Type != FrameType.HelloReply) return ReachableNotWellFormed;
+
+                var dto = JsonSerializer.Deserialize(reply.Text, HelloIpcJsonContext.Default.HelloReplyDto);
+                if (dto is null) return ReachableNotWellFormed;
+                return new HelloProbeResult(true, dto.ProtocolVersion, dto.DaemonVersion, dto.DaemonName) { Reachable = true };
+            } catch {
+                return ReachableNotWellFormed;
+            }
         }
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerConcurrentProbeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerConcurrentProbeTests.cs
@@ -1,0 +1,73 @@
+namespace Capacitor.Cli.Daemon.Tests.Unit;
+
+/// <summary>
+/// <see cref="DaemonRunner.ProbeVendorsConcurrently{T}"/> is the seam that keeps startup from
+/// serializing one bounded vendor `--version` probe behind another: N vendors probed concurrently
+/// cost roughly one probe's budget, not the sum across N. These pin the two properties startup relies
+/// on — the probes overlap, and a probe still unfinished at the ceiling maps to the miss value without
+/// holding the rest of the pass hostage.
+/// </summary>
+[ParallelLimiter<SubprocessLimit>]
+public class DaemonRunnerConcurrentProbeTests {
+    static void InterlockedMax(ref int target, int value) {
+        int seen;
+        do { seen = Volatile.Read(ref target); }
+        while (value > seen && Interlocked.CompareExchange(ref target, value, seen) != seen);
+    }
+
+    /// <summary>A sequential pass can never hold two probes in flight at once, so an observed peak of
+    /// two or more is proof the pass overlapped them.</summary>
+    [Test]
+    public async Task ProbeVendorsConcurrently_OverlapsProbes_RatherThanSerializing() {
+        string[] vendors = ["a", "b", "c", "d", "e"];
+        var current       = 0;
+        var maxConcurrent = 0;
+
+        var result = DaemonRunner.ProbeVendorsConcurrently(
+            vendors,
+            vendor => {
+                var now = Interlocked.Increment(ref current);
+                InterlockedMax(ref maxConcurrent, now);
+                Thread.Sleep(300);   // hold the slot so peers can pile up
+                Interlocked.Decrement(ref current);
+
+                return vendor + "-ok";
+            },
+            timedOut: "TIMEOUT");
+
+        await Assert.That(maxConcurrent).IsGreaterThanOrEqualTo(2)
+            .Because("a sequential pass would never show two probes in flight at once");
+        await Assert.That(result.Keys).IsEquivalentTo(vendors);
+        await Assert.That(result.Values.All(v => v == "TIMEOUT")).IsFalse();
+        await Assert.That(result["c"]).IsEqualTo("c-ok");
+    }
+
+    /// <summary>A single slow vendor is cut at the ceiling and maps to the miss value; the vendors that
+    /// answered still resolve, so one wedged CLI does not withhold the rest of the advertisement.</summary>
+    [Test]
+    public async Task ProbeVendorsConcurrently_SlowVendorMapsToTimeout_FastVendorsStillResolve() {
+        string[] vendors = ["fast1", "slow", "fast2"];
+
+        var result = DaemonRunner.ProbeVendorsConcurrently(
+            vendors,
+            vendor => {
+                if (vendor == "slow") Thread.Sleep(4_000);
+
+                return vendor + "-v";
+            },
+            timedOut: "TIMEOUT",
+            ceilingMs: 800);
+
+        await Assert.That(result["fast1"]).IsEqualTo("fast1-v");
+        await Assert.That(result["fast2"]).IsEqualTo("fast2-v");
+        await Assert.That(result["slow"]).IsEqualTo("TIMEOUT");
+    }
+
+    [Test]
+    public async Task ProbeVendorsConcurrently_NoVendors_ReturnsEmpty() {
+        var result = DaemonRunner.ProbeVendorsConcurrently(
+            Array.Empty<string>(), _ => "unused", timedOut: "TIMEOUT");
+
+        await Assert.That(result).IsEmpty();
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerStartupPhaseTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerStartupPhaseTests.cs
@@ -1,0 +1,32 @@
+namespace Capacitor.Cli.Daemon.Tests.Unit;
+
+/// <summary>
+/// <see cref="DaemonRunner.StartupPhase"/> is the pre-host breadcrumb: before the host (and its
+/// <c>ILogger</c>) exists, a stall between lock acquisition and host construction would otherwise
+/// leave no record of how far the boot got. Each call must land one greppable, phase-named line on
+/// stderr so the last one printed names the last phase reached.
+/// </summary>
+public class DaemonRunnerStartupPhaseTests {
+    [Test]
+    [NotInParallel]   // Console is process-global
+    public async Task StartupPhase_WritesTheNamedPhaseToStderr() {
+        using var capture = ConsoleOutput.StartErrorCapture();
+
+        DaemonRunner.StartupPhase("lock acquired");
+
+        await Assert.That(capture.GetCapturedError()).Contains("[startup] lock acquired");
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task StartupPhase_KeepsPhasesInTheOrderTheyWereReached() {
+        using var capture = ConsoleOutput.StartErrorCapture();
+
+        DaemonRunner.StartupPhase("lock acquired");
+        DaemonRunner.StartupPhase("boot checks done");
+
+        var lines = capture.GetCapturedError();
+        await Assert.That(lines.IndexOf("lock acquired", StringComparison.Ordinal))
+            .IsLessThan(lines.IndexOf("boot checks done", StringComparison.Ordinal));
+    }
+}

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerVersionProbeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerVersionProbeTests.cs
@@ -85,4 +85,33 @@ public class DaemonRunnerVersionProbeTests {
 
         await Assert.That(DaemonRunner.ProbeCliVersionForLaunch(cli)).IsEqualTo("9.9.9");
     }
+
+    /// <summary>A CLI that exits while a descendant keeps the redirected stdout open must not wedge the
+    /// probe. The pipe never reaches EOF while the descendant lives, so reading the drain to the end
+    /// would block forever — hanging daemon startup and stacking one leaked task per later capability
+    /// refresh. The probe is bounded on its own budget instead, and it still recovers the version the
+    /// CLI printed before the descendant wedged the pipe: closing the read end hands the drain back the
+    /// bytes it had buffered. POSIX stub, so Windows is skipped like the other real-binary checks.</summary>
+    [Test]
+    public async Task A_descendant_holding_the_pipe_open_is_bounded_and_still_reads_the_version() {
+        Skip.Unless(!OperatingSystem.IsWindows(), "The stub binary is a POSIX shell script.");
+        using var tmp = new TempDir();
+        // Prints the version, then leaves a child holding the inherited stdout open after the CLI
+        // itself exits — the shape that made ProbeCliVersionOnce block on a drain that never saw EOF.
+        var cli = tmp.CreateFile(
+            "faketool", "#!/bin/sh\necho 'faketool 9.9.9'\nsleep 20 &\nexit 0\n");
+        if (!OperatingSystem.IsWindows())
+            File.SetUnixFileMode(cli, UnixFileMode.UserRead | UnixFileMode.UserWrite | UnixFileMode.UserExecute);
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var version = await Task.Run(() => DaemonRunner.ProbeCliVersionForLaunch(cli));
+        sw.Stop();
+
+        // Bounded: a return well under the descendant's 20s lifetime proves the drain was not blocked
+        // to an EOF that never comes.
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(12));
+        // Recovered: the version printed ahead of the block survives, so registration advertises it
+        // rather than an unknown version that would reject a launch.
+        await Assert.That(version).IsEqualTo("9.9.9");
+    }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/DaemonLogsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/DaemonLogsTests.cs
@@ -1,0 +1,63 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>
+/// <c>kcap daemon logs</c> must surface the sibling stderr capture (<c>daemon.out.log</c>), not only
+/// the primary <c>daemon.log</c>. The pre-host startup breadcrumbs and native fatal messages land in
+/// the capture, and a detached start redirects the daemon's fds there — so an operator following the
+/// documented command would otherwise never see the diagnostics meant for an early startup stall.
+/// </summary>
+public class DaemonLogsTests {
+    [TempDaemonPaths] public required TempDaemonStore Daemons { get; init; }
+    [TempConfigRoot]  public required TempConfigRoot  Config  { get; init; }
+    [TempHome]        public required TempHome        Home    { get; init; }
+
+    DaemonCommands Sut() => new(
+        Daemons.Store, Config.Root, Resolutions.None(Config.Root), Home,
+        TestHarnesses.All(), TestBinaries.None);
+
+    string LogPath          => Config.Root.Path("daemon.log");
+    string StderrCapturePath => System.IO.Path.ChangeExtension(LogPath, null) + ".out.log";
+
+    [Test]
+    [NotInParallel]
+    public async Task Logs_surfaces_the_stderr_capture_sibling() {
+        await File.WriteAllTextAsync(LogPath, "primary-log-line\n");
+        await File.WriteAllTextAsync(StderrCapturePath, "startup: lock acquired\n");
+
+        using var capture = ConsoleOutput.StartFullCapture();
+
+        var exit = await Sut().HandleAsync(["daemon", "logs"]);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(capture.GetCapturedOutput()).Contains("primary-log-line");
+        await Assert.That(capture.GetCapturedOutput()).Contains("startup: lock acquired");
+        await Assert.That(capture.GetCapturedError()).Contains("daemon.out.log");
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task Logs_skips_an_empty_stderr_capture() {
+        await File.WriteAllTextAsync(LogPath, "primary-log-line\n");
+        await File.WriteAllTextAsync(StderrCapturePath, "");   // a clean run leaves it empty
+
+        using var capture = ConsoleOutput.StartFullCapture();
+
+        var exit = await Sut().HandleAsync(["daemon", "logs"]);
+
+        await Assert.That(exit).IsEqualTo(0);
+        await Assert.That(capture.GetCapturedError()).DoesNotContain("daemon.out.log");
+    }
+
+    [Test]
+    [NotInParallel]
+    public async Task Logs_reports_nothing_when_neither_file_exists() {
+        using var capture = ConsoleOutput.StartFullCapture();
+
+        var exit = await Sut().HandleAsync(["daemon", "logs"]);
+
+        await Assert.That(exit).IsEqualTo(1);
+        await Assert.That(capture.GetCapturedError()).Contains("No log file found");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/DaemonStatusServingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/DaemonStatusServingTests.cs
@@ -1,0 +1,25 @@
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>
+/// <c>kcap daemon status</c> must distinguish a daemon that is actually serving from one whose PID is
+/// live but whose local control socket does not yet answer — it has taken its lock but has not
+/// finished binding and connecting. <see cref="DaemonCommands.DescribeRunningDaemon"/> is the pure
+/// classifier that maps the two liveness signals (validated PID, well-formed Hello) to the reported
+/// line, so the distinction is testable without a real socket (the socket leg is
+/// <c>HelloProbeTests</c>).
+/// </summary>
+public class DaemonStatusServingTests {
+    [Test]
+    public async Task DescribeRunningDaemon_SocketAnswers_ReportsPlainRunning() {
+        await Assert.That(DaemonCommands.DescribeRunningDaemon(12345, serving: true))
+            .IsEqualTo("running (PID 12345)");
+    }
+
+    [Test]
+    public async Task DescribeRunningDaemon_SocketSilent_ReportsStartingNotYetServing() {
+        await Assert.That(DaemonCommands.DescribeRunningDaemon(12345, serving: false))
+            .IsEqualTo("running (PID 12345, starting — not yet serving)");
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/Commands/DaemonStatusServingTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/DaemonStatusServingTests.cs
@@ -4,11 +4,11 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 
 /// <summary>
 /// <c>kcap daemon status</c> must distinguish a daemon that is actually serving from one whose PID is
-/// live but whose local control socket does not yet answer — it has taken its lock but has not
-/// finished binding and connecting. <see cref="DaemonCommands.DescribeRunningDaemon"/> is the pure
-/// classifier that maps the two liveness signals (validated PID, well-formed Hello) to the reported
-/// line, so the distinction is testable without a real socket (the socket leg is
-/// <c>HelloProbeTests</c>).
+/// live but whose local control socket does not yet accept a connection — it has taken its lock but
+/// has not finished binding. <see cref="DaemonCommands.DescribeRunningDaemon"/> is the pure classifier
+/// that maps the two liveness signals (validated PID, reachable control socket) to the reported line,
+/// so the distinction is testable without a real socket (the socket leg — including that an older
+/// daemon which cannot answer Hello is still reachable — is <c>HelloProbeTests</c>).
 /// </summary>
 public class DaemonStatusServingTests {
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Services/HelloProbeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/HelloProbeTests.cs
@@ -43,6 +43,11 @@ public class HelloProbeTests {
             await FrameCodec.WriteAsync(s, reply, ct);
     };
 
+    // Accept the connection, read the Hello, then close without replying — a daemon built before the
+    // Hello frame drops the unknown frame this way. Reachable (serving) yet not well-formed. The read's
+    // result is unused; the connection closes when the server disposes the stream after this returns.
+    static readonly ConnScript ReadThenClose = FrameCodec.ReadAsync;
+
     async Task WithServerAsync(ConnScript script, Func<string, Task> body) {
         var name = "hp-" + Guid.NewGuid().ToString("N")[..6];
         await using var server = new OneShotServer(Daemons.Store.SocketPath(name), script);
@@ -60,6 +65,7 @@ public class HelloProbeTests {
             var result = await HelloProbe.RunAsync(Daemons.Store, name, TimeSpan.FromSeconds(5));
 
             await Assert.That(result.WellFormed).IsTrue();
+            await Assert.That(result.Reachable).IsTrue();
             await Assert.That(result.ProtocolVersion).IsEqualTo(1);
             await Assert.That(result.DaemonVersion).IsEqualTo("9.9.9");
             await Assert.That(result.DaemonName).IsEqualTo("probed-daemon");
@@ -67,12 +73,13 @@ public class HelloProbeTests {
     }
 
     [Test]
-    public async Task No_listener_is_not_well_formed() {
+    public async Task No_listener_is_unreachable_and_not_well_formed() {
         Skip.When(OperatingSystem.IsWindows(), "Unix-domain socket path");
 
         // Short name: macOS allows 104 bytes of socket path and $TMPDIR takes 49.
         var result = await HelloProbe.RunAsync(Daemons.Store, "no-such-daemon", TimeSpan.FromSeconds(2));
 
+        await Assert.That(result.Reachable).IsFalse();   // nothing to connect to → still starting
         await Assert.That(result.WellFormed).IsFalse();
         await Assert.That(result.ProtocolVersion).IsNull();
         await Assert.That(result.DaemonVersion).IsNull();
@@ -80,12 +87,28 @@ public class HelloProbeTests {
     }
 
     [Test]
-    public async Task Error_frame_reply_is_not_well_formed() {
+    public async Task Error_frame_reply_is_reachable_but_not_well_formed() {
         Skip.When(OperatingSystem.IsWindows(), "Unix-domain socket path");
 
         await WithServerAsync(ReplyWith(LocalFrame.Error("nope")), async name => {
             var result = await HelloProbe.RunAsync(Daemons.Store, name, TimeSpan.FromSeconds(5));
 
+            await Assert.That(result.Reachable).IsTrue();    // the connection opened → serving
+            await Assert.That(result.WellFormed).IsFalse();
+        });
+    }
+
+    [Test]
+    public async Task A_socket_that_accepts_then_closes_without_replying_is_reachable() {
+        Skip.When(OperatingSystem.IsWindows(), "Unix-domain socket path");
+
+        // The pre-Hello daemon: accepts the connection (so it is serving) and drops the unknown Hello
+        // frame without a reply. Reachability, not a well-formed Hello, is the serving signal — a
+        // CLI-only update that read WellFormed here reported an already-serving old daemon as starting.
+        await WithServerAsync(ReadThenClose, async name => {
+            var result = await HelloProbe.RunAsync(Daemons.Store, name, TimeSpan.FromSeconds(5));
+
+            await Assert.That(result.Reachable).IsTrue();
             await Assert.That(result.WellFormed).IsFalse();
         });
     }


### PR DESCRIPTION
Closes #859 — AI-2684

## What & why

The version-probe deadlock that caused the multi-minute silent startup was fixed earlier (#869). This closes the three residuals that issue left open.

The vendor `--version` probes ran sequentially before the host existed, so N bounded probes serialized ahead of the socket bind and the server connect. They now run concurrently under one wall-clock ceiling — strictly above a single vendor's own budget, so overlapping only removes the N-way serialization and never cuts a probe short; a vendor still unfinished at the ceiling is a miss the capability-refresh path re-probes. Startup now emits a phase trace ("lock acquired", "vendors probed", "host built", …) so a future stall shows the last phase reached, where before the pre-host window logged nothing. And `kcap daemon status` now distinguishes a daemon that is serving from one whose PID is live but whose control socket does not yet answer, reporting "running (PID, starting — not yet serving)" instead of a flat "running".

## Where to look

The concurrent probe keeps each vendor's per-vendor budget; the ceiling is only a backstop above it. `status` dials the local control socket with a 2 s Hello — a bound daemon answers immediately, an unbound one refuses at once — so it does not hang.

Deferred (a minor follow-up, not a core residual): moving the full vendor-*list* advertisement after connect. The list is produced by the gated-reviewer spawns that the connect path reads synchronously, so deferring it risks a brief no-reviewers window; the concurrency here already delivers the fast-startup goal.

## Verification

- New tests: a concurrent probe pass finishes in roughly one probe's budget, not the sum; the phase trace records each phase; `status` reports serving vs still-starting from the Hello outcome. Regression `DaemonRunnerCursorAvailabilityTests` 37/37.
- Daemon and CLI suites green apart from known env flakes; both AOT publishes clean; README updated for the new status wording.
