### PR TITLE
Allow multi-line text in the launcher prompt box

### DIFF
--- a/src/Capacitor.App/Views/LauncherPaneView.axaml
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml
@@ -64,8 +64,8 @@
                     <TextBox x:Name="GoalInput" Classes="kcapEmbedded" Text="{Binding Goal}"
                              PlaceholderText="What should we build? Type a goal or paste an issue, PR, or work-item URL…"
                              Background="Transparent" Foreground="{StaticResource KcapTextBrush}"
-                             BorderThickness="0" MinHeight="72" TextWrapping="Wrap" FontSize="14"
-                             VerticalContentAlignment="Top" AcceptsReturn="False" />
+                             BorderThickness="0" MinHeight="72" MaxHeight="220" TextWrapping="Wrap" FontSize="14"
+                             VerticalContentAlignment="Top" AcceptsReturn="True" />
 
                     <!-- Repo on its own row (capped width + ellipsis); settings + Start below so a
                          long leaf never orphans Permissions alone under the repo pill. -->

--- a/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
+++ b/src/Capacitor.App/Views/LauncherPaneView.axaml.cs
@@ -18,16 +18,18 @@ namespace Capacitor.App.Views;
 public partial class LauncherPaneView : UserControl {
     public LauncherPaneView() {
         InitializeComponent();
-        // Tunnel, not bubble: TextBox can still mark Enter handled on the bubble route even when
-        // AcceptsReturn is false, so Start must see the key on the way down.
+        // Tunnel, not bubble: the TextBox marks Enter handled on the bubble route, so bare-Enter
+        // submit must see the key on the way down. Shift+Enter falls through untouched, so the
+        // TextBox inserts a newline (AcceptsReturn is true).
         GoalInput.AddHandler(KeyDownEvent, OnGoalKeyDown, RoutingStrategies.Tunnel);
     }
 
     /// Bare Enter starts a session when Start can run; otherwise the key is consumed so it does
-    /// not leave a stray newline. Mirrors the Start button: connection readiness from CanExecute,
-    /// repository from SelectedRepoPath (the button's IsEnabled binding).
+    /// not leave a stray newline. Shift+Enter is left for the TextBox to insert a newline. Mirrors
+    /// the Start button: connection readiness from CanExecute, repository from SelectedRepoPath.
     void OnGoalKeyDown(object? sender, KeyEventArgs e) {
         if (e.Key != Key.Enter) return;
+        if (e.KeyModifiers.HasFlag(KeyModifiers.Shift)) return;
         e.Handled = true;
         if (DataContext is not HomeViewModel vm) return;
         if (string.IsNullOrEmpty(vm.SelectedRepoPath)) return;

--- a/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/HomeViewSmokeTests.cs
@@ -307,6 +307,46 @@ public class HomeViewSmokeTests {
         await Assert.That(goalAfter).IsEqualTo("ship it");
     }
 
+    /// Shift+Enter inserts a newline instead of launching — even when Start could run — matching
+    /// the chat composer. Bare Enter still launches (covered above).
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Shift_Enter_in_the_goal_box_inserts_a_newline_and_does_not_start() {
+        var (goalText, acceptsReturn, startCount) = await AvaloniaSession.DispatchAsync(async () => {
+            var (_, vm, _, launch, tmp) = Build();
+            using var _tmp = tmp;
+            var window = new Window { Content = new LauncherPaneView { DataContext = vm }, Width = 900, Height = 600 };
+            window.Show();
+            Dispatcher.UIThread.RunJobs();
+
+            await vm.SelectRepositoryAsync("/repos/kcap-cli");
+            Dispatcher.UIThread.RunJobs();
+
+            var goal = Find<TextBox>(window, "GoalInput")!;
+            var accepts = goal.AcceptsReturn;
+            goal.Focus();
+            Dispatcher.UIThread.RunJobs();
+            window.KeyTextInput("line one");
+            window.KeyPressQwerty(PhysicalKey.Enter, RawInputModifiers.Shift);
+            window.KeyTextInput("line two");
+            Dispatcher.UIThread.RunJobs();
+
+            var text = goal.Text;
+            var count = launch.StartCount;
+
+            window.Close();
+            Dispatcher.UIThread.RunJobs();
+            vm.Dispose();
+            return (text, accepts, count);
+        });
+
+        await Assert.That(acceptsReturn).IsTrue();
+        await Assert.That(startCount).IsEqualTo(0);
+        await Assert.That(goalText).Contains("line one");
+        await Assert.That(goalText).Contains("line two");
+        await Assert.That(goalText!.Contains('\n')).IsTrue();
+    }
+
     [Test]
     [NotInParallel("AvaloniaSession")]
     public async Task StartErrorText_visibility_follows_StartError() {


### PR DESCRIPTION
Closes #903 — AI-2721

## What & why

The launcher goal box ("What should we build?") was hard single-line: `AcceptsReturn="False"`, and its tunnel Enter handler consumed every Enter, including Shift+Enter, so a newline could never be entered. It now accepts returns, and the handler lets Shift+Enter fall through to insert a newline while bare Enter still launches — the same convention as the ongoing-chat composer.

## Verification

App test suite (filtered): HomeViewSmokeTests 14/14, including a new test that types across a Shift+Enter, asserts the goal text spans two lines with a newline, and that no launch fired — even with a repo selected (so Start *could* have run).
