### PR TITLE
Bind Cmd+N / Ctrl+N to start a new session

### DIFF
--- a/src/Capacitor.App/Views/MainWindow.axaml
+++ b/src/Capacitor.App/Views/MainWindow.axaml
@@ -11,9 +11,6 @@
                      Width="1200" MinWidth="1200" Height="760" MinHeight="560"
                      Background="{StaticResource KcapCanvasBrush}"
                      ExtendClientAreaToDecorationsHint="True">
-    <!-- New session: deselect the workspace (the launcher pane IS the empty state). The rail's
-         New session button carries the same command; this makes the advertised ⌘N fire, and
-         Ctrl+N covers Windows/Linux. -->
     <Window.KeyBindings>
         <KeyBinding Gesture="Meta+N" Command="{Binding CloseWorkspaceCommand}" />
         <KeyBinding Gesture="Ctrl+N" Command="{Binding CloseWorkspaceCommand}" />

--- a/src/Capacitor.App/Views/MainWindow.axaml
+++ b/src/Capacitor.App/Views/MainWindow.axaml
@@ -11,6 +11,13 @@
                      Width="1200" MinWidth="1200" Height="760" MinHeight="560"
                      Background="{StaticResource KcapCanvasBrush}"
                      ExtendClientAreaToDecorationsHint="True">
+    <!-- New session: deselect the workspace (the launcher pane IS the empty state). The rail's
+         New session button carries the same command; this makes the advertised ⌘N fire, and
+         Ctrl+N covers Windows/Linux. -->
+    <Window.KeyBindings>
+        <KeyBinding Gesture="Meta+N" Command="{Binding CloseWorkspaceCommand}" />
+        <KeyBinding Gesture="Ctrl+N" Command="{Binding CloseWorkspaceCommand}" />
+    </Window.KeyBindings>
     <!-- Sessions is the home surface: rail | launcher-or-workspace. The right pane's empty state
          IS the launcher. Home stays in the tree but hidden (ShowHomeCommand still exists).
          Workspace content is a template so the terminal is only built once a session opens.

--- a/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/MainWindowSmokeTests.cs
@@ -1,5 +1,6 @@
 using System.Reactive.Threading.Tasks;
 using Avalonia.Controls;
+using Avalonia.Input;
 using Avalonia.Media;
 using Avalonia.Threading;
 using Avalonia.VisualTree;
@@ -566,6 +567,47 @@ public class MainWindowSmokeTests {
             await Assert.That(opened.SelectedAlpha).IsGreaterThan((byte)0); // the highlight actually paints
             await Assert.That(opened.SiblingAlpha).IsEqualTo((byte)0); // an unopened row stays transparent
             await Assert.That(opened.WorktreeAlpha).IsGreaterThan((byte)0);
+        });
+    }
+
+    /// Cmd+N / Ctrl+N: the window binds the advertised New session shortcut to CloseWorkspaceCommand,
+    /// which drops an open workspace back to the launcher (the new-session empty state).
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task New_session_shortcut_is_bound_and_returns_to_the_launcher() {
+        await AvaloniaSession.WithImmediateRxScheduler(async () => {
+            var (hadWorkspace, hasMeta, hasCtrl, afterInvoke) = await AvaloniaSession.DispatchAsync(() => {
+                var service = new FakeDaemonClientService();
+                var (actions, _) = NewActions(service);
+                var vm = new MainWindowViewModel(
+                    service, CancellationToken.None, TestActivity.New(),
+                    workspaceFactory: id => NewWorkspace(service, actions, id));
+                var window = new MainWindow { DataContext = vm };
+                window.Show();
+                Dispatcher.UIThread.RunJobs();
+
+                vm.OpenSession("0123456789abcdef0123456789abcdef");
+                Dispatcher.UIThread.RunJobs();
+                var had = vm.CurrentWorkspace is not null;
+
+                bool Bound(KeyModifiers mod) => window.KeyBindings.Any(
+                    k => k.Gesture is { Key: Key.N } g && g.KeyModifiers.HasFlag(mod));
+                var meta = Bound(KeyModifiers.Meta);
+                var ctrl = Bound(KeyModifiers.Control);
+
+                window.KeyBindings.First(k => k.Gesture is { Key: Key.N } g && g.KeyModifiers.HasFlag(KeyModifiers.Meta))
+                    .Command!.Execute(null);
+                Dispatcher.UIThread.RunJobs();
+                var after = vm.CurrentWorkspace;
+
+                window.Close();
+                Dispatcher.UIThread.RunJobs();
+                return (had, meta, ctrl, after);
+            });
+            await Assert.That(hadWorkspace).IsTrue();
+            await Assert.That(hasMeta).IsTrue();
+            await Assert.That(hasCtrl).IsTrue();
+            await Assert.That(afterInvoke).IsNull();
         });
     }
 


### PR DESCRIPTION
Closes #901 — AI-2719

## What & why

Command+N did nothing: the rail's New session button showed a `⌘N` hint but no gesture was ever bound to it. The window now binds Meta+N (macOS) and Ctrl+N (Windows/Linux) to `CloseWorkspaceCommand`, which deselects the open workspace and returns to the launcher — the new-session empty state the button already triggers.

## Verification

App test suite (filtered): MainWindowSmokeTests 12/12, including a new test that opens a workspace, invokes the bound Meta+N command, and asserts it returns to the launcher (and that both Meta+N and Ctrl+N are bound).
