### PR TITLE
Show harness and model as coloured chips in the session rail

### DIFF
--- a/src/Capacitor.App/App.axaml
+++ b/src/Capacitor.App/App.axaml
@@ -30,6 +30,9 @@
             <SolidColorBrush x:Key="KcapPurpleDimBrush" Color="#29233E" />
             <SolidColorBrush x:Key="KcapDangerBrush" Color="#FF7272" />
             <SolidColorBrush x:Key="KcapDangerDimBrush" Color="#321F29" />
+            <!-- Model chip: one info tint for every model (the web UI's hk-chip-model). -->
+            <SolidColorBrush x:Key="KcapInfoBrush" Color="#7BA7F7" />
+            <SolidColorBrush x:Key="KcapInfoDimBrush" Color="#1B2740" />
             <ResourceDictionary.MergedDictionaries>
                 <ResourceInclude Source="avares://Kurrent Capacitor/Views/PendingCardTemplates.axaml" />
             </ResourceDictionary.MergedDictionaries>

--- a/src/Capacitor.App/App.axaml
+++ b/src/Capacitor.App/App.axaml
@@ -30,7 +30,6 @@
             <SolidColorBrush x:Key="KcapPurpleDimBrush" Color="#29233E" />
             <SolidColorBrush x:Key="KcapDangerBrush" Color="#FF7272" />
             <SolidColorBrush x:Key="KcapDangerDimBrush" Color="#321F29" />
-            <!-- Model chip: one info tint for every model (the web UI's hk-chip-model). -->
             <SolidColorBrush x:Key="KcapInfoBrush" Color="#7BA7F7" />
             <SolidColorBrush x:Key="KcapInfoDimBrush" Color="#1B2740" />
             <ResourceDictionary.MergedDictionaries>

--- a/src/Capacitor.App/Services/VendorChipPalette.cs
+++ b/src/Capacitor.App/Services/VendorChipPalette.cs
@@ -1,0 +1,27 @@
+using System.Collections.Frozen;
+
+namespace Capacitor.App.Services;
+
+/// Per-vendor chip colours, mirroring the web UI's vendor chips. The desktop app paints a fixed
+/// dark surface, so these are literal hex rather than theme-swapped brushes. cursor and any vendor
+/// not listed fall back to the neutral surface pair (KcapSurfaceRaised / KcapFaint).
+public static class VendorChipPalette {
+    public readonly record struct ChipColors(string Background, string Foreground);
+
+    static readonly ChipColors Neutral = new("#191D27", "#949BAA");
+
+    static readonly FrozenDictionary<string, ChipColors> Map =
+        new Dictionary<string, ChipColors>(StringComparer.OrdinalIgnoreCase) {
+            ["claude"] = new("#C87B3A", "#1E1E1E"),
+            ["codex"] = new("#10A37F", "#1E1E1E"),
+            ["copilot"] = new("#8957E5", "#F5F1FB"),
+            ["gemini"] = new("#1A73E8", "#FFFFFF"),
+            ["kiro"] = new("#1E293B", "#E2E8F0"),
+            ["pi"] = new("#E64980", "#FFF0F6"),
+            ["opencode"] = new("#DC2626", "#FEF2F2"),
+            ["antigravity"] = new("#34A853", "#FFFFFF"),
+        }.ToFrozenDictionary(StringComparer.OrdinalIgnoreCase);
+
+    public static ChipColors For(string? vendor) =>
+        vendor is not null && Map.TryGetValue(vendor, out var colors) ? colors : Neutral;
+}

--- a/src/Capacitor.App/ViewModels/RailSessionViewModel.cs
+++ b/src/Capacitor.App/ViewModels/RailSessionViewModel.cs
@@ -15,16 +15,13 @@ namespace Capacitor.App.ViewModels;
 /// point-in-time snapshot (SessionCardViewModel precedent).
 public sealed class RailSessionViewModel : ReactiveObject, IDisposable {
     public string Id { get; }
-    /// The session title; null when the row has none, in which case the chips line stands alone.
+    /// Null when the row has no title, in which case the chips line stands alone as the row.
     public string? Primary { get; }
     public bool HasTitle { get; }
-    /// The vendor key — both the chip's label and its palette lookup (VendorChipPalette).
     public string Vendor { get; }
     public bool HasVendor { get; }
-    /// The model in use; null when the daemon has not resolved one (then no model chip is shown).
     public string? Model { get; }
     public bool HasModel { get; }
-    /// The faint trailing line: any non-agent kind, a borrowed marker, and the age.
     public string Meta { get; }
     public IBrush StatusDot { get; }
     public string Tooltip { get; }

--- a/src/Capacitor.App/ViewModels/RailSessionViewModel.cs
+++ b/src/Capacitor.App/ViewModels/RailSessionViewModel.cs
@@ -15,8 +15,17 @@ namespace Capacitor.App.ViewModels;
 /// point-in-time snapshot (SessionCardViewModel precedent).
 public sealed class RailSessionViewModel : ReactiveObject, IDisposable {
     public string Id { get; }
-    public string Primary { get; }
-    public string Sub { get; }
+    /// The session title; null when the row has none, in which case the chips line stands alone.
+    public string? Primary { get; }
+    public bool HasTitle { get; }
+    /// The vendor key — both the chip's label and its palette lookup (VendorChipPalette).
+    public string Vendor { get; }
+    public bool HasVendor { get; }
+    /// The model in use; null when the daemon has not resolved one (then no model chip is shown).
+    public string? Model { get; }
+    public bool HasModel { get; }
+    /// The faint trailing line: any non-agent kind, a borrowed marker, and the age.
+    public string Meta { get; }
     public IBrush StatusDot { get; }
     public string Tooltip { get; }
     /// The daemon name badge for a remote row; null for a local one.
@@ -47,14 +56,17 @@ public sealed class RailSessionViewModel : ReactiveObject, IDisposable {
             Action<string> openLocal, Action<string> openRemote) {
         Id = row.Id;
         CreatedAt = row.CreatedAt;
-        var kindLine = row.Kind == "agent" ? row.Vendor : $"{row.Vendor} · {row.Kind}";
-        var vendorLine = row.WorkLocation == WorkLocationText.Borrowed ? $"{kindLine} · borrowed" : kindLine;
+        var kindExtra = row.Kind == "agent" ? null : row.Kind;
+        var borrowed = row.WorkLocation == WorkLocationText.Borrowed ? "borrowed" : null;
         var age = UptimeFormat.Format(DateTime.UtcNow - DateTime.SpecifyKind(row.CreatedAt, DateTimeKind.Utc));
 
-        Primary = row.Title ?? vendorLine;
-        Sub = row.Title is null
-            ? Join(row.Model, age)
-            : Join(vendorLine, row.Model, age);
+        Primary = string.IsNullOrEmpty(row.Title) ? null : row.Title;
+        HasTitle = Primary is not null;
+        Vendor = row.Vendor;
+        HasVendor = !string.IsNullOrEmpty(row.Vendor);
+        Model = string.IsNullOrEmpty(row.Model) ? null : row.Model;
+        HasModel = Model is not null;
+        Meta = Join(kindExtra, borrowed, age);
         StatusDot = SessionStatusDots.For(row.Status);
         Tooltip = Join(row.Id, row.Status, SessionStatusDots.WaitsOnUser(row) ? "waiting for input" : null,
             row.RequesterDisplay, row.BorrowedFrom is null ? null : $"borrowed {row.BorrowedFrom}");

--- a/src/Capacitor.App/Views/Converters.cs
+++ b/src/Capacitor.App/Views/Converters.cs
@@ -2,7 +2,6 @@ using System.Globalization;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
-using Capacitor.App.Services;
 
 namespace Capacitor.App.Views;
 
@@ -63,31 +62,6 @@ public sealed class OffscreenWhenInactiveConverter : IValueConverter {
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         value is true ? Avalonia.Automation.IsOffscreenBehavior.Default : Avalonia.Automation.IsOffscreenBehavior.Offscreen;
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotSupportedException();
-}
-
-/// The vendor chip's fill, keyed on the vendor string. RailSessionViewModel stays free of Avalonia
-/// brushes (UI-thread affinity, same reason as the dot brushes), so the vendor→colour lookup lives
-/// here over VendorChipPalette.
-public sealed class VendorChipBackgroundConverter : IValueConverter {
-    public static readonly VendorChipBackgroundConverter Instance = new();
-
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        new ImmutableSolidColorBrush(Color.Parse(VendorChipPalette.For(value as string).Background));
-
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        throw new NotSupportedException();
-}
-
-/// The vendor chip's text colour, paired with VendorChipBackgroundConverter for contrast on each
-/// vendor's fill.
-public sealed class VendorChipForegroundConverter : IValueConverter {
-    public static readonly VendorChipForegroundConverter Instance = new();
-
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
-        new ImmutableSolidColorBrush(Color.Parse(VendorChipPalette.For(value as string).Foreground));
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/Converters.cs
+++ b/src/Capacitor.App/Views/Converters.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using Avalonia.Data.Converters;
 using Avalonia.Media;
 using Avalonia.Media.Immutable;
+using Capacitor.App.Services;
 
 namespace Capacitor.App.Views;
 
@@ -62,6 +63,31 @@ public sealed class OffscreenWhenInactiveConverter : IValueConverter {
 
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         value is true ? Avalonia.Automation.IsOffscreenBehavior.Default : Avalonia.Automation.IsOffscreenBehavior.Offscreen;
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// The vendor chip's fill, keyed on the vendor string. RailSessionViewModel stays free of Avalonia
+/// brushes (UI-thread affinity, same reason as the dot brushes), so the vendor→colour lookup lives
+/// here over VendorChipPalette.
+public sealed class VendorChipBackgroundConverter : IValueConverter {
+    public static readonly VendorChipBackgroundConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        new ImmutableSolidColorBrush(Color.Parse(VendorChipPalette.For(value as string).Background));
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}
+
+/// The vendor chip's text colour, paired with VendorChipBackgroundConverter for contrast on each
+/// vendor's fill.
+public sealed class VendorChipForegroundConverter : IValueConverter {
+    public static readonly VendorChipForegroundConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        new ImmutableSolidColorBrush(Color.Parse(VendorChipPalette.For(value as string).Foreground));
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
         throw new NotSupportedException();

--- a/src/Capacitor.App/Views/SessionRailView.axaml
+++ b/src/Capacitor.App/Views/SessionRailView.axaml
@@ -183,25 +183,40 @@
                                                                             <Grid ColumnDefinitions="Auto,*" ColumnSpacing="8">
                                                                                 <Ellipse Grid.Column="0" Width="7" Height="7" Fill="{Binding StatusDot}"
                                                                                          VerticalAlignment="Top" Margin="0,4,0,0" />
-                                                                                <StackPanel Grid.Column="1" Spacing="2">
-                                                                                    <!-- Star column bounds the title so CharacterEllipsis can actually
-                                                                                         trim it; a horizontal StackPanel gives Primary unbounded width
-                                                                                         and CharacterEllipsis never engages, badge or no badge. -->
-                                                                                    <Grid ColumnDefinitions="*,Auto">
-                                                                                        <TextBlock Grid.Column="0" Text="{Binding Primary}" FontSize="13" LineHeight="18"
-                                                                                                   Foreground="{StaticResource KcapTextBrush}"
-                                                                                                   TextTrimming="CharacterEllipsis" />
-                                                                                        <Border Grid.Column="1"
-                                                                                                IsVisible="{Binding MachineBadge, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                                                                <StackPanel Grid.Column="1" Spacing="3">
+                                                                                    <!-- Title stands alone on its line; a plain TextBlock in this vertical
+                                                                                         StackPanel is width-bounded, so CharacterEllipsis engages. When the
+                                                                                         row has no title the chips line below is the row's identity. -->
+                                                                                    <TextBlock Text="{Binding Primary}" FontSize="13" LineHeight="18"
+                                                                                               IsVisible="{Binding HasTitle}"
+                                                                                               Foreground="{StaticResource KcapTextBrush}"
+                                                                                               TextTrimming="CharacterEllipsis" />
+                                                                                    <StackPanel Orientation="Horizontal" Spacing="6">
+                                                                                        <!-- Vendor chip: web-UI palette via VendorChipPalette. -->
+                                                                                        <Border IsVisible="{Binding HasVendor}" CornerRadius="999"
+                                                                                                Padding="6,1" VerticalAlignment="Center"
+                                                                                                Background="{Binding Vendor, Converter={x:Static views:VendorChipBackgroundConverter.Instance}}">
+                                                                                            <TextBlock Text="{Binding Vendor}" FontSize="10" FontWeight="SemiBold"
+                                                                                                       Foreground="{Binding Vendor, Converter={x:Static views:VendorChipForegroundConverter.Instance}}" />
+                                                                                        </Border>
+                                                                                        <!-- Model chip: one info tint for every model, matching the web UI. -->
+                                                                                        <Border IsVisible="{Binding HasModel}" CornerRadius="999" MaxWidth="150"
+                                                                                                Padding="6,1" VerticalAlignment="Center"
+                                                                                                Background="{StaticResource KcapInfoDimBrush}">
+                                                                                            <TextBlock Text="{Binding Model}" FontSize="10"
+                                                                                                       Foreground="{StaticResource KcapInfoBrush}"
+                                                                                                       TextTrimming="CharacterEllipsis" />
+                                                                                        </Border>
+                                                                                        <Border IsVisible="{Binding MachineBadge, Converter={x:Static ObjectConverters.IsNotNull}}"
                                                                                                 Background="{StaticResource KcapSurfaceRaisedBrush}"
-                                                                                                CornerRadius="3" Padding="4,0" Margin="6,0,0,0" VerticalAlignment="Center">
+                                                                                                CornerRadius="3" Padding="4,0" VerticalAlignment="Center">
                                                                                             <TextBlock Text="{Binding MachineBadge}" FontSize="10"
                                                                                                        Foreground="{StaticResource KcapFaintBrush}" />
                                                                                         </Border>
-                                                                                    </Grid>
-                                                                                    <TextBlock Text="{Binding Sub}" FontSize="11"
-                                                                                               Foreground="{StaticResource KcapFaintBrush}"
-                                                                                               TextTrimming="CharacterEllipsis" />
+                                                                                        <TextBlock Text="{Binding Meta}" FontSize="11" VerticalAlignment="Center"
+                                                                                                   Foreground="{StaticResource KcapFaintBrush}"
+                                                                                                   TextTrimming="CharacterEllipsis" />
+                                                                                    </StackPanel>
                                                                                 </StackPanel>
                                                                             </Grid>
                                                                         </DockPanel>

--- a/src/Capacitor.App/Views/SessionRailView.axaml
+++ b/src/Capacitor.App/Views/SessionRailView.axaml
@@ -191,37 +191,35 @@
                                                                                                IsVisible="{Binding HasTitle}"
                                                                                                Foreground="{StaticResource KcapTextBrush}"
                                                                                                TextTrimming="CharacterEllipsis" />
-                                                                                    <!-- A Grid, not a StackPanel: Meta takes the remaining (star) width so its
-                                                                                         ellipsis engages, and each chip is width-capped, so the whole row stays
-                                                                                         within the 310px rail even with long vendor/model/daemon names. Per-child
-                                                                                         left margins (not ColumnSpacing) so a hidden chip leaves no gap. -->
-                                                                                    <Grid ColumnDefinitions="Auto,Auto,Auto,*">
-                                                                                        <Border Grid.Column="0" IsVisible="{Binding HasVendor}" CornerRadius="999" MaxWidth="120"
-                                                                                                Padding="6,1" VerticalAlignment="Center"
+                                                                                    <!-- WrapPanel, not a fixed row: chips + meta wrap to a second line rather
+                                                                                         than overflow the 310px rail when a vendor token, model id, or daemon
+                                                                                         name is unusually long. Each label is also individually width-capped and
+                                                                                         trims, so no single chip can push a line past the rail either. -->
+                                                                                    <WrapPanel>
+                                                                                        <Border IsVisible="{Binding HasVendor}" CornerRadius="999" MaxWidth="120"
+                                                                                                Padding="6,1" Margin="0,0,6,3" VerticalAlignment="Center"
                                                                                                 Background="{Binding Vendor, Converter={x:Static views:VendorChipBackgroundConverter.Instance}}">
                                                                                             <TextBlock Text="{Binding Vendor}" FontSize="10" FontWeight="SemiBold"
                                                                                                        TextTrimming="CharacterEllipsis"
                                                                                                        Foreground="{Binding Vendor, Converter={x:Static views:VendorChipForegroundConverter.Instance}}" />
                                                                                         </Border>
-                                                                                        <Border Grid.Column="1" IsVisible="{Binding HasModel}" CornerRadius="999" MaxWidth="150"
-                                                                                                Padding="6,1" Margin="6,0,0,0" VerticalAlignment="Center"
+                                                                                        <Border IsVisible="{Binding HasModel}" CornerRadius="999" MaxWidth="150"
+                                                                                                Padding="6,1" Margin="0,0,6,3" VerticalAlignment="Center"
                                                                                                 Background="{StaticResource KcapInfoDimBrush}">
                                                                                             <TextBlock Text="{Binding Model}" FontSize="10"
                                                                                                        Foreground="{StaticResource KcapInfoBrush}"
                                                                                                        TextTrimming="CharacterEllipsis" />
                                                                                         </Border>
-                                                                                        <Border Grid.Column="2" IsVisible="{Binding MachineBadge, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                                                                        <Border IsVisible="{Binding MachineBadge, Converter={x:Static ObjectConverters.IsNotNull}}"
                                                                                                 Background="{StaticResource KcapSurfaceRaisedBrush}" MaxWidth="100"
-                                                                                                CornerRadius="3" Padding="4,0" Margin="6,0,0,0" VerticalAlignment="Center">
+                                                                                                CornerRadius="3" Padding="4,0" Margin="0,0,6,3" VerticalAlignment="Center">
                                                                                             <TextBlock Text="{Binding MachineBadge}" FontSize="10"
                                                                                                        TextTrimming="CharacterEllipsis"
                                                                                                        Foreground="{StaticResource KcapFaintBrush}" />
                                                                                         </Border>
-                                                                                        <TextBlock Grid.Column="3" Text="{Binding Meta}" FontSize="11" VerticalAlignment="Center"
-                                                                                                   Margin="6,0,0,0"
-                                                                                                   Foreground="{StaticResource KcapFaintBrush}"
-                                                                                                   TextTrimming="CharacterEllipsis" />
-                                                                                    </Grid>
+                                                                                        <TextBlock Text="{Binding Meta}" FontSize="11" VerticalAlignment="Center"
+                                                                                                   Foreground="{StaticResource KcapFaintBrush}" />
+                                                                                    </WrapPanel>
                                                                                 </StackPanel>
                                                                             </Grid>
                                                                         </DockPanel>

--- a/src/Capacitor.App/Views/SessionRailView.axaml
+++ b/src/Capacitor.App/Views/SessionRailView.axaml
@@ -191,15 +191,16 @@
                                                                                                IsVisible="{Binding HasTitle}"
                                                                                                Foreground="{StaticResource KcapTextBrush}"
                                                                                                TextTrimming="CharacterEllipsis" />
+                                                                                    <!-- Every externally-sourced label is width-capped and trims, so a long
+                                                                                         vendor token, model id, or daemon name cannot overflow the 310px rail. -->
                                                                                     <StackPanel Orientation="Horizontal" Spacing="6">
-                                                                                        <!-- Vendor chip: web-UI palette via VendorChipPalette. -->
-                                                                                        <Border IsVisible="{Binding HasVendor}" CornerRadius="999"
+                                                                                        <Border IsVisible="{Binding HasVendor}" CornerRadius="999" MaxWidth="120"
                                                                                                 Padding="6,1" VerticalAlignment="Center"
                                                                                                 Background="{Binding Vendor, Converter={x:Static views:VendorChipBackgroundConverter.Instance}}">
                                                                                             <TextBlock Text="{Binding Vendor}" FontSize="10" FontWeight="SemiBold"
+                                                                                                       TextTrimming="CharacterEllipsis"
                                                                                                        Foreground="{Binding Vendor, Converter={x:Static views:VendorChipForegroundConverter.Instance}}" />
                                                                                         </Border>
-                                                                                        <!-- Model chip: one info tint for every model, matching the web UI. -->
                                                                                         <Border IsVisible="{Binding HasModel}" CornerRadius="999" MaxWidth="150"
                                                                                                 Padding="6,1" VerticalAlignment="Center"
                                                                                                 Background="{StaticResource KcapInfoDimBrush}">
@@ -208,9 +209,10 @@
                                                                                                        TextTrimming="CharacterEllipsis" />
                                                                                         </Border>
                                                                                         <Border IsVisible="{Binding MachineBadge, Converter={x:Static ObjectConverters.IsNotNull}}"
-                                                                                                Background="{StaticResource KcapSurfaceRaisedBrush}"
+                                                                                                Background="{StaticResource KcapSurfaceRaisedBrush}" MaxWidth="100"
                                                                                                 CornerRadius="3" Padding="4,0" VerticalAlignment="Center">
                                                                                             <TextBlock Text="{Binding MachineBadge}" FontSize="10"
+                                                                                                       TextTrimming="CharacterEllipsis"
                                                                                                        Foreground="{StaticResource KcapFaintBrush}" />
                                                                                         </Border>
                                                                                         <TextBlock Text="{Binding Meta}" FontSize="11" VerticalAlignment="Center"

--- a/src/Capacitor.App/Views/SessionRailView.axaml
+++ b/src/Capacitor.App/Views/SessionRailView.axaml
@@ -191,34 +191,37 @@
                                                                                                IsVisible="{Binding HasTitle}"
                                                                                                Foreground="{StaticResource KcapTextBrush}"
                                                                                                TextTrimming="CharacterEllipsis" />
-                                                                                    <!-- Every externally-sourced label is width-capped and trims, so a long
-                                                                                         vendor token, model id, or daemon name cannot overflow the 310px rail. -->
-                                                                                    <StackPanel Orientation="Horizontal" Spacing="6">
-                                                                                        <Border IsVisible="{Binding HasVendor}" CornerRadius="999" MaxWidth="120"
+                                                                                    <!-- A Grid, not a StackPanel: Meta takes the remaining (star) width so its
+                                                                                         ellipsis engages, and each chip is width-capped, so the whole row stays
+                                                                                         within the 310px rail even with long vendor/model/daemon names. Per-child
+                                                                                         left margins (not ColumnSpacing) so a hidden chip leaves no gap. -->
+                                                                                    <Grid ColumnDefinitions="Auto,Auto,Auto,*">
+                                                                                        <Border Grid.Column="0" IsVisible="{Binding HasVendor}" CornerRadius="999" MaxWidth="120"
                                                                                                 Padding="6,1" VerticalAlignment="Center"
                                                                                                 Background="{Binding Vendor, Converter={x:Static views:VendorChipBackgroundConverter.Instance}}">
                                                                                             <TextBlock Text="{Binding Vendor}" FontSize="10" FontWeight="SemiBold"
                                                                                                        TextTrimming="CharacterEllipsis"
                                                                                                        Foreground="{Binding Vendor, Converter={x:Static views:VendorChipForegroundConverter.Instance}}" />
                                                                                         </Border>
-                                                                                        <Border IsVisible="{Binding HasModel}" CornerRadius="999" MaxWidth="150"
-                                                                                                Padding="6,1" VerticalAlignment="Center"
+                                                                                        <Border Grid.Column="1" IsVisible="{Binding HasModel}" CornerRadius="999" MaxWidth="150"
+                                                                                                Padding="6,1" Margin="6,0,0,0" VerticalAlignment="Center"
                                                                                                 Background="{StaticResource KcapInfoDimBrush}">
                                                                                             <TextBlock Text="{Binding Model}" FontSize="10"
                                                                                                        Foreground="{StaticResource KcapInfoBrush}"
                                                                                                        TextTrimming="CharacterEllipsis" />
                                                                                         </Border>
-                                                                                        <Border IsVisible="{Binding MachineBadge, Converter={x:Static ObjectConverters.IsNotNull}}"
+                                                                                        <Border Grid.Column="2" IsVisible="{Binding MachineBadge, Converter={x:Static ObjectConverters.IsNotNull}}"
                                                                                                 Background="{StaticResource KcapSurfaceRaisedBrush}" MaxWidth="100"
-                                                                                                CornerRadius="3" Padding="4,0" VerticalAlignment="Center">
+                                                                                                CornerRadius="3" Padding="4,0" Margin="6,0,0,0" VerticalAlignment="Center">
                                                                                             <TextBlock Text="{Binding MachineBadge}" FontSize="10"
                                                                                                        TextTrimming="CharacterEllipsis"
                                                                                                        Foreground="{StaticResource KcapFaintBrush}" />
                                                                                         </Border>
-                                                                                        <TextBlock Text="{Binding Meta}" FontSize="11" VerticalAlignment="Center"
+                                                                                        <TextBlock Grid.Column="3" Text="{Binding Meta}" FontSize="11" VerticalAlignment="Center"
+                                                                                                   Margin="6,0,0,0"
                                                                                                    Foreground="{StaticResource KcapFaintBrush}"
                                                                                                    TextTrimming="CharacterEllipsis" />
-                                                                                    </StackPanel>
+                                                                                    </Grid>
                                                                                 </StackPanel>
                                                                             </Grid>
                                                                         </DockPanel>

--- a/src/Capacitor.App/Views/VendorChipBackgroundConverter.cs
+++ b/src/Capacitor.App/Views/VendorChipBackgroundConverter.cs
@@ -1,0 +1,20 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Views;
+
+/// The vendor chip's fill brush, from the vendor string via VendorChipPalette. The lookup lives in
+/// the view layer (not the row VM) so the VM carries no Avalonia brushes; the brush is immutable, so
+/// it is safe to share across the rows that bind it.
+public sealed class VendorChipBackgroundConverter : IValueConverter {
+    public static readonly VendorChipBackgroundConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        new ImmutableSolidColorBrush(Color.Parse(VendorChipPalette.For(value as string).Background));
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/src/Capacitor.App/Views/VendorChipBackgroundConverter.cs
+++ b/src/Capacitor.App/Views/VendorChipBackgroundConverter.cs
@@ -6,9 +6,7 @@ using Capacitor.App.Services;
 
 namespace Capacitor.App.Views;
 
-/// The vendor chip's fill brush, from the vendor string via VendorChipPalette. The lookup lives in
-/// the view layer (not the row VM) so the VM carries no Avalonia brushes; the brush is immutable, so
-/// it is safe to share across the rows that bind it.
+/// The vendor chip's fill brush, from the vendor string via VendorChipPalette.
 public sealed class VendorChipBackgroundConverter : IValueConverter {
     public static readonly VendorChipBackgroundConverter Instance = new();
 

--- a/src/Capacitor.App/Views/VendorChipBackgroundConverter.cs
+++ b/src/Capacitor.App/Views/VendorChipBackgroundConverter.cs
@@ -6,7 +6,6 @@ using Capacitor.App.Services;
 
 namespace Capacitor.App.Views;
 
-/// The vendor chip's fill brush, from the vendor string via VendorChipPalette.
 public sealed class VendorChipBackgroundConverter : IValueConverter {
     public static readonly VendorChipBackgroundConverter Instance = new();
 

--- a/src/Capacitor.App/Views/VendorChipForegroundConverter.cs
+++ b/src/Capacitor.App/Views/VendorChipForegroundConverter.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+using Avalonia.Data.Converters;
+using Avalonia.Media;
+using Avalonia.Media.Immutable;
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Views;
+
+/// The vendor chip's text brush, paired with VendorChipBackgroundConverter for contrast on each
+/// vendor's fill. Immutable, so it is safe to share across rows.
+public sealed class VendorChipForegroundConverter : IValueConverter {
+    public static readonly VendorChipForegroundConverter Instance = new();
+
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        new ImmutableSolidColorBrush(Color.Parse(VendorChipPalette.For(value as string).Foreground));
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture) =>
+        throw new NotSupportedException();
+}

--- a/src/Capacitor.App/Views/VendorChipForegroundConverter.cs
+++ b/src/Capacitor.App/Views/VendorChipForegroundConverter.cs
@@ -6,8 +6,7 @@ using Capacitor.App.Services;
 
 namespace Capacitor.App.Views;
 
-/// The vendor chip's text brush, paired with VendorChipBackgroundConverter for contrast on each
-/// vendor's fill. Immutable, so it is safe to share across rows.
+/// The vendor chip's text brush, paired with VendorChipBackgroundConverter for contrast on the fill.
 public sealed class VendorChipForegroundConverter : IValueConverter {
     public static readonly VendorChipForegroundConverter Instance = new();
 

--- a/src/Capacitor.App/Views/VendorChipForegroundConverter.cs
+++ b/src/Capacitor.App/Views/VendorChipForegroundConverter.cs
@@ -6,7 +6,6 @@ using Capacitor.App.Services;
 
 namespace Capacitor.App.Views;
 
-/// The vendor chip's text brush, paired with VendorChipBackgroundConverter for contrast on the fill.
 public sealed class VendorChipForegroundConverter : IValueConverter {
     public static readonly VendorChipForegroundConverter Instance = new();
 

--- a/test/Capacitor.App.Tests.Unit/RailSessionViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/RailSessionViewModelTests.cs
@@ -32,53 +32,61 @@ public class RailSessionViewModelTests {
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Title_is_primary_with_vendor_model_age_sub() {
+    public async Task Title_is_primary_with_vendor_and_model_as_chips() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var row = new RailSessionViewModel(Row(), new BehaviorSubject<string?>(null), NoPending, NotStale, _ => { }, _ => { });
             await Assert.That(row.Primary).IsEqualTo("Fix the flaky test");
-            await Assert.That(row.Sub).StartsWith("claude · Opus 5 · ");
+            await Assert.That(row.HasTitle).IsTrue();
+            await Assert.That(row.Vendor).IsEqualTo("claude");
+            await Assert.That(row.HasVendor).IsTrue();
+            await Assert.That(row.Model).IsEqualTo("Opus 5");
+            await Assert.That(row.HasModel).IsTrue();
         });
     }
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Null_title_promotes_vendor_and_drops_it_from_sub() {
+    public async Task Null_title_leaves_the_chips_line_to_carry_the_row() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var row = new RailSessionViewModel(Row(title: null), new BehaviorSubject<string?>(null), NoPending, NotStale, _ => { }, _ => { });
-            await Assert.That(row.Primary).IsEqualTo("claude");
-            await Assert.That(row.Sub).StartsWith("Opus 5 · ");
+            await Assert.That(row.HasTitle).IsFalse();
+            await Assert.That(row.Vendor).IsEqualTo("claude");
+            await Assert.That(row.Model).IsEqualTo("Opus 5");
         });
     }
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Review_kind_is_appended_to_the_vendor() {
+    public async Task Non_agent_kind_goes_to_the_meta_line_not_the_vendor_chip() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var row = new RailSessionViewModel(Row(kind: "review", title: null), new BehaviorSubject<string?>(null), NoPending, NotStale, _ => { }, _ => { });
-            await Assert.That(row.Primary).IsEqualTo("claude · review");
+            await Assert.That(row.Vendor).IsEqualTo("claude");
+            await Assert.That(row.Meta).StartsWith("review · ");
         });
     }
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Borrowed_work_location_marks_the_vendor_line_and_the_tooltip_names_the_checkout() {
+    public async Task Borrowed_work_location_marks_the_meta_line_and_the_tooltip_names_the_checkout() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             var dto = new AgentStatusDto("a1", "review-flow", "codex", "/repo", "Running", null, null, null, DateTime.UtcNow, "Opus 5", null, Title: "Fix the flaky test") with {
                 WorktreePath = "/repo/.capacitor/worktrees/agent-1", WorkLocation = "borrowed",
                 BorrowedFrom = "/repo/.capacitor/worktrees/agent-1" };
             using var row = new RailSessionViewModel(AgentRow.FromLocal(dto, Repo), new BehaviorSubject<string?>(null), NoPending, NotStale, _ => { }, _ => { });
-            await Assert.That(row.Sub).StartsWith("codex · review-flow · borrowed · Opus 5 · ");
+            await Assert.That(row.Vendor).IsEqualTo("codex");
+            await Assert.That(row.Model).IsEqualTo("Opus 5");
+            await Assert.That(row.Meta).StartsWith("review-flow · borrowed · ");
             await Assert.That(row.Tooltip).Contains("/repo/.capacitor/worktrees/agent-1");
         });
     }
 
     [Test]
     [NotInParallel("AvaloniaSession")]
-    public async Task Null_model_is_omitted_from_sub() {
+    public async Task Null_model_hides_the_model_chip() {
         await AvaloniaSession.WithImmediateRxScheduler(async () => {
             using var row = new RailSessionViewModel(Row(model: null), new BehaviorSubject<string?>(null), NoPending, NotStale, _ => { }, _ => { });
-            await Assert.That(row.Sub).DoesNotContain("· ·");
-            await Assert.That(row.Sub).DoesNotStartWith("·");
+            await Assert.That(row.Model).IsNull();
+            await Assert.That(row.HasModel).IsFalse();
         });
     }
 

--- a/test/Capacitor.App.Tests.Unit/VendorChipPaletteTests.cs
+++ b/test/Capacitor.App.Tests.Unit/VendorChipPaletteTests.cs
@@ -1,0 +1,27 @@
+using Capacitor.App.Services;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class VendorChipPaletteTests {
+    [Test]
+    public async Task Known_vendor_gets_its_web_colour() {
+        var claude = VendorChipPalette.For("claude");
+        await Assert.That(claude.Background).IsEqualTo("#C87B3A");
+        await Assert.That(claude.Foreground).IsEqualTo("#1E1E1E");
+    }
+
+    [Test]
+    public async Task Vendor_lookup_is_case_insensitive() {
+        await Assert.That(VendorChipPalette.For("Codex")).IsEqualTo(VendorChipPalette.For("codex"));
+    }
+
+    [Test]
+    public async Task Cursor_and_unknown_fall_back_to_the_neutral_pair() {
+        var cursor = VendorChipPalette.For("cursor");
+        var unknown = VendorChipPalette.For("something-else");
+        var missing = VendorChipPalette.For(null);
+        await Assert.That(cursor).IsEqualTo(unknown);
+        await Assert.That(unknown).IsEqualTo(missing);
+        await Assert.That(cursor.Background).IsEqualTo("#191D27");
+    }
+}


### PR DESCRIPTION
Closes #898 — AI-2716
Part of #899 — AI-2717 (model-chip UI; daemon model resolution follows separately)

## What & why

The session rail rendered the harness/vendor and model as plain text. The web UI shows the vendor as a per-vendor coloured chip and the model as a single info-tint chip. This brings the rail to that treatment: the vendor palette mirrors the web values exactly, and cursor / any unknown vendor fall back to a neutral pair.

## Where to look

`VendorChipPalette` holds the vendor→colour map. The session-row template now carries a title line plus a chips line (vendor, model, machine badge, meta); a row with no title lets the chips line stand as its identity. Model chips show wherever a model is resolved — Pi today and any explicitly chosen model — so other vendors' default launches stay blank until the daemon resolution (AI-2717) lands.

## Verification

`dotnet build src/Capacitor.App` → 0 warnings. Filtered `dotnet run` on the App test suite: VendorChipPaletteTests 3/3, RailSessionViewModelTests 13/13, MainWindowSmokeTests 11/11.
