### PR TITLE
Keep npm installs of kcap complete and within the server's version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -564,6 +564,16 @@ jobs:
 
           for dir in npm-artifacts/npm-kcap-*/; do
             pkg_name=$(basename "$dir" | sed 's/^npm-//')
+
+            # A re-run after a later step failed finds this commit's packages already on npm, and npm
+            # refuses to publish a version twice: skip those, refuse one published from another commit.
+            published=$(npm view "@kurrent/$pkg_name@$VERSION" kcapReleaseCommit --registry https://registry.npmjs.org 2>/dev/null || true)
+            case "$(bash scripts/verify-release-not-recut.sh "${{ github.sha }}" "$published" || true)" in
+              ok) ;;
+              republish) echo "@kurrent/$pkg_name@$VERSION is already published from this commit; skipping"; continue ;;
+              *) echo "::error::@kurrent/$pkg_name@$VERSION is already published from commit $published"; exit 1 ;;
+            esac
+
             cp "npm/$pkg_name/package.json" "$dir/package.json"
             cp LICENSE.md "$dir/LICENSE.md"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -619,6 +619,13 @@ jobs:
       - name: Copy license into wrapper package
         run: cp LICENSE.md npm/kcap/LICENSE.md
 
+      # A wrapper installable before its platform packages installs without them, silently: npm
+      # skips an optional dependency it cannot resolve.
+      - name: Wait for the platform packages to become installable
+        run: |
+          read -ra pkgs <<< "$(node -p "Object.keys(require('./npm/kcap/package.json').optionalDependencies).join(' ')")"
+          bash scripts/wait-npm-available.sh "${{ steps.version.outputs.VERSION }}" "${pkgs[@]}"
+
       - name: Publish wrapper package
         run: |
           VERSION=${{ steps.version.outputs.VERSION }}

--- a/README.md
+++ b/README.md
@@ -2121,7 +2121,9 @@ kcap feedback --feedback                               # send feedback; prompts 
 > registry, runs `npm install -g @kurrent/kcap@<tag>`, then refreshes your
 > opted-in agent plugins — so it picks up new skills/hooks even when your package
 > manager blocks install scripts. It exits early if you're already up to date,
-> and tells you what to run instead for non-npm installs (e.g. Homebrew). Use
+> and tells you what to run instead for non-npm installs (e.g. Homebrew). On the
+> stable channel it stops at your connected server's version when the server
+> trails npm, so it never installs a CLI newer than the server it talks to. Use
 > `kcap update --check` for a machine-readable `{current, latest, newer}` probe.
 >
 > **Windows:** the update works even while Claude Code sessions (whose kcap MCP

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -10,8 +10,9 @@ code moves on; where an entry disagrees with the code, the code wins.
 
 `npm publish` returns while the registry is still processing a tarball, and a platform package carrying
 two native binaries took about ten minutes to become installable. A wrapper visible in that window
-installs without its binary, silently: npm skips an optional dependency it cannot resolve. The release
-now polls every platform package until it resolves before publishing the wrapper, and the desktop
+installs without its binary, silently: npm skips an optional dependency it cannot resolve or download.
+The release now polls every platform package until it resolves and its tarball answers before
+publishing the wrapper, and the desktop
 publish reuses that poll before comparing its binaries with npm's. Every poll and every install the
 launcher runs passes `--prefer-online`, because npm serves a cached packument for five minutes and a
 plain retry re-reads the same miss.

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -24,7 +24,9 @@ The update hint caps its target at the connected server's version on the stable 
 command users know. `kcap update --check` now resolves the same capped advisory and reports the
 server's version as `install_tag`; the launcher already installs whatever tag it is handed, so a
 launcher from any release follows the pin. A CLI at its server's version reads as up to date even
-when npm has newer.
+when npm has newer. The cached server version changes only on an authenticated response, so
+`kcap update` sends one read-only probe before capping; without a credential it keeps the cached
+value.
 
 ## Desktop Settings use the profile and the mutation lane
 

--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,25 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## The npm wrapper waits for its platform packages
+
+`npm publish` returns while the registry is still processing a tarball, and a platform package carrying
+two native binaries took about ten minutes to become installable. A wrapper visible in that window
+installs without its binary, silently: npm skips an optional dependency it cannot resolve. The release
+now polls every platform package until it resolves before publishing the wrapper, and the desktop
+publish reuses that poll before comparing its binaries with npm's. Every poll and every install the
+launcher runs passes `--prefer-online`, because npm serves a cached packument for five minutes and a
+plain retry re-reads the same miss.
+
+## `kcap update` stops at the server's version
+
+The update hint caps its target at the connected server's version on the stable channel, but
+`kcap update` followed the dist-tag, so the hint had to print a pinned `npm install` instead of the
+command users know. `kcap update --check` now resolves the same capped advisory and reports the
+server's version as `install_tag`; the launcher already installs whatever tag it is handed, so a
+launcher from any release follows the pin. A CLI at its server's version reads as up to date even
+when npm has newer.
+
 ## Desktop Settings use the profile and the mutation lane
 
 The Settings window edits the profile bound to the app's daemon graph and refuses a profile whose

--- a/npm/kcap/bin/kcap.js
+++ b/npm/kcap/bin/kcap.js
@@ -11,15 +11,20 @@ const fs = require("fs");
 // module.exports below, so it would see partial exports).
 const { PLATFORM_PACKAGES, platformKey } = require("./resolve");
 
-// Resolves the npm dist-tag to install for `kcap update`, based on the
-// resolved channel reported by `kcap update --check`'s `install_tag` field.
-// Falls back to "latest" when the probe is missing, failed, or has no tag,
-// preserving today's default behavior.
+// The package spec `kcap update` installs, from `kcap update --check`'s `install_tag`: the channel's
+// dist-tag, or an exact version when the connected server caps the update. Falls back to "latest"
+// when the probe is missing, failed, or has no tag.
 function resolveInstallSpec(info) {
   const tag = info && typeof info.install_tag === "string" && info.install_tag
     ? info.install_tag
     : "latest";
   return `@kurrent/kcap@${tag}`;
+}
+
+// npm serves a packument from its cache for five minutes; within that window an install can
+// resolve against a listing that predates the platform package's version and silently skip it.
+function npmInstallArgs(spec) {
+  return ["install", "-g", spec, "--prefer-online"];
 }
 
 // Builds the arg list for the `kcap update --check` probe, forwarding only
@@ -201,7 +206,7 @@ if (require.main === module) {
     binaryDir = path.dirname(require.resolve(`${packageName}/package.json`));
   } catch {
     console.error(`Platform package ${packageName} is not installed.`);
-    console.error(`Try: npm install -g @kurrent/kcap`);
+    console.error(`Try: npm ${npmInstallArgs(`@kurrent/kcap@${require("../package.json").version}`).join(" ")}`);
     process.exit(1);
   }
 
@@ -354,7 +359,7 @@ function runUpdate(binaryPath, updArgs) {
     }
   }
 
-  const res = spawnSync("npm", ["install", "-g", resolveInstallSpec(info)], {
+  const res = spawnSync("npm", npmInstallArgs(resolveInstallSpec(info)), {
     stdio: "inherit",
     windowsHide: true,
     ...npmOpts,
@@ -400,6 +405,7 @@ function runUpdate(binaryPath, updArgs) {
 
 module.exports = {
   resolveInstallSpec,
+  npmInstallArgs,
   probeArgs,
   trashDirFor,
   trashDirFromLauncher,

--- a/npm/kcap/bin/kcap.test.js
+++ b/npm/kcap/bin/kcap.test.js
@@ -18,7 +18,7 @@ assert.strictEqual(resolveInstallSpec({ install_tag: "latest" }), "@kurrent/kcap
 assert.strictEqual(resolveInstallSpec({}), "@kurrent/kcap@latest");          // missing → latest
 assert.strictEqual(resolveInstallSpec(null), "@kurrent/kcap@latest");        // no probe → latest
 assert.strictEqual(resolveInstallSpec({ install_tag: "" }), "@kurrent/kcap@latest");
-assert.strictEqual(resolveInstallSpec({ install_tag: "1.0.1" }), "@kurrent/kcap@1.0.1"); // server-capped pin
+assert.strictEqual(resolveInstallSpec({ install_tag: "1.0.1" }), "@kurrent/kcap@1.0.1");
 
 // Revalidates npm's cached packument, so a platform package published minutes ago is not skipped.
 assert.deepStrictEqual(npmInstallArgs("@kurrent/kcap@1.0.2"), ["install", "-g", "@kurrent/kcap@1.0.2", "--prefer-online"]);

--- a/npm/kcap/bin/kcap.test.js
+++ b/npm/kcap/bin/kcap.test.js
@@ -4,6 +4,7 @@ const os = require("node:os");
 const path = require("node:path");
 const {
   resolveInstallSpec,
+  npmInstallArgs,
   probeArgs,
   trashDirFor,
   trashDirFromLauncher,
@@ -17,6 +18,14 @@ assert.strictEqual(resolveInstallSpec({ install_tag: "latest" }), "@kurrent/kcap
 assert.strictEqual(resolveInstallSpec({}), "@kurrent/kcap@latest");          // missing → latest
 assert.strictEqual(resolveInstallSpec(null), "@kurrent/kcap@latest");        // no probe → latest
 assert.strictEqual(resolveInstallSpec({ install_tag: "" }), "@kurrent/kcap@latest");
+assert.strictEqual(resolveInstallSpec({ install_tag: "1.0.1" }), "@kurrent/kcap@1.0.1"); // server-capped pin
+
+// Revalidates npm's cached packument, so a platform package published minutes ago is not skipped.
+assert.deepStrictEqual(npmInstallArgs("@kurrent/kcap@1.0.2"), ["install", "-g", "@kurrent/kcap@1.0.2", "--prefer-online"]);
+{
+  const src = fs.readFileSync(path.join(__dirname, "kcap.js"), "utf8");
+  assert(src.includes('spawnSync("npm", npmInstallArgs('), "kcap update must install through npmInstallArgs");
+}
 
 assert.deepStrictEqual(probeArgs([]), ["update", "--check", "--no-update-check"]);
 assert.deepStrictEqual(probeArgs(["--beta"]), ["update", "--check", "--no-update-check", "--beta"]);

--- a/scripts/verify-npm-trio.sh
+++ b/scripts/verify-npm-trio.sh
@@ -14,17 +14,8 @@ tarball="${5:-}"
 tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
 
 if [ "${4:-}" != "--tarball" ]; then
-  # npm pack runs seconds after publish-npm finished; the registry needs a moment to propagate.
-  packed=0
-  for attempt in 1 2 3 4 5 6; do
-    if (cd "$tmp" && npm pack "@kurrent/kcap-darwin-arm64@$version" --registry https://registry.npmjs.org --pack-destination "$tmp" >/dev/null 2>"$tmp/npm.err"); then
-      packed=1
-      break
-    fi
-    echo "npm pack attempt $attempt/6 failed: $(tail -1 "$tmp/npm.err")" >&2
-    [ "$attempt" -lt 6 ] && sleep 20
-  done
-  [ "$packed" -eq 1 ] || { echo "npm pack failed after 6 attempts" >&2; exit 1; }
+  NPM_WAIT_TIMEOUT="${NPM_WAIT_TIMEOUT:-600}" bash "$here/wait-npm-available.sh" "$version" @kurrent/kcap-darwin-arm64
+  (cd "$tmp" && npm pack "@kurrent/kcap-darwin-arm64@$version" --prefer-online --registry https://registry.npmjs.org --pack-destination "$tmp" >/dev/null)
   tarball="$(ls "$tmp"/*.tgz | head -1)"
 fi
 [ -f "$tarball" ] || { echo "no tarball for @kurrent/kcap-darwin-arm64@$version" >&2; exit 1; }

--- a/scripts/wait-npm-available.sh
+++ b/scripts/wait-npm-available.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
-# Blocks until every <package>@<version> resolves from the npm registry, or fails at the deadline.
+# Blocks until every <package>@<version> resolves from the npm registry and its tarball downloads, or
+# fails at the deadline.
 # npm publish returns while the registry is still processing the tarball, for minutes on a large one.
 # Usage: wait-npm-available.sh <version> <package>...
 # NPM_WAIT_TIMEOUT (seconds, default 1800) and NPM_WAIT_INTERVAL (seconds, default 15) tune the poll.
@@ -15,7 +16,9 @@ err="$(mktemp)"; trap 'rm -f "$err"' EXIT
 for pkg in "$@"; do
   while :; do
     # --prefer-online: npm caches a packument for five minutes, so a plain re-poll re-reads the miss.
-    if [ "$(npm view "$pkg@$version" version --prefer-online --registry https://registry.npmjs.org 2>"$err")" = "$version" ]; then
+    tarball="$(npm view "$pkg@$version" dist.tarball --prefer-online --registry https://registry.npmjs.org 2>"$err")" || tarball=""
+    # npm also skips an optional dependency whose tarball fails to download.
+    if [ -n "$tarball" ] && curl -fsSI "$tarball" >/dev/null 2>>"$err"; then
       echo "$pkg@$version is available"
       break
     fi

--- a/scripts/wait-npm-available.sh
+++ b/scripts/wait-npm-available.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Blocks until every <package>@<version> resolves from the npm registry, or fails at the deadline.
+# npm publish returns while the registry is still processing the tarball, for minutes on a large one.
+# Usage: wait-npm-available.sh <version> <package>...
+# NPM_WAIT_TIMEOUT (seconds, default 1800) and NPM_WAIT_INTERVAL (seconds, default 15) tune the poll.
+set -euo pipefail
+usage="usage: wait-npm-available.sh <version> <package>..."
+version="${1:?$usage}"; shift
+[ "$#" -gt 0 ] || { echo "$usage" >&2; exit 2; }
+timeout="${NPM_WAIT_TIMEOUT:-1800}"
+interval="${NPM_WAIT_INTERVAL:-15}"
+deadline=$(( SECONDS + timeout ))
+err="$(mktemp)"; trap 'rm -f "$err"' EXIT
+
+for pkg in "$@"; do
+  while :; do
+    # --prefer-online: npm caches a packument for five minutes, so a plain re-poll re-reads the miss.
+    if [ "$(npm view "$pkg@$version" version --prefer-online --registry https://registry.npmjs.org 2>"$err")" = "$version" ]; then
+      echo "$pkg@$version is available"
+      break
+    fi
+    if [ "$SECONDS" -ge "$deadline" ]; then
+      reason="$(sed -n '/complete log/d; /npm error code /d; /./{p;q;}' "$err")"
+      echo "$pkg@$version is still unavailable after ${timeout}s: ${reason:-<no npm output>}" >&2
+      exit 1
+    fi
+    sleep "$interval"
+  done
+done

--- a/scripts/wait-npm-available.test.sh
+++ b/scripts/wait-npm-available.test.sh
@@ -13,22 +13,33 @@ spec="$2"; key="$(printf '%s' "${spec%@*}" | tr '/@' '__')"
 case " $* " in *" --prefer-online "*) ;; *) echo "npm error polled without --prefer-online" >&2; exit 1 ;; esac
 n=$(( $(cat "$STATE/$key.calls" 2>/dev/null || echo 0) + 1 )); echo "$n" > "$STATE/$key.calls"
 after="$(cat "$STATE/$key.after")"
-if [ "$after" != never ] && [ "$n" -ge "$after" ]; then echo "${spec##*@}"; exit 0; fi
+if [ "$after" != never ] && [ "$n" -ge "$after" ]; then echo "https://registry.example/$key.tgz"; exit 0; fi
 echo "npm error code E404" >&2
 echo "npm error 404 No match found for version ${spec##*@}" >&2
 echo "npm error A complete log of this run can be found in: /x/debug-0.log" >&2
 exit 1
 EOF
-chmod +x "$tmp/bin/npm"
+# Fake curl: the tarball answers unless $STATE/<key>.tarball says "missing".
+cat > "$tmp/bin/curl" <<'EOF'
+#!/usr/bin/env bash
+url="${!#}"; key="$(basename "$url" .tgz)"
+if [ "$(cat "$STATE/$key.tarball" 2>/dev/null || echo ok)" = ok ]; then exit 0; fi
+echo "curl: (22) The requested URL returned error: 404" >&2
+exit 22
+EOF
+chmod +x "$tmp/bin/npm" "$tmp/bin/curl"
 
 fail=0
-run() { # <name> <want-rc> <timeout> <package=after>...
+run() { # <name> <want-rc> <timeout> <package=after[:missing]>...
   local name="$1" want="$2" timeout="$3" kv rc; shift 3
   local pkgs=()
   rm -rf "$tmp/state"; mkdir -p "$tmp/state"
   for kv in "$@"; do
-    pkgs+=("${kv%=*}")
-    printf '%s' "${kv#*=}" > "$tmp/state/$(printf '%s' "${kv%=*}" | tr '/@' '__').after"
+    local pkg="${kv%%=*}" spec="${kv#*=}" key
+    key="$(printf '%s' "$pkg" | tr '/@' '__')"
+    pkgs+=("$pkg")
+    printf '%s' "${spec%%:*}" > "$tmp/state/$key.after"
+    case "$spec" in *:missing) echo missing > "$tmp/state/$key.tarball" ;; esac
   done
   set +e
   STATE="$tmp/state" PATH="$tmp/bin:$PATH" NPM_WAIT_TIMEOUT="$timeout" NPM_WAIT_INTERVAL=0 \
@@ -44,5 +55,9 @@ run "waits for every package"         0 30 "@kurrent/a=1" "@kurrent/b=3"
 run "fails when one never appears"    1 0  "@kurrent/a=1" "@kurrent/b=never"
 if ! grep -q "@kurrent/b@1.0.2 is still unavailable after 0s: npm error 404 No match found for version 1.0.2" "$tmp/out"; then
   echo "FAIL: deadline message names the package and npm's reason: $(cat "$tmp/out")"; fail=1
+fi
+run "fails while the tarball is missing" 1 0 "@kurrent/a=1:missing"
+if ! grep -q "@kurrent/a@1.0.2 is still unavailable after 0s: curl: (22)" "$tmp/out"; then
+  echo "FAIL: deadline message names the tarball failure: $(cat "$tmp/out")"; fail=1
 fi
 [ "$fail" -eq 0 ] && echo "ok" || exit 1

--- a/scripts/wait-npm-available.test.sh
+++ b/scripts/wait-npm-available.test.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+set -euo pipefail
+here="$(cd "$(dirname "$0")" && pwd)"
+sh="$here/wait-npm-available.sh"
+tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
+
+# Fake npm: a package resolves from its Nth poll on (N in $STATE/<key>.after, or "never"). It refuses a
+# poll without --prefer-online, which would re-read npm's cached packument instead of the registry.
+mkdir -p "$tmp/bin"
+cat > "$tmp/bin/npm" <<'EOF'
+#!/usr/bin/env bash
+spec="$2"; key="$(printf '%s' "${spec%@*}" | tr '/@' '__')"
+case " $* " in *" --prefer-online "*) ;; *) echo "npm error polled without --prefer-online" >&2; exit 1 ;; esac
+n=$(( $(cat "$STATE/$key.calls" 2>/dev/null || echo 0) + 1 )); echo "$n" > "$STATE/$key.calls"
+after="$(cat "$STATE/$key.after")"
+if [ "$after" != never ] && [ "$n" -ge "$after" ]; then echo "${spec##*@}"; exit 0; fi
+echo "npm error code E404" >&2
+echo "npm error 404 No match found for version ${spec##*@}" >&2
+echo "npm error A complete log of this run can be found in: /x/debug-0.log" >&2
+exit 1
+EOF
+chmod +x "$tmp/bin/npm"
+
+fail=0
+run() { # <name> <want-rc> <timeout> <package=after>...
+  local name="$1" want="$2" timeout="$3" kv rc; shift 3
+  local pkgs=()
+  rm -rf "$tmp/state"; mkdir -p "$tmp/state"
+  for kv in "$@"; do
+    pkgs+=("${kv%=*}")
+    printf '%s' "${kv#*=}" > "$tmp/state/$(printf '%s' "${kv%=*}" | tr '/@' '__').after"
+  done
+  set +e
+  STATE="$tmp/state" PATH="$tmp/bin:$PATH" NPM_WAIT_TIMEOUT="$timeout" NPM_WAIT_INTERVAL=0 \
+    bash "$sh" 1.0.2 "${pkgs[@]}" >"$tmp/out" 2>&1
+  rc=$?
+  set -e
+  if [ "$rc" != "$want" ]; then echo "FAIL: $name -> rc=$rc (want $want): $(cat "$tmp/out")"; fail=1; fi
+}
+
+run "visible on the first poll"       0 30 "@kurrent/a=1"
+run "visible after retries"           0 30 "@kurrent/a=3"
+run "waits for every package"         0 30 "@kurrent/a=1" "@kurrent/b=3"
+run "fails when one never appears"    1 0  "@kurrent/a=1" "@kurrent/b=never"
+if ! grep -q "@kurrent/b@1.0.2 is still unavailable after 0s: npm error 404 No match found for version 1.0.2" "$tmp/out"; then
+  echo "FAIL: deadline message names the package and npm's reason: $(cat "$tmp/out")"; fail=1
+fi
+[ "$fail" -eq 0 ] && echo "ok" || exit 1

--- a/src/Capacitor.Cli.Core/Resources/help-update.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-update.txt
@@ -27,14 +27,13 @@ Options:
 Beta releases correspond to server versions rolled out to internal
 tenants first. Most users should stay on the default stable channel.
 
-The passive "update available" hint and the kcap status version line are
-capped at the version of the server you're connected to: when your tenant's
-server trails npm (rollouts are manual and can lag by days), they recommend
-the server's version — shown with a "(server version)" marker and a pinned
-"npm install -g @kurrent/kcap@<version>" command — rather than steering you
-to a CLI newer than the server supports. `kcap update` itself is never
-capped; it always installs the latest on your channel. The cap applies on
-the stable channel only; beta deliberately rides ahead.
+kcap update, the passive "update available" hint and the kcap status version
+line are capped at the version of the server you're connected to: when your
+tenant's server trails npm (rollouts are manual and can lag by days), they
+target the server's version — shown with a "(server version)" marker —
+rather than a CLI newer than the server supports, and kcap update installs
+exactly that version. The cap applies on the stable channel only; beta
+deliberately rides ahead.
 
 update_check (kcap config set update_check false):
   Controls ALL kcap update nudging, not just the local stderr hint. With

--- a/src/Capacitor.Cli/Commands/ReportVersionCommand.cs
+++ b/src/Capacitor.Cli/Commands/ReportVersionCommand.cs
@@ -1,40 +1,16 @@
 using Capacitor.Cli.Core;
-using Capacitor.Cli.Core.Config;
-
 using Capacitor.Cli.Core.Http;
 
 namespace Capacitor.Cli.Commands;
 
 /// <summary>
-/// Hidden command spawned by the npm wrapper right after <c>kcap update</c> installs a new
-/// binary: makes one authenticated GET against <see cref="WhoamiCommand.ProbePath"/> (read-only,
-/// no side effects — unlike <see cref="SetupCommand"/>'s cli-setup POST) so the server's
-/// endpoint-agnostic version-observer middleware sees the new <see cref="HttpClientExtensions.CliVersionHeader"/>
-/// immediately. Fail-open: never throws, never prints, always returns 0, bounded to
-/// <see cref="Budget"/> total (discovery + request).
+/// Hidden command spawned by the npm wrapper right after <c>kcap update</c> installs a new binary: sends
+/// <see cref="ServerProbe"/> so the server's endpoint-agnostic version-observer middleware sees the new
+/// <see cref="HttpClientExtensions.CliVersionHeader"/> immediately. Never prints, always returns 0.
 /// </summary>
 public sealed class ReportVersionCommand(CapacitorServer server, ICapacitorHttpClient http) {
-    static readonly TimeSpan Budget = TimeSpan.FromSeconds(5);
-
     public async Task<int> HandleAsync() {
-        try {
-            using var cts = new CancellationTokenSource(Budget);
-
-            var (client, status) =
-                await http.ForHookAsync(cts.Token);
-
-            using (client) {
-                // Reached with no server configured — it is an offline command — and the status says
-                // so before a URL is needed, which is also what keeps the silent return honest.
-                if (status is not (AuthStatus.Ok or AuthStatus.NoAuthRequired)) return 0;
-
-                var url = AppConfig.NormalizeUrl(server.Url) + WhoamiCommand.ProbePath;
-
-                using var _ = await client.GetOnceAsync(url, Budget, cts.Token);
-            }
-        } catch {
-            // Fail-open — see class doc.
-        }
+        await ServerProbe.SendAsync(server, http);
 
         return 0;
     }

--- a/src/Capacitor.Cli/Commands/ServerProbe.cs
+++ b/src/Capacitor.Cli/Commands/ServerProbe.cs
@@ -1,0 +1,35 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Config;
+
+using Capacitor.Cli.Core.Http;
+
+namespace Capacitor.Cli.Commands;
+
+/// <summary>
+/// One authenticated, read-only GET against <see cref="WhoamiCommand.ProbePath"/>: the server observes the
+/// CLI's version header on it and answers with its own version, which the hook lane records in
+/// <see cref="ServerVersionStore"/>. Fail-open, and bounded to <see cref="Budget"/> with discovery included.
+/// </summary>
+internal static class ServerProbe {
+    static readonly TimeSpan Budget = TimeSpan.FromSeconds(5);
+
+    public static async Task SendAsync(CapacitorServer server, ICapacitorHttpClient http) {
+        try {
+            using var cts = new CancellationTokenSource(Budget);
+
+            var (client, status) = await http.ForHookAsync(cts.Token);
+
+            using (client) {
+                // Reached with no server configured — every caller is an offline command — and the status
+                // says so before a URL is needed.
+                if (status is not (AuthStatus.Ok or AuthStatus.NoAuthRequired)) return;
+
+                var url = AppConfig.NormalizeUrl(server.Url) + WhoamiCommand.ProbePath;
+
+                using var _ = await client.GetOnceAsync(url, Budget, cts.Token);
+            }
+        } catch {
+            // No caller can act on a failed probe.
+        }
+    }
+}

--- a/src/Capacitor.Cli/Commands/UpdateCommand.cs
+++ b/src/Capacitor.Cli/Commands/UpdateCommand.cs
@@ -5,7 +5,9 @@ using Capacitor.Cli.Core.Http;
 
 namespace Capacitor.Cli.Commands;
 
-public sealed class UpdateCommand(ConfigRoot root, ProfileContext profiles, NpmRegistryClient npm, bool? appBundled = null) {
+public sealed class UpdateCommand(
+        ConfigRoot root, ProfileContext profiles, NpmRegistryClient npm, CapacitorServer server, ICapacitorHttpClient http,
+        bool? appBundled = null) {
     /// Printed by every `kcap update` invocation of a CLI that lives inside the desktop app.
     internal const string BundledMessage =
         "This kcap is bundled with the Kurrent Capacitor desktop app; updates arrive through the app (\"Check for Updates…\" in the menu bar).";
@@ -79,7 +81,11 @@ public sealed class UpdateCommand(ConfigRoot root, ProfileContext profiles, NpmR
             }
         }
 
+        // The cap reads a cached server version that only an authenticated response refreshes, so a
+        // server upgraded since the last one would otherwise hold this update back.
+        var probe             = channel == "latest" ? ServerProbe.SendAsync(server, http) : Task.CompletedTask;
         var checkResult       = await CheckForUpdateAsync(forceCheck: true, channel, root, npm);
+        await probe;
         var advisory          = UpdateAdvisoryResolver.Resolve(checkResult, channel, profiles.Resolution.ServerUrl, root);
         var (latest, current) = (advisory.Target, advisory.Current);
 

--- a/src/Capacitor.Cli/Commands/UpdateCommand.cs
+++ b/src/Capacitor.Cli/Commands/UpdateCommand.cs
@@ -80,29 +80,12 @@ public sealed class UpdateCommand(ConfigRoot root, ProfileContext profiles, NpmR
         }
 
         var checkResult       = await CheckForUpdateAsync(forceCheck: true, channel, root, npm);
-        var (latest, current) = (checkResult.Latest, checkResult.Current);
+        var advisory          = UpdateAdvisoryResolver.Resolve(checkResult, channel, profiles.Resolution.ServerUrl, root);
+        var (latest, current) = (advisory.Target, advisory.Current);
 
         if (checkOnly) {
-            // Machine-readable probe consumed by the npm launcher (kcap.js).
-            // One JSON line on stdout; exit 1 only when the check itself failed.
-            //
-            // `newer` is a tri-state: true => upgrade, false => confidently up to
-            // date, null => can't tell (current version unknown or registry check
-            // failed). The launcher must NOT skip on null — otherwise a binary
-            // that reports "unknown" would strand the user on a stale CLI.
-            bool? newer = string.IsNullOrEmpty(current) || latest is null
-                ? null
-                : IsNewer(latest, current);
-
-            var obj = new JsonObject {
-                ["current"]     = current,
-                ["latest"]      = latest,
-                ["newer"]       = newer,
-                ["channel"]     = channel,
-                ["install_tag"] = channel,
-            };
-
-            await Console.Out.WriteLineAsync(obj.ToJsonString());
+            // One JSON line for the npm launcher (kcap.js); exit 1 only when the check itself failed.
+            await Console.Out.WriteLineAsync(CheckJson(advisory, channel));
 
             return latest is null ? 1 : 0;
         }
@@ -131,7 +114,7 @@ public sealed class UpdateCommand(ConfigRoot root, ProfileContext profiles, NpmR
         await Console.Out.WriteLineAsync($"Update available: {current} {Arrow} {latest}");
         await Console.Out.WriteLineAsync();
         await Console.Out.WriteLineAsync("Run `kcap update` to update, or upgrade directly:");
-        await Console.Out.WriteLineAsync("  npm install -g @kurrent/kcap@latest");
+        await Console.Out.WriteLineAsync($"  npm install -g @kurrent/kcap@{InstallTag(advisory, channel)}");
 
         return 0;
     }
@@ -363,6 +346,24 @@ public sealed class UpdateCommand(ConfigRoot root, ProfileContext profiles, NpmR
     }
 
     static bool IsNewer(string? latest, string? current) => PrereleaseSemver.IsNewer(latest, current);
+
+    /// <summary>
+    /// The `--check` contract the npm launcher installs from. <c>newer</c> is null when either version
+    /// is unknown, which the launcher must not read as "up to date" — that would strand a stale CLI.
+    /// </summary>
+    internal static string CheckJson(UpdateAdvisory advisory, string channel) =>
+        new JsonObject {
+            ["current"]     = advisory.Current,
+            ["latest"]      = advisory.Target,
+            ["newer"]       = string.IsNullOrEmpty(advisory.Current) || advisory.Target is null ? (bool?)null : advisory.Newer,
+            ["channel"]     = channel,
+            ["install_tag"] = InstallTag(advisory, channel),
+        }.ToJsonString();
+
+    /// <summary>The server's version when it caps the target, so an update never installs a CLI newer
+    /// than the server it talks to; otherwise the channel's dist-tag.</summary>
+    internal static string InstallTag(UpdateAdvisory advisory, string channel) =>
+        advisory is { ServerCapped: true, Target: { } target } ? target : channel;
 
     /// <summary>
     /// The `--check` contract for a bundled CLI: the launcher must see "confidently up to date",

--- a/src/Capacitor.Cli/UpdateAdvisory.cs
+++ b/src/Capacitor.Cli/UpdateAdvisory.cs
@@ -6,8 +6,9 @@ namespace Capacitor.Cli;
 /// <summary>
 /// The effective "update available" advisory after capping the raw npm-latest target at the connected
 /// server's version. A manually-rolled tenant can trail npm for days, so recommending a CLI newer than
-/// the server it talks to only risks protocol mismatch; the passive update notice and <c>kcap status</c>
-/// render this instead of the raw npm result. <see cref="ServerCapped"/> drives the pinned-install copy.
+/// the server it talks to only risks protocol mismatch; the passive update notice, <c>kcap status</c> and
+/// <c>kcap update</c> use this instead of the raw npm result. <see cref="ServerCapped"/> pins the version
+/// <c>kcap update</c> installs.
 /// </summary>
 internal readonly record struct UpdateAdvisory(string? Current, string? Target, bool Newer, bool ServerCapped);
 

--- a/src/Capacitor.Cli/UpdateNotice.cs
+++ b/src/Capacitor.Cli/UpdateNotice.cs
@@ -105,18 +105,12 @@ internal static class UpdateNotice {
 
             _reported = true;
 
-            await Console.Error.WriteLineAsync();
+            var marker = advisory.ServerCapped ? " (server version)" : "";
 
-            if (advisory.ServerCapped) {
-                // The server is behind npm latest; plain `kcap update` follows the dist-tag and would
-                // overshoot the cap, so recommend the pinned install of the server's version.
-                await Console.Error.WriteLineAsync(
-                    $"Update available: {advisory.Current} {UpdateCommand.Arrow} {advisory.Target} (server version)");
-                await Console.Error.WriteLineAsync($"Run: npm install -g @kurrent/kcap@{advisory.Target}");
-            } else {
-                await Console.Error.WriteLineAsync($"Update available: {advisory.Current} {UpdateCommand.Arrow} {advisory.Target}");
-                await Console.Error.WriteLineAsync("Run `kcap update` to update");
-            }
+            await Console.Error.WriteLineAsync();
+            await Console.Error.WriteLineAsync($"Update available: {advisory.Current} {UpdateCommand.Arrow} {advisory.Target}{marker}");
+            // `kcap update` applies the same cap, so it installs this target rather than npm latest.
+            await Console.Error.WriteLineAsync("Run `kcap update` to update");
         } catch {
             // Best effort — an update notice must never break the command it's attached to.
         }

--- a/test/Capacitor.Cli.Tests.Integration/UpdateNoticeDeliveryTests.cs
+++ b/test/Capacitor.Cli.Tests.Integration/UpdateNoticeDeliveryTests.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Capacitor.Cli.Core;
 
 namespace Capacitor.Cli.Tests.Integration;
 
@@ -49,6 +50,29 @@ public class UpdateNoticeDeliveryTests : IDisposable {
         await Assert.That(r.Stderr).Contains($"Update available:");
         await Assert.That(r.Stderr).Contains(NewerVersion);
         await Assert.That(r.Stderr).Contains("Run `kcap update` to update");
+    }
+
+    /// <summary>
+    /// A server trailing npm latest caps the target at its own version; the hint still names
+    /// <c>kcap update</c>, which installs that same capped version, never a raw npm command.
+    /// </summary>
+    [Test]
+    public async Task ServerCappedHint_NamesTheServerVersion_AndAdvisesKcapUpdate() {
+        const string server        = "https://tenant.example";
+        const string serverVersion = "998.0.0";
+
+        var cfgDir = SeedFreshNewerCache();
+        cfgDir.CreateFile("config.json", $$$"""
+            {"version":2,"active_profile":"default","profiles":{"default":{"server_url":"{{{server}}}"}},"profile_bindings":{},"cwd_remap":[]}
+            """);
+        ServerVersionStore.Set(server, serverVersion, cfgDir.Root);
+
+        var r = await RunAsync(["config", "show"], cfgDir);
+
+        await Assert.That(r.ExitCode).IsEqualTo(0);
+        await Assert.That(r.Stderr).Contains($"{serverVersion} (server version)");
+        await Assert.That(r.Stderr).Contains("Run `kcap update` to update");
+        await Assert.That(r.Stderr).DoesNotContain("npm install");
     }
 
     // --- Structural: --help and the no-server path fall through the same finally ---

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ReportVersionCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ReportVersionCommandTests.cs
@@ -103,6 +103,26 @@ public class ReportVersionCommandTests : IDisposable {
     }
 
     /// <summary>
+    /// <c>kcap update</c> sends this probe to refresh the server version its cap reads: the cached value
+    /// changes only on an authenticated response, so a server upgraded since the last one would hold the
+    /// update back.
+    /// </summary>
+    [Test]
+    public async Task Probe_refreshes_the_cached_server_version() {
+        StubDiscovery("github_app");
+        _server.Given(Request.Create().WithPath(ProbePath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader(HttpClientExtensions.ServerVersionHeader, "1.0.2"));
+
+        var profiles = await SeedValidTokenAsync("report-version-refresh");
+        ServerVersionStore.Set(_server.Urls[0], "1.0.1", Config.Root);
+
+        await Command(profiles).HandleAsync();
+
+        await Assert.That(ServerVersionStore.Get(_server.Urls[0], Config.Root)).IsEqualTo("1.0.2");
+    }
+
+    /// <summary>
     /// An <c>Auth:Provider=None</c> tenant: no bearer token exists (there is nothing to log
     /// into), but the request still authenticates via the server's synthetic principal, so the
     /// middleware still observes it — <see cref="AuthStatus.NoAuthRequired"/> must proceed exactly

--- a/test/Capacitor.Cli.Tests.Unit/Commands/UpdateCommandServerRefreshTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/UpdateCommandServerRefreshTests.cs
@@ -1,0 +1,106 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Auth;
+using Capacitor.Cli.Core.Config;
+using Capacitor.Cli.Core.Http;
+using Microsoft.Extensions.DependencyInjection;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace Capacitor.Cli.Tests.Unit.Commands;
+
+/// <summary>
+/// <c>kcap update --check</c> refreshes the server version before capping the install at it: the cached
+/// value changes only on an authenticated response, so a server upgraded since the last one would pin the
+/// update to its old version. Here npm latest is 999.0.0, the cache holds 997.0.0 and the live server
+/// answers 998.0.0.
+/// </summary>
+// Bare, not keyed: the command writes to Console, and KCAP_URL is read by every resolution in the assembly.
+[NotInParallel]
+public class UpdateCommandServerRefreshTests : IDisposable {
+    [TempConfigRoot] public required TempConfigRoot Config { get; init; }
+
+    readonly WireMockServer _server = WireMockServer.Start();
+
+    ServiceProvider? _sp;
+
+    public void Dispose() {
+        _sp?.Dispose();
+        _server.Stop();
+    }
+
+    void StubRegistryAndServer() {
+        _server.Given(Request.Create().WithPath("/@kurrent/kcap/latest").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"version":"999.0.0"}"""));
+        _server.Given(Request.Create().WithPath("/auth/config").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("""{"provider":"github_app"}"""));
+        _server.Given(Request.Create().WithPath(WhoamiCommand.ProbePath).UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(200)
+                .WithHeader(HttpClientExtensions.ServerVersionHeader, "998.0.0"));
+
+        ServerVersionStore.Set(_server.Urls[0], "997.0.0", Config.Root);
+    }
+
+    ProfileContext Profiles(string profileName) =>
+        Resolutions.Of(new Profile { ServerUrl = _server.Urls[0] }, profileName, _server.Urls[0]);
+
+    async Task<ProfileContext> SeedValidTokenAsync(string profileName) {
+        await AuthFixtures.NewTokenStore(Config.Root).SaveAsync(profileName, new StoredTokens {
+            AccessToken    = "tok-" + profileName,
+            ExpiresAt      = DateTimeOffset.UtcNow.AddHours(1),
+            GitHubUsername = "alice",
+            Provider       = AuthProvider.GitHubApp,
+            ServerUrl      = _server.Urls[0],
+        });
+
+        return Profiles(profileName);
+    }
+
+    async Task<JsonObject> CheckAsync(ProfileContext profiles) {
+        var services = new ServiceCollection();
+
+        services.AddSingleton(Config.Root);
+        services.AddSingleton(profiles);
+        services.AddSingleton(new CapacitorServer(profiles.Resolution.ServerUrl ?? "", Config.Root, profiles));
+        services.AddCapacitorHttp(ProfileOverrides.None, MachineAuth.None);
+        _sp = services.BuildServiceProvider();
+
+        using var registry = new HttpClient { BaseAddress = new Uri(_server.Urls[0] + "/") };
+
+        var command = new UpdateCommand(
+            Config.Root, profiles, new NpmRegistryClient(registry),
+            _sp.GetRequiredService<CapacitorServer>(), _sp.GetRequiredService<ICapacitorHttpClient>(), appBundled: false);
+
+        using var output = ConsoleOutput.StartCapture();
+        await command.HandleAsync(["--check"]);
+
+        return JsonNode.Parse(output.GetCapturedOutput().Trim())!.AsObject();
+    }
+
+    [Test]
+    public async Task The_live_server_version_replaces_the_cached_one_before_capping() {
+        StubRegistryAndServer();
+
+        var json = await CheckAsync(await SeedValidTokenAsync("update-refresh"));
+
+        await Assert.That(json["install_tag"]!.GetValue<string>()).IsEqualTo("998.0.0");
+        await Assert.That(ServerVersionStore.Get(_server.Urls[0], Config.Root)).IsEqualTo("998.0.0");
+    }
+
+    /// <summary>Without a credential no probe goes out, and the cached version still caps the install.</summary>
+    [Test]
+    public async Task Without_a_credential_the_cached_version_still_caps() {
+        StubRegistryAndServer();
+
+        var json = await CheckAsync(Profiles("update-no-token"));
+
+        await Assert.That(json["install_tag"]!.GetValue<string>()).IsEqualTo("997.0.0");
+        await Assert.That(_server.LogEntries.Any(e => e.RequestMessage.Path == WhoamiCommand.ProbePath)).IsFalse();
+    }
+}

--- a/test/Capacitor.Cli.Tests.Unit/UpdateCommandCheckJsonTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/UpdateCommandCheckJsonTests.cs
@@ -1,0 +1,58 @@
+using System.Text.Json.Nodes;
+using Capacitor.Cli.Commands;
+
+namespace Capacitor.Cli.Tests.Unit;
+
+/// <summary>
+/// The <c>kcap update --check</c> JSON the npm launcher installs from: a server that trails npm latest
+/// pins <c>install_tag</c> to its own version, so <c>kcap update</c> never installs past it.
+/// </summary>
+public class UpdateCommandCheckJsonTests {
+    static JsonObject Check(string? current, string? latest, bool newer, string channel, string? serverVersion) {
+        var result   = new UpdateCommand.UpdateCheckResult(current, latest, newer, FromCache: false);
+        var advisory = UpdateAdvisoryResolver.Resolve(result, channel, serverVersion);
+
+        return JsonNode.Parse(UpdateCommand.CheckJson(advisory, channel))!.AsObject();
+    }
+
+    [Test]
+    public async Task A_server_behind_npm_latest_pins_the_install_to_its_version() {
+        var json = Check("1.0.0", "1.0.2", newer: true, "latest", serverVersion: "1.0.1");
+
+        await Assert.That(json["latest"]!.GetValue<string>()).IsEqualTo("1.0.1");
+        await Assert.That(json["newer"]!.GetValue<bool>()).IsTrue();
+        await Assert.That(json["install_tag"]!.GetValue<string>()).IsEqualTo("1.0.1");
+        await Assert.That(json["channel"]!.GetValue<string>()).IsEqualTo("latest");
+    }
+
+    [Test]
+    public async Task A_cli_at_the_server_version_is_up_to_date_although_npm_has_newer() {
+        var json = Check("1.0.1", "1.0.2", newer: true, "latest", serverVersion: "1.0.1");
+
+        await Assert.That(json["newer"]!.GetValue<bool>()).IsFalse();
+    }
+
+    [Test]
+    public async Task Without_a_known_server_version_the_channel_tag_is_installed() {
+        var json = Check("1.0.1", "1.0.2", newer: true, "latest", serverVersion: null);
+
+        await Assert.That(json["latest"]!.GetValue<string>()).IsEqualTo("1.0.2");
+        await Assert.That(json["install_tag"]!.GetValue<string>()).IsEqualTo("latest");
+    }
+
+    [Test]
+    public async Task The_beta_channel_is_never_capped() {
+        var json = Check("1.0.1", "1.1.0-beta.1", newer: true, "beta", serverVersion: "1.0.1");
+
+        await Assert.That(json["latest"]!.GetValue<string>()).IsEqualTo("1.1.0-beta.1");
+        await Assert.That(json["install_tag"]!.GetValue<string>()).IsEqualTo("beta");
+    }
+
+    [Test]
+    public async Task An_unknown_latest_reports_newer_as_null_not_false() {
+        var json = Check("1.0.1", latest: null, newer: false, "latest", serverVersion: "1.0.1");
+
+        await Assert.That(json.ContainsKey("newer")).IsTrue();
+        await Assert.That(json["newer"]).IsNull();
+    }
+}


### PR DESCRIPTION
Closes #891 — AI-2708

## What & why

Release 1.0.2's desktop publish failed, and `kcap update` to 1.0.x left macOS installs without their binary. `npm publish` returns while the registry is still processing a large tarball (darwin-arm64 took ~10 min), so the wrapper became installable first and npm silently skipped the unresolvable optional platform package. The release now waits for every platform package before publishing the wrapper, and every npm poll and install passes `--prefer-online` to bypass npm's 5-minute packument cache. The update hint now always says `kcap update`: `--check` pins `install_tag` to a trailing server's version.

## Where to look

`kcap update` on a CLI already at its server's version reports "Already up to date" even when npm has newer — deliberate, matching the hint's cap.

## Verification

- `bash scripts/run-shell-tests.sh` → all ok; a copy of the wait script without `--prefer-online` fails all 4 cases
- live `wait-npm-available.sh 1.0.2 <six packages>` → all available; `99.0.0` → `npm error 404 No match found for version 99.0.0`
- CLI unit suite: 4042 passed, 19 skipped, 0 failed; `UpdateNoticeDeliveryTests` 12/12
- `dotnet publish -c Release`: no IL2xxx/IL3xxx warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)
