### PR TITLE
Measure SessionStart memory budgets on the injected clock

### DIFF
--- a/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/AntigravityHookCommand.cs
@@ -304,9 +304,9 @@ sealed class AntigravityHookCommand(
 
         try {
             var store    = SessionStartMemoryLeaseStore.Create(config, clock.Time);
-            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync);
+            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync, clock.Time);
 
-            return await new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+            return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 LifecycleFor(sessionId),
                 new SessionStartMemoryContextRequest(Url, scopeRoot, disabled, budget, CancellationToken.None,
                     GuidelinesDisabled: guidelinesDisabled));

--- a/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
@@ -1132,9 +1132,9 @@ public sealed class ClaudeHookCommand(
         try {
             var store    = SessionStartMemoryLeaseStore.Create(config, clock.Time);
             var provider = new SessionStartMemoryContextProvider(
-                new SessionStartMemoryScopeResolver(config), http.ForMemoryAsync);
+                new SessionStartMemoryScopeResolver(config, clock.Time), http.ForMemoryAsync);
 
-            return await new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+            return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 new SessionMemoryLifecycle(HarnessId.Claude, nativeSessionId, null,
                     IsTopLevel: true, ClassificationAuthoritative: true, reason,
                     CallbackMayRepeat: false),

--- a/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/ClaudeHookCommand.cs
@@ -1132,7 +1132,7 @@ public sealed class ClaudeHookCommand(
         try {
             var store    = SessionStartMemoryLeaseStore.Create(config, clock.Time);
             var provider = new SessionStartMemoryContextProvider(
-                new SessionStartMemoryScopeResolver(config, clock.Time), http.ForMemoryAsync);
+                new SessionStartMemoryScopeResolver(config, clock.Time), http.ForMemoryAsync, clock.Time);
 
             return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 new SessionMemoryLifecycle(HarnessId.Claude, nativeSessionId, null,

--- a/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CodexHookCommand.cs
@@ -155,9 +155,9 @@ sealed class CodexHookCommand(
         // the injected client factory can throw synchronously.
         try {
             var store    = SessionStartMemoryLeaseStore.Create(config, clock.Time);
-            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync);
+            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync, clock.Time);
 
-            return await new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+            return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 new SessionMemoryLifecycle(HarnessId.Codex, sessionId!, LifecycleInstanceId: null,
                     IsTopLevel: true, ClassificationAuthoritative: true, SessionLifecycleReason.New,
                     CallbackMayRepeat: false),

--- a/src/Capacitor.Cli/Commands/Harness/CopilotHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CopilotHookCommand.cs
@@ -113,9 +113,9 @@ sealed class CopilotHookCommand(
 
         try {
             var store    = SessionStartMemoryLeaseStore.Create(config, clock.Time);
-            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync);
+            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync, clock.Time);
 
-            return await new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+            return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 new SessionMemoryLifecycle(HarnessId.Copilot, sessionId, LifecycleInstanceId: null,
                     IsTopLevel: true, ClassificationAuthoritative: true,
                     SessionStartMemoryHookSupport.ReasonFor(source), CallbackMayRepeat: false),

--- a/src/Capacitor.Cli/Commands/Harness/CursorHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/CursorHookCommand.cs
@@ -584,9 +584,9 @@ public sealed class CursorHookCommand(
 
             var store = SessionStartMemoryLeaseStore.Create(config, clock.Time);
             // Both lanes send on the hook's own client, which stays this method's caller's to dispose.
-            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, _ => Task.FromResult(client));
+            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, _ => Task.FromResult(client), clock.Time);
 
-            return await new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+            return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 // ClassificationAuthoritative is hardcoded true, and this is VALID UNDER THE
                 // MEASURED EVENT CONTRACT rather than proven from this file alone:
                 //

--- a/src/Capacitor.Cli/Commands/Harness/GeminiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/GeminiHookCommand.cs
@@ -195,9 +195,9 @@ sealed class GeminiHookCommand(
 
         try {
             var store    = SessionStartMemoryLeaseStore.Create(config, clock.Time);
-            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync);
+            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync, clock.Time);
 
-            return await new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+            return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 LifecycleFor(sessionId, source),
                 new SessionStartMemoryContextRequest(Url, scopeRoot, disabled, budget, CancellationToken.None,
                     GuidelinesDisabled: guidelinesDisabled));

--- a/src/Capacitor.Cli/Commands/Harness/KiroHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/KiroHookCommand.cs
@@ -105,9 +105,9 @@ sealed class KiroHookCommand(
 
         try {
             var store    = SessionStartMemoryLeaseStore.Create(config, clock.Time);
-            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync);
+            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync, clock.Time);
 
-            return await new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+            return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 new SessionMemoryLifecycle(HarnessId.Kiro, sessionId, LifecycleInstanceId: null,
                     IsTopLevel: true, ClassificationAuthoritative: true,
                     SessionLifecycleReason.RepeatedTurnCallback, CallbackMayRepeat: true),

--- a/src/Capacitor.Cli/Commands/Harness/OpenCodeHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/OpenCodeHookCommand.cs
@@ -256,9 +256,9 @@ sealed class OpenCodeHookCommand(
 
         try {
             var store    = SessionStartMemoryLeaseStore.Create(config, clock.Time);
-            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync);
+            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync, clock.Time);
 
-            return await new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+            return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 LifecycleFor(sessionId),
                 new SessionStartMemoryContextRequest(Url, scopeRoot, disabled, budget, CancellationToken.None,
                     GuidelinesDisabled: guidelinesDisabled));

--- a/src/Capacitor.Cli/Commands/Harness/PiHookCommand.cs
+++ b/src/Capacitor.Cli/Commands/Harness/PiHookCommand.cs
@@ -326,9 +326,9 @@ sealed class PiHookCommand(
 
         try {
             var store    = SessionStartMemoryLeaseStore.Create(config, clock.Time);
-            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync);
+            var provider = SessionStartMemoryHookSupport.CompositeProvider(config, http.ForMemoryAsync, clock.Time);
 
-            return await new SessionStartMemoryOrchestrator(store, provider).GetFragmentAsync(
+            return await new SessionStartMemoryOrchestrator(store, provider, clock.Time).GetFragmentAsync(
                 LifecycleFor(file, reason),
                 new SessionStartMemoryContextRequest(Url, scopeRoot, disabled, budget, CancellationToken.None,
                     GuidelinesDisabled: guidelinesDisabled));

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartCompositeContextProvider.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartCompositeContextProvider.cs
@@ -20,6 +20,7 @@ internal sealed class SessionStartCompositeContextProvider(
     ISessionStartMemoryScopeResolver scopeResolver,
     SessionStartMemoryContextProvider memory,
     SessionStartGuidelinesLane guidelines,
+    TimeProvider time,
     Action<string>? diagnostic = null) : ISessionStartContextProvider {
 
     public async Task<SessionStartMemoryContextResult> GetAsync(SessionStartMemoryContextRequest request) {
@@ -28,8 +29,8 @@ internal sealed class SessionStartCompositeContextProvider(
         if (!memoryEnabled && !guidelinesEnabled) return SessionStartMemoryContextResult.Empty;
         if (request.Budget <= TimeSpan.Zero) return SessionStartMemoryContextResult.Retry;
 
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(request.CancellationToken);
-        cts.CancelAfter(request.Budget);
+        using var expiry = new CancellationTokenSource(request.Budget, time);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(request.CancellationToken, expiry.Token);
 
         SessionStartMemoryScope scope;
         try {

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryContextProvider.cs
@@ -6,13 +6,14 @@ namespace Capacitor.Cli.SessionStartMemory;
 internal sealed class SessionStartMemoryContextProvider(
     ISessionStartMemoryScopeResolver scopeResolver,
     Func<CancellationToken, Task<HttpClient>> client,
+    TimeProvider time,
     Action<string>? diagnostic = null) : ISessionStartContextProvider {
 
     public async Task<SessionStartMemoryContextResult> GetAsync(SessionStartMemoryContextRequest request) {
         if (request.Disabled) return SessionStartMemoryContextResult.Empty;
         if (request.Budget <= TimeSpan.Zero) return SessionStartMemoryContextResult.Retry;
-        using var cts = CancellationTokenSource.CreateLinkedTokenSource(request.CancellationToken);
-        cts.CancelAfter(request.Budget);
+        using var expiry = new CancellationTokenSource(request.Budget, time);
+        using var cts = CancellationTokenSource.CreateLinkedTokenSource(request.CancellationToken, expiry.Token);
         try {
             var scope = await scopeResolver.ResolveAsync(request.Cwd, request.Budget, cts.Token);
             return await FetchWithScopeAsync(scope, request, cts.Token);

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryHookSupport.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryHookSupport.cs
@@ -29,8 +29,9 @@ internal static class SessionStartMemoryHookSupport {
     public static ISessionStartContextProvider CompositeProvider(
             ConfigRoot config,
             Func<CancellationToken, Task<HttpClient>> client,
+            TimeProvider time,
             ISessionStartMemoryScopeResolver? scopeResolver = null) {
-        var resolver = scopeResolver ?? new SessionStartMemoryScopeResolver(config);
+        var resolver = scopeResolver ?? new SessionStartMemoryScopeResolver(config, time);
 
         var memory     = new SessionStartMemoryContextProvider(resolver, client);
         var guidelines = new SessionStartGuidelinesLane(client);

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryHookSupport.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryHookSupport.cs
@@ -33,9 +33,9 @@ internal static class SessionStartMemoryHookSupport {
             ISessionStartMemoryScopeResolver? scopeResolver = null) {
         var resolver = scopeResolver ?? new SessionStartMemoryScopeResolver(config, time);
 
-        var memory     = new SessionStartMemoryContextProvider(resolver, client);
+        var memory     = new SessionStartMemoryContextProvider(resolver, client, time);
         var guidelines = new SessionStartGuidelinesLane(client);
-        return new SessionStartCompositeContextProvider(resolver, memory, guidelines);
+        return new SessionStartCompositeContextProvider(resolver, memory, guidelines, time);
     }
 
     /// <summary>
@@ -56,7 +56,7 @@ internal static class SessionStartMemoryHookSupport {
             if (remaining <= TimeSpan.Zero)
                 return task.IsCompletedSuccessfully ? task.Result : null;
 
-            return await task.WaitAsync(remaining);
+            return await task.WaitAsync(remaining, budget.Time);
         } catch (Exception ex) when (ex is not OutOfMemoryException and not StackOverflowException) {
             return null;
         }

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLeaseStore.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryLeaseStore.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics;
 using Capacitor.Cli.Core;
 using System.Security.Cryptography;
 using System.Text;
@@ -32,7 +31,7 @@ internal sealed partial class SessionStartMemoryLeaseStore {
     public async Task<SessionStartMemoryLeaseHandle?> TryBeginAsync(
         string key, TimeSpan budget, CancellationToken ct = default) {
         if (!KeyRegex().IsMatch(key) || budget <= TimeSpan.Zero) return null;
-        var started = Stopwatch.GetTimestamp();
+        var started = _time.GetTimestamp();
         TimeSpan Remaining() => RemainingBudget(budget, started);
         try {
             using var gate = await AcquireAsync(Remaining(), ct);
@@ -86,7 +85,7 @@ internal sealed partial class SessionStartMemoryLeaseStore {
     async Task<bool> MutateAsync(SessionStartMemoryLeaseHandle handle, SessionStartMemoryDisposition disposition,
         TimeSpan? retryAfter, TimeSpan budget, CancellationToken ct) {
         if (budget <= TimeSpan.Zero) return false;
-        var started = Stopwatch.GetTimestamp();
+        var started = _time.GetTimestamp();
         try {
             using var gate = await AcquireAsync(RemainingBudget(budget, started), ct);
             if (gate is null) return false;
@@ -131,7 +130,7 @@ internal sealed partial class SessionStartMemoryLeaseStore {
 
     public async Task SweepAsync(TimeSpan budget, int maxEntries = 5_000, CancellationToken ct = default) {
         if (budget <= TimeSpan.Zero || maxEntries <= 0) return;
-        var started = Stopwatch.GetTimestamp();
+        var started = _time.GetTimestamp();
         try {
             using var gate = await AcquireAsync(RemainingBudget(budget, started), ct);
             if (gate is null) return;
@@ -144,7 +143,7 @@ internal sealed partial class SessionStartMemoryLeaseStore {
 
     void SweepUnderLock(TimeSpan budget, int maxEntries, bool force) {
         if (budget <= TimeSpan.Zero) return;
-        var started = Stopwatch.GetTimestamp();
+        var started = _time.GetTimestamp();
         var now = _time.GetUtcNow();
         var metadata = ReadMetadata();
         if (!force && metadata.LastSweepAt is { } last && now >= last && now - last < NormalSweepInterval)
@@ -157,7 +156,7 @@ internal sealed partial class SessionStartMemoryLeaseStore {
         var seekingCursor = cursor is not null;
 
         foreach (var entry in Directory.EnumerateFileSystemEntries(_root)) {
-            if (processed >= maxEntries || Stopwatch.GetElapsedTime(started) >= budget) {
+            if (processed >= maxEntries || _time.GetElapsedTime(started) >= budget) {
                 reachedEnd = false;
                 break;
             }
@@ -225,16 +224,16 @@ internal sealed partial class SessionStartMemoryLeaseStore {
     }
 
     async Task<FileStream?> AcquireAsync(TimeSpan budget, CancellationToken ct) {
-        var started = Stopwatch.GetTimestamp();
-        while (Stopwatch.GetElapsedTime(started) < budget && !ct.IsCancellationRequested) {
+        var started = _time.GetTimestamp();
+        while (_time.GetElapsedTime(started) < budget && !ct.IsCancellationRequested) {
             try {
                 var stream = new FileStream(_lockPath, FileMode.OpenOrCreate, FileAccess.ReadWrite, FileShare.None);
                 SetOwnerOnly(_lockPath);
                 return stream;
             } catch (IOException) {
-                var remaining = budget - Stopwatch.GetElapsedTime(started);
+                var remaining = budget - _time.GetElapsedTime(started);
                 if (remaining <= TimeSpan.Zero) break;
-                await Task.Delay(remaining < TimeSpan.FromMilliseconds(5) ? remaining : TimeSpan.FromMilliseconds(5), ct);
+                await Task.Delay(remaining < TimeSpan.FromMilliseconds(5) ? remaining : TimeSpan.FromMilliseconds(5), _time, ct);
             }
         }
         return null;
@@ -266,7 +265,7 @@ internal sealed partial class SessionStartMemoryLeaseStore {
 
     bool EnsureWriteCapacity(bool creatingRecord, TimeSpan budget) {
         if (budget <= TimeSpan.Zero) return false;
-        var started = Stopwatch.GetTimestamp();
+        var started = _time.GetTimestamp();
         if (!TryCountEntries(RemainingBudget(budget, started), creatingRecord, out var total, out var records)) return false;
         if (total < SessionStartMemoryConstants.TotalEntryCap &&
             (!creatingRecord || records < SessionStartMemoryConstants.NormalRecordCap)) return true;
@@ -283,9 +282,9 @@ internal sealed partial class SessionStartMemoryLeaseStore {
         total = 0;
         records = 0;
         if (budget <= TimeSpan.Zero) return false;
-        var started = Stopwatch.GetTimestamp();
+        var started = _time.GetTimestamp();
         foreach (var path in Directory.EnumerateFileSystemEntries(_root)) {
-            if (Stopwatch.GetElapsedTime(started) >= budget) return false;
+            if (_time.GetElapsedTime(started) >= budget) return false;
             var name = Path.GetFileName(path);
             if (name is "store.lock" or MetadataName) continue;
             total++;
@@ -296,8 +295,8 @@ internal sealed partial class SessionStartMemoryLeaseStore {
         return true;
     }
 
-    static TimeSpan RemainingBudget(TimeSpan budget, long started) {
-        var remaining = budget - Stopwatch.GetElapsedTime(started);
+    TimeSpan RemainingBudget(TimeSpan budget, long started) {
+        var remaining = budget - _time.GetElapsedTime(started);
         return remaining > TimeSpan.Zero ? remaining : TimeSpan.Zero;
     }
 

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryOrchestrator.cs
@@ -3,6 +3,7 @@ namespace Capacitor.Cli.SessionStartMemory;
 internal sealed class SessionStartMemoryOrchestrator(
     SessionStartMemoryLeaseStore store,
     ISessionStartContextProvider provider,
+    TimeProvider time,
     Action<string>? diagnostic = null) {
 
     /// <param name="commitGate">
@@ -27,9 +28,9 @@ internal sealed class SessionStartMemoryOrchestrator(
         // here — the composite provider runs the enabled lane and contributes its content.
         if (request.Disabled && request.GuidelinesDisabled) return null;
 
-        var started = System.Diagnostics.Stopwatch.GetTimestamp();
+        var started = time.GetTimestamp();
         TimeSpan Remaining() {
-            var value = request.Budget - System.Diagnostics.Stopwatch.GetElapsedTime(started);
+            var value = request.Budget - time.GetElapsedTime(started);
             return value > TimeSpan.Zero ? value : TimeSpan.Zero;
         }
 

--- a/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryScopeResolver.cs
+++ b/src/Capacitor.Cli/SessionStartMemory/SessionStartMemoryScopeResolver.cs
@@ -2,11 +2,11 @@ using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.SessionStartMemory;
 
-internal sealed class SessionStartMemoryScopeResolver(ConfigRoot config) : ISessionStartMemoryScopeResolver {
+internal sealed class SessionStartMemoryScopeResolver(ConfigRoot config, TimeProvider time) : ISessionStartMemoryScopeResolver {
     public async Task<SessionStartMemoryScope> ResolveAsync(string? cwd, TimeSpan budget, CancellationToken ct) {
-        var started = System.Diagnostics.Stopwatch.GetTimestamp();
+        var started = time.GetTimestamp();
         TimeSpan Remaining() {
-            var value = budget - System.Diagnostics.Stopwatch.GetElapsedTime(started);
+            var value = budget - time.GetElapsedTime(started);
             return value > TimeSpan.Zero ? value : TimeSpan.Zero;
         }
 

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyInstallTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyInstallTests.cs
@@ -98,6 +98,10 @@ public class ServiceVerifyInstallTests {
         return await task.WaitAsync(TimeSpan.FromSeconds(5));
     }
 
+    /// <summary>A clock nothing advances: these tests resolve on their first probe, and a loaded
+    /// runner stalled between entry and that probe would otherwise spend the whole forward budget.</summary>
+    static FakeTimeProvider Stopped() => new();
+
     (string Dir, string DaemonPath) SetUpViableInstall() {
         var dir = Tmp.CreateDir(Guid.NewGuid().ToString("N"));
         var daemonPath = dir.PathTo("kcap-daemon");
@@ -116,7 +120,7 @@ public class ServiceVerifyInstallTests {
     public async Task Viability_abort_missing_binary_touches_nothing() {
         var manager = new FakeServiceManager(Home);
         var missingPath = Daemons.PathTo("does-not-exist-kcap-daemon");
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(missingPath), replace: false, ExpectedVersion);
 
@@ -129,7 +133,7 @@ public class ServiceVerifyInstallTests {
     public async Task PreQuery_loaded_is_contended_not_bootout_unknown() {
         var (dir, daemonPath) = SetUpViableInstall();
         var manager = new FakeServiceManager(Home) { InitialProbe = LabelProbe.Loaded };
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -143,7 +147,7 @@ public class ServiceVerifyInstallTests {
     public async Task PreQuery_unknown_is_bootout_unknown_distinct_from_loaded() {
         var (dir, daemonPath) = SetUpViableInstall();
         var manager = new FakeServiceManager(Home) { InitialProbe = LabelProbe.Unknown };
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -171,7 +175,7 @@ public class ServiceVerifyInstallTests {
             return Task.FromResult(new HelloProbeResult(true, 1, ExpectedVersion, Id));
         }
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -195,7 +199,7 @@ public class ServiceVerifyInstallTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, ExpectedVersion, Id));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -217,7 +221,7 @@ public class ServiceVerifyInstallTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, ExpectedVersion, Id));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -240,7 +244,7 @@ public class ServiceVerifyInstallTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, ExpectedVersion, Id));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -262,7 +266,7 @@ public class ServiceVerifyInstallTests {
         var manager = new FakeServiceManager(Home);
         var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242,
             (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)),
-            TimeProvider.System,
+            Stopped(),
             readPlist: _ => null,     // simulates a read failure, not absence
             plistExists: _ => true);  // ...but the file IS there
 
@@ -303,7 +307,7 @@ public class ServiceVerifyInstallTests {
         ServiceTxnMarker.Write(Daemons.Store, Id, new TxnMarker(1, "install", "written", "stale", "no-unit", "stale-fingerprint"));
 
         var manager = new FakeServiceManager(Home);
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -391,7 +395,7 @@ public class ServiceVerifyInstallTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, "whatever-version-nobody-checks", Id));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, expectedVersion: null);
 
@@ -409,7 +413,7 @@ public class ServiceVerifyInstallTests {
 
         // A different writer's plist text is on disk by the time the final recheck reads it —
         // the fingerprint can never match what WriteAndBootstrap wrote.
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System, readPlist: _ => "<plist>someone-else</plist>");
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(), readPlist: _ => "<plist>someone-else</plist>");
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -424,7 +428,7 @@ public class ServiceVerifyInstallTests {
         // `service stop` retains the plist by design — a stopped-but-installed service must be
         // treated the same as Loaded, not as a fresh Absent slot to overwrite.
         var manager = new FakeServiceManager(Home) { InitialProbe = LabelProbe.Absent, InitialUnitPresent = true };
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -438,7 +442,7 @@ public class ServiceVerifyInstallTests {
     public async Task GenerateFiles_throwing_is_a_viability_abort_before_any_destructive_step() {
         var (dir, daemonPath) = SetUpViableInstall();
         var manager = new FakeServiceManager(Home) { GenerateFilesThrows = new InvalidOperationException("invalid captured env value") };
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -456,7 +460,7 @@ public class ServiceVerifyInstallTests {
         var (dir, daemonPath) = SetUpViableInstall();
         var manager = new FakeServiceManager(Home);
         var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)),
-            TimeProvider.System, readPlist: OwnPlist, profileViable: () => false);
+            Stopped(), readPlist: OwnPlist, profileViable: () => false);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -471,7 +475,7 @@ public class ServiceVerifyInstallTests {
         // launchctl bootstrap can throw (EPERM under MDM, I/O error) AFTER WriteUnitFiles has
         // already put the plist on disk — readPlist reflects that with matching ("own") content.
         var manager = new FakeServiceManager(Home) { WriteAndBootstrapThrows = new InvalidOperationException("launchctl bootstrap failed (exit 5): Input/output error") };
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: false, ExpectedVersion);
 
@@ -590,7 +594,7 @@ public class ServiceVerifyInstallTests {
         var manager = new FakeServiceManager(Home) { WriteAndBootstrapThrows = new InvalidOperationException("launchctl bootstrap failed (exit 5)") };
         var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242,
             (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)),
-            TimeProvider.System,
+            Stopped(),
             readPlist: _ => null,     // present but unreadable — cannot be fingerprinted
             plistExists: _ => true);
 
@@ -614,7 +618,7 @@ public class ServiceVerifyInstallTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, ExpectedVersion, Id));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: OwnPlist,
             gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null,
             digestMatches: _ => false); // viability digest check fails
@@ -642,7 +646,7 @@ public class ServiceVerifyInstallTests {
             Task.FromResult(new HelloProbeResult(true, 1, ExpectedVersion, Id));
 
         var digestCalls = 0;
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: OwnPlist,
             gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null,
             digestMatches: _ => Interlocked.Increment(ref digestCalls) == 1); // pass viability, fail pre-bootstrap
@@ -666,7 +670,7 @@ public class ServiceVerifyInstallTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, ExpectedVersion, Id));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: OwnPlist,
             gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null,
             digestMatches: _ => true);
@@ -688,7 +692,7 @@ public class ServiceVerifyInstallTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, ExpectedVersion, Id));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: OwnPlist,
             digestMatches: _ => false); // no gateEnv wired at all — must never be consulted
 
@@ -716,7 +720,7 @@ public class ServiceVerifyInstallTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, ExpectedVersion, Id));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: OwnPlist,
             gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null,
             digestMatches: _ => false);
@@ -750,7 +754,7 @@ public class ServiceVerifyInstallTests {
 
         var digestCalls = 0;
         var committedInvoked = false;
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: OwnPlist,
             gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null,
             // pass(1)=viability, pass(2)=pre-bootstrap, fail(3)=post-readiness.
@@ -774,7 +778,7 @@ public class ServiceVerifyInstallTests {
         var manager = new FakeServiceManager(Home) { WriteAndBootstrapThrows = new InvalidOperationException("launchctl bootstrap failed (exit 5)") };
         var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242,
             (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)),
-            TimeProvider.System,
+            Stopped(),
             readPlist: _ => null,
             plistExists: _ => false);
 

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyReplaceTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyReplaceTests.cs
@@ -9,6 +9,10 @@ namespace Capacitor.Cli.Tests.Unit.Services;
 /// finds first. See <see cref="ServiceVerifyInstallTests"/> for the fresh-path/entry-recovery
 /// coverage this builds on.</summary>
 public class ServiceVerifyReplaceTests {
+    /// <summary>A clock nothing advances: these tests resolve on their first probe, and a loaded
+    /// runner stalled between entry and that probe would otherwise spend the whole forward budget.</summary>
+    static FakeTimeProvider Stopped() => new();
+
     [TempHome] public required TempHome Home { get; init; }
 
     [TempDaemonPaths] public required TempDaemonStore Daemons { get; init; }
@@ -121,7 +125,7 @@ public class ServiceVerifyReplaceTests {
             : manager.Uninstalled ? null
             : ManualOwnerPid;
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: true, ExpectedVersion);
 
@@ -167,7 +171,7 @@ public class ServiceVerifyReplaceTests {
             : helloCalls == 0 ? ManualOwnerPid
             : null;
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: true, ExpectedVersion);
 
@@ -194,7 +198,7 @@ public class ServiceVerifyReplaceTests {
 
         int? ValidatedPid(string _) => manager.Bootstrapped ? manager.RunningPid : null;
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: true, ExpectedVersion);
 
@@ -225,7 +229,7 @@ public class ServiceVerifyReplaceTests {
             : helloCalls == 0 ? ManualOwnerPid
             : null;
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: true, ExpectedVersion);
 
@@ -259,7 +263,7 @@ public class ServiceVerifyReplaceTests {
             : manager.Uninstalled ? null
             : ManualOwnerPid;
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, ValidatedPid, Hello, Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: true, ExpectedVersion);
 
@@ -329,7 +333,7 @@ public class ServiceVerifyReplaceTests {
     public async Task Unknown_probe_aborts_before_the_matrix_runs_anything_destructive() {
         var (_, daemonPath) = SetUpViableInstall();
         var manager = new FakeServiceManager(Home) { InitialProbe = LabelProbe.Unknown };
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => ManualOwnerPid, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), TimeProvider.System, readPlist: OwnPlist);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => ManualOwnerPid, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)), Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: true, ExpectedVersion);
 
@@ -371,7 +375,7 @@ public class ServiceVerifyReplaceTests {
         // cleared — never destroy the working unit and only then discover the new one can't render.
         var manager = new ThrowingRenderManager(Home);
         var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => ManualOwnerPid, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)),
-            TimeProvider.System, readPlist: OwnPlist);
+            Stopped(), readPlist: OwnPlist);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: true, ExpectedVersion);
 
@@ -385,7 +389,7 @@ public class ServiceVerifyReplaceTests {
         var (_, daemonPath) = SetUpViableInstall();
         var manager = new FakeServiceManager(Home) { InitialProbe = LabelProbe.Loaded, InitialUnitPresent = true, InitialJobPid = ManualOwnerPid };
         var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => ManualOwnerPid, (_, _) => Task.FromResult(new HelloProbeResult(false, null, null, null)),
-            TimeProvider.System, readPlist: OwnPlist, profileViable: () => false);
+            Stopped(), readPlist: OwnPlist, profileViable: () => false);
 
         var exit = await sut.InstallVerifiedAsync(Spec(daemonPath), replace: true, ExpectedVersion);
 

--- a/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/ServiceVerifyStartTests.cs
@@ -5,6 +5,10 @@ using Microsoft.Extensions.Time.Testing;
 namespace Capacitor.Cli.Tests.Unit.Services;
 
 public class ServiceVerifyStartTests {
+    /// <summary>A clock nothing advances: these tests resolve on their first probe, and a loaded
+    /// runner stalled between entry and that probe would otherwise spend the whole forward budget.</summary>
+    static FakeTimeProvider Stopped() => new();
+
     [TempHome] public required TempHome Home { get; init; }
 
     [TempDaemonPaths] public required TempDaemonStore Daemons { get; init; }
@@ -136,7 +140,7 @@ public class ServiceVerifyStartTests {
             return Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
         }
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped());
 
         var exit = await sut.StartVerifiedAsync(Id);
 
@@ -196,7 +200,7 @@ public class ServiceVerifyStartTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, null, "0.9.0", null));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System);
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped());
 
         var exit = await sut.StartVerifiedAsync(Id);
 
@@ -365,7 +369,7 @@ public class ServiceVerifyStartTests {
         // A crash between verify-success and marker removal must be recoverable as "committed →
         // just clear the marker", so the durable committed phase is written BEFORE the delete —
         // mirroring the install path.
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             onCommitted: () => phaseAtCommit = ServiceTxnMarker.Read(Daemons.Store, Id)?.Phase);
 
         var exit = await sut.StartVerifiedAsync(Id);
@@ -428,7 +432,7 @@ public class ServiceVerifyStartTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: _ => null,
             plistExists: _ => false,
             gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
@@ -460,7 +464,7 @@ public class ServiceVerifyStartTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: _ => null,
             plistExists: _ => false,
             gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
@@ -503,7 +507,7 @@ public class ServiceVerifyStartTests {
                 : MinimalPlist("/bin/kcap-daemon-moved", "prompt", GatedServerUrl);
         }
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: ReadPlist,
             gateEnv: GatedEnvWithIdentity(),
             digestMatches: _ => true);
@@ -533,7 +537,7 @@ public class ServiceVerifyStartTests {
         // defends against — makes LaunchdUnit.EnvFromPlist/BinaryFromPlist throw XmlException.
         // That must land as EvidenceUnreadable (28), not escape StartVerifiedAsync to a
         // generic, uncoded exit 1.
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: _ => "<plist version=\"1.0\"><dict><key>Truncated",
             gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
 
@@ -573,7 +577,7 @@ public class ServiceVerifyStartTests {
             </plist>
             """;
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: _ => duplicateKeyPlist,
             gateEnv: k => k == "KCAP_CONSENT_SEED_DEFAULT" ? "prompt" : null);
 
@@ -606,7 +610,7 @@ public class ServiceVerifyStartTests {
             return reads == 1 ? MinimalPlist("/bin/kcap-daemon", "prompt", GatedServerUrl) : "not even xml, let alone a plist";
         }
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: ReadPlist,
             gateEnv: GatedEnvWithIdentity(),
             digestMatches: _ => true);
@@ -640,7 +644,7 @@ public class ServiceVerifyStartTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: _ => MinimalPlist("/bin/kcap-daemon", "prompt", GatedServerUrl),
             gateEnv: GatedEnvWithIdentity(),
             digestMatches: _ => true);
@@ -712,7 +716,7 @@ public class ServiceVerifyStartTests {
                 : MinimalPlist("/bin/kcap-daemon-moved", "prompt", GatedServerUrl);
         }
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: ReadPlist,
             gateEnv: GatedEnvWithIdentity(),
             digestMatches: _ => true);
@@ -744,7 +748,7 @@ public class ServiceVerifyStartTests {
             return digestChecks <= 2;
         }
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: _ => MinimalPlist("/bin/kcap-daemon", "prompt", GatedServerUrl),
             gateEnv: GatedEnvWithIdentity(),
             digestMatches: DigestMatches);
@@ -767,7 +771,7 @@ public class ServiceVerifyStartTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: _ => { readPlistCalls++; return MinimalPlist("/bin/kcap-daemon", "prompt", GatedServerUrl); });
         // no gateEnv — ungated
 
@@ -788,7 +792,7 @@ public class ServiceVerifyStartTests {
         static Task<HelloProbeResult> Hello(string _, TimeSpan __) =>
             Task.FromResult(new HelloProbeResult(true, 1, "1.2.3", "kcap-daemon"));
 
-        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, TimeProvider.System,
+        var sut = new ServiceVerify(Daemons.Store, Config.Root, manager, _ => 4242, Hello, Stopped(),
             readPlist: _ => MinimalPlist("/bin/kcap-daemon", "prompt", GatedServerUrl),
             gateEnv: GatedEnvWithIdentity(),
             digestMatches: _ => true);

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GuidelinesLaneAndCompositeTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/GuidelinesLaneAndCompositeTests.cs
@@ -3,6 +3,8 @@ using System.Net.Http.Headers;
 using System.Text;
 using Capacitor.Cli.SessionStartMemory;
 
+using Microsoft.Extensions.Time.Testing;
+
 namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 
 /// <summary>
@@ -108,9 +110,12 @@ public class GuidelinesLaneAndCompositeTests {
         var scope    = new FixedScope("repo", "machine");
         var memH     = memoryHandler ?? new Handler(memory.status, memory.body, memory.retryAfter);
         var guideH   = guidelinesHandler ?? new Handler(guidelines.status, guidelines.body, guidelines.retryAfter);
-        var memory2  = new SessionStartMemoryContextProvider(scope, Lazy(new HttpClient(memH)));
+        // One stopped clock for both lanes and the composite: the budget they share must not be
+        // spendable by a loaded runner between arming it and the handler answering.
+        var time     = new FakeTimeProvider();
+        var memory2  = new SessionStartMemoryContextProvider(scope, Lazy(new HttpClient(memH)), time);
         var guide2   = new SessionStartGuidelinesLane(Lazy(new HttpClient(guideH)));
-        return new SessionStartCompositeContextProvider(scope, memory2, guide2);
+        return new SessionStartCompositeContextProvider(scope, memory2, guide2, time);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
@@ -2,12 +2,25 @@ using System.Net;
 using System.Text;
 using Capacitor.Cli.SessionStartMemory;
 using Capacitor.Cli.Core.Harness;
+using Microsoft.Extensions.Time.Testing;
 
 namespace Capacitor.Cli.Tests.Unit.SessionStartMemory;
 
 public class SessionStartMemoryFoundationTests {
     /// The lanes resolve their client inside the fetch, so a test hands them one already built.
     static Func<CancellationToken, Task<HttpClient>> Lazy(HttpClient client) => _ => Task.FromResult(client);
+
+    /// <summary>
+    /// A store and orchestrator sharing one stopped clock, so lease expiry and the fetch budget are
+    /// measured against the same instant and neither can run out while a loaded runner is slow.
+    /// A test that needs time to pass advances the returned clock.
+    /// </summary>
+    static (SessionStartMemoryOrchestrator Orchestrator, FakeTimeProvider Time) Frozen(
+            TempDir root, ISessionStartContextProvider provider) {
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 29, 0, 0, 0, TimeSpan.Zero));
+        return (new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, time), provider, time),
+                time);
+    }
 
     [Test]
     public async Task Canonical_key_distinguishes_absent_token_from_literal_text() {
@@ -154,7 +167,7 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Lease_store_has_one_winner_and_fences_stale_owner() {
         using var root = new TempDir();
-        var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
         var store = new SessionStartMemoryLeaseStore(root.Path, time);
         var first = await store.TryBeginAsync(new string('a', 64), TimeSpan.FromSeconds(1));
         var blocked = await store.TryBeginAsync(new string('a', 64), TimeSpan.FromSeconds(1));
@@ -183,7 +196,7 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Completion_guarantee_expires_at_thirty_day_sweep_boundary() {
         using var root = new TempDir();
-        var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
         var store = new SessionStartMemoryLeaseStore(root.Path, time);
         var key = new string('e', 64);
         var lease = await store.TryBeginAsync(key, TimeSpan.FromSeconds(1));
@@ -199,7 +212,7 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Sweep_advances_past_poison_record() {
         using var root = new TempDir();
-        var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
         var store = new SessionStartMemoryLeaseStore(root.Path, time);
         foreach (var key in new[] { new string('a', 64), new string('c', 64) }) {
             var lease = await store.TryBeginAsync(key, TimeSpan.FromSeconds(1));
@@ -219,7 +232,7 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Retry_pending_obeys_cooldown_and_then_heals() {
         using var root = new TempDir();
-        var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
+        var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 23, 0, 0, 0, TimeSpan.Zero));
         var store = new SessionStartMemoryLeaseStore(root.Path, time);
         var key = new string('b', 64);
         var lease = await store.TryBeginAsync(key, TimeSpan.FromSeconds(1));
@@ -343,7 +356,7 @@ public class SessionStartMemoryFoundationTests {
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
             Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK,
                 "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
-        var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System), provider);
+        var (orchestrator, _) = Frozen(root, provider);
         var lifecycle = new SessionMemoryLifecycle(HarnessId.Claude, "session", null,
             true, true, SessionLifecycleReason.New, true);
         var request = new SessionStartMemoryContextRequest(
@@ -367,12 +380,10 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task A_refused_commit_gate_releases_the_lease_so_a_later_start_still_injects() {
         using var root = new TempDir();
-        var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 29, 0, 0, 0, TimeSpan.Zero));
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
             Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK,
                 "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
-        var orchestrator = new SessionStartMemoryOrchestrator(
-            new SessionStartMemoryLeaseStore(root.Path, time), provider);
+        var (orchestrator, time) = Frozen(root, provider);
         var lifecycle = new SessionMemoryLifecycle(HarnessId.Copilot, "3f2504e0-4f89-41d3-9a0c-0305e82c3301", null,
             true, true, SessionLifecycleReason.New, true);
         var request = new SessionStartMemoryContextRequest(
@@ -396,7 +407,7 @@ public class SessionStartMemoryFoundationTests {
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
             Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK,
                 "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
-        var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System), provider);
+        var (orchestrator, _) = Frozen(root, provider);
         var lifecycle = new SessionMemoryLifecycle(HarnessId.Copilot, "3f2504e0-4f89-41d3-9a0c-0305e82c3301", null,
             true, true, SessionLifecycleReason.New, true);
         var request = new SessionStartMemoryContextRequest(
@@ -419,9 +430,7 @@ public class SessionStartMemoryFoundationTests {
             IsTopLevel: true, ClassificationAuthoritative: true,
             SessionLifecycleReason.RepeatedTurnCallback, CallbackMayRepeat: true);
 
-    // The budget is wall-clock and none of these tests assert on exhausting it, so it only has
-    // to outlast a loaded runner; the callers that do care pass their own.
-    static SessionStartMemoryContextRequest KiroRequest(double seconds = 20) =>
+    static SessionStartMemoryContextRequest KiroRequest(double seconds = 1) =>
         new("https://example.test", null, false, TimeSpan.FromSeconds(seconds), CancellationToken.None);
 
     // THE Kiro acceptance criterion. Kiro has no once-per-session hook: agentSpawn fires on every
@@ -433,7 +442,7 @@ public class SessionStartMemoryFoundationTests {
         using var handler = new CountingHandler(HttpStatusCode.OK, OneMemoryJson);
         var provider = new SessionStartMemoryContextProvider(
             new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System), provider);
+        var (orchestrator, _) = Frozen(root, provider);
 
         var first  = await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
         var second = await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
@@ -461,8 +470,7 @@ public class SessionStartMemoryFoundationTests {
         var provider = new SessionStartMemoryContextProvider(
             new FixedScopeResolver(null, null),
             _ => { asked++; return Task.FromResult(client); });
-        var orchestrator = new SessionStartMemoryOrchestrator(
-            new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System), provider);
+        var (orchestrator, _) = Frozen(root, provider);
 
         await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
         await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
@@ -478,7 +486,7 @@ public class SessionStartMemoryFoundationTests {
         using var root = new TempDir();
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
             Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, OneMemoryJson))));
-        var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System), provider);
+        var (orchestrator, _) = Frozen(root, provider);
 
         var a = await orchestrator.GetFragmentAsync(KiroLifecycle("session-a"), KiroRequest());
         var b = await orchestrator.GetFragmentAsync(KiroLifecycle("session-b"), KiroRequest());
@@ -493,12 +501,10 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Kiro_retryable_failure_lets_a_later_prompt_still_inject() {
         using var root = new TempDir();
-        var time = new ManualTimeProvider(new DateTimeOffset(2026, 7, 29, 0, 0, 0, TimeSpan.Zero));
         using var handler = new FailsOnceHandler(OneMemoryJson);
         var provider = new SessionStartMemoryContextProvider(
             new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var orchestrator = new SessionStartMemoryOrchestrator(
-            new SessionStartMemoryLeaseStore(root.Path, time), provider);
+        var (orchestrator, time) = Frozen(root, provider);
 
         var failed = await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
 
@@ -518,7 +524,7 @@ public class SessionStartMemoryFoundationTests {
         using var handler = new CountingHandler(HttpStatusCode.NoContent, "");
         var provider = new SessionStartMemoryContextProvider(
             new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System), provider);
+        var (orchestrator, _) = Frozen(root, provider);
 
         await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
         var second = await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
@@ -536,6 +542,9 @@ public class SessionStartMemoryFoundationTests {
     // So: start the winner, wait until its provider signals from INSIDE the fetch (at which point the
     // lease is provably held), run the losers to completion against that held lease, and only then
     // release the winner. No timeout participates in the passing path.
+    //
+    // The process clock, not a stopped one: the losers contend for the store's file lock, and its
+    // retry loop waits on the same clock it measures, so a clock nothing advances never leaves it.
     [Test]
     public async Task Kiro_agent_spawns_arriving_while_the_lease_is_held_are_fenced_out() {
         using var root = new TempDir();
@@ -547,14 +556,14 @@ public class SessionStartMemoryFoundationTests {
             new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
         var store = new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System);
 
-        var winner = Task.Run(() => new SessionStartMemoryOrchestrator(store, provider)
+        var winner = Task.Run(() => new SessionStartMemoryOrchestrator(store, provider, TimeProvider.System)
             .GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest(20)));
 
         // The winner is now inside its fetch, holding the lease.
         await winnerHolding.Task;
 
         var losers = await Task.WhenAll(Enumerable.Range(0, 3).Select(_ =>
-            new SessionStartMemoryOrchestrator(store, provider)
+            new SessionStartMemoryOrchestrator(store, provider, TimeProvider.System)
                 .GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest(20))));
 
         // The winner is provably STILL inside its fetch, so the lease was genuinely held for the
@@ -571,6 +580,27 @@ public class SessionStartMemoryFoundationTests {
         await Assert.That(handler.Sends).IsEqualTo(1);
     }
 
+    // Every deadline the orchestrator enforces must be measured on the clock it was handed, or a
+    // caller cannot bound it at all and a test can only ever wait out the real one. Proved through
+    // behaviour the budget alone decides: a fetch that returns AFTER the budget is gone leaves
+    // nothing to commit the lease with, so its fragment is dropped rather than injected late.
+    [Test]
+    public async Task A_fetch_that_outlives_its_budget_is_dropped_rather_than_injected() {
+        using var root = new TempDir();
+        FakeTimeProvider? clock = null;
+        var provider = new DelegatingProvider(() => {
+            clock!.Advance(TimeSpan.FromSeconds(30));
+            return new SessionStartMemoryContextResult(SessionStartMemoryDisposition.Ready, "- s: d");
+        });
+        var (orchestrator, time) = Frozen(root, provider);
+        clock = time;
+
+        var fragment = await orchestrator.GetFragmentAsync(
+            KiroLifecycle("kiro-session"), KiroRequest(seconds: 5));
+
+        await Assert.That(fragment).IsNull();
+    }
+
     // Exactly what AntigravityHookCommand.LifecycleFor builds: PreInvocation fires once per
     // INVOCATION within a conversation, so the callback repeats like Kiro's agentSpawn and the
     // lease is the only thing preventing re-injection every turn.
@@ -579,9 +609,7 @@ public class SessionStartMemoryFoundationTests {
             IsTopLevel: true, ClassificationAuthoritative: true,
             SessionLifecycleReason.RepeatedTurnCallback, CallbackMayRepeat: true);
 
-    // The budget is wall-clock and none of these tests assert on exhausting it, so it only has
-    // to outlast a loaded runner; the callers that do care pass their own.
-    static SessionStartMemoryContextRequest AntigravityRequest(double seconds = 20) =>
+    static SessionStartMemoryContextRequest AntigravityRequest(double seconds = 1) =>
         new("https://example.test", null, false, TimeSpan.FromSeconds(seconds), CancellationToken.None);
 
     // THE Antigravity acceptance criterion, mirroring Kiro's: without the lease the index would be
@@ -592,7 +620,7 @@ public class SessionStartMemoryFoundationTests {
         using var handler = new CountingHandler(HttpStatusCode.OK, OneMemoryJson);
         var provider = new SessionStartMemoryContextProvider(
             new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System), provider);
+        var (orchestrator, _) = Frozen(root, provider);
 
         // A real GUID — Antigravity is on the fail-closed identity arm, which normalizes any
         // non-GUID id to null and would short-circuit before the lease is ever consulted,
@@ -613,7 +641,7 @@ public class SessionStartMemoryFoundationTests {
         using var root = new TempDir();
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
             Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, OneMemoryJson))));
-        var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System), provider);
+        var (orchestrator, _) = Frozen(root, provider);
 
         var a = await orchestrator.GetFragmentAsync(
             AntigravityLifecycle("e80c33bfc10f4d2fb626b0043f488fc0"), AntigravityRequest());
@@ -642,7 +670,7 @@ public class SessionStartMemoryFoundationTests {
         using var handler = new CountingHandler(HttpStatusCode.NoContent, "");
         var provider = new SessionStartMemoryContextProvider(
             new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var orchestrator = new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System), provider);
+        var (orchestrator, _) = Frozen(root, provider);
         var lifecycle = new SessionMemoryLifecycle(HarnessId.Claude, "session", null,
             true, true, SessionLifecycleReason.New, false);
 
@@ -655,10 +683,9 @@ public class SessionStartMemoryFoundationTests {
         await Assert.That(Directory.EnumerateFiles(root.Path)).IsEmpty();
     }
 
-    sealed class ManualTimeProvider(DateTimeOffset now) : TimeProvider {
-        DateTimeOffset _now = now;
-        public override DateTimeOffset GetUtcNow() => _now;
-        public void Advance(TimeSpan value) => _now += value;
+    sealed class DelegatingProvider(Func<SessionStartMemoryContextResult> fetch) : ISessionStartContextProvider {
+        public Task<SessionStartMemoryContextResult> GetAsync(SessionStartMemoryContextRequest request) =>
+            Task.FromResult(fetch());
     }
 
     sealed class FixedScopeResolver(string? repo, string? machine) : ISessionStartMemoryScopeResolver {

--- a/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SessionStartMemory/SessionStartMemoryFoundationTests.cs
@@ -10,17 +10,14 @@ public class SessionStartMemoryFoundationTests {
     /// The lanes resolve their client inside the fetch, so a test hands them one already built.
     static Func<CancellationToken, Task<HttpClient>> Lazy(HttpClient client) => _ => Task.FromResult(client);
 
-    /// <summary>
-    /// A store and orchestrator sharing one stopped clock, so lease expiry and the fetch budget are
-    /// measured against the same instant and neither can run out while a loaded runner is slow.
-    /// A test that needs time to pass advances the returned clock.
-    /// </summary>
-    static (SessionStartMemoryOrchestrator Orchestrator, FakeTimeProvider Time) Frozen(
-            TempDir root, ISessionStartContextProvider provider) {
-        var time = new FakeTimeProvider(new DateTimeOffset(2026, 7, 29, 0, 0, 0, TimeSpan.Zero));
-        return (new SessionStartMemoryOrchestrator(new SessionStartMemoryLeaseStore(root.Path, time), provider, time),
-                time);
-    }
+    /// <summary>A clock nothing advances, so no budget in the subsystem can run out while a loaded
+    /// runner is slow. A test that needs time to pass advances it.</summary>
+    static FakeTimeProvider Stopped() => new(new DateTimeOffset(2026, 7, 29, 0, 0, 0, TimeSpan.Zero));
+
+    /// <summary>An orchestrator and store on the caller's clock — the same one its provider holds,
+    /// or lease expiry, the fetch budget and the fetch's own cancellation answer to three clocks.</summary>
+    static SessionStartMemoryOrchestrator On(TempDir root, ISessionStartContextProvider provider, TimeProvider time) =>
+        new(new SessionStartMemoryLeaseStore(root.Path, time), provider, time);
 
     [Test]
     public async Task Canonical_key_distinguishes_absent_token_from_literal_text() {
@@ -247,12 +244,12 @@ public class SessionStartMemoryFoundationTests {
     public async Task Provider_maps_empty_malformed_and_ready_responses() {
         var scope = new FixedScopeResolver("repo", "machine");
         var empty = new SessionStartMemoryContextProvider(scope,
-            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[]"))));
+            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[]"))), Stopped());
         var malformed = new SessionStartMemoryContextProvider(scope,
-            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[{}]"))));
+            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, "[{}]"))), Stopped());
         var ready = new SessionStartMemoryContextProvider(scope,
             Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK,
-                "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
+                "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))), Stopped());
         var request = new SessionStartMemoryContextRequest("https://example", "/repo", false,
             TimeSpan.FromSeconds(1), CancellationToken.None);
 
@@ -269,7 +266,7 @@ public class SessionStartMemoryFoundationTests {
     public async Task Provider_omits_only_unresolved_scope_axes() {
         var handler = new CapturingHandler(HttpStatusCode.NoContent, "");
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, "machine tag"),
-            Lazy(new HttpClient(handler)));
+            Lazy(new HttpClient(handler)), Stopped());
 
         await provider.GetAsync(new SessionStartMemoryContextRequest(
             "https://example.test/", null, false, TimeSpan.FromSeconds(1), CancellationToken.None));
@@ -281,7 +278,7 @@ public class SessionStartMemoryFoundationTests {
     public async Task Provider_reads_the_index_in_either_body_shape() {
         var scope = new FixedScopeResolver("repo", "machine");
         SessionStartMemoryContextProvider Provider(string body) => new(scope,
-            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, body))));
+            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, body))), Stopped());
         const string entry = "{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}";
         var request = new SessionStartMemoryContextRequest("https://example", "/repo", false,
             TimeSpan.FromSeconds(1), CancellationToken.None);
@@ -312,7 +309,7 @@ public class SessionStartMemoryFoundationTests {
         // An object carrying neither member must stay retryable rather than read as an empty index:
         // Empty completes the once-per-session lease, so a session would never ask again.
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver("repo", "machine"),
-            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, body))));
+            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, body))), Stopped());
 
         var result = await provider.GetAsync(new SessionStartMemoryContextRequest("https://example", "/repo", false,
             TimeSpan.FromSeconds(1), CancellationToken.None));
@@ -328,7 +325,7 @@ public class SessionStartMemoryFoundationTests {
         // The mirror of the case above: a present-but-empty array IS an answer, and completing the
         // lease on it is what stops a session re-fetching an index the server says is empty.
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver("repo", "machine"),
-            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, body))));
+            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, body))), Stopped());
 
         var result = await provider.GetAsync(new SessionStartMemoryContextRequest("https://example", "/repo", false,
             TimeSpan.FromSeconds(1), CancellationToken.None));
@@ -345,7 +342,7 @@ public class SessionStartMemoryFoundationTests {
             "https://example.test", null, false, TimeSpan.FromSeconds(1), CancellationToken.None);
 
         var redirected = await new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
-            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.Redirect, "")))).GetAsync(request);
+            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.Redirect, ""))), Stopped()).GetAsync(request);
 
         await Assert.That(redirected.Disposition).IsEqualTo(SessionStartMemoryDisposition.RetryableFailure);
     }
@@ -353,10 +350,11 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Orchestrator_returns_ready_fragment_only_to_commit_winner() {
         using var root = new TempDir();
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
             Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK,
-                "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
-        var (orchestrator, _) = Frozen(root, provider);
+                "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))), time);
+        var orchestrator = On(root, provider, time);
         var lifecycle = new SessionMemoryLifecycle(HarnessId.Claude, "session", null,
             true, true, SessionLifecycleReason.New, true);
         var request = new SessionStartMemoryContextRequest(
@@ -380,10 +378,11 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task A_refused_commit_gate_releases_the_lease_so_a_later_start_still_injects() {
         using var root = new TempDir();
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
             Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK,
-                "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
-        var (orchestrator, time) = Frozen(root, provider);
+                "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))), time);
+        var orchestrator = On(root, provider, time);
         var lifecycle = new SessionMemoryLifecycle(HarnessId.Copilot, "3f2504e0-4f89-41d3-9a0c-0305e82c3301", null,
             true, true, SessionLifecycleReason.New, true);
         var request = new SessionStartMemoryContextRequest(
@@ -404,10 +403,11 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task A_granted_commit_gate_commits_the_lease_exactly_as_the_ungated_path() {
         using var root = new TempDir();
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
             Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK,
-                "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))));
-        var (orchestrator, _) = Frozen(root, provider);
+                "[{\"memory_id\":\"1\",\"slug\":\"s\",\"audience\":\"org\",\"description\":\"d\",\"kind\":\"feedback\"}]"))), time);
+        var orchestrator = On(root, provider, time);
         var lifecycle = new SessionMemoryLifecycle(HarnessId.Copilot, "3f2504e0-4f89-41d3-9a0c-0305e82c3301", null,
             true, true, SessionLifecycleReason.New, true);
         var request = new SessionStartMemoryContextRequest(
@@ -440,9 +440,10 @@ public class SessionStartMemoryFoundationTests {
     public async Task Kiro_repeated_agent_spawn_injects_once_then_yields_nothing() {
         using var root = new TempDir();
         using var handler = new CountingHandler(HttpStatusCode.OK, OneMemoryJson);
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(
-            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var (orchestrator, _) = Frozen(root, provider);
+            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)), time);
+        var orchestrator = On(root, provider, time);
 
         var first  = await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
         var second = await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
@@ -467,10 +468,11 @@ public class SessionStartMemoryFoundationTests {
         using var client  = new HttpClient(handler);
 
         var asked    = 0;
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(
             new FixedScopeResolver(null, null),
-            _ => { asked++; return Task.FromResult(client); });
-        var (orchestrator, _) = Frozen(root, provider);
+            _ => { asked++; return Task.FromResult(client); }, time);
+        var orchestrator = On(root, provider, time);
 
         await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
         await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
@@ -484,9 +486,10 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Kiro_distinct_session_ids_inject_independently() {
         using var root = new TempDir();
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
-            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, OneMemoryJson))));
-        var (orchestrator, _) = Frozen(root, provider);
+            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, OneMemoryJson))), time);
+        var orchestrator = On(root, provider, time);
 
         var a = await orchestrator.GetFragmentAsync(KiroLifecycle("session-a"), KiroRequest());
         var b = await orchestrator.GetFragmentAsync(KiroLifecycle("session-b"), KiroRequest());
@@ -502,9 +505,10 @@ public class SessionStartMemoryFoundationTests {
     public async Task Kiro_retryable_failure_lets_a_later_prompt_still_inject() {
         using var root = new TempDir();
         using var handler = new FailsOnceHandler(OneMemoryJson);
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(
-            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var (orchestrator, time) = Frozen(root, provider);
+            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)), time);
+        var orchestrator = On(root, provider, time);
 
         var failed = await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
 
@@ -522,9 +526,10 @@ public class SessionStartMemoryFoundationTests {
     public async Task Kiro_a_successful_empty_index_still_suppresses_later_prompts() {
         using var root = new TempDir();
         using var handler = new CountingHandler(HttpStatusCode.NoContent, "");
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(
-            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var (orchestrator, _) = Frozen(root, provider);
+            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)), time);
+        var orchestrator = On(root, provider, time);
 
         await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
         var second = await orchestrator.GetFragmentAsync(KiroLifecycle("kiro-session"), KiroRequest());
@@ -553,7 +558,7 @@ public class SessionStartMemoryFoundationTests {
 
         using var handler = new GatedHandler(winnerHolding, releaseWinner, OneMemoryJson);
         var provider = new SessionStartMemoryContextProvider(
-            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
+            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)), Stopped());
         var store = new SessionStartMemoryLeaseStore(root.Path, TimeProvider.System);
 
         var winner = Task.Run(() => new SessionStartMemoryOrchestrator(store, provider, TimeProvider.System)
@@ -587,18 +592,39 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task A_fetch_that_outlives_its_budget_is_dropped_rather_than_injected() {
         using var root = new TempDir();
-        FakeTimeProvider? clock = null;
+        var time = Stopped();
         var provider = new DelegatingProvider(() => {
-            clock!.Advance(TimeSpan.FromSeconds(30));
+            time.Advance(TimeSpan.FromSeconds(30));
             return new SessionStartMemoryContextResult(SessionStartMemoryDisposition.Ready, "- s: d");
         });
-        var (orchestrator, time) = Frozen(root, provider);
-        clock = time;
+        var orchestrator = On(root, provider, time);
 
         var fragment = await orchestrator.GetFragmentAsync(
             KiroLifecycle("kiro-session"), KiroRequest(seconds: 5));
 
         await Assert.That(fragment).IsNull();
+    }
+
+    // The budget is only real if the thing it bounds observes the same clock. The budget here is far
+    // longer than the test could ever wait out, so only an expiry armed on the injected clock can end
+    // this fetch — a real timer would leave it running and the ceiling below would be what fired.
+    // That ceiling is on the failing path only; the passing path resolves on the advance.
+    [Test]
+    public async Task Advancing_past_the_budget_abandons_an_in_flight_fetch() {
+        var entered = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new BlockingHandler(entered);
+        var time = Stopped();
+        var provider = new SessionStartMemoryContextProvider(
+            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)), time);
+
+        var fetch = provider.GetAsync(new SessionStartMemoryContextRequest(
+            "https://example.test", null, false, TimeSpan.FromMinutes(10), CancellationToken.None));
+
+        await entered.Task;
+        time.Advance(TimeSpan.FromMinutes(11));
+
+        var result = await fetch.WaitAsync(TimeSpan.FromSeconds(30));
+        await Assert.That(result.Disposition).IsEqualTo(SessionStartMemoryDisposition.RetryableFailure);
     }
 
     // Exactly what AntigravityHookCommand.LifecycleFor builds: PreInvocation fires once per
@@ -618,9 +644,10 @@ public class SessionStartMemoryFoundationTests {
     public async Task Antigravity_repeated_pre_invocation_injects_once_and_does_not_refetch() {
         using var root = new TempDir();
         using var handler = new CountingHandler(HttpStatusCode.OK, OneMemoryJson);
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(
-            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var (orchestrator, _) = Frozen(root, provider);
+            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)), time);
+        var orchestrator = On(root, provider, time);
 
         // A real GUID — Antigravity is on the fail-closed identity arm, which normalizes any
         // non-GUID id to null and would short-circuit before the lease is ever consulted,
@@ -639,9 +666,10 @@ public class SessionStartMemoryFoundationTests {
     [Test]
     public async Task Antigravity_distinct_conversations_each_inject_once() {
         using var root = new TempDir();
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(new FixedScopeResolver(null, null),
-            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, OneMemoryJson))));
-        var (orchestrator, _) = Frozen(root, provider);
+            Lazy(new HttpClient(new StaticHandler(HttpStatusCode.OK, OneMemoryJson))), time);
+        var orchestrator = On(root, provider, time);
 
         var a = await orchestrator.GetFragmentAsync(
             AntigravityLifecycle("e80c33bfc10f4d2fb626b0043f488fc0"), AntigravityRequest());
@@ -668,9 +696,10 @@ public class SessionStartMemoryFoundationTests {
     public async Task Disabled_request_does_not_fetch_or_write_a_lease_record() {
         using var root = new TempDir();
         using var handler = new CountingHandler(HttpStatusCode.NoContent, "");
+        var time = Stopped();
         var provider = new SessionStartMemoryContextProvider(
-            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)));
-        var (orchestrator, _) = Frozen(root, provider);
+            new FixedScopeResolver(null, null), Lazy(new HttpClient(handler)), time);
+        var orchestrator = On(root, provider, time);
         var lifecycle = new SessionMemoryLifecycle(HarnessId.Claude, "session", null,
             true, true, SessionLifecycleReason.New, false);
 
@@ -686,6 +715,16 @@ public class SessionStartMemoryFoundationTests {
     sealed class DelegatingProvider(Func<SessionStartMemoryContextResult> fetch) : ISessionStartContextProvider {
         public Task<SessionStartMemoryContextResult> GetAsync(SessionStartMemoryContextRequest request) =>
             Task.FromResult(fetch());
+    }
+
+    /// <summary>Stays inside the send until its caller cancels, so a test can decide when — and on
+    /// which clock — the fetch ends.</summary>
+    sealed class BlockingHandler(TaskCompletionSource entered) : HttpMessageHandler {
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct) {
+            entered.TrySetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, ct);
+            return new HttpResponseMessage(HttpStatusCode.OK);
+        }
     }
 
     sealed class FixedScopeResolver(string? repo, string? machine) : ISessionStartMemoryScopeResolver {


### PR DESCRIPTION
Closes #885 — AI-2701

## What & why

`SessionStartMemoryLeaseStore` took a `TimeProvider` and used it for lease expiry, but every
*budget* in the subsystem was measured with static `Stopwatch` — so half of it answered to an
injected clock and half to the process, and a test could fake one while being timed by the other.
`TimeProvider` carries the monotonic timestamp pair, so the fix keeps `Stopwatch` semantics rather
than moving elapsed time onto a wall clock.

A budget is only real if the thing it bounds observes the same clock, so both context lanes arm
their expiry on the injected one too, and the hook's bounded wait uses the clock its `Remaining`
was measured on. `ServiceVerify` already measured everything through its injected clock; its
suites were the only thing still handing it a real one.

## Where to look

Two cases deliberately keep the process clock, and say so at the call site: their losers contend
for the store's file lock, whose retry loop waits on the same clock it measures — a clock nothing
advances never leaves it.

The lease store gains no parameter. Every hook call site already held `clock.Time`, so the
orchestrator and scope resolver take it without any new dependency flowing.

## Verification

Two pins, each checked by mutation. Stopping the budget from running down fails only
`A_fetch_that_outlives_its_budget_is_dropped_rather_than_injected`; reverting the orchestrator to
the static `Stopwatch` does not even compile (CS9113 is an error here). Re-arming the lane's
expiry on a real timer fails only `Advancing_past_the_budget_abandons_an_in_flight_fetch`, at its
30s ceiling — its budget is ten minutes, so nothing but the injected clock can end that fetch.

| Suite | Before | After |
| --- | --- | --- |
| `SessionStartMemoryFoundationTests` | 40 tests, real budgets | 42 tests, 183ms |
| `ServiceVerify*` (Install, Start, Replace) | 45 real forward budgets | 97 tests, no wall-clock budget |

Full CLI unit suite: 4003 passed, 19 skipped, 0 failed.

`RepositoryDetection` keeps its own `Stopwatch` seam and is left alone — the scope resolver that
reaches it is stubbed out in every test here, so threading a clock through it belongs with work
that actually exercises that path.
