### PR TITLE
Surface ACP permission requests to the desktop app, first answer wins

### DIFF
--- a/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
+++ b/src/Capacitor.Cli.Daemon/Acp/AcpInteractionBridge.cs
@@ -14,7 +14,7 @@ namespace Capacitor.Cli.Daemon.Acp;
 /// by <see cref="Capacitor.Cli.Daemon.Services.AcpHostedAgentRuntime"/> (Task B4).
 ///
 /// <paramref name="requestInteraction"/> is injected as a plain delegate — matching the shape of
-/// <see cref="Capacitor.Cli.Daemon.Services.ServerConnection.RequestAcpInteractionAsync"/> — rather
+/// <see cref="Capacitor.Cli.Daemon.Services.ServerConnection.RequestAcpInteractionAsync(Capacitor.Cli.Core.AcpInteractionRequest, System.Threading.CancellationToken)"/> — rather
 /// than taking a concrete <c>ServerConnection</c> dependency, so this class is unit-testable
 /// without a real SignalR connection (see <c>AcpInteractionBridgeTests</c>).
 ///

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -462,7 +462,8 @@ public static partial class DaemonRunner {
                 AcpVendorDescriptors.Cursor,
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
-                sp.GetRequiredService<ServerConnection>() // spec-review Finding 4 — real production wiring
+                sp.GetRequiredService<ServerConnection>(),
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
             )
         );
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
@@ -470,7 +471,8 @@ public static partial class DaemonRunner {
                 AcpVendorDescriptors.Copilot,
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
-                sp.GetRequiredService<ServerConnection>()
+                sp.GetRequiredService<ServerConnection>(),
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
             )
         );
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
@@ -478,7 +480,8 @@ public static partial class DaemonRunner {
                 AcpVendorDescriptors.Kiro,
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
-                sp.GetRequiredService<ServerConnection>()
+                sp.GetRequiredService<ServerConnection>(),
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
             )
         );
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
@@ -486,7 +489,8 @@ public static partial class DaemonRunner {
                 AcpVendorDescriptors.Gemini,
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
-                sp.GetRequiredService<ServerConnection>()
+                sp.GetRequiredService<ServerConnection>(),
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
             )
         );
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
@@ -494,7 +498,8 @@ public static partial class DaemonRunner {
                 AcpVendorDescriptors.OpenCode,
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
-                sp.GetRequiredService<ServerConnection>()
+                sp.GetRequiredService<ServerConnection>(),
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
             )
         );
 

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -463,7 +463,8 @@ public static partial class DaemonRunner {
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
                 sp.GetRequiredService<ServerConnection>(),
-                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>(),
+                permissionDecisionLog: sp.GetRequiredService<PermissionDecisionLog>()
             )
         );
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
@@ -472,7 +473,8 @@ public static partial class DaemonRunner {
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
                 sp.GetRequiredService<ServerConnection>(),
-                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>(),
+                permissionDecisionLog: sp.GetRequiredService<PermissionDecisionLog>()
             )
         );
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
@@ -481,7 +483,8 @@ public static partial class DaemonRunner {
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
                 sp.GetRequiredService<ServerConnection>(),
-                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>(),
+                permissionDecisionLog: sp.GetRequiredService<PermissionDecisionLog>()
             )
         );
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
@@ -490,7 +493,8 @@ public static partial class DaemonRunner {
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
                 sp.GetRequiredService<ServerConnection>(),
-                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>(),
+                permissionDecisionLog: sp.GetRequiredService<PermissionDecisionLog>()
             )
         );
         builder.Services.AddSingleton<IHostedAgentRuntimeFactory>(sp =>
@@ -499,7 +503,8 @@ public static partial class DaemonRunner {
                 sp.GetRequiredService<DaemonConfig>(),
                 sp.GetRequiredService<ILoggerFactory>(),
                 sp.GetRequiredService<ServerConnection>(),
-                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>()
+                permissionBroker: sp.GetRequiredService<PermissionPromptBroker>(),
+                permissionDecisionLog: sp.GetRequiredService<PermissionDecisionLog>()
             )
         );
 

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -23,18 +23,15 @@ namespace Capacitor.Cli.Daemon.Services;
 /// <see cref="AcpHostedAgentRuntime.StartAsync"/>. Cursor and Copilot descriptors share this path;
 /// each descriptor declares its own unattended and MCP transport capabilities.
 ///
-/// <b>Spec-review Finding 4:</b> gained a <see cref="ServerConnection"/> constructor
-/// dependency so every runtime this factory produces has the real permission/elicitation bridge
-/// wired — <see cref="StartAsync"/> passes <c>ctx.AgentId</c> and
-/// <see cref="ServerConnection.RequestAcpInteractionAsync"/> into <see cref="AcpHostedAgentRuntime"/>'s
-/// optional parameters instead of leaving them at their <c>""</c>/<see langword="null"/> defaults.
+/// <para>The <see cref="ServerConnection"/> dependency wires the permission/elicitation bridge into
+/// every runtime this factory produces: <see cref="StartAsync"/> passes <c>ctx.AgentId</c> and the
+/// interaction delegate into <see cref="AcpHostedAgentRuntime"/> rather than leaving them at their
+/// <c>""</c>/<see langword="null"/> defaults.</para>
 ///
-/// <b>Round-4 Finding 3:</b> process-spawning + stream construction is extracted into
-/// <paramref name="connectionSource"/> (defaulting to <see cref="StartRealProcess"/>) purely so
-/// <c>AcpHostedAgentRuntimeFactoryTests</c> can construct THIS class for real and drive its
-/// REAL <see cref="StartAsync"/> against an in-memory <c>FakeAcpAgent</c> peer instead of a real
-/// <c>cursor-agent acp</c> child process (unavailable and non-portable in CI) — the seam changes
-/// nothing about production behavior, since the default IS the real `Process.Start`-backed path.
+/// <para><paramref name="connectionSource"/> (defaulting to <see cref="StartRealProcess"/>) is a test
+/// seam: it lets a test drive the real <see cref="StartAsync"/> against an in-memory
+/// <c>FakeAcpAgent</c> peer instead of a real <c>cursor-agent acp</c> child, unavailable in CI. The
+/// default is the real <c>Process.Start</c>-backed path, so production behavior is unchanged.</para>
 /// </summary>
 internal sealed partial class AcpHostedAgentRuntimeFactory(
         AcpVendorDescriptor                                                            descriptor,
@@ -52,18 +49,23 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         TimeProvider? timeProvider = null,
         // The desktop app's local permission surface. Non-null (production) presents a permission on
         // it alongside the server's web card, first answer wins; null leaves every launch server-only.
-        PermissionPromptBroker? permissionBroker = null
+        PermissionPromptBroker? permissionBroker = null,
+        // Audit sink for locally-settled permissions; null (tests) skips the record.
+        PermissionDecisionLog? permissionDecisionLog = null
     ) : IHostedAgentRuntimeFactory {
     readonly Func<string, string?>? _resolveVendorVersion = resolveVendorVersion;
     readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
     readonly PermissionPromptBroker? _permissionBroker = permissionBroker;
+    readonly PermissionDecisionLog? _permissionDecisionLog = permissionDecisionLog;
 
     /// <summary>The delegate the interaction bridge calls to answer a request. With a desktop
     /// surface wired, a permission is raced across the web card and the desktop card (first wins);
     /// without one it is the raw server request, unchanged.</summary>
     Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> RequestInteraction =>
         _permissionBroker is { } broker
-            ? new AcpPermissionSurface(broker, descriptor.Vendor, connection.RequestAcpInteractionAsync, _timeProvider).RequestAsync
+            ? new AcpPermissionSurface(
+                    broker, descriptor.Vendor, connection.RequestAcpInteractionAsync,
+                    _permissionDecisionLog, _timeProvider).RequestAsync
             : connection.RequestAcpInteractionAsync;
 
     readonly Func<RuntimeStartContext, (Stream Input, Stream Output, IAcpProcess Process)> _connectionSource =

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -65,7 +65,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         _permissionBroker is { } broker
             ? new AcpPermissionSurface(
                     broker, descriptor.Vendor, connection.RequestAcpInteractionAsync,
-                    _permissionDecisionLog, _timeProvider).RequestAsync
+                    connection.ResolveAcpInteractionAsync, _permissionDecisionLog, _timeProvider).RequestAsync
             : connection.RequestAcpInteractionAsync;
 
     readonly Func<RuntimeStartContext, (Stream Input, Stream Output, IAcpProcess Process)> _connectionSource =

--- a/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpHostedAgentRuntimeFactory.cs
@@ -49,10 +49,22 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
         Func<string, string?>? resolveVendorVersion = null,
         // Test seam ONLY for the per-stage launch-handshake cap. Production passes null → the
         // TimeProvider.System every other daemon-local timing decision uses.
-        TimeProvider? timeProvider = null
+        TimeProvider? timeProvider = null,
+        // The desktop app's local permission surface. Non-null (production) presents a permission on
+        // it alongside the server's web card, first answer wins; null leaves every launch server-only.
+        PermissionPromptBroker? permissionBroker = null
     ) : IHostedAgentRuntimeFactory {
     readonly Func<string, string?>? _resolveVendorVersion = resolveVendorVersion;
     readonly TimeProvider _timeProvider = timeProvider ?? TimeProvider.System;
+    readonly PermissionPromptBroker? _permissionBroker = permissionBroker;
+
+    /// <summary>The delegate the interaction bridge calls to answer a request. With a desktop
+    /// surface wired, a permission is raced across the web card and the desktop card (first wins);
+    /// without one it is the raw server request, unchanged.</summary>
+    Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> RequestInteraction =>
+        _permissionBroker is { } broker
+            ? new AcpPermissionSurface(broker, descriptor.Vendor, connection.RequestAcpInteractionAsync, _timeProvider).RequestAsync
+            : connection.RequestAcpInteractionAsync;
 
     readonly Func<RuntimeStartContext, (Stream Input, Stream Output, IAcpProcess Process)> _connectionSource =
         connectionSource ?? (ctx => StartRealProcess(descriptor, config, ctx, loggerFactory));
@@ -208,7 +220,7 @@ internal sealed partial class AcpHostedAgentRuntimeFactory(
                 acpProcess,
                 runtimeLogger,
                 agentId: ctx.AgentId,
-                requestInteraction: connection.RequestAcpInteractionAsync,
+                requestInteraction: RequestInteraction,
                 // Drives the handshake's per-stage caps (RunHandshakeStageAsync), so a test's
                 // FakeTimeProvider controls them without a real 90-second wait.
                 timeProvider: _timeProvider,

--- a/src/Capacitor.Cli.Daemon/Services/AcpPermissionSurface.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpPermissionSurface.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 
@@ -18,14 +17,18 @@ namespace Capacitor.Cli.Daemon.Services;
 ///
 /// <para>The server request id, once minted, is paired with the local card via
 /// <see cref="PermissionPromptBroker.TryCorrelate"/> so a client that sees both lanes coalesces them
-/// into one card. Every settled request is written to the <see cref="PermissionDecisionLog"/>. A tool
-/// payload too large to ride a control frame is not presented locally at all — it would poison every
-/// subscription — and falls back to a server-only request.</para>
+/// into one card. When the desktop answers first the same decision is submitted back to the server so
+/// its history records that allow/deny rather than the cancel a bare abandonment would leave; the
+/// server keeps the first writer, so a web answer that already landed still wins. Every settled
+/// request is written to the <see cref="PermissionDecisionLog"/>. A tool payload too large to ride a
+/// control frame is not presented locally at all — it would poison every subscription — and falls
+/// back to a server-only request.</para>
 /// </summary>
 internal sealed class AcpPermissionSurface(
         PermissionPromptBroker                                                                       broker,
         string                                                                                       vendor,
         Func<AcpInteractionRequest, Action<string>?, CancellationToken, Task<AcpInteractionDecision>> requestServer,
+        Func<string, string, AcpInteractionDecision, Task>?                                           resolveServer = null,
         PermissionDecisionLog?                                                                        decisionLog = null,
         TimeProvider?                                                                                 timeProvider = null) {
 
@@ -43,9 +46,10 @@ internal sealed class AcpPermissionSurface(
 
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
+        var serverId = new TaskCompletionSource<string>(TaskCreationOptions.RunContinuationsAsynchronously);
         // Register before the server leg so the server id can correlate onto a live entry.
         var localTask  = broker.Register(pending);
-        var serverTask = requestServer(request, id => broker.TryCorrelate(localId, id), linked.Token);
+        var serverTask = requestServer(request, id => { serverId.TrySetResult(id); broker.TryCorrelate(localId, id); }, linked.Token);
 
         var winner = await Task.WhenAny(serverTask, localTask).ConfigureAwait(false);
 
@@ -66,10 +70,24 @@ internal sealed class AcpPermissionSurface(
         }
 
         var settlement = await localTask.ConfigureAwait(false);
+        var mapped = MapSettlement(settlement, request.Options ?? []);
+        await ResolveServer(request, serverId, settlement, mapped).ConfigureAwait(false);
         linked.Cancel();
         Observe(serverTask);
         Record(request, settlement.Outcome, settlement.Source);
-        return MapSettlement(settlement, request.Options ?? []);
+        return mapped;
+    }
+
+    // The desktop answered first: mirror that decision onto the still-open server interaction so its
+    // history is the allow/deny the agent received, not the cancel the cancelled server await would
+    // otherwise leave. A withdrawal (agent gone) has nothing to record, and a server id that never
+    // arrived (nothing to answer) is skipped. Best-effort — a failure leaves the abandonment path,
+    // fired by the cancel below, to resolve the server as it did before.
+    async Task ResolveServer(AcpInteractionRequest request, TaskCompletionSource<string> serverId, PermissionSettlement settlement, AcpInteractionDecision mapped) {
+        if (resolveServer is null || settlement.Outcome == PermissionSettlements.Withdrawn || !serverId.Task.IsCompletedSuccessfully)
+            return;
+        try { await resolveServer(request.AcpSessionId, serverId.Task.Result, mapped).ConfigureAwait(false); }
+        catch { /* the cancel's abandonment path still resolves the server */ }
     }
 
     PermissionPendingDto? BuildPending(string requestId, AcpInteractionRequest request) =>
@@ -85,7 +103,8 @@ internal sealed class AcpPermissionSurface(
             request.ToolName ?? "", outcome, source));
 
     static AcpInteractionDecision MapSettlement(PermissionSettlement settlement, IReadOnlyList<AcpInteractionOption> options) {
-        if (settlement.Outcome == PermissionSettlements.Allow && PickAllow(options, IsTrue(settlement.Decision.ApplyPermissions)) is { } allow)
+        var preferAlways = settlement.Decision.ApplyPermissions is { } apply && apply.IsTrue;
+        if (settlement.Outcome == PermissionSettlements.Allow && PickAllow(options, preferAlways) is { } allow)
             return new AcpInteractionDecision(allow.Kind ?? "allow", allow.OptionId, allow.Label, null, null, null);
 
         // A deny (or a withdrawal, or an allow with no once-scoped option to point at): the daemon's
@@ -112,8 +131,6 @@ internal sealed class AcpPermissionSurface(
 
     static bool IsAffirmative(string outcome) =>
         outcome is "allow" or "allow_once" or "allow_always" or "answered";
-
-    static bool IsTrue(JsonElement? value) => value is { ValueKind: JsonValueKind.True };
 
     static void Observe(Task task) => _ = task.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
 }

--- a/src/Capacitor.Cli.Daemon/Services/AcpPermissionSurface.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpPermissionSurface.cs
@@ -5,43 +5,47 @@ using Capacitor.Cli.Core.LocalIpc;
 namespace Capacitor.Cli.Daemon.Services;
 
 /// <summary>
-/// Presents an ACP permission request on the desktop app's local surface (the
-/// <see cref="PermissionPromptBroker"/>, which the app subscribes to over local control IPC) IN
-/// ADDITION to the server's web UI, and lets whichever surface answers first settle it — the loser
-/// is dismissed. Wraps the server-facing <c>requestInteraction</c> delegate the ACP interaction
-/// bridge already calls, so the bridge itself is unchanged.
+/// Presents an ACP permission on the desktop app's local surface (the
+/// <see cref="PermissionPromptBroker"/>) alongside the server's web card and lets whichever answers
+/// first settle it; the loser is dismissed. Only a permission raises a desktop card — an elicitation
+/// (or any other kind) goes straight to the server.
 ///
-/// <para>Only a permission carries a desktop card; an elicitation (or any other kind) goes straight
-/// to the server. The desktop card answers allow/deny (its Claude/Codex shape); this maps that to
-/// one of the agent's own offered options by kind — an allow to an allow option, a deny to a reject
-/// option — so <c>AcpInteractionBridge.MapPermissionDecision</c> resolves the id exactly as a
-/// server-side option pick would. A deny with no reject option, or an allow with no allow option,
-/// falls through to that method's fail-closed cancelled.</para>
+/// <para>The desktop card answers allow/deny; that maps to one of the agent's own offered options by
+/// kind so <c>AcpInteractionBridge.MapPermissionDecision</c> resolves the id exactly as a server-side
+/// pick would. A generic allow never selects an <c>allow_always</c> option — a one-time allow must
+/// not silently become a standing grant, so an allow with no once-scoped option to point at fails
+/// closed to a deny.</para>
 ///
-/// <para>When the desktop answers first, the server await is cancelled; the server's own web card is
-/// not withdrawn (that needs a server-side channel this daemon does not have), so it lingers until
-/// dismissed there, and a late answer to it finds no pending daemon entry and is dropped — the agent
-/// has already been answered.</para>
+/// <para>The server request id, once minted, is paired with the local card via
+/// <see cref="PermissionPromptBroker.TryCorrelate"/> so a client that sees both lanes coalesces them
+/// into one card. Every settled request is written to the <see cref="PermissionDecisionLog"/>. A tool
+/// payload too large to ride a control frame is not presented locally at all — it would poison every
+/// subscription — and falls back to a server-only request.</para>
 /// </summary>
 internal sealed class AcpPermissionSurface(
-        PermissionPromptBroker                                                        broker,
-        string                                                                        vendor,
-        Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>>  requestServer,
-        TimeProvider?                                                                 timeProvider = null) {
+        PermissionPromptBroker                                                                       broker,
+        string                                                                                       vendor,
+        Func<AcpInteractionRequest, Action<string>?, CancellationToken, Task<AcpInteractionDecision>> requestServer,
+        PermissionDecisionLog?                                                                        decisionLog = null,
+        TimeProvider?                                                                                 timeProvider = null) {
 
     readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
 
     public async Task<AcpInteractionDecision> RequestAsync(AcpInteractionRequest request, CancellationToken ct) {
         if (request.Kind != "permission")
-            return await requestServer(request, ct).ConfigureAwait(false);
+            return await requestServer(request, null, ct).ConfigureAwait(false);
 
         var localId = Guid.NewGuid().ToString("N");
         var pending = BuildPending(localId, request);
+        if (pending is null)
+            // Over-cap: a frame the codec would reject, replayed on every subscription forever.
+            return await requestServer(request, null, ct).ConfigureAwait(false);
 
         using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
 
-        var serverTask = requestServer(request, linked.Token);
+        // Register before the server leg so the server id can correlate onto a live entry.
         var localTask  = broker.Register(pending);
+        var serverTask = requestServer(request, id => broker.TryCorrelate(localId, id), linked.Token);
 
         var winner = await Task.WhenAny(serverTask, localTask).ConfigureAwait(false);
 
@@ -50,51 +54,48 @@ internal sealed class AcpPermissionSurface(
             try {
                 decision = await serverTask.ConfigureAwait(false);
             } catch {
-                // The server request's own failure — clear the desktop card and let the bridge's
-                // catch turn the throw into a well-formed cancelled.
                 broker.TrySettle(localId, PermissionSettlements.DenyDecision, PermissionSettlements.Deny, PermissionSettlements.SourceServer);
+                Record(request, PermissionSettlements.Deny, PermissionSettlements.SourceServer);
                 throw;
             }
 
-            // Server (web UI) answered first — dismiss the desktop card with the matching outcome.
             var brokerOutcome = IsAffirmative(decision.Outcome) ? PermissionSettlements.Allow : PermissionSettlements.Deny;
             broker.TrySettle(localId, new PermissionDecision(brokerOutcome, null, null), brokerOutcome, PermissionSettlements.SourceServer);
+            Record(request, brokerOutcome, PermissionSettlements.SourceServer);
             return decision;
         }
 
-        // Desktop app answered first — stop waiting on the server, map allow/deny to an offered option.
         var settlement = await localTask.ConfigureAwait(false);
         linked.Cancel();
         Observe(serverTask);
-
+        Record(request, settlement.Outcome, settlement.Source);
         return MapSettlement(settlement, request.Options ?? []);
     }
 
-    PermissionPendingDto BuildPending(string requestId, AcpInteractionRequest request) =>
-        new(RequestId: requestId,
-            AgentId:    request.AgentId,
-            SessionId:  request.AcpSessionId,
-            Vendor:     vendor,
-            ToolName:   request.ToolName ?? "",
-            ToolInput:  request.ToolInput,
-            // The agent's per-option choices stay on the web card; the desktop card is allow/deny,
-            // so it needs no suggestions payload.
-            Suggestions:        null,
-            ToolInputOmitted:   false,
-            SuggestionsOmitted: true,
-            RequestedAt:        _time.GetUtcNow().ToString("o"),
-            ToolUseId:          request.ToolCallId);
+    PermissionPendingDto? BuildPending(string requestId, AcpInteractionRequest request) =>
+        // The agent's per-option choices stay on the web card; the desktop card is allow/deny, so it
+        // carries no suggestions payload. The shared builder bounds every caller-controlled value.
+        LocalPermissionBridge.BuildPending(
+            requestId, request.AgentId, request.AcpSessionId, vendor, request.ToolName ?? "",
+            request.ToolInput, suggestions: null, _time.GetUtcNow().ToString("o"), request.ToolCallId);
+
+    void Record(AcpInteractionRequest request, string outcome, string source) =>
+        decisionLog?.Record(new PermissionDecisionRecord(
+            _time.GetUtcNow().ToString("O"), request.AgentId, request.AcpSessionId, vendor,
+            request.ToolName ?? "", outcome, source));
 
     static AcpInteractionDecision MapSettlement(PermissionSettlement settlement, IReadOnlyList<AcpInteractionOption> options) {
         if (settlement.Outcome == PermissionSettlements.Allow && PickAllow(options, IsTrue(settlement.Decision.ApplyPermissions)) is { } allow)
             return new AcpInteractionDecision(allow.Kind ?? "allow", allow.OptionId, allow.Label, null, null, null);
 
-        // A deny (or a withdrawal, or an allow with no allow option to point at): the daemon's
+        // A deny (or a withdrawal, or an allow with no once-scoped option to point at): the daemon's
         // DenyResult picks the least-privilege reject itself, and falls through to cancelled when
         // the agent offered no reject.
         return new AcpInteractionDecision("deny", null, null, null, null, null);
     }
 
+    /// A standing grant is offered only when the desktop explicitly asked for one (preferAlways); a
+    /// generic allow never resolves to <c>allow_always</c> — it would grant more than was shown.
     static AcpInteractionOption? PickAllow(IReadOnlyList<AcpInteractionOption> options, bool preferAlways) {
         AcpInteractionOption? once = null, always = null, other = null;
         foreach (var o in options) {
@@ -106,7 +107,7 @@ internal sealed class AcpPermissionSurface(
                     break;
             }
         }
-        return preferAlways ? always ?? once ?? other : once ?? other ?? always;
+        return preferAlways ? always ?? once ?? other : once ?? other;
     }
 
     static bool IsAffirmative(string outcome) =>

--- a/src/Capacitor.Cli.Daemon/Services/AcpPermissionSurface.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AcpPermissionSurface.cs
@@ -1,0 +1,118 @@
+using System.Text.Json;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+
+namespace Capacitor.Cli.Daemon.Services;
+
+/// <summary>
+/// Presents an ACP permission request on the desktop app's local surface (the
+/// <see cref="PermissionPromptBroker"/>, which the app subscribes to over local control IPC) IN
+/// ADDITION to the server's web UI, and lets whichever surface answers first settle it — the loser
+/// is dismissed. Wraps the server-facing <c>requestInteraction</c> delegate the ACP interaction
+/// bridge already calls, so the bridge itself is unchanged.
+///
+/// <para>Only a permission carries a desktop card; an elicitation (or any other kind) goes straight
+/// to the server. The desktop card answers allow/deny (its Claude/Codex shape); this maps that to
+/// one of the agent's own offered options by kind — an allow to an allow option, a deny to a reject
+/// option — so <c>AcpInteractionBridge.MapPermissionDecision</c> resolves the id exactly as a
+/// server-side option pick would. A deny with no reject option, or an allow with no allow option,
+/// falls through to that method's fail-closed cancelled.</para>
+///
+/// <para>When the desktop answers first, the server await is cancelled; the server's own web card is
+/// not withdrawn (that needs a server-side channel this daemon does not have), so it lingers until
+/// dismissed there, and a late answer to it finds no pending daemon entry and is dropped — the agent
+/// has already been answered.</para>
+/// </summary>
+internal sealed class AcpPermissionSurface(
+        PermissionPromptBroker                                                        broker,
+        string                                                                        vendor,
+        Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>>  requestServer,
+        TimeProvider?                                                                 timeProvider = null) {
+
+    readonly TimeProvider _time = timeProvider ?? TimeProvider.System;
+
+    public async Task<AcpInteractionDecision> RequestAsync(AcpInteractionRequest request, CancellationToken ct) {
+        if (request.Kind != "permission")
+            return await requestServer(request, ct).ConfigureAwait(false);
+
+        var localId = Guid.NewGuid().ToString("N");
+        var pending = BuildPending(localId, request);
+
+        using var linked = CancellationTokenSource.CreateLinkedTokenSource(ct);
+
+        var serverTask = requestServer(request, linked.Token);
+        var localTask  = broker.Register(pending);
+
+        var winner = await Task.WhenAny(serverTask, localTask).ConfigureAwait(false);
+
+        if (winner == serverTask) {
+            AcpInteractionDecision decision;
+            try {
+                decision = await serverTask.ConfigureAwait(false);
+            } catch {
+                // The server request's own failure — clear the desktop card and let the bridge's
+                // catch turn the throw into a well-formed cancelled.
+                broker.TrySettle(localId, PermissionSettlements.DenyDecision, PermissionSettlements.Deny, PermissionSettlements.SourceServer);
+                throw;
+            }
+
+            // Server (web UI) answered first — dismiss the desktop card with the matching outcome.
+            var brokerOutcome = IsAffirmative(decision.Outcome) ? PermissionSettlements.Allow : PermissionSettlements.Deny;
+            broker.TrySettle(localId, new PermissionDecision(brokerOutcome, null, null), brokerOutcome, PermissionSettlements.SourceServer);
+            return decision;
+        }
+
+        // Desktop app answered first — stop waiting on the server, map allow/deny to an offered option.
+        var settlement = await localTask.ConfigureAwait(false);
+        linked.Cancel();
+        Observe(serverTask);
+
+        return MapSettlement(settlement, request.Options ?? []);
+    }
+
+    PermissionPendingDto BuildPending(string requestId, AcpInteractionRequest request) =>
+        new(RequestId: requestId,
+            AgentId:    request.AgentId,
+            SessionId:  request.AcpSessionId,
+            Vendor:     vendor,
+            ToolName:   request.ToolName ?? "",
+            ToolInput:  request.ToolInput,
+            // The agent's per-option choices stay on the web card; the desktop card is allow/deny,
+            // so it needs no suggestions payload.
+            Suggestions:        null,
+            ToolInputOmitted:   false,
+            SuggestionsOmitted: true,
+            RequestedAt:        _time.GetUtcNow().ToString("o"),
+            ToolUseId:          request.ToolCallId);
+
+    static AcpInteractionDecision MapSettlement(PermissionSettlement settlement, IReadOnlyList<AcpInteractionOption> options) {
+        if (settlement.Outcome == PermissionSettlements.Allow && PickAllow(options, IsTrue(settlement.Decision.ApplyPermissions)) is { } allow)
+            return new AcpInteractionDecision(allow.Kind ?? "allow", allow.OptionId, allow.Label, null, null, null);
+
+        // A deny (or a withdrawal, or an allow with no allow option to point at): the daemon's
+        // DenyResult picks the least-privilege reject itself, and falls through to cancelled when
+        // the agent offered no reject.
+        return new AcpInteractionDecision("deny", null, null, null, null, null);
+    }
+
+    static AcpInteractionOption? PickAllow(IReadOnlyList<AcpInteractionOption> options, bool preferAlways) {
+        AcpInteractionOption? once = null, always = null, other = null;
+        foreach (var o in options) {
+            switch (o.Kind) {
+                case "allow_once"   when once   is null: once   = o; break;
+                case "allow_always" when always is null: always = o; break;
+                default:
+                    if (other is null && (o.Kind is null || o.Kind.StartsWith("allow", StringComparison.Ordinal))) other = o;
+                    break;
+            }
+        }
+        return preferAlways ? always ?? once ?? other : once ?? other ?? always;
+    }
+
+    static bool IsAffirmative(string outcome) =>
+        outcome is "allow" or "allow_once" or "allow_always" or "answered";
+
+    static bool IsTrue(JsonElement? value) => value is { ValueKind: JsonValueKind.True };
+
+    static void Observe(Task task) => _ = task.ContinueWith(static t => _ = t.Exception, TaskScheduler.Default);
+}

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1086,6 +1086,20 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
         }
     }
 
+    /// <summary>Submits an ACP interaction's decision — its outcome as the behavior plus the selected
+    /// option id the server resolves by — so a request a second local surface answered first records
+    /// that same answer on the server. The server keeps the first writer, so a web answer that already
+    /// landed wins; best-effort, a fault is classified rather than thrown.</summary>
+    public virtual async Task<RespondOutcome> ResolveAcpInteractionAsync(string sessionId, string serverRequestId, AcpInteractionDecision decision) {
+        try {
+            await _hub.InvokeAsync("RespondToPermission", sessionId, serverRequestId, decision.Outcome,
+                null, null, decision.SelectedOptionId, decision.SelectedOptionLabel, _ct);
+            return new RespondOutcome(RespondOutcomeKind.Applied, null);
+        } catch (Exception ex) {
+            return ClassifyRespondFailure(ex);
+        }
+    }
+
     internal static RespondOutcome ClassifyRespondFailure(Exception ex) =>
         ex is Microsoft.AspNetCore.SignalR.HubException he && he.Message.Contains("no longer pending", StringComparison.Ordinal)
             ? new RespondOutcome(RespondOutcomeKind.NotPending, he.Message)

--- a/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
+++ b/src/Capacitor.Cli.Daemon/Services/ServerConnection.cs
@@ -1098,9 +1098,18 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
     /// see that method's remarks for why the invoke returns a requestId immediately rather than
     /// blocking the connection's parallel-invocation slot for the whole interaction wait.
     /// </summary>
-    public virtual async Task<AcpInteractionDecision> RequestAcpInteractionAsync(
+    public virtual Task<AcpInteractionDecision> RequestAcpInteractionAsync(
             AcpInteractionRequest request,
             CancellationToken     ct = default
+        ) => RequestAcpInteractionAsync(request, onServerRequestId: null, ct);
+
+    /// <summary><paramref name="onServerRequestId"/> fires once the server has minted its id for this
+    /// interaction, before the decision wait — the seam a second local surface uses to pair its own
+    /// card with the server's so a client seeing both lanes coalesces them.</summary>
+    public virtual async Task<AcpInteractionDecision> RequestAcpInteractionAsync(
+            AcpInteractionRequest request,
+            Action<string>?       onServerRequestId,
+            CancellationToken     ct
         ) {
         var requestId = await ConnectionRetry.InvokeWithConnectionRetryAsync(
             () => _hub.InvokeAsync<string>("AcpRequestInteraction", request, ct),
@@ -1112,6 +1121,7 @@ internal partial class ServerConnection : IAsyncDisposable, IDaemonHeartbeatPort
             maxServerErrorRetries: OwnershipNotReadyMaxRetries
         );
 
+        onServerRequestId?.Invoke(requestId);
         return await AwaitInteractionDecisionAsync(request, requestId, ct);
     }
 

--- a/src/Capacitor.Models.Transcripts/JsonElementExtensions.cs
+++ b/src/Capacitor.Models.Transcripts/JsonElementExtensions.cs
@@ -11,6 +11,7 @@ public static class JsonElementExtensions {
         public bool IsArray  => el.ValueKind == JsonValueKind.Array;
         public bool IsNumber => el.ValueKind == JsonValueKind.Number;
         public bool IsNull   => el.ValueKind == JsonValueKind.Null;
+        public bool IsTrue   => el.ValueKind == JsonValueKind.True;
 
         public string? Str(string property) => el.IsObject && el.TryGetProperty(property, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() : null;
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpInteractionBridgeTests.cs
@@ -13,7 +13,7 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Acp;
 /// <see cref="AcpInteractionBridge"/> parses an inbound <c>session/request_permission</c>
 /// (spec-derived shape, NOT probe-confirmed — see <c>docs/acp-probe-findings.md</c>) or capability-
 /// gated <c>elicitation/create</c> server request, forwards it to an injected
-/// "ask the server" delegate (standing in for <see cref="Capacitor.Cli.Daemon.Services.ServerConnection.RequestAcpInteractionAsync"/>),
+/// "ask the server" delegate (standing in for <see cref="Capacitor.Cli.Daemon.Services.ServerConnection.RequestAcpInteractionAsync(Capacitor.Cli.Core.AcpInteractionRequest, System.Threading.CancellationToken)"/>),
 /// and maps the returned <see cref="AcpInteractionDecision"/> back to the ACP JSON-RPC result
 /// shape. Unit-tested against the delegate directly — no real SignalR connection involved.
 /// </summary>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpHostedAgentRuntimeFactoryTests.cs
@@ -148,7 +148,7 @@ public class AcpHostedAgentRuntimeFactoryTests : IDisposable {
     }
 
     /// <summary>
-    /// Records whether <see cref="ServerConnection.RequestAcpInteractionAsync"/> was actually
+    /// Records whether <see cref="ServerConnection.RequestAcpInteractionAsync(Capacitor.Cli.Core.AcpInteractionRequest, System.Threading.CancellationToken)"/> was actually
     /// invoked BY THE RUNTIME THE FACTORY PRODUCED (not by the test calling it directly) — a real
     /// (non-connecting) <see cref="ServerConnection"/> subclass, matching the established
     /// <c>CaptureServerConnection</c>-style pattern used elsewhere in this test project (e.g.

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpPermissionSurfaceTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpPermissionSurfaceTests.cs
@@ -1,15 +1,18 @@
+using System.Text.Json;
 using System.Threading.Channels;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.LocalIpc;
 using Capacitor.Cli.Daemon.Services;
+using Microsoft.Extensions.Logging.Abstractions;
 
 namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
 
 /// <summary>
 /// <see cref="AcpPermissionSurface"/> presents an ACP permission on the desktop app's local broker
 /// alongside the server's web card, first answer wins. These pin: the desktop's allow/deny maps back
-/// to one of the agent's own offered options by kind; the server's answer is returned and dismisses
-/// the desktop card; and an elicitation never registers a card at all.
+/// to one of the agent's own offered options by kind; a generic allow never escalates to a standing
+/// grant; the server id is correlated onto the local card; every settlement is audited; an oversized
+/// payload never raises a local card; and an elicitation never registers one.
 /// </summary>
 public class AcpPermissionSurfaceTests {
     static readonly AcpInteractionOption[] Options = [
@@ -17,23 +20,29 @@ public class AcpPermissionSurfaceTests {
         new("opt-reject", "Reject", null, "reject_once"),
     ];
 
-    static AcpInteractionRequest Request(string kind = "permission") =>
-        new("agent-1", "sess-1", kind, "Bash", null, "call-1", null, Options, false);
+    static AcpInteractionRequest Request(string kind = "permission", string? toolName = "Bash", AcpInteractionOption[]? options = null) =>
+        new("agent-1", "sess-1", kind, toolName, null, "call-1", null, options ?? Options, false);
 
     // A server that never answers on its own — it resolves only when its token cancels, which is what
-    // the desktop-wins path does. Lets a test guarantee the desktop is the first answer.
-    static Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> BlockingServer() =>
-        (_, ct) => {
+    // the desktop-wins path does. Lets a test guarantee the desktop is the first answer. When given a
+    // server id it fires the correlation callback first, exactly as the real connection does.
+    static Func<AcpInteractionRequest, Action<string>?, CancellationToken, Task<AcpInteractionDecision>> BlockingServer(string? serverRequestId = null) =>
+        (_, onServerRequestId, ct) => {
+            if (serverRequestId is not null) onServerRequestId?.Invoke(serverRequestId);
             var tcs = new TaskCompletionSource<AcpInteractionDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
             ct.Register(() => tcs.TrySetCanceled());
             return tcs.Task;
         };
 
-    static async Task<PermissionPendingDto> NextPending(ChannelReader<PermissionStreamItem> reader) {
+    static Func<AcpInteractionRequest, Action<string>?, CancellationToken, Task<AcpInteractionDecision>> AnsweringServer(AcpInteractionDecision decision) =>
+        (_, _, _) => Task.FromResult(decision);
+
+    static async Task<PermissionPendingDto> NextPending(ChannelReader<PermissionStreamItem> reader, Func<PermissionPendingDto, bool>? until = null) {
+        until ??= _ => true;
         while (await reader.WaitToReadAsync())
             while (reader.TryRead(out var item))
-                if (item is PermissionStreamItem.Pending p) return p.Dto;
-        throw new InvalidOperationException("no pending item was broadcast");
+                if (item is PermissionStreamItem.Pending p && until(p.Dto)) return p.Dto;
+        throw new InvalidOperationException("no matching pending item was broadcast");
     }
 
     [Test]
@@ -69,10 +78,80 @@ public class AcpPermissionSurfaceTests {
     }
 
     [Test]
+    public async Task DesktopAllow_WithOnlyAStandingGrantOffered_FailsClosed() {
+        // The desktop shows a generic "Allow"; the agent offers only a permanent grant. Honouring
+        // the click would grant more than was shown, so it denies rather than escalates.
+        AcpInteractionOption[] alwaysOnly = [new("opt-always", "Always allow", null, "allow_always"), new("opt-reject", "Reject", null, "reject_once")];
+        var broker = new PermissionPromptBroker();
+        var (_, reader) = broker.Subscribe();
+        var surface = new AcpPermissionSurface(broker, "copilot", BlockingServer());
+
+        var task = surface.RequestAsync(Request(options: alwaysOnly), CancellationToken.None);
+        var pending = await NextPending(reader);
+        broker.TrySettle(pending.RequestId, new PermissionDecision("allow", null, null), "allow", PermissionSettlements.SourceApp);
+
+        var decision = await task;
+        await Assert.That(decision.Outcome).IsEqualTo("deny");
+        await Assert.That(decision.SelectedOptionId).IsNull();
+    }
+
+    [Test]
+    public async Task ServerRequestId_IsCorrelatedOntoTheLocalCard() {
+        var broker = new PermissionPromptBroker();
+        var (_, reader) = broker.Subscribe();
+        var surface = new AcpPermissionSurface(broker, "copilot", BlockingServer(serverRequestId: "srv-99"));
+
+        var task = surface.RequestAsync(Request(), CancellationToken.None);
+
+        var correlated = await NextPending(reader, until: d => d.ServerRequestId is not null);
+        await Assert.That(correlated.ServerRequestId).IsEqualTo("srv-99");
+
+        broker.TrySettle(correlated.RequestId, new PermissionDecision("allow", null, null), "allow", PermissionSettlements.SourceApp);
+        await task;
+    }
+
+    [Test]
+    public async Task SettledDecision_IsWrittenToTheAuditLog() {
+        using var tmp = new TempDir();
+        var logPath = tmp.PathTo("permission-decisions.jsonl");
+        var log = new PermissionDecisionLog(tmp.Path, NullLogger.Instance);
+        var broker = new PermissionPromptBroker();
+        var (_, reader) = broker.Subscribe();
+        var surface = new AcpPermissionSurface(broker, "copilot", BlockingServer(), log);
+
+        var task = surface.RequestAsync(Request(), CancellationToken.None);
+        var pending = await NextPending(reader);
+        broker.TrySettle(pending.RequestId, new PermissionDecision("allow", null, null), "allow", PermissionSettlements.SourceApp);
+        await task;
+
+        var line = (await File.ReadAllTextAsync(logPath)).Trim();
+        using var doc = JsonDocument.Parse(line);
+        var root = doc.RootElement;
+        await Assert.That(root.GetProperty("outcome").GetString()).IsEqualTo("allow");
+        await Assert.That(root.GetProperty("source").GetString()).IsEqualTo(PermissionSettlements.SourceApp);
+        await Assert.That(root.GetProperty("agent_id").GetString()).IsEqualTo("agent-1");
+        await Assert.That(root.GetProperty("tool_name").GetString()).IsEqualTo("Bash");
+        await Assert.That(root.GetProperty("vendor").GetString()).IsEqualTo("copilot");
+    }
+
+    [Test]
+    public async Task OversizedToolName_SkipsTheDesktopCard_ServerOnly() {
+        var broker = new PermissionPromptBroker();
+        var surface = new AcpPermissionSurface(
+            broker, "copilot", AnsweringServer(new AcpInteractionDecision("allow_once", "opt-allow", "Allow", null, null, null)));
+
+        var giantToolName = new string('x', 4096);
+        var decision = await surface.RequestAsync(Request(toolName: giantToolName), CancellationToken.None);
+
+        await Assert.That(decision.SelectedOptionId).IsEqualTo("opt-allow");
+        await Assert.That(broker.PendingSnapshot()).IsEmpty();
+    }
+
+    [Test]
     public async Task ServerAnswer_IsReturned_AndDismissesTheDesktopCard() {
         var broker  = new PermissionPromptBroker();
         var surface = new AcpPermissionSurface(
-            broker, "copilot", (_, _) => Task.FromResult(new AcpInteractionDecision("allow_once", "opt-allow", "Allow", null, null, null)));
+            broker, "copilot", AnsweringServer(new AcpInteractionDecision("allow_once", "opt-allow", "Allow", null, null, null)));
 
         var decision = await surface.RequestAsync(Request(), CancellationToken.None);
 
@@ -84,7 +163,7 @@ public class AcpPermissionSurfaceTests {
     public async Task Elicitation_GoesStraightToTheServer_WithNoDesktopCard() {
         var broker  = new PermissionPromptBroker();
         var surface = new AcpPermissionSurface(
-            broker, "copilot", (_, _) => Task.FromResult(new AcpInteractionDecision("answered", "opt-allow", "Allow", null, null, null)));
+            broker, "copilot", AnsweringServer(new AcpInteractionDecision("answered", "opt-allow", "Allow", null, null, null)));
 
         var decision = await surface.RequestAsync(Request("elicitation"), CancellationToken.None);
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpPermissionSurfaceTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpPermissionSurfaceTests.cs
@@ -37,6 +37,8 @@ public class AcpPermissionSurfaceTests {
     static Func<AcpInteractionRequest, Action<string>?, CancellationToken, Task<AcpInteractionDecision>> AnsweringServer(AcpInteractionDecision decision) =>
         (_, _, _) => Task.FromResult(decision);
 
+    sealed record ServerResolution(string SessionId, string RequestId, AcpInteractionDecision Decision);
+
     static async Task<PermissionPendingDto> NextPending(ChannelReader<PermissionStreamItem> reader, Func<PermissionPendingDto, bool>? until = null) {
         until ??= _ => true;
         while (await reader.WaitToReadAsync())
@@ -96,6 +98,66 @@ public class AcpPermissionSurfaceTests {
     }
 
     [Test]
+    public async Task DesktopAllow_ResolvesTheServerWithTheSameDecision() {
+        // The desktop wins; the server interaction is still open. Its history must record the
+        // mapped allow (option and all), not the cancel a bare abandonment would leave.
+        var resolutions = new List<ServerResolution>();
+        var broker = new PermissionPromptBroker();
+        var (_, reader) = broker.Subscribe();
+        var surface = new AcpPermissionSurface(
+            broker, "copilot", BlockingServer(serverRequestId: "srv-7"),
+            resolveServer: (s, r, d) => { resolutions.Add(new ServerResolution(s, r, d)); return Task.CompletedTask; });
+
+        var task = surface.RequestAsync(Request(), CancellationToken.None);
+        var pending = await NextPending(reader);
+        broker.TrySettle(pending.RequestId, new PermissionDecision("allow", null, null), "allow", PermissionSettlements.SourceApp);
+        await task;
+
+        await Assert.That(resolutions).HasSingleItem();
+        await Assert.That(resolutions[0].SessionId).IsEqualTo("sess-1");
+        await Assert.That(resolutions[0].RequestId).IsEqualTo("srv-7");
+        await Assert.That(resolutions[0].Decision.Outcome).IsEqualTo("allow_once");
+        await Assert.That(resolutions[0].Decision.SelectedOptionId).IsEqualTo("opt-allow");
+    }
+
+    [Test]
+    public async Task DesktopDeny_ResolvesTheServerWithADeny() {
+        var resolutions = new List<ServerResolution>();
+        var broker = new PermissionPromptBroker();
+        var (_, reader) = broker.Subscribe();
+        var surface = new AcpPermissionSurface(
+            broker, "copilot", BlockingServer(serverRequestId: "srv-8"),
+            resolveServer: (s, r, d) => { resolutions.Add(new ServerResolution(s, r, d)); return Task.CompletedTask; });
+
+        var task = surface.RequestAsync(Request(), CancellationToken.None);
+        var pending = await NextPending(reader);
+        broker.TrySettle(pending.RequestId, PermissionSettlements.DenyDecision, "deny", PermissionSettlements.SourceApp);
+        await task;
+
+        await Assert.That(resolutions).HasSingleItem();
+        await Assert.That(resolutions[0].Decision.Outcome).IsEqualTo("deny");
+        await Assert.That(resolutions[0].Decision.SelectedOptionId).IsNull();
+    }
+
+    [Test]
+    public async Task AgentWithdrawal_DoesNotResolveTheServer() {
+        // The agent is gone; there is no answer to record, and the server's own session-end cleanup owns it.
+        var resolutions = new List<ServerResolution>();
+        var broker = new PermissionPromptBroker();
+        var (_, reader) = broker.Subscribe();
+        var surface = new AcpPermissionSurface(
+            broker, "copilot", BlockingServer(serverRequestId: "srv-9"),
+            resolveServer: (s, r, d) => { resolutions.Add(new ServerResolution(s, r, d)); return Task.CompletedTask; });
+
+        var task = surface.RequestAsync(Request(), CancellationToken.None);
+        await NextPending(reader);
+        broker.WithdrawForAgent("agent-1");
+        await task;
+
+        await Assert.That(resolutions).IsEmpty();
+    }
+
+    [Test]
     public async Task ServerRequestId_IsCorrelatedOntoTheLocalCard() {
         var broker = new PermissionPromptBroker();
         var (_, reader) = broker.Subscribe();
@@ -117,7 +179,7 @@ public class AcpPermissionSurfaceTests {
         var log = new PermissionDecisionLog(tmp.Path, NullLogger.Instance);
         var broker = new PermissionPromptBroker();
         var (_, reader) = broker.Subscribe();
-        var surface = new AcpPermissionSurface(broker, "copilot", BlockingServer(), log);
+        var surface = new AcpPermissionSurface(broker, "copilot", BlockingServer(), decisionLog: log);
 
         var task = surface.RequestAsync(Request(), CancellationToken.None);
         var pending = await NextPending(reader);

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpPermissionSurfaceTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/AcpPermissionSurfaceTests.cs
@@ -1,0 +1,94 @@
+using System.Threading.Channels;
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.LocalIpc;
+using Capacitor.Cli.Daemon.Services;
+
+namespace Capacitor.Cli.Daemon.Tests.Unit.Services;
+
+/// <summary>
+/// <see cref="AcpPermissionSurface"/> presents an ACP permission on the desktop app's local broker
+/// alongside the server's web card, first answer wins. These pin: the desktop's allow/deny maps back
+/// to one of the agent's own offered options by kind; the server's answer is returned and dismisses
+/// the desktop card; and an elicitation never registers a card at all.
+/// </summary>
+public class AcpPermissionSurfaceTests {
+    static readonly AcpInteractionOption[] Options = [
+        new("opt-allow", "Allow", null, "allow_once"),
+        new("opt-reject", "Reject", null, "reject_once"),
+    ];
+
+    static AcpInteractionRequest Request(string kind = "permission") =>
+        new("agent-1", "sess-1", kind, "Bash", null, "call-1", null, Options, false);
+
+    // A server that never answers on its own — it resolves only when its token cancels, which is what
+    // the desktop-wins path does. Lets a test guarantee the desktop is the first answer.
+    static Func<AcpInteractionRequest, CancellationToken, Task<AcpInteractionDecision>> BlockingServer() =>
+        (_, ct) => {
+            var tcs = new TaskCompletionSource<AcpInteractionDecision>(TaskCreationOptions.RunContinuationsAsynchronously);
+            ct.Register(() => tcs.TrySetCanceled());
+            return tcs.Task;
+        };
+
+    static async Task<PermissionPendingDto> NextPending(ChannelReader<PermissionStreamItem> reader) {
+        while (await reader.WaitToReadAsync())
+            while (reader.TryRead(out var item))
+                if (item is PermissionStreamItem.Pending p) return p.Dto;
+        throw new InvalidOperationException("no pending item was broadcast");
+    }
+
+    [Test]
+    public async Task DesktopAllow_MapsToTheAgentsAllowOption() {
+        var broker = new PermissionPromptBroker();
+        var (_, reader) = broker.Subscribe();
+        var surface = new AcpPermissionSurface(broker, "copilot", BlockingServer());
+
+        var task = surface.RequestAsync(Request(), CancellationToken.None);
+
+        var pending = await NextPending(reader);
+        await Assert.That(pending.Vendor).IsEqualTo("copilot");
+        await Assert.That(pending.ToolName).IsEqualTo("Bash");
+        broker.TrySettle(pending.RequestId, new PermissionDecision("allow", null, null), "allow", PermissionSettlements.SourceApp);
+
+        var decision = await task;
+        await Assert.That(decision.Outcome).IsEqualTo("allow_once");
+        await Assert.That(decision.SelectedOptionId).IsEqualTo("opt-allow");
+    }
+
+    [Test]
+    public async Task DesktopDeny_MapsToADenyOutcome() {
+        var broker = new PermissionPromptBroker();
+        var (_, reader) = broker.Subscribe();
+        var surface = new AcpPermissionSurface(broker, "copilot", BlockingServer());
+
+        var task = surface.RequestAsync(Request(), CancellationToken.None);
+        var pending = await NextPending(reader);
+        broker.TrySettle(pending.RequestId, PermissionSettlements.DenyDecision, "deny", PermissionSettlements.SourceApp);
+
+        var decision = await task;
+        await Assert.That(decision.Outcome).IsEqualTo("deny");
+    }
+
+    [Test]
+    public async Task ServerAnswer_IsReturned_AndDismissesTheDesktopCard() {
+        var broker  = new PermissionPromptBroker();
+        var surface = new AcpPermissionSurface(
+            broker, "copilot", (_, _) => Task.FromResult(new AcpInteractionDecision("allow_once", "opt-allow", "Allow", null, null, null)));
+
+        var decision = await surface.RequestAsync(Request(), CancellationToken.None);
+
+        await Assert.That(decision.SelectedOptionId).IsEqualTo("opt-allow");
+        await Assert.That(broker.PendingSnapshot()).IsEmpty();
+    }
+
+    [Test]
+    public async Task Elicitation_GoesStraightToTheServer_WithNoDesktopCard() {
+        var broker  = new PermissionPromptBroker();
+        var surface = new AcpPermissionSurface(
+            broker, "copilot", (_, _) => Task.FromResult(new AcpInteractionDecision("answered", "opt-allow", "Allow", null, null, null)));
+
+        var decision = await surface.RequestAsync(Request("elicitation"), CancellationToken.None);
+
+        await Assert.That(decision.Outcome).IsEqualTo("answered");
+        await Assert.That(broker.PendingSnapshot()).IsEmpty();
+    }
+}


### PR DESCRIPTION
AI-2197

## What & why

An ACP agent's permission request (Copilot, Cursor, Gemini, Kiro) went only to the server's web card; the desktop app's local permission broker was fed only by the Claude Code / Codex HTTP hooks, so a hosted ACP agent's permission never appeared in the desktop app. This wraps the server-facing interaction delegate the ACP bridge already calls: for a permission it registers a card on the local `PermissionPromptBroker` (which the app subscribes to over local control IPC) alongside the server and races the two — first answer wins, the loser is dismissed. The desktop card answers allow/deny, which maps back to one of the agent's own offered options by kind, so `MapPermissionDecision` resolves the option id exactly as a server-side pick would. Elicitations stay server-only.

## Where to look

`AcpPermissionSurface` is the whole race + mapping. It is wired at the five ACP factory registrations in `DaemonRunner` and used by `AcpHostedAgentRuntimeFactory` only when a broker is present — null keeps a launch server-only, so every existing test and the review-flow path are unchanged. The broker is the same DI singleton the desktop app's `PermissionIpc` reads and the Claude/Codex `LocalPermissionBridge` already writes.

Safety properties the surface holds, mirroring `LocalPermissionBridge`:

- **A generic allow never becomes a standing grant.** The desktop shows one "Allow"; if the agent offers only an `allow_always` option, honouring the click would grant more than was shown, so it fails closed to a deny rather than escalating.
- **The local card reuses the bounded pending builder.** An arbitrarily large tool name or input from an ACP child would otherwise ride a control frame the codec rejects and replays on every subscription forever; an over-cap payload skips the local card and stays server-only.
- **The server id is paired onto the local card** via `PermissionPromptBroker.TryCorrelate`, so a client that sees both the server and the local lane coalesces them into one card instead of showing two.
- **Every settlement is written to `permission-decisions.jsonl`**, so a locally-answered ACP decision is in the audit log like a Claude/Codex one.

When the desktop answers first, the same mapped decision is submitted back to the still-open server interaction, so server history records that allow/deny and the server's first-writer-wins tracker keeps a web answer that already landed. A visible web card may linger in a browser until refreshed, but the interaction is resolved and the agent is answered exactly once.

## Verification

`AcpPermissionSurfaceTests` (8): a desktop allow maps to the allow option's id; a deny to a deny outcome; a generic allow with only a standing grant offered fails closed; the server id is correlated onto the local card; a settlement is written to the audit log; an oversized tool name skips the local card and stays server-only; a server answer is returned and dismisses the desktop card; an elicitation never registers a card. `AcpHostedAgentRuntimeFactoryTests` and `AcpHostedAgentRuntimePermissionTests` stay green; daemon AOT publish is IL-clean.
