### PR TITLE
Keep PR context readable while the app is unfocused

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -158,7 +158,9 @@ also available on ended sessions and sessions without a terminal.
 
 The tenant server owns GitHub reads and current user/repository admission. The
 desktop negotiates a versioned contract, subtracts network time from short access
-leases and masks protected content when the workspace loses foreground. A transient
+leases and masks protected content while the workspace is off screen: the window
+hidden to the tray or minimized. Losing keyboard focus alone keeps the reader
+readable and its lease renewed, so it can sit beside another app's window. A transient
 failure can retain the already visible view temporarily; a denial clears it.
 Frozen pages keep stable ordering, expose incomplete coverage and bound retained
 content. Markdown uses native controls with explicit safe links and no remote images.

--- a/src/Capacitor.App/Services/AgentActionService.cs
+++ b/src/Capacitor.App/Services/AgentActionService.cs
@@ -133,24 +133,30 @@ public sealed class AgentActionService {
     public void OpenInWeb(string agentId) {
         string? serverUrl;
         lock (_lock) serverUrl = _serverUrl;
-        OpenAgentUrl(serverUrl, agentId, "Not connected to a daemon yet"); // cannot happen from live UI; defensive only
+        OpenUrl(serverUrl, AgentPath(agentId), "Not connected to a daemon yet"); // cannot happen from live UI; defensive only
     }
 
     /// Same URL shape as OpenInWeb, but always against the app profile's own server rather than
     /// the local daemon's latest snapshot — a remote row's daemon can live behind a different
     /// server than this machine's local one. Never throws.
     public void OpenInWebRemote(string agentId) =>
-        OpenAgentUrl(_remoteServerUrl, agentId, "Not signed in to a server");
+        OpenUrl(_remoteServerUrl, AgentPath(agentId), "Not signed in to a server");
 
-    void OpenAgentUrl(string? serverUrl, string agentId, string missingServerMessage) {
+    /// The work item's page, always on the app profile's own server: that is the server whose read
+    /// named the id, and a daemon snapshot's server may be a different one. Never throws.
+    public void OpenWorkItemInWeb(string workItemId) =>
+        OpenUrl(_remoteServerUrl, $"/work-items/{Uri.EscapeDataString(workItemId)}", "Not signed in to a server");
+
+    static string AgentPath(string agentId) => $"/agents/{Uri.EscapeDataString(agentId)}";
+
+    void OpenUrl(string? serverUrl, string path, string missingServerMessage) {
         if (serverUrl is null) {
             _notifier.Notify(missingServerMessage);
             return;
         }
 
-        var url = $"{serverUrl.TrimEnd('/')}/agents/{Uri.EscapeDataString(agentId)}";
         try {
-            _opener.Open(url);
+            _opener.Open(serverUrl.TrimEnd('/') + path);
         } catch (Exception ex) {
             _notifier.Notify($"Couldn't open the browser: {ex.Message}");
         }

--- a/src/Capacitor.App/Services/AgentActionService.cs
+++ b/src/Capacitor.App/Services/AgentActionService.cs
@@ -2,6 +2,7 @@ using System.Collections.Immutable;
 using System.Reactive.Linq;
 using System.Reactive.Subjects;
 using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Core.WorkItems;
 
 namespace Capacitor.App.Services;
 
@@ -144,8 +145,13 @@ public sealed class AgentActionService {
 
     /// The work item's page, always on the app profile's own server: that is the server whose read
     /// named the id, and a daemon snapshot's server may be a different one. Never throws.
-    public void OpenWorkItemInWeb(string workItemId) =>
-        OpenUrl(_remoteServerUrl, $"/work-items/{Uri.EscapeDataString(workItemId)}", "Not signed in to a server");
+    public void OpenWorkItemInWeb(string workItemId) {
+        if (WorkContextIds.ValidWorkItemId(workItemId) is not { } id) {
+            _notifier.Notify("This work item has no usable id");
+            return;
+        }
+        OpenUrl(_remoteServerUrl, $"/work-items/{Uri.EscapeDataString(id)}", "Not signed in to a server");
+    }
 
     static string AgentPath(string agentId) => $"/agents/{Uri.EscapeDataString(agentId)}";
 

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Presentation.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.Presentation.cs
@@ -20,7 +20,6 @@ public sealed partial class PullRequestContextViewModel {
     public string FreshnessLabel => IsOverview ? FetchedLabel : SnapshotLabel;
     public bool HasStaleOverview => CanDisplay && (_grace || _overviewRead?.Kind == PullRequestReadKind.Stale);
     public string OverviewFreshnessLabel => HasStaleOverview ? "Earlier snapshot" + (FetchedLabel.Length > 0 ? " · " + FetchedLabel : "") : FetchedLabel;
-    public string RefreshTip => OverviewFreshnessLabel is { Length: > 0 } freshness ? $"Refresh pull request · {freshness}" : "Refresh pull request";
 
     public int SelectedTabIndex {
         get => _section switch { "checks" => 1, "reviewers" or "reviews" or "threads" or "thread_comments" => 2, "conversation" => 3, _ => 0 };
@@ -75,7 +74,7 @@ public sealed partial class PullRequestContextViewModel {
     void NotifyPresentation() {
         foreach (var property in new[] { nameof(HasMultipleChoices), nameof(RepositoryLabel), nameof(NumberLabel), nameof(ProviderLabel),
             nameof(CanOpenSource), nameof(IsChecks), nameof(IsReviewers), nameof(IsReviewSection), nameof(IsDiscussion), nameof(FreshnessLabel),
-            nameof(HasStaleOverview), nameof(OverviewFreshnessLabel), nameof(RefreshTip),
+            nameof(HasStaleOverview), nameof(OverviewFreshnessLabel),
             nameof(SelectedTabIndex), nameof(SelectedReviewTabIndex), nameof(LifecycleStatus), nameof(ReviewStatus), nameof(ChecksStatus),
             nameof(ReviewerRows), nameof(CheckRows), nameof(DiscussionRows) })
             this.RaisePropertyChanged(property);

--- a/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/PullRequestContextViewModel.cs
@@ -117,7 +117,7 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
         _openReader = openReader;
         _primaryRepo = primaryRepo;
         _readers = source as IPullRequestReaders;
-        RefreshCommand = ReactiveCommand.Create(() => RequestRefresh(manual: true));
+        RefreshCommand = ReactiveCommand.Create(Refresh);
         OpenReaderCommand = ReactiveCommand.Create(() => { _openReader(); SetReaderVisible(true); });
         ShowSectionCommand = ReactiveCommand.Create<string>(ShowSection);
         LoadMoreCommand = ReactiveCommand.Create(() => { if (CurrentSection?.Next is { } cursor) RequestPage(cursor); });
@@ -183,6 +183,8 @@ public sealed partial class PullRequestContextViewModel : ReactiveObject {
         _refreshDiscovery = true;
         RequestRefresh();
     }
+    /// The user's own refresh: rediscovers support and reloads the list, overview and open section.
+    public void Refresh() => RequestRefresh(manual: true);
     public void SetReaderVisible(bool visible) {
         if (_readerVisible == visible) return;
         _readerVisible = visible;

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
@@ -19,6 +19,13 @@ public sealed partial class WorkContextViewModel {
     // rather than the assignment's; the requested id stands in when a read carried no item.
     string? _primaryId;
     string? _requestedId;
+    string? PrimaryId {
+        get => _primaryId;
+        set {
+            _primaryId = value;
+            _canOpenWorkItem.OnNext(value is not null && _openWorkItem is not null);
+        }
+    }
 
     public IAvaloniaReadOnlyList<WorkContextPartViewModel> Parts => _parts;
     public IAvaloniaReadOnlyList<string> BlockedBy => _blockedBy;
@@ -155,7 +162,7 @@ public sealed partial class WorkContextViewModel {
     }
 
     void ClearCard() {
-        _primaryId = null;
+        PrimaryId = null;
         _requestedId = null;
         ClearItem();
         ClearTopology();
@@ -200,11 +207,11 @@ public sealed partial class WorkContextViewModel {
         var requested = read.Primary.WorkItemId;
         var served = read.Item?.WorkItemId;
         var samePrimary = served is not null
-            ? Same(served, _primaryId)
-            : Same(requested, _requestedId) || Same(requested, _primaryId);
+            ? Same(served, PrimaryId)
+            : Same(requested, _requestedId) || Same(requested, PrimaryId);
         _requestedId = requested;
-        if (served is not null) _primaryId = served;
-        else if (!samePrimary) _primaryId = requested;
+        if (served is not null) PrimaryId = served;
+        else if (!samePrimary) PrimaryId = requested;
 
         if (read.Item is { } item) ApplyItem(item, read.Assignments);
         else if (!samePrimary) {

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.Projections.cs
@@ -23,7 +23,7 @@ public sealed partial class WorkContextViewModel {
         get => _primaryId;
         set {
             _primaryId = value;
-            _canOpenWorkItem.OnNext(value is not null && _openWorkItem is not null);
+            _canOpenWorkItem.OnNext(WorkContextIds.ValidWorkItemId(value) is not null && _openWorkItem is not null);
         }
     }
 

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
@@ -48,6 +48,8 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
     readonly IWorkContextSource _source;
     readonly IUrlOpener _opener;
     readonly TimeProvider _time;
+    readonly Action<string>? _openWorkItem;
+    readonly BehaviorSubject<bool> _canOpenWorkItem = new(false);
     readonly CompositeDisposable _disposables = new();
     readonly List<ReadLease> _outstanding = [];
     ReadLease? _current;
@@ -131,6 +133,8 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
         : "Waiting for the session ID";
 
     public ReactiveCommand<Unit, Unit> RefreshCommand { get; }
+    /// The item's own page in the web UI; enabled once a read has named the item.
+    public ReactiveCommand<Unit, Unit> OpenWorkItemCommand { get; }
     public ReactiveCommand<Unit, Unit> SignInCommand { get; }
 
     /// Test-only seam: the current lease's read, or the last one started.
@@ -138,24 +142,30 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
 
     public WorkContextViewModel(
             IObservable<AgentStatusDto?> presence, IWorkContextSource source, TimeProvider time, IUrlOpener opener,
-            Action? requestSignIn = null, IObservable<Unit>? signInCompleted = null) {
+            Action? requestSignIn = null, IObservable<Unit>? signInCompleted = null, Action<string>? openWorkItem = null) {
         _source = source;
         _opener = opener;
         _time = time;
+        _openWorkItem = openWorkItem;
         InitializeProjections();
         _disposables.Add(_hasSessionChanges);
+        _disposables.Add(_canOpenWorkItem);
 
-        // Enabled for any known session id. A click while a read is in flight queues one follow-up
+        // The pane's one refresh: the linked pull requests reload with the work item. Enabled for
+        // any known session id. A click while a read is in flight queues one follow-up
         // (RefreshPending) instead of disabling the control — a greyed icon looked broken and ate
         // the click with no feedback.
         RefreshCommand = ReactiveCommand.Create(
             () => {
+                PullRequests?.Refresh();
                 if (_current is null) return;
                 if (_current.IsReading) _current.RefreshPending = true;
                 else StartRead(_current);
             },
             _hasSessionChanges);
         _disposables.Add(RefreshCommand);
+        OpenWorkItemCommand = ReactiveCommand.Create(() => { if (PrimaryId is { } id) _openWorkItem?.Invoke(id); }, _canOpenWorkItem);
+        _disposables.Add(OpenWorkItemCommand);
         SignInCommand = ReactiveCommand.Create(() => { requestSignIn?.Invoke(); });
         _disposables.Add(SignInCommand);
 

--- a/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkContextViewModel.cs
@@ -164,7 +164,9 @@ public sealed partial class WorkContextViewModel : ReactiveObject {
             },
             _hasSessionChanges);
         _disposables.Add(RefreshCommand);
-        OpenWorkItemCommand = ReactiveCommand.Create(() => { if (PrimaryId is { } id) _openWorkItem?.Invoke(id); }, _canOpenWorkItem);
+        OpenWorkItemCommand = ReactiveCommand.Create(
+            () => { if (WorkContextIds.ValidWorkItemId(PrimaryId) is { } id) _openWorkItem?.Invoke(id); },
+            _canOpenWorkItem);
         _disposables.Add(OpenWorkItemCommand);
         SignInCommand = ReactiveCommand.Create(() => { requestSignIn?.Invoke(); });
         _disposables.Add(SignInCommand);

--- a/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
+++ b/src/Capacitor.App/ViewModels/WorkspaceViewModel.cs
@@ -99,7 +99,7 @@ public sealed class WorkspaceViewModel : ReactiveObject {
             .Replay(1)
             .RefCount();
 
-        WorkContext = new WorkContextViewModel(presence.Select(p => p.Dto), workContext, time, opener, requestSignIn, signInCompleted);
+        WorkContext = new WorkContextViewModel(presence.Select(p => p.Dto), workContext, time, opener, requestSignIn, signInCompleted, actions.OpenWorkItemInWeb);
         PullRequests = pullRequests is null ? null : new PullRequestContextViewModel(presence.Select(p => p.Dto), pullRequests, time, opener,
             () => ActiveTab = WorkspaceTab.PullRequest, requestSignIn, linkGitHub, signInCompleted, () => WorkContext.PrimaryRepository);
         WorkContext.PullRequests = PullRequests;

--- a/src/Capacitor.App/Views/MainWindow.axaml.cs
+++ b/src/Capacitor.App/Views/MainWindow.axaml.cs
@@ -102,19 +102,20 @@ public partial class MainWindow : ReactiveWindow<MainWindowViewModel> {
         // first Show(), but this keeps the check correct even if a caller (a test) does it the
         // other way around.
         if (change.Property == IsVisibleProperty || change.Property == DataContextProperty
-            || change.Property == IsActiveProperty || change.Property == WindowStateProperty) UpdateActivityVisibility();
+            || change.Property == WindowStateProperty) UpdateActivityVisibility();
     }
 
-    // Activity polls only when it is ACTUALLY on screen: window visible AND the launcher pane
-    // showing (Sessions surface, no workspace open) AND the flyout open — the same contract the
-    // Activity tab's selection used to carry.
+    // Activity polls only while it is actually on screen: window visible AND the launcher pane
+    // showing (Sessions surface, no workspace open) AND the flyout open. PR context follows the
+    // window being on screen — visible and not minimized — never keyboard focus: a reader left
+    // beside another app's window stays readable and keeps its access lease renewed.
     void UpdateActivityVisibility() {
         if (DataContext is MainWindowViewModel vm) {
             vm.Activity.OnTabVisibleChanged(_activityOpen && IsVisible && vm.IsSessionsView && vm.CurrentWorkspace is null);
             var workspace = vm.IsSessionsView ? vm.CurrentWorkspace : null;
             if (_foregroundWorkspace != workspace) _foregroundWorkspace?.PullRequests?.SetForeground(false);
             _foregroundWorkspace = workspace;
-            workspace?.PullRequests?.SetForeground(IsVisible && IsActive && WindowState != Avalonia.Controls.WindowState.Minimized);
+            workspace?.PullRequests?.SetForeground(IsVisible && WindowState != Avalonia.Controls.WindowState.Minimized);
         } else {
             _foregroundWorkspace?.PullRequests?.SetForeground(false);
             _foregroundWorkspace = null;

--- a/src/Capacitor.App/Views/PullRequestCard.axaml
+++ b/src/Capacitor.App/Views/PullRequestCard.axaml
@@ -50,18 +50,16 @@
                 <Button Content="{Binding InstallToolLabel}" Command="{Binding InstallToolCommand}" IsVisible="{Binding ShowsInstallTool}" Classes="prButton prPrimary" Margin="0,0,8,0" />
                 <Button Content="Recheck" Command="{Binding RefreshCommand}" Classes="prButton" />
             </WrapPanel>
-            <Border BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="0,1,0,0" Padding="0,10,0,0">
-                <Grid ColumnDefinitions="*,Auto,Auto" ColumnSpacing="4">
-                    <Button Content="View PR" Command="{Binding OpenReaderCommand}" IsVisible="{Binding HasChoice}"
+            <Border BorderBrush="{StaticResource KcapBorderBrush}" BorderThickness="0,1,0,0" Padding="0,10,0,0" IsVisible="{Binding HasChoice}">
+                <Grid ColumnDefinitions="*,Auto" ColumnSpacing="4">
+                    <Button Content="View PR" Command="{Binding OpenReaderCommand}"
                             IsEnabled="{Binding !IsLegacy}" Classes="prButton prPrimary" HorizontalAlignment="Left" />
-                    <Button Grid.Column="1" Command="{Binding RefreshCommand}" Classes="prButton" ToolTip.Tip="{Binding RefreshTip}"
-                            AutomationProperties.Name="Refresh pull request">
-                        <Path Width="14" Height="14" Stretch="Uniform" Stroke="{StaticResource KcapMutedBrush}" StrokeThickness="1.4" StrokeLineCap="Round"
-                              Data="M11.5,6.5 A5,5 0 1 1 10,3 M10,0.5 L10,3 L7.5,3" />
-                    </Button>
-                    <Button Grid.Column="2" Command="{Binding OpenGitHubCommand}" IsVisible="{Binding HasChoice}" IsEnabled="{Binding CanOpenSource}"
+                    <Button Grid.Column="1" Command="{Binding OpenGitHubCommand}" IsEnabled="{Binding CanOpenSource}"
                             Classes="prButton" AutomationProperties.Name="Open pull request in browser">
-                        <StackPanel Orientation="Horizontal" Spacing="6"><TextBlock Text="{Binding ProviderLabel}" /><Path Classes="prExternal" /></StackPanel>
+                        <StackPanel Orientation="Horizontal" Spacing="6">
+                            <TextBlock Text="{Binding ProviderLabel}" VerticalAlignment="Center" />
+                            <Path Classes="prExternal prAfterLabel" />
+                        </StackPanel>
                     </Button>
                 </Grid>
             </Border>

--- a/src/Capacitor.App/Views/PullRequestReader.axaml
+++ b/src/Capacitor.App/Views/PullRequestReader.axaml
@@ -21,7 +21,10 @@
             <DockPanel Margin="0,3,0,0" LastChildFill="True">
                 <Button DockPanel.Dock="Right" Command="{Binding OpenGitHubCommand}" Classes="prButton" IsEnabled="{Binding CanOpenSource}"
                         AutomationProperties.Name="Open pull request in browser" VerticalAlignment="Top">
-                    <StackPanel Orientation="Horizontal" Spacing="6"><TextBlock Text="{Binding ProviderLabel}" /><Path Classes="prExternal" /></StackPanel>
+                    <StackPanel Orientation="Horizontal" Spacing="6">
+                        <TextBlock Text="{Binding ProviderLabel}" VerticalAlignment="Center" />
+                        <Path Classes="prExternal prAfterLabel" />
+                    </StackPanel>
                 </Button>
                 <WrapPanel IsVisible="{Binding CanDisplay}">
                     <Button Classes="prButton prStatusButton" Command="{Binding ShowSectionCommand}" CommandParameter="checks"

--- a/src/Capacitor.App/Views/PullRequestStyles.axaml
+++ b/src/Capacitor.App/Views/PullRequestStyles.axaml
@@ -113,6 +113,10 @@
         <Setter Property="VerticalAlignment" Value="Center" />
         <Setter Property="Data" Value="M9,2 H14 V7 M14,2 L7,9 M6,3 H3 Q2,3 2,4 V13 Q2,14 3,14 H12 Q13,14 13,13 V10" />
     </Style>
+    <!-- Beside a label: centred on the line box the icon lands a pixel under the glyphs' visual centre. -->
+    <Style Selector="Path.prExternal.prAfterLabel">
+        <Setter Property="RenderTransform" Value="translateY(-1px)" />
+    </Style>
     <Style Selector="Path.prChevron">
         <Setter Property="Width" Value="10" /><Setter Property="Height" Value="10" />
         <Setter Property="Stroke" Value="{StaticResource KcapMutedBrush}" /><Setter Property="StrokeThickness" Value="1.4" />

--- a/src/Capacitor.App/Views/WorkContextView.axaml
+++ b/src/Capacitor.App/Views/WorkContextView.axaml
@@ -179,8 +179,8 @@
                                     <TextBlock x:Name="WorkContextKey" Text="{Binding Key}" FontSize="13" FontWeight="SemiBold"
                                                Foreground="{StaticResource KcapSuccessBrush}" VerticalAlignment="Center"
                                                IsVisible="{Binding Key, Converter={x:Static StringConverters.IsNotNullOrEmpty}}" />
-                                    <Button x:Name="InlineIssueButton" Classes="prButton" Command="{Binding Issue.OpenCommand}" IsVisible="{Binding HasInlineIssue}"
-                                            AutomationProperties.Name="Open work item issue" ToolTip.Tip="Open issue in browser" Padding="4">
+                                    <Button x:Name="OpenWorkItemButton" Classes="prButton" Command="{Binding OpenWorkItemCommand}"
+                                            AutomationProperties.Name="Open work item in web" ToolTip.Tip="Open in web" Padding="4">
                                         <Path Classes="prExternal" />
                                     </Button>
                                 </StackPanel>

--- a/test/Capacitor.App.Tests.Unit/AgentActionServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentActionServiceTests.cs
@@ -307,10 +307,23 @@ public class AgentActionServiceTests {
         var service = NewService(ops, notifier, opener, snapshots, fallbackServerUrl: "https://a.kcap.ai/");
         snapshots.OnNext(FakeDaemonClientService.Snap(serverUrl: "https://b.kcap.ai"));
 
-        service.OpenWorkItemInWeb("w/1");
+        service.OpenWorkItemInWeb(" w/1 ");
 
         await Assert.That(opener.Opened).IsEquivalentTo(["https://a.kcap.ai/work-items/w%2F1"], CollectionOrdering.Matching);
         await Assert.That(notifier.Notified).IsEmpty();
+    }
+
+    [Test]
+    public async Task OpenWorkItemInWeb_refuses_an_id_the_api_client_would_refuse() {
+        var ops = new ScriptedLocalControlOps();
+        var notifier = new RecordingNotifier();
+        var opener = new RecordingOpener();
+        var service = NewService(ops, notifier, opener, fallbackServerUrl: "https://a.kcap.ai");
+
+        service.OpenWorkItemInWeb("..");
+
+        await Assert.That(opener.Opened).IsEmpty();
+        await Assert.That(notifier.Notified).IsEquivalentTo(["This work item has no usable id"], CollectionOrdering.Matching);
     }
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/AgentActionServiceTests.cs
+++ b/test/Capacitor.App.Tests.Unit/AgentActionServiceTests.cs
@@ -298,6 +298,34 @@ public class AgentActionServiceTests {
         await Assert.That(notifier.Notified).IsEquivalentTo(["Not signed in to a server"], CollectionOrdering.Matching);
     }
 
+    [Test]
+    public async Task OpenWorkItemInWeb_uses_the_profile_server_not_the_snapshot_and_escapes_the_id() {
+        var ops = new ScriptedLocalControlOps();
+        var notifier = new RecordingNotifier();
+        var opener = new RecordingOpener();
+        var snapshots = new ReplaySubject<DaemonStatusDto>(1);
+        var service = NewService(ops, notifier, opener, snapshots, fallbackServerUrl: "https://a.kcap.ai/");
+        snapshots.OnNext(FakeDaemonClientService.Snap(serverUrl: "https://b.kcap.ai"));
+
+        service.OpenWorkItemInWeb("w/1");
+
+        await Assert.That(opener.Opened).IsEquivalentTo(["https://a.kcap.ai/work-items/w%2F1"], CollectionOrdering.Matching);
+        await Assert.That(notifier.Notified).IsEmpty();
+    }
+
+    [Test]
+    public async Task OpenWorkItemInWeb_without_a_profile_notifies_and_returns() {
+        var ops = new ScriptedLocalControlOps();
+        var notifier = new RecordingNotifier();
+        var opener = new RecordingOpener();
+        var service = NewService(ops, notifier, opener);
+
+        service.OpenWorkItemInWeb("w1");
+
+        await Assert.That(opener.Opened).IsEmpty();
+        await Assert.That(notifier.Notified).IsEquivalentTo(["Not signed in to a server"], CollectionOrdering.Matching);
+    }
+
     // ---- confirm-then-force for protected kinds (decision 5) ----
 
     [Test]

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -373,6 +373,70 @@ public class MainWindowSmokeTests {
         await Assert.That(reads.afterReshow).IsEqualTo(4);
     }
 
+    /// What the OS does when another app takes focus. The platform layer's Deactivated hook is
+    /// internal to Avalonia, so it is reached through the interface map by member name.
+    static void LoseKeyboardFocus(Window window) {
+        var impl = window.PlatformImpl!;
+        var contract = impl.GetType().GetInterfaces().First(i => i.Name == "IWindowBaseImpl");
+        var map = impl.GetType().GetInterfaceMap(contract);
+        var getter = Array.FindIndex(map.InterfaceMethods, m => m.Name == "get_Deactivated");
+        (map.TargetMethods[getter].Invoke(impl, null) as Action)?.Invoke();
+    }
+
+    /// PR context follows the window being on screen: an open workspace in a visible window loads
+    /// and shows its pull request while another app holds keyboard focus, and only minimizing or
+    /// hiding the window masks it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Pull_request_context_follows_the_window_being_on_screen_not_keyboard_focus() {
+        await AvaloniaSession.RunOnUiAsync(async () => {
+            var service = new FakeDaemonClientService();
+            var (actions, _) = NewActions(service);
+            var time = new FakeTimeProvider();
+            var source = new FakePullRequestSource(time);
+            var attach = new FakeTerminalAttachClientFactory();
+            var vm = new MainWindowViewModel(
+                service, CancellationToken.None, TestActivity.New(),
+                workspaceFactory: agentId => new WorkspaceViewModel(
+                    agentId, service, actions, attach.Factory, () => new FakeTerminalSurface(), time, new RecordingOpener(),
+                    new FakePermissionService(), new FakeWorkContextSource(), new ScriptedLocalControlOps(), pullRequests: source));
+            var window = new MainWindow { DataContext = vm };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+            try {
+                vm.OpenSession("agent");
+                Dispatcher.UIThread.RunJobs();
+                var workspace = vm.CurrentWorkspace!;
+                var pullRequests = workspace.PullRequests!;
+                service.Agents.AddOrUpdate(WorkspaceFixtures.Agent("agent", "claude", hasTerminal: false, sessionId: "session"));
+                await (workspace.Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
+                await WorkspaceFixtures.WaitUntilAsync(() => pullRequests.CanReveal, what: "PR shown in the visible window");
+
+                await Assert.That(window.IsActive).IsTrue();
+                LoseKeyboardFocus(window);
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(window.IsActive).IsFalse();
+                await Assert.That(pullRequests.CanReveal).IsTrue();
+
+                window.WindowState = WindowState.Minimized;
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(pullRequests.CanReveal).IsFalse();
+
+                window.WindowState = WindowState.Normal;
+                Dispatcher.UIThread.RunJobs();
+                await WorkspaceFixtures.WaitUntilAsync(() => pullRequests.CanReveal, what: "PR shown again after restoring");
+
+                window.Hide();
+                Dispatcher.UIThread.RunJobs();
+                await Assert.That(pullRequests.CanReveal).IsFalse();
+            } finally {
+                vm.CloseWorkspace();
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+            }
+        });
+    }
+
     /// The surface swap itself (spec §3) — the XAML side of what WorkspaceNavigationTests pins on
     /// the ViewModel. WorkspaceView is materialized from a template rather than always present, so
     /// this also proves the terminal control is CONSTRUCTED only once a workspace exists; closing

--- a/test/Capacitor.App.Tests.Unit/WorkContextViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkContextViewModelTests.cs
@@ -443,6 +443,32 @@ public class WorkContextViewModelTests {
         });
     }
 
+    /// The browser route escapes but never normalizes, so an id the API client refuses stays
+    /// closed here too, and a padded one opens canonical.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    [Arguments("..", null)]
+    [Arguments("", null)]
+    [Arguments(" ", null)]
+    [Arguments(" w1 ", "w1")]
+    public async Task The_open_action_applies_the_work_item_id_rules(string assigned, string? opened) {
+        await RunOnUiAsync(async () => {
+            var h = new Harness();
+            h.Source.Enqueue(ReadyWith(Row(assigned, "WK-2198")));
+            try {
+                await h.PushAsync(Dto());
+                await Assert.That(h.Vm.Phase).IsEqualTo(WorkContextPhase.Ready);
+                await Assert.That(await h.Vm.OpenWorkItemCommand.CanExecute.FirstAsync()).IsEqualTo(opened is not null);
+                if (opened is not null) {
+                    await h.Vm.OpenWorkItemCommand.Execute();
+                    await Assert.That(h.OpenedWorkItems).IsEquivalentTo(new[] { opened });
+                }
+            } finally {
+                await h.Vm.TeardownAsync();
+            }
+        });
+    }
+
     static SessionWorkItemAssignmentDto Row(string id, string label, bool primary = true) =>
         new() { WorkItemId = id, Label = label, Source = "mcp", Confidence = 1, IsPrimary = primary };
 

--- a/test/Capacitor.App.Tests.Unit/WorkContextViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkContextViewModelTests.cs
@@ -26,10 +26,11 @@ public class WorkContextViewModelTests {
         public RecordingOpener Opener { get; } = new();
         public Subject<ReactiveUnit> SignIn { get; } = new();
         public int SignInRequests;
+        public List<string> OpenedWorkItems { get; } = [];
         public WorkContextViewModel Vm { get; }
 
         public Harness() =>
-            Vm = new WorkContextViewModel(Presence, Source, Time, Opener, () => SignInRequests++, SignIn);
+            Vm = new WorkContextViewModel(Presence, Source, Time, Opener, () => SignInRequests++, SignIn, OpenedWorkItems.Add);
 
         /// For a read that will answer from the queue: pushes and awaits the read it starts.
         public async Task PushAsync(AgentStatusDto dto) {
@@ -390,6 +391,58 @@ public class WorkContextViewModelTests {
         });
     }
 
+    /// The pane's refresh is the pull requests' refresh too: the card has no control of its own.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Refresh_reloads_the_linked_pull_requests_with_the_work_item() {
+        await RunOnUiAsync(async () => {
+            var h = new Harness();
+            var source = new FakePullRequestSource(h.Time);
+            var pullRequests = new PullRequestContextViewModel(h.Presence, source, h.Time, h.Opener, () => { });
+            h.Vm.PullRequests = pullRequests;
+            pullRequests.SetForeground(true);
+            h.Source.Enqueue(Ready(), Ready());
+            try {
+                await h.PushAsync(Dto());
+                await WaitUntilAsync(() => source.Lists == 1 && !pullRequests.IsReading, what: "first PR list");
+                await Assert.That(h.Source.Requested.Count).IsEqualTo(1);
+
+                h.Time.Advance(TimeSpan.FromSeconds(16));
+                await h.Vm.RefreshCommand.Execute();
+                await (h.Vm.PendingReadForTesting ?? Task.CompletedTask);
+                await WaitUntilAsync(() => source.Lists == 2, what: "PR list reloaded by the pane refresh");
+                await Assert.That(h.Source.Requested.Count).IsEqualTo(2);
+            } finally {
+                await pullRequests.TeardownAsync();
+                await h.Vm.TeardownAsync();
+            }
+        });
+    }
+
+    /// The open action names the item the server served, which for an absorbed item is not the
+    /// assignment's id, and a terminal read that clears the card disables it again.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task The_open_action_waits_for_a_read_to_name_the_item_and_opens_the_served_id() {
+        await RunOnUiAsync(async () => {
+            var h = new Harness();
+            h.Source.Enqueue(ReadyWith(Row("w1", "WK-2198"), Item(id: "w9")), WorkContextRead.Of(WorkContextReadKind.SignedOut));
+            try {
+                await Assert.That(await h.Vm.OpenWorkItemCommand.CanExecute.FirstAsync()).IsFalse();
+
+                await h.PushAsync(Dto());
+                await Assert.That(await h.Vm.OpenWorkItemCommand.CanExecute.FirstAsync()).IsTrue();
+                await h.Vm.OpenWorkItemCommand.Execute();
+                await Assert.That(h.OpenedWorkItems).IsEquivalentTo(new[] { "w9" });
+
+                await h.TickAsync();
+                await Assert.That(await h.Vm.OpenWorkItemCommand.CanExecute.FirstAsync()).IsFalse();
+            } finally {
+                await h.Vm.TeardownAsync();
+            }
+        });
+    }
+
     static SessionWorkItemAssignmentDto Row(string id, string label, bool primary = true) =>
         new() { WorkItemId = id, Label = label, Source = "mcp", Confidence = 1, IsPrimary = primary };
 
@@ -685,7 +738,7 @@ public class WorkContextViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public Task The_sidebar_hides_empty_parts_and_repeated_identity_but_keeps_the_issue_action() => RunOnUiAsync(async () => {
+    public Task The_sidebar_hides_empty_parts_and_repeated_identity_but_keeps_the_open_action() => RunOnUiAsync(async () => {
         var h = new Harness();
         var view = new WorkContextView { DataContext = h.Vm };
         var window = new Window { Content = view, Width = 320, Height = 800 };
@@ -704,10 +757,11 @@ public class WorkContextViewModelTests {
             await Assert.That(view.FindControl<Button>("PartsToggle")!.IsEffectivelyVisible).IsFalse();
             await Assert.That(view.FindControl<TextBlock>("WorkContextTitle")!.IsEffectivelyVisible).IsFalse();
             await Assert.That(view.FindControl<ContentControl>("IssueCard")!.IsEffectivelyVisible).IsFalse();
-            var issue = view.FindControl<Button>("InlineIssueButton")!;
-            await Assert.That(issue.IsEffectivelyVisible).IsTrue();
-            issue.Command!.Execute(issue.CommandParameter);
-            await Assert.That(h.Opener.Opened).IsEquivalentTo(new[] { "https://linear.app/example/issue/WK-2198" });
+            var open = view.FindControl<Button>("OpenWorkItemButton")!;
+            await Assert.That(open.IsEffectivelyVisible).IsTrue();
+            open.Command!.Execute(open.CommandParameter);
+            await Assert.That(h.OpenedWorkItems).IsEquivalentTo(new[] { "w1" });
+            await Assert.That(h.Opener.Opened).IsEmpty();
 
             await h.TickAsync();
             window.UpdateLayout();
@@ -715,7 +769,7 @@ public class WorkContextViewModelTests {
             await Assert.That(view.FindControl<TextBlock>("WorkContextTitle")!.Text).IsEqualTo("A useful title");
             await Assert.That(view.FindControl<TextBlock>("WorkContextTitle")!.IsEffectivelyVisible).IsTrue();
             await Assert.That(view.FindControl<ContentControl>("IssueCard")!.IsEffectivelyVisible).IsTrue();
-            await Assert.That(issue.IsEffectivelyVisible).IsFalse();
+            await Assert.That(open.IsEffectivelyVisible).IsTrue();
         } finally {
             window.Close();
             await h.Vm.TeardownAsync();
@@ -744,7 +798,7 @@ public class WorkContextViewModelTests {
             var title = view.FindControl<TextBlock>("WorkContextTitle")!;
             await Assert.That(title.IsEffectivelyVisible).IsEqualTo(displayTitle.Length > 0);
             await Assert.That(title.Text).IsEqualTo(displayTitle);
-            await Assert.That(view.FindControl<Button>("InlineIssueButton")!.IsEffectivelyVisible).IsEqualTo(inline);
+            await Assert.That(view.FindControl<Button>("OpenWorkItemButton")!.IsEffectivelyVisible).IsTrue();
             await Assert.That(view.FindControl<ContentControl>("IssueCard")!.IsEffectivelyVisible).IsEqualTo(!inline);
             await Assert.That(h.Vm.Issue!.Title).IsEqualTo(issueTitle);
         } finally {

--- a/test/Capacitor.App.Tests.Unit/WorkContextViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WorkContextViewSmokeTests.cs
@@ -93,7 +93,7 @@ public class WorkContextViewSmokeTests {
             await Assert.That(host.Find<TextBlock>("WorkContextTitle").IsEffectivelyVisible).IsFalse();
 
             var issueCard = host.Find<ContentControl>("IssueCard");
-            await Assert.That(host.Find<Button>("InlineIssueButton").IsEffectivelyVisible).IsEqualTo(inline);
+            await Assert.That(host.Find<Button>("OpenWorkItemButton").IsEffectivelyVisible).IsTrue();
             await Assert.That(issueCard.IsEffectivelyVisible).IsEqualTo(!inline);
             if (!inline) {
                 var linkKey = issueCard.GetVisualDescendants().OfType<TextBlock>().First(t => t.Name == "LinkKey");


### PR DESCRIPTION
Closes #883 — AI-2700

## What & why

The PR card and reader masked every protected field the moment another app took keyboard focus, because the window fed the PR context a foreground flag that required it to be active. Foreground is now the window being on screen, visible and not minimized, so the reader stays readable beside another window and keeps its access lease renewed. The pane's single refresh reloads the work item and the pull requests together; the card has no refresh of its own. The open button beside the work item key opens the item's page in the web UI on the profile server, since a Linear-keyed issue link arrives without a tracker URL. The external-link icon beside a label sits on the glyphs' visual centre, 1px above the line-box centre.

## Where to look

`MainWindow.UpdateActivityVisibility` is the one predicate; hiding to the tray and minimizing still mask. The new smoke test deactivates the headless window through the platform interface map, because that hook is internal to Avalonia.

## Verification

- `dotnet run --project test/Capacitor.App.Tests.Unit`: 1684 passed, 0 failed.
- Against the focus-keyed predicate the new window test fails at `pullRequests.CanReveal` right after focus loss.
- `dotnet build src/Capacitor.App --no-incremental`: 0 warnings.
- The icon offset was measured from the report's screenshot; the sandbox cannot launch the app, so it wants an eyeball check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
