### PR TITLE
Inject the telemetry facade instead of reaching process-wide statics

### DIFF
--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Telemetry;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Reactive.Subjects;
@@ -51,6 +52,11 @@ public partial class App : Application {
     readonly ProfileOverrides _serverEnv  = ProfileOverrides.FromEnvironment();
     readonly MachineAuth      _machineEnv = MachineAuth.FromEnvironment();
     readonly UserHome   _userHome = UserHome.FromEnvironment();
+
+    /// The wizard signs in through the CLI's own stack, which reports the signup funnel. The app
+    /// shows no privacy notice and offers no opt-out of its own, so it hands that stack a facade
+    /// that is off — nothing a wizard run does can emit.
+    readonly CliTelemetry _telemetry = CliTelemetry.Disabled();
 
     /// Process-lifetime rather than per wizard run — a provisioning poll can outlive the window that
     /// started it, and this client degrades a transport failure but not a disposed handler. What it
@@ -657,7 +663,7 @@ public partial class App : Application {
             profiles.Name, serverUrl,
             WizardComposition.BuildBridges(
                 action => Dispatcher.UIThread.Post(action),
-                _foreignHttp.GetRequiredService<TenantProvisioningClient>()),
+                _foreignHttp.GetRequiredService<TenantProvisioningClient>(), _telemetry),
             new ConsentFlipClaims(_config),
             new AppStateStore(_config.Path("app-state.json")),
             new ShellUrlOpener(),
@@ -733,7 +739,7 @@ public partial class App : Application {
             OperatingSystem.IsMacOS(), shimTarget, ct => probe.KcapOnPathAsync(ct), _shutdown.Token);
         var bridges = WizardComposition.BuildBridges(
             action => Dispatcher.UIThread.Post(action),
-            _foreignHttp.GetRequiredService<TenantProvisioningClient>());
+            _foreignHttp.GetRequiredService<TenantProvisioningClient>(), _telemetry);
         var surface = new WizardLifecycleSurface(ConfirmLifecyclePromptAsync, action => Dispatcher.UIThread.Post(action));
 
         var graph = WizardComposition.BuildGraph(new WizardGraphOptions(

--- a/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardAuthBridges.cs
@@ -108,6 +108,7 @@ public sealed class WizardTenantProvisioner(
         TenantProvisioningClient client,
         string                   baseUrl,
         IAuthProgress            progress,
+        CliTelemetry             telemetry,
         TimeProvider?            time = null) : ITenantProvisioner {
     internal const int PollIntervalMs = 4000;
     internal const int MaxPolls       = 150; // ~10 minutes (server budget is 15)
@@ -125,13 +126,13 @@ public sealed class WizardTenantProvisioner(
         // Says what was actually established, not more: single sign-on returned nothing.
         progress.Notice("Single sign-on found no Capacitor workspace for your account.");
         progress.Notice("A workspace that signs in with the GitHub App won't appear here.");
-        SetupFunnel.WorkspaceOffered();
+        telemetry.Funnel.WorkspaceOffered();
 
         var mode = OfferMode is null ? new ProvisionMode.Cancel() : await OfferMode(ct);
 
         switch (mode) {
             case ProvisionMode.Existing existing when !string.IsNullOrWhiteSpace(existing.Input):
-                SetupFunnel.WorkspaceRedirected();
+                telemetry.Funnel.WorkspaceRedirected();
 
                 return ProvisionOffer.ExistingWorkspace(existing.Input.Trim());
             case ProvisionMode.Create:
@@ -154,13 +155,14 @@ public sealed class WizardTenantProvisioner(
 
         if (ConfirmCreate is null || !await ConfirmCreate(slug, origin, ct)) return Declined();
 
-        SetupFunnel.WorkspaceRequested();
+        telemetry.Funnel.WorkspaceRequested();
 
-        var outcome = await client.ProvisionAsync(baseUrl, await tokens.GetAsync(ct), orgName, slug, ct);
+        var outcome = await client.ProvisionAsync(
+            baseUrl, await tokens.GetAsync(ct), orgName, slug, telemetry.Join.Current, ct);
 
         switch (outcome.StatusCode) {
             case 200 when outcome.Body?.WorkosOrgId is { Length: > 0 } orgId:
-                SetupFunnel.WorkspaceProvisioned();
+                telemetry.Funnel.WorkspaceProvisioned();
 
                 return ProvisionOffer.Created(new ProvisionedTenant(orgId, slug, orgName, outcome.Body.Url ?? origin));
             case 202 or 200:
@@ -230,7 +232,7 @@ public sealed class WizardTenantProvisioner(
 
             switch (ProvisioningPoll.Classify(status.StatusCode, status.Body?.State, status.Body?.WorkosOrgId)) {
                 case PollVerdict.Active:
-                    SetupFunnel.WorkspaceProvisioned();
+                    telemetry.Funnel.WorkspaceProvisioned();
 
                     return ProvisionOffer.Created(
                         new ProvisionedTenant(status.Body!.WorkosOrgId!, slug, orgName, status.Body.Url ?? origin));
@@ -252,7 +254,7 @@ public sealed class WizardTenantProvisioner(
         // Notice, not Error: the workspace is being created, nothing has gone wrong. The reason on the
         // result is what lets the step headline it as pending rather than failed.
         progress.Notice($"Still provisioning — finish later by joining '{slug}' from the Connect step.");
-        SetupFunnel.WorkspaceFailed("poll_timeout");
+        telemetry.Funnel.WorkspaceFailed("poll_timeout");
 
         return ProvisionOffer.InProgress(slug);
     }
@@ -261,14 +263,14 @@ public sealed class WizardTenantProvisioner(
     // or the step renders a bare failure for something the user chose.
     ProvisionOffer Declined() {
         progress.Notice("No workspace created.");
-        SetupFunnel.WorkspaceDeclined();
+        telemetry.Funnel.WorkspaceDeclined();
 
         return ProvisionOffer.Declined;
     }
 
     ProvisionOffer Failed(string message, string reason) {
         progress.Error(message);
-        SetupFunnel.WorkspaceFailed(reason);
+        telemetry.Funnel.WorkspaceFailed(reason);
 
         return ProvisionOffer.Failed;
     }
@@ -292,14 +294,17 @@ public sealed class WizardTenantProvisioner(
 /// not representable.
 /// </summary>
 public sealed class WizardBridges {
-    public WizardBridges(Action<Action> post, Func<IAuthProgress, WizardTenantProvisioner> provisioner) {
+    public WizardBridges(
+            Action<Action> post, CliTelemetry telemetry, Func<IAuthProgress, WizardTenantProvisioner> provisioner) {
         Post        = post;
+        Telemetry   = telemetry;
         Progress    = new UiAuthProgress(post);
         Picker      = new WizardTenantPicker(Progress);
         Provisioner = provisioner(Progress);
     }
 
     public Action<Action>          Post        { get; }
+    public CliTelemetry            Telemetry   { get; }
     public UiAuthProgress          Progress    { get; }
     public WizardTenantPicker      Picker      { get; }
     public WizardTenantProvisioner Provisioner { get; }

--- a/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
+++ b/src/Capacitor.App/Services/Onboarding/WizardComposition.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Telemetry;
 using Capacitor.App.Services.Mutation;
 using Capacitor.App.ViewModels.Onboarding;
 using Capacitor.Cli.Core.Auth;
@@ -21,6 +22,7 @@ internal sealed record WizardFacadeSpec(
     IAuthProgress                                              Progress,
     ITenantPicker                                              Picker,
     ITenantProvisioner?                                        Provisioner,
+    CliTelemetry                                               Telemetry,
     Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task> BeforeCommit);
 
 /// What wizard-first mode runs on: the shell, the sign-in driver the close path awaits, every step
@@ -74,16 +76,17 @@ internal static class WizardComposition {
 
     /// Production bridges: one marshalling boundary (Avalonia's dispatcher in the app) and a
     /// provisioner built from the bridges' OWN sink, per WizardBridges' contract.
-    internal static WizardBridges BuildBridges(Action<Action> post, TenantProvisioningClient provisioning) =>
-        new(post, progress => new WizardTenantProvisioner(
-            provisioning, ProvisioningEndpoint.Url, progress));
+    internal static WizardBridges BuildBridges(
+            Action<Action> post, TenantProvisioningClient provisioning, CliTelemetry telemetry) =>
+        new(post, telemetry, progress => new WizardTenantProvisioner(
+            provisioning, ProvisioningEndpoint.Url, progress, telemetry));
 
     /// Production operation: the spec IS the façade's arguments, and WizardSignInOperation owns
     /// the intent→call map (paste adopts the server; create/discover run WorkOS discovery).
     internal static Func<ConnectIntent, CancellationToken, Task<AuthResult>> NewOperation(WizardFacadeSpec spec) =>
         WizardSignInOperation.For(new OnboardingFacade(
             spec.Root, spec.TokenStore, spec.HttpFactory, spec.Proxy, spec.GitHub, spec.WorkOS, spec.Progress,
-            SystemBrowser.Instance, spec.Picker, spec.Provisioner, spec.BeforeCommit), spec.Profile);
+            SystemBrowser.Instance, spec.Picker, spec.Provisioner, spec.Telemetry, spec.BeforeCommit), spec.Profile);
 
     /// The ONE façade a wizard run signs in through — provisioner armed (a provisioner-less façade
     /// dead-ends "Create a workspace" at "ask your admin") and the decision-7 arming hook wired as
@@ -95,7 +98,7 @@ internal static class WizardComposition {
             Func<WizardFacadeSpec, Func<ConnectIntent, CancellationToken, Task<AuthResult>>> operation) =>
         operation(new WizardFacadeSpec(
             root, tokenStore, httpFactory, proxy, github, workos, profile, bridges.Progress, bridges.Picker,
-            bridges.Provisioner, WizardAuthService.ArmingHook(claims)));
+            bridges.Provisioner, bridges.Telemetry, WizardAuthService.ArmingHook(claims)));
 
     internal static WizardGraph BuildGraph(WizardGraphOptions options) {
         var claims = options.Claims;

--- a/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
+++ b/src/Capacitor.Cli.Core/Auth/OAuthLoginFlow.cs
@@ -291,6 +291,7 @@ public static class OAuthLoginFlow {
     /// </summary>
     public static async Task<string?> RunGitHubBrowserFlowAsync(
             GitHubOAuthClient github, string clientId, string codeExchangeUrl, IBrowserLauncher launcher,
+            ILoopbackJoin join,
             IBrowser? browser = null, TimeSpan? timeout = null,
             CancellationToken ct = default, IAuthProgress? progress = null) {
         progress ??= ConsoleAuthProgress.Instance;
@@ -301,7 +302,7 @@ public static class OAuthLoginFlow {
         // injected one would tear down a test's stand-in, or a future caller's shared instance.
         // `using` on a nullable disposes only when non-null, which is exactly the distinction.
         using LoopbackBrowser? created =
-            browser is null ? new LoopbackBrowser(launcher, progress, join: SetupJoin.Loopback) : null;
+            browser is null ? new LoopbackBrowser(launcher, progress, join: join) : null;
         browser ??= created!; // non-null exactly when browser was null, which is when we built it
 
         var redirectUri = $"http://127.0.0.1:{GetAvailablePort()}/callback";
@@ -502,7 +503,7 @@ public static class OAuthLoginFlow {
 
     internal static async Task<string?> AcquireGitHubTokenAsync(
             GitHubOAuthClient github, string clientId, string? codeExchangeUrl, bool forceDevice,
-            IBrowserLauncher launcher,
+            IBrowserLauncher launcher, ILoopbackJoin join,
             CancellationToken ct = default, IAuthProgress? progress = null) {
         progress ??= ConsoleAuthProgress.Instance;
 
@@ -512,7 +513,7 @@ public static class OAuthLoginFlow {
         if (choice == GitHubFlow.Browser) {
             try {
                 var token = await RunGitHubBrowserFlowAsync(
-                    github, clientId, codeExchangeUrl!, launcher, ct: ct, progress: progress);
+                    github, clientId, codeExchangeUrl!, launcher, join, ct: ct, progress: progress);
 
                 return token ??
                     // Browser flow ran but user cancelled / state mismatch — don't silently fall back.
@@ -680,11 +681,11 @@ public static class OAuthLoginFlow {
     /// device grant reachable by pressing <c>d</c> at any point and taken automatically when loopback
     /// cannot bind. A loopback attempt that RAN and failed returns <c>null</c> rather than falling
     /// through — a cancel or a state mismatch is an answer, and silently re-asking through another
-    /// channel would ignore it. Mirrors <see cref="AcquireGitHubTokenAsync(GitHubOAuthClient,string,string?,bool,IBrowserLauncher,CancellationToken,IAuthProgress?)"/>.
+    /// channel would ignore it. Mirrors <see cref="AcquireGitHubTokenAsync(GitHubOAuthClient,string,string?,bool,IBrowserLauncher,Telemetry.ILoopbackJoin,CancellationToken,IAuthProgress?)"/>.
     /// </summary>
     internal static async Task<WorkOSAuthResponse?> AcquireWorkOSAsync(
             WorkOSClient workos, string clientId, string? organizationId, bool forceDevice,
-            IBrowserLauncher launcher,
+            IBrowserLauncher launcher, ILoopbackJoin join,
             IBrowser? browser = null, string apiBase = WorkOSApiBase, CancellationToken ct = default,
             IAuthProgress? progress = null, IKeyWatcher? keys = null, TimeProvider? time = null) {
         progress ??= ConsoleAuthProgress.Instance;
@@ -709,7 +710,7 @@ public static class OAuthLoginFlow {
         // round trip merged in under a second) but genuinely tighter, not equivalent.
         using LoopbackBrowser? created = browser is null
             ? new LoopbackBrowser(
-                launcher, progress, keys.CanWatch ? WorkOSBrowserHint() : null, SetupJoin.Loopback)
+                launcher, progress, keys.CanWatch ? WorkOSBrowserHint() : null, join)
             : null;
 
         var login = AuthenticateWorkOSAsync(
@@ -793,12 +794,12 @@ public static class OAuthLoginFlow {
     /// </summary>
     internal static async Task<(StoredTokens Tokens, string Username)?> WorkOSTokensForServerAsync(
             WorkOSClient workos, string serverUrl, string clientId, string? organizationId, bool forceDevice,
-            IBrowserLauncher launcher,
+            IBrowserLauncher launcher, ILoopbackJoin join,
             IBrowser? browser, CancellationToken ct, IAuthProgress progress, string apiBase = WorkOSApiBase,
             IKeyWatcher? keys = null, TimeProvider? time = null) {
         // AcquireWorkOSAsync already reported the specific failure reason.
         var json = await AcquireWorkOSAsync(
-            workos, clientId, organizationId, forceDevice, launcher, browser, apiBase, ct, progress, keys, time);
+            workos, clientId, organizationId, forceDevice, launcher, join, browser, apiBase, ct, progress, keys, time);
         if (json is null) return null;
 
         // Org gate: a multi-org user must not be "logged in" to the wrong org — every API call would

--- a/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
+++ b/src/Capacitor.Cli.Core/Auth/OnboardingFacade.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Telemetry;
 using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Http;
 using Duende.IdentityModel.OidcClient.Browser;
@@ -148,6 +149,7 @@ public sealed class OnboardingFacade(
         IBrowserLauncher                                            launcher,
         ITenantPicker                                               picker,
         ITenantProvisioner?                                         provisioner,
+        CliTelemetry                                                telemetry,
         Func<IReadOnlyList<AuthIdentity>, CancellationToken, Task>? beforeCommit) {
     /// <summary>Test seam for the one WorkOS effect with no HTTP surface (loopback browser + OidcClient).</summary>
     internal Func<CancellationToken, Task<WorkOSAuthResponse?>>? WorkOSOrglessLogin { get; init; }
@@ -227,7 +229,8 @@ public sealed class OnboardingFacade(
     async Task<AuthResult> LoginGitHubAsync(
             HttpClient http, AuthDiscoveryResponse config, bool forceDevice, LoginTarget target, CancellationToken ct) {
         var accessToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
-            github, config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice, launcher, ct, progress);
+            github, config.GithubClientId!, config.GithubCodeExchangeUrl, forceDevice, launcher,
+            telemetry.Join, ct, progress);
 
         if (accessToken is null) return Stop("GitHub sign-in did not complete.", ct, AuthFailureReason.SigninDenied);
 
@@ -241,12 +244,11 @@ public sealed class OnboardingFacade(
 
     async Task<AuthResult> LoginWorkOSAsync(
             AuthDiscoveryResponse config, bool forceDevice, LoginTarget target, CancellationToken ct) {
-        // No local browser any more: construction moved into OAuthLoginFlow.AcquireWorkOSAsync, which
-        // is where the join collaborator is attached and where the instance is owned. One site instead
-        // of three — see the ownership guard, which enumerates them.
+        // The loopback browser is owned by OAuthLoginFlow.AcquireWorkOSAsync, which is where the join
+        // collaborator is attached — see the ownership guard, which enumerates every site.
         var authenticated = await OAuthLoginFlow.WorkOSTokensForServerAsync(
             workos, target.ServerUrl, config.ClientId!, config.OrganizationId, forceDevice, launcher,
-            WorkOSBrowser, ct, progress,
+            telemetry.Join, WorkOSBrowser, ct, progress,
             WorkOSApiBaseOverride ?? OAuthLoginFlow.WorkOSApiBase, KeyWatcher);
 
         if (authenticated is null) return Stop("WorkOS sign-in did not complete.", ct, AuthFailureReason.SigninDenied);
@@ -294,12 +296,13 @@ public sealed class OnboardingFacade(
         var clientId = proxyConfig.WorkOSClientId ?? "";
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
-            AuthProxyEndpoint.Url, proxyConfig, proxy, picker,
+            AuthProxyEndpoint.Url, proxyConfig, proxy, picker, telemetry.Funnel,
             orglessLogin: () => WorkOSOrglessLogin is not null
                 ? WorkOSOrglessLogin(ct)
                 // Org-less: the sign-in picks the organization, and discovery reconciles it afterwards.
                 : OAuthLoginFlow.AcquireWorkOSAsync(
-                    workos, clientId, organizationId: null, forceDevice, launcher, browser: null,
+                    workos, clientId, organizationId: null, forceDevice, launcher, telemetry.Join,
+                    browser: null,
                     apiBase: WorkOSApiBaseOverride ?? OAuthLoginFlow.WorkOSApiBase,
                     ct: ct, progress: progress, keys: KeyWatcher),
             orgSwitch: (refreshToken, organizationId) =>
@@ -333,7 +336,7 @@ public sealed class OnboardingFacade(
 
         var accessToken = await OAuthLoginFlow.AcquireGitHubTokenAsync(
             github, proxyConfig.GitHubClientId, proxyConfig.GitHubCodeExchangeUrl, forceDevice, launcher,
-            ct, progress);
+            telemetry.Join, ct, progress);
 
         if (accessToken is null) return Stop("GitHub sign-in did not complete.", ct, AuthFailureReason.SigninDenied);
 

--- a/src/Capacitor.Cli.Core/Auth/TenantProvisioningClient.cs
+++ b/src/Capacitor.Cli.Core/Auth/TenantProvisioningClient.cs
@@ -1,7 +1,6 @@
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
-using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Core.Auth;
 
@@ -36,13 +35,15 @@ public sealed class TenantProvisioningClient(HttpClient http) {
         }
     }
 
+    /// <param name="joinId">
+    /// The run's correlation key, or null when telemetry is off. A request field rather than a
+    /// dependency of this client: every host that stands up foreign HTTP registers this client, and
+    /// only the two that provision a workspace have a telemetry facade to take one from.
+    /// </param>
     public async Task<ProvisionOutcome> ProvisionAsync(
-            string baseUrl, string token, string orgName, string slug, CancellationToken ct) {
+            string baseUrl, string token, string orgName, string slug, string? joinId, CancellationToken ct) {
         var payload = JsonSerializer.Serialize(
-            // Read off the process-wide static rather than threaded down through the provisioner:
-            // it is per-run state, the same shape CliTelemetry already has everywhere, and null by
-            // construction whenever telemetry is off.
-            new ProvisionRequest { OrgName = orgName, Slug = slug, Tier = "free", JoinId = SetupJoin.Current },
+            new ProvisionRequest { OrgName = orgName, Slug = slug, Tier = "free", JoinId = joinId },
             CapacitorJsonContext.Default.ProvisionRequest);
 
         try {

--- a/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
+++ b/src/Capacitor.Cli.Core/Auth/WorkOSDiscovery.cs
@@ -41,6 +41,7 @@ public static class WorkOSDiscovery {
             ProxyConfigResponse                             proxyConfig,
             IAuthProxyClient                                proxy,
             ITenantPicker                                   picker,
+            SetupFunnel                                     funnel,
             Func<Task<WorkOSAuthResponse?>>                 orglessLogin,
             Func<string, string, Task<WorkOSAuthResponse?>> orgSwitch,     // args: refreshToken, organizationId
             Func<string, CancellationToken, Task<WorkOSAuthResponse?>>? orglessRefresh = null, // args: refreshToken, ct
@@ -62,12 +63,12 @@ public static class WorkOSDiscovery {
             // tenant_none/workspace_provisioned and make signin_failed fire for declined offers,
             // provisioning failures, and the deliberately-non-zero retarget path — none of which
             // are a sign-in failure.
-            SetupFunnel.SigninFailed("workos_signin_failed");
+            funnel.SigninFailed("workos_signin_failed");
 
             return Failed(progress, "WorkOS sign-in failed.", ct);
         }
 
-        SetupFunnel.SigninCompleted(AuthProvider.WorkOS);
+        funnel.SigninCompleted(AuthProvider.WorkOS);
 
         var result = await proxy.DiscoverWorkOSTenantsAsync(proxyUrl, auth.AccessToken, ct);
         if (result.Error != DiscoveryError.None) {
@@ -80,7 +81,7 @@ public static class WorkOSDiscovery {
         }
 
         if (result.Tenants.Length == 0) {
-            return await OfferCreateAsync(proxyConfig, auth, orgSwitch, orglessRefresh, provisioner, ct, progress);
+            return await OfferCreateAsync(proxyConfig, auth, orgSwitch, orglessRefresh, provisioner, funnel, ct, progress);
         }
 
         var picked = result.Tenants.Length == 1
@@ -105,12 +106,13 @@ public static class WorkOSDiscovery {
             Func<string, string, Task<WorkOSAuthResponse?>>             orgSwitch,
             Func<string, CancellationToken, Task<WorkOSAuthResponse?>>? orglessRefresh,
             ITenantProvisioner?                                         provisioner,
+            SetupFunnel                                                 funnel,
             CancellationToken                                           ct,
             IAuthProgress                                               progress) {
         // Fires before the provisioner-null check below: a headless run (null provisioner,
         // "ask your admin" dead-end) still reached the fork and must count as such — this is
         // the denominator for "reached signup".
-        SetupFunnel.TenantNone(AuthProvider.WorkOS);
+        funnel.TenantNone(AuthProvider.WorkOS);
 
         if (provisioner is null) {
             progress.Error("No Capacitor tenants are linked to your account. Ask your admin to invite you.");

--- a/src/Capacitor.Cli.Core/Telemetry/CliTelemetry.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/CliTelemetry.cs
@@ -8,137 +8,132 @@ namespace Capacitor.Cli.Core.Telemetry;
 /// The only telemetry surface call sites touch. Every method swallows every exception:
 /// an exception escaping to the NativeAOT runtime aborts the process (see Program.cs), so a
 /// telemetry bug must never become a crash-on-every-command regression.
+///
+/// <para>One facade per process entry, constructed by <see cref="Start(TelemetryStartup, ConfigRoot)"/> and injected. A process
+/// that starts a second one — an MCP server re-deriving its startup under the reportable
+/// <c>mcp-server</c> pseudo-command — passes the same <see cref="TelemetryStartup"/> forward, so
+/// suppression and the resolved server travel as values rather than as state the first facade left
+/// behind.</para>
 /// </summary>
-public static class CliTelemetry {
+public sealed class CliTelemetry {
     const string Endpoint = "https://phog.kurrent.io";
     const string Token    = "phc_DeHBgHGersY4LmDlADnPrsCPOAmMO7QFOH8f4DVEVmD";
 
     static readonly TimeSpan FlushBudget = TimeSpan.FromSeconds(1.5);
 
-    static TelemetryClient? _client;
-    static string?          _deviceId;
-    static string?          _orgGroup;
-    static JsonObject       _shared = new();
-    static bool             _debug;
-    static bool             _suppressedSticky; // Once set true, remains true for process lifetime
-
-    /// <summary>Test seam: when set, events are collected here instead of being queued.</summary>
-    public static List<TelemetryEvent>? TestSink { get; set; }
-
-    public static bool Enabled { get; private set; }
+    readonly ITelemetrySink _sink;
+    readonly string         _command;
+    readonly string?        _deviceId;
+    readonly string?        _orgGroup;
+    readonly bool           _debug;
 
     /// <summary>
-    /// Restores every static below to its pristine, never-initialized state. Every test that
-    /// touches these statics (assigns <see cref="TestSink"/>, calls <see cref="Initialize"/>,
-    /// or drives a code path that reaches <see cref="DiscardAndDisable"/>) must call this FIRST —
-    /// before assigning <see cref="TestSink"/> — because a prior test in the same process can
-    /// leave <see cref="Enabled"/> false: <see cref="DiscardAndDisable"/> is real production
-    /// behaviour (it runs whenever telemetry is persisted to "off"), not a test artifact, so its
-    /// effects are exactly the kind of thing a later test must not silently inherit.
+    /// Guards <see cref="_shared"/>, which is written after construction as well as during it: the
+    /// loopback browser's background wait merges the returned web identity whenever the browser
+    /// comes back, and that moment coincides with the foreground funnel by design, since sign-in
+    /// reports completion immediately after the browser call returns.
+    /// <para>Unsynchronised, an insert during a capture's read faults the read, the exception is
+    /// swallowed on the way out (telemetry must never throw), and the event silently never
+    /// appears. Reproduced, and it takes the event the feature exists to measure.</para>
     /// </summary>
-    public static void Reset() {
-        _client = null; _deviceId = null; _orgGroup = null;
-        lock (_sharedGate) _shared = new JsonObject();
-        Enabled = false; TestSink = null; _suppressedSticky = false;
+    readonly object _sharedGate = new();
+
+    readonly JsonObject _shared;
+
+    CliTelemetry(
+            ITelemetrySink sink, string command, bool enabled,
+            string? deviceId, string? orgGroup, bool debug, JsonObject shared) {
+        _sink     = sink;
+        _command  = command;
+        _deviceId = deviceId;
+        _orgGroup = orgGroup;
+        _debug    = debug;
+        _shared   = shared;
+        Enabled   = enabled;
+        Join      = new SetupJoin(this);
+        Funnel    = new SetupFunnel(this);
     }
 
-    /// <summary>
-    /// The app-spawned-child marker (spec decision 9): consumed for telemetry suppression and
-    /// REMOVED from the process environment before command dispatch, so nothing this process
-    /// spawns (a detached daemon, hosted children) can observe it. Never touches the user's own
-    /// KCAP_TELEMETRY choice.
-    /// </summary>
-    public const string SpawnNoTelemetryVar = "KCAP_APP_SPAWN_NO_TELEMETRY";
+    public bool Enabled { get; private set; }
+
+    /// <summary>The correlation key for this run, minted for the interactive auth commands.</summary>
+    public SetupJoin Join { get; }
+
+    /// <summary>The signup funnel's event vocabulary, for the setup and login lanes.</summary>
+    public SetupFunnel Funnel { get; }
+
+    /// <summary>A facade that is off: nothing resolved, nothing minted, nothing captured.</summary>
+    public static CliTelemetry Disabled() =>
+        new(new NullTelemetrySink(), command: "", enabled: false,
+            deviceId: null, orgGroup: null, debug: false, new JsonObject());
 
     /// <summary>
-    /// Consumes the spawn marker from the environment and marks suppression as sticky for this
-    /// process. Sets <see cref="_suppressedSticky"/> so every future Initialize call in this
-    /// process honors suppression regardless of its `suppressed` parameter.
+    /// Resolves the opt-out decision, mints the device id and builds the shared property bag,
+    /// returning a facade that is either live or <see cref="Disabled"/>.
+    ///
+    /// <para>Reaches no console and captures nothing: the one-time privacy notice and
+    /// <c>cli_first_run</c> belong to <see cref="Announce"/>, which the caller invokes once the
+    /// shared bag is complete. Keeping them apart is what lets a container resolve this without
+    /// printing a disclosure or consuming a once-per-device marker.</para>
     /// </summary>
-    public static bool ConsumeSpawnMarker(Func<string, string?> get, Action<string> clear) {
-        if (string.IsNullOrEmpty(get(SpawnNoTelemetryVar))) return false;
-        clear(SpawnNoTelemetryVar);
-        _suppressedSticky = true;
-        return true;
-    }
+    public static CliTelemetry Start(TelemetryStartup startup, ConfigRoot config) =>
+        Start(startup, config,
+            () => new TelemetryClient(new HttpClientHandler(), Spool(config), Token, Endpoint));
 
-    public static void Initialize(string command, string? serverUrl, bool loggedIn, ConfigRoot config, bool suppressed = false) {
+    /// <param name="sink">
+    /// Invoked only when the facade comes up live, so a run that is opted out builds no HTTP
+    /// handler and touches no spool. Internal because the endpoint a run ships to is this class's
+    /// to decide, not a caller's; the test assemblies reach it through their grant.
+    /// </param>
+    internal static CliTelemetry Start(TelemetryStartup startup, ConfigRoot config, Func<ITelemetrySink> sink) {
         try {
-            if (suppressed) {
-                _suppressedSticky = true;
-            }
-            if (_suppressedSticky) return; // app-spawned child: no notice, no device id, no events, _client stays null
-            Enabled = TelemetrySettings.Resolve(TelemetryState.PersistedEnabled(config)).Enabled
-                   && CommandEvents.IsReportable(command);
-            if (!Enabled) return;
+            // An app-spawned child: no notice, no device id, no events.
+            if (startup.Suppressed) return Disabled();
 
-            _debug = Environment.GetEnvironmentVariable("KCAP_TELEMETRY_DEBUG") == "1";
+            var enabled = TelemetrySettings.Resolve(TelemetryState.PersistedEnabled(config)).Enabled
+                       && CommandEvents.IsReportable(startup.Command);
+            if (!enabled) return Disabled();
+
+            var version = Version();
 
             // A device id that can't be persisted still gets an in-memory-only id for this
             // process, rather than disabling telemetry outright: silently going dark on a disk
             // hiccup costs more in data quality than a marginally inflated unique-device count in
             // this rare fallback case.
-            _deviceId = TelemetryDeviceId.GetOrCreate(config) ?? Guid.NewGuid().ToString("N");
+            var telemetry = new CliTelemetry(
+                sink(),
+                startup.Command,
+                enabled: true,
+                TelemetryDeviceId.GetOrCreate(config) ?? Guid.NewGuid().ToString("N"),
+                PostHogPayload.OrgGroup(startup.ServerUrl),
+                startup.Debug,
+                new JsonObject {
+                    ["source"]        = "cli",
+                    ["cli_version"]   = version,
+                    ["build_channel"] = TelemetryEnvironment.BuildChannel(version),
+                    ["os"]            = OS(),
+                    ["arch"]          = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
+                    ["is_ci"]         = TelemetryEnvironment.IsCi(),
+                    ["is_headless"]   = Auth.HeadlessEnvironment.IsHeadless(),
+                    ["has_server"]    = startup.ServerUrl is not null,
+                });
 
-            var version = Version();
+            // Minted here rather than in Announce so the key is in the shared bag before ANY event
+            // can be captured — cli_first_run included, which is once per device and unrepairable by
+            // a later run. Gated to the two interactive auth commands so it never attaches to a
+            // recap or an import, which have no auth run to correlate, and minted ahead of any lane
+            // the command later chooses so every setup/login lane carries it.
+            if (startup.Command is "setup" or "login")
+                telemetry.Join.Mint();
 
-            _orgGroup = PostHogPayload.OrgGroup(serverUrl);
-            var shared = new JsonObject {
-                ["source"]        = "cli",
-                ["cli_version"]   = version,
-                ["build_channel"] = TelemetryEnvironment.BuildChannel(version),
-                ["os"]            = OS(),
-                ["arch"]          = RuntimeInformation.ProcessArchitecture.ToString().ToLowerInvariant(),
-                ["is_ci"]         = TelemetryEnvironment.IsCi(),
-                ["is_headless"]   = Auth.HeadlessEnvironment.IsHeadless(),
-                ["has_server"]    = serverUrl is not null,
-                ["logged_in"]     = loggedIn,
-            };
-            lock (_sharedGate) _shared = shared;
-
-            if (TestSink is null)
-                _client = new TelemetryClient(new HttpClientHandler(), Spool(config), Token, Endpoint);
-
-            // The join key has to be in the shared bag BEFORE cli_first_run fires just below, or that
-            // once-per-device event ships without it and no later run can repair it. Gated to the two
-            // interactive auth commands so it never attaches to a recap or an import — which have no
-            // auth run to correlate — and minted here, ahead of any lane the command later chooses, so
-            // every setup/login lane (loopback, device-code, headless) carries it. No-ops when
-            // telemetry is off, which by this point it is not.
-            if (command is "setup" or "login")
-                SetupJoin.Mint();
-
-            // "mcp-server" is the re-initialise long-lived MCP servers perform on top of the
-            // denylisted "mcp" (see McpTelemetry) — an agent-spawned, non-interactive process
-            // whose stderr no human is watching. kcap-memory/-sessions/-flows/-review
-            // auto-register and spawn on every agent session, so on a fresh machine one of them
-            // is plausibly the very first kcap-family process ever run. Letting the notice fire
-            // there would print the disclosure into a void AND consume the once-per-device
-            // marker, so no human-invoked command would ever show it — silently reproducing the
-            // silent-by-default posture this feature exists to avoid. Skip the notice, the
-            // marker, and the cli_first_run event for this pseudo-command; the first
-            // human-invoked (reportable, non-"mcp-server") command still shows it as designed.
-            if (command != "mcp-server")
-                NoticeAndFirstRun(config);
+            return telemetry;
         } catch {
-            Enabled = false;
+            return Disabled();
         }
     }
 
-    /// <summary>
-    /// Guards <see cref="_shared"/>. It used to be written once during <see cref="Initialize"/>
-    /// and only read afterwards, so no lock was needed. It is now also written from the loopback
-    /// browser's background wait, which merges the returned web identity at whatever moment the
-    /// browser comes back — and that moment coincides with the foreground funnel by design, since
-    /// sign-in reports completion immediately after the browser call returns.
-    /// <para>Unsynchronised, an insert during a capture's read faults the read, the exception is
-    /// swallowed on the way out (telemetry must never throw), and the event silently never
-    /// appears. Reproduced, and it takes the event the feature exists to measure.</para>
-    /// </summary>
-    static readonly object _sharedGate = new();
-
     /// <summary>Queue an event for the exit flush.</summary>
-    public static void Capture(string name, JsonObject properties) {
+    public void Capture(string name, JsonObject properties) {
         try {
             if (!Enabled) return;
 
@@ -150,16 +145,15 @@ public static class CliTelemetry {
 
             if (_debug) Console.Error.WriteLine($"[telemetry] {name} {DebugRender(properties)}");
 
-            if (TestSink is not null) TestSink.Add(e);
-            else                      _client?.Enqueue(e);
+            _sink.Enqueue(e);
         } catch { }
     }
 
     /// <summary>
-    /// Attach a property to every event this process captures from here on. Swallowing like
+    /// Attach a property to every event this facade captures from here on. Swallowing like
     /// everything else in this class.
     /// </summary>
-    public static void AddSharedProperty(string name, JsonNode? value) {
+    public void AddSharedProperty(string name, JsonNode? value) {
         try {
             if (!Enabled) return;
 
@@ -173,7 +167,7 @@ public static class CliTelemetry {
     /// holding one host's id while the other is still missing would read as a real absence rather
     /// than a moment mid-merge.
     /// </summary>
-    public static void AddSharedProperties(JsonObject properties) {
+    public void AddSharedProperties(JsonObject properties) {
         try {
             if (!Enabled) return;
 
@@ -191,12 +185,12 @@ public static class CliTelemetry {
     /// console app with no SynchronizationContext to deadlock against; do not convert to
     /// fire-and-forget.
     /// </summary>
-    public static void CaptureNow(string name, JsonObject properties) {
+    public void CaptureNow(string name, JsonObject properties) {
         Capture(name, properties);
         FlushAndClose().GetAwaiter().GetResult();
     }
 
-    public static void RecordCommand(string command, string[] args, int exitCode, long durationMs) {
+    public void RecordCommand(string command, string[] args, int exitCode, long durationMs) {
         try {
             if (!Enabled || !CommandEvents.IsReportable(command)) return;
 
@@ -227,46 +221,61 @@ public static class CliTelemetry {
         } catch { }
     }
 
-    public static async Task FlushAndClose() {
+    public async Task FlushAndClose() {
         try {
-            if (_client is null || _deviceId is null) return;
-            await _client.FlushAsync(_deviceId, _orgGroup, FlushBudget);
+            if (!Enabled || _deviceId is null) return;
+
+            await _sink.FlushAsync(_deviceId, _orgGroup, FlushBudget);
         } catch { }
     }
 
     /// <summary>
     /// Tears telemetry down in THIS process the instant the persisted flag flips to false.
-    /// Program.cs calls <see cref="Initialize"/> before any command handler runs, so by the time
+    /// Program.cs starts the facade before any command handler runs, so by the time
     /// `kcap config set telemetry off` executes, telemetry has already resolved enabled (no file
     /// on a fresh machine), minted a device id, and possibly queued <c>cli_first_run</c> — the
     /// persisted flag alone would not stop THIS process's own ProcessExit flush from shipping it.
     /// Called from <c>ConfigCommand.TryApplyTelemetry</c> right after
     /// <see cref="TelemetryState.SetEnabled"/> persists the "off" (which already clears the
-    /// on-disk id — this clears the in-memory copy and whatever was queued for it). Re-enabling
-    /// later mints a fresh id via the normal <see cref="Initialize"/> path.
+    /// on-disk id — this drops the queue it was minted for).
     /// </summary>
-    public static void DiscardAndDisable() {
+    public void DiscardAndDisable() {
         try {
-            TestSink?.Clear();
-            _client   = null;
-            _deviceId = null;
-            Enabled   = false;
+            _sink.Discard();
+            Enabled = false;
         } catch { }
     }
 
-    static void NoticeAndFirstRun(ConfigRoot config) {
-        if (TelemetryState.Read(config).NoticeShown) return;
+    /// <summary>
+    /// Shows the one-time privacy notice and queues <c>cli_first_run</c>. Called once the shared bag
+    /// is complete, because <c>cli_first_run</c> is captured here and is once per device — a
+    /// property missing from it is missing for good.
+    ///
+    /// <para>"mcp-server" is the pseudo-command long-lived MCP servers start under, on top of the
+    /// denylisted "mcp" (see <see cref="McpTelemetry"/>) — an agent-spawned, non-interactive process
+    /// whose stderr no human is watching. kcap-memory/-sessions/-flows/-review auto-register and
+    /// spawn on every agent session, so on a fresh machine one of them is plausibly the very first
+    /// kcap-family process ever run. Letting the notice fire there would print the disclosure into a
+    /// void AND consume the once-per-device marker, so no human-invoked command would ever show it —
+    /// silently reproducing the silent-by-default posture this feature exists to avoid. Refused here
+    /// rather than at the call site, so a new server cannot consume it by forgetting.</para>
+    /// </summary>
+    public void Announce(ConfigRoot config) {
+        try {
+            if (!Enabled || _command == "mcp-server") return;
+            if (TelemetryState.Read(config).NoticeShown) return;
 
-        Console.Error.WriteLine(
-            "kcap collects pseudonymous usage data — command and flag names only, never argument values,");
-        Console.Error.WriteLine(
-            "file paths, or transcript content. It can be associated with your workspace and its creator.");
-        Console.Error.WriteLine(
-            "Opt out: kcap config set telemetry off (or DO_NOT_TRACK=1).");
-        Console.Error.WriteLine("https://capacitor.kurrent.io/privacy");
+            Console.Error.WriteLine(
+                "kcap collects pseudonymous usage data — command and flag names only, never argument values,");
+            Console.Error.WriteLine(
+                "file paths, or transcript content. It can be associated with your workspace and its creator.");
+            Console.Error.WriteLine(
+                "Opt out: kcap config set telemetry off (or DO_NOT_TRACK=1).");
+            Console.Error.WriteLine("https://capacitor.kurrent.io/privacy");
 
-        TelemetryState.MarkNoticeShown(config);
-        Capture("cli_first_run", new JsonObject());
+            TelemetryState.MarkNoticeShown(config);
+            Capture("cli_first_run", new JsonObject());
+        } catch { }
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Core/Telemetry/ITelemetrySink.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/ITelemetrySink.cs
@@ -1,0 +1,15 @@
+namespace Capacitor.Cli.Core.Telemetry;
+
+/// <summary>
+/// Where a <see cref="CliTelemetry"/> puts what it captures. Production ships to PostHog via
+/// <see cref="TelemetryClient"/>; a disabled facade drops everything; a test keeps the events.
+/// </summary>
+public interface ITelemetrySink {
+    void Enqueue(TelemetryEvent e);
+
+    /// <summary>Ships what is queued. False means nothing reached the far side.</summary>
+    Task<bool> FlushAsync(string distinctId, string? orgGroup, TimeSpan budget);
+
+    /// <summary>Drops everything queued, unsent, when telemetry is turned off mid-run.</summary>
+    void Discard();
+}

--- a/src/Capacitor.Cli.Core/Telemetry/McpTelemetry.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/McpTelemetry.cs
@@ -9,16 +9,41 @@ namespace Capacitor.Cli.Core.Telemetry;
 ///
 /// Tool arguments are never recorded — they carry repo paths, prompts, and session ids.
 /// </summary>
-public static class McpTelemetry {
+public sealed class McpTelemetry : IAsyncDisposable {
     // MCP servers are long-lived (a session can run for hours), so without a periodic flush
-    // every captured event would sit queued until process exit — and a server killed alongside
-    // its harness (the common way one of these ends) would never report anything at all.
+    // every captured event would sit queued until process exit.
     const int FlushEvery = 20;
 
-    static int _sinceFlush;
+    readonly CliTelemetry _telemetry;
+    readonly EventHandler _shipOnExit;
 
-    public static void ToolCalled(string server, string tool, bool ok, long durationMs) {
-        CliTelemetry.Capture("mcp_tool_called", new JsonObject {
+    int _sinceFlush;
+
+    /// <summary>
+    /// A session ends one of two ways and both have to ship what it queued, because between flush
+    /// intervals everything it captured is held in memory — unsent AND unspooled.
+    ///
+    /// <para>Usually the harness closes stdin, the read loop returns, and disposal ships it. It can
+    /// instead be signalled, and then the read is still parked when the runtime runs its exit
+    /// handlers, so nothing unwinds — hence the handler armed here. The process-exit flush the
+    /// top-level command arms is no help: <c>mcp</c> is denylisted, so that facade is off and has
+    /// nothing to send. Disposal disarms this one, so a session flushes once either way.</para>
+    /// </summary>
+    public McpTelemetry(CliTelemetry telemetry) {
+        _telemetry  = telemetry;
+        _shipOnExit = (_, _) => _telemetry.FlushAndClose().GetAwaiter().GetResult();
+
+        AppDomain.CurrentDomain.ProcessExit += _shipOnExit;
+    }
+
+    public async ValueTask DisposeAsync() {
+        AppDomain.CurrentDomain.ProcessExit -= _shipOnExit;
+
+        await _telemetry.FlushAndClose();
+    }
+
+    public void ToolCalled(string server, string tool, bool ok, long durationMs) {
+        _telemetry.Capture("mcp_tool_called", new JsonObject {
             ["server"]      = server,
             ["tool"]        = tool,
             ["ok"]          = ok,
@@ -26,7 +51,7 @@ public static class McpTelemetry {
         });
 
         if (Interlocked.Increment(ref _sinceFlush) % FlushEvery == 0)
-            _ = CliTelemetry.FlushAndClose();
+            _ = _telemetry.FlushAndClose();
     }
 
     /// <summary>

--- a/src/Capacitor.Cli.Core/Telemetry/NullTelemetrySink.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/NullTelemetrySink.cs
@@ -1,0 +1,11 @@
+namespace Capacitor.Cli.Core.Telemetry;
+
+/// <summary>The sink of a facade that is off: it must not queue, ship, or keep anything.</summary>
+sealed class NullTelemetrySink : ITelemetrySink {
+    public void Enqueue(TelemetryEvent e) { }
+
+    public Task<bool> FlushAsync(string distinctId, string? orgGroup, TimeSpan budget) =>
+        Task.FromResult(true);
+
+    public void Discard() { }
+}

--- a/src/Capacitor.Cli.Core/Telemetry/SetupFunnel.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/SetupFunnel.cs
@@ -27,33 +27,33 @@ namespace Capacitor.Cli.Core.Telemetry;
 /// producer of that name would double-count across two different persons (the CLI user and
 /// whoever the server attributes the event to).
 /// </summary>
-public static class SetupFunnel {
-    public static void Started(bool hasExistingProfile, bool serverUrlProvided, bool noPrompt) =>
+public sealed class SetupFunnel(CliTelemetry telemetry) {
+    public void Started(bool hasExistingProfile, bool serverUrlProvided, bool noPrompt) =>
         Emit("cli_setup_started", new JsonObject {
             ["has_existing_profile"] = hasExistingProfile,
             ["server_url_provided"]  = serverUrlProvided,
             ["no_prompt"]            = noPrompt,
         });
 
-    public static void SigninOpened(string mode, string provider) =>
+    public void SigninOpened(string mode, string provider) =>
         Emit("cli_setup_signin_opened", new JsonObject { ["mode"] = mode, ["provider"] = provider });
 
-    public static void SigninCompleted(string provider) =>
+    public void SigninCompleted(string provider) =>
         Emit("cli_setup_signin_completed", new JsonObject { ["provider"] = provider });
 
-    public static void SigninFailed(string reason) =>
+    public void SigninFailed(string reason) =>
         Emit("cli_setup_signin_failed", new JsonObject { ["reason"] = reason });
 
     /// <summary>
     /// The denominator for "reached signup": the user authenticated but has no tenant. The single
     /// most important event in the feature.
     /// </summary>
-    public static void TenantNone(string provider) =>
+    public void TenantNone(string provider) =>
         Emit("cli_setup_tenant_none", new JsonObject { ["provider"] = provider });
 
-    public static void WorkspaceOffered()   => Emit("cli_setup_workspace_offered", new JsonObject());
-    public static void WorkspaceDeclined()  => Emit("cli_setup_workspace_declined", new JsonObject());
-    public static void WorkspaceRequested() => Emit("cli_setup_workspace_requested", new JsonObject());
+    public void WorkspaceOffered()   => Emit("cli_setup_workspace_offered", new JsonObject());
+    public void WorkspaceDeclined()  => Emit("cli_setup_workspace_declined", new JsonObject());
+    public void WorkspaceRequested() => Emit("cli_setup_workspace_requested", new JsonObject());
 
     /// <summary>
     /// Terminal event for the "I already have a workspace" branch: the user was offered a new
@@ -63,11 +63,11 @@ public static class SetupFunnel {
     /// reach <see cref="Succeeded"/>. Fires before any commitment to THIS offer (no
     /// <see cref="WorkspaceRequested"/> ever follows it), so it stays on the eager path.
     /// </summary>
-    public static void WorkspaceRedirected() => Emit("cli_setup_workspace_redirected", new JsonObject());
+    public void WorkspaceRedirected() => Emit("cli_setup_workspace_redirected", new JsonObject());
 
-    public static void WorkspaceProvisioned() => EmitDeferred("cli_setup_workspace_provisioned", new JsonObject());
+    public void WorkspaceProvisioned() => EmitDeferred("cli_setup_workspace_provisioned", new JsonObject());
 
-    public static void WorkspaceFailed(string reason) =>
+    public void WorkspaceFailed(string reason) =>
         EmitDeferred("cli_setup_workspace_failed", new JsonObject { ["reason"] = reason });
 
     /// <param name="agentsConfigured">
@@ -75,9 +75,9 @@ public static class SetupFunnel {
     /// ones. Keeping vendor identity out of this event avoids a growing set of per-vendor
     /// properties every time a new agent is supported.
     /// </param>
-    public static void Succeeded(int agentsConfigured) =>
+    public void Succeeded(int agentsConfigured) =>
         Emit("cli_setup_succeeded", new JsonObject { ["agents_configured"] = agentsConfigured });
 
-    static void Emit(string name, JsonObject props)         => CliTelemetry.CaptureNow(name, props);
-    static void EmitDeferred(string name, JsonObject props) => CliTelemetry.Capture(name, props);
+    void Emit(string name, JsonObject props)         => telemetry.CaptureNow(name, props);
+    void EmitDeferred(string name, JsonObject props) => telemetry.Capture(name, props);
 }

--- a/src/Capacitor.Cli.Core/Telemetry/SetupJoin.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/SetupJoin.cs
@@ -8,8 +8,8 @@ namespace Capacitor.Cli.Core.Telemetry;
 /// <summary>
 /// The loopback browser's view of the join: build the URL the closing page should navigate to,
 /// and accept whatever comes back afterwards. Kept as an interface so
-/// <see cref="Auth.LoopbackBrowser"/> stays dumb and testable, and so a test can drive it
-/// without touching the process-wide statics in <see cref="SetupJoin"/>.
+/// <see cref="Auth.LoopbackBrowser"/> stays dumb and testable, and so a test can drive it with a
+/// stand-in rather than a real <see cref="SetupJoin"/>.
 /// </summary>
 public interface ILoopbackJoin {
     string? FirstHopUrl(int port);
@@ -45,7 +45,7 @@ public interface ILoopbackJoin {
 /// one check: no key means no redirect and no <c>joinId</c> on any request, off by construction
 /// rather than by four separate guards.</para>
 /// </summary>
-public static class SetupJoin {
+public sealed class SetupJoin(CliTelemetry telemetry) : ILoopbackJoin {
     /// <summary>
     /// The property name the key travels under, shared by everything that has to recognise it.
     /// There are exactly two places the key could otherwise escape the process — the debug
@@ -55,11 +55,11 @@ public static class SetupJoin {
     /// </summary>
     public const string PropertyName = "join_id";
 
-    static string? _current;
-    static int     _consumed;
+    string? _current;
+    int     _consumed;
 
     /// <summary>The key for this run, or null when telemetry is off or nothing minted one.</summary>
-    public static string? Current => _current;
+    public string? Current => _current;
 
     /// <summary>
     /// Mints the key and registers it as a telemetry shared property, so every event captured
@@ -67,14 +67,14 @@ public static class SetupJoin {
     /// the existing key rather than rotating it mid-run. Returns null — and does nothing — when
     /// telemetry is disabled.
     /// </summary>
-    public static string? Mint() {
+    public string? Mint() {
         try {
-            if (!CliTelemetry.Enabled) return null;
+            if (!telemetry.Enabled) return null;
             if (_current is not null) return _current;
 
             // Same shape and minting discipline as MachineId/TelemetryDeviceId.
             _current = Guid.NewGuid().ToString("N");
-            CliTelemetry.AddSharedProperty(PropertyName, _current);
+            telemetry.AddSharedProperty(PropertyName, _current);
 
             return _current;
         } catch {
@@ -89,7 +89,7 @@ public static class SetupJoin {
     /// itself, so accepting one here would make a production web page redirect anywhere a caller
     /// named.</para>
     /// </summary>
-    public static string? FirstHopUrl(int port) {
+    public string? FirstHopUrl(int port) {
         try {
             return _current is null ? null : $"{ProvisioningEndpoint.Url}/api/cli/return?j={_current}&p={port}";
         } catch {
@@ -119,7 +119,7 @@ public static class SetupJoin {
     /// burning it would let any local process kill the bridge by racing a junk request, and
     /// guessing a 128-bit key inside the drain's few seconds is not a real threat.</para>
     /// </summary>
-    public static bool Accept(string query) {
+    public bool Accept(string query) {
         try {
             if (_current is null) return false;
             if (Volatile.Read(ref _consumed) != 0) return false;
@@ -144,7 +144,7 @@ public static class SetupJoin {
             if (Param(query, "w2") is { } wwwId && IsWebId(wwwId))
                 accepted["web_device_id_www"] = wwwId;
 
-            CliTelemetry.AddSharedProperties(accepted);
+            telemetry.AddSharedProperties(accepted);
 
             return true;
         } catch {
@@ -154,7 +154,7 @@ public static class SetupJoin {
 
     // Constant-time, so a local process probing the port cannot recover the key one byte at a
     // time from response timing.
-    static bool KeyMatches(string candidate) {
+    bool KeyMatches(string candidate) {
         var expected = _current;
         if (expected is null || candidate.Length != expected.Length) return false;
 
@@ -186,19 +186,5 @@ public static class SetupJoin {
         }
 
         return null;
-    }
-
-    /// <summary>Test seam: restores the pristine, nothing-minted state.</summary>
-    public static void Reset() {
-        _current  = null;
-        _consumed = 0;
-    }
-
-    /// <summary>The adapter handed to <see cref="Auth.LoopbackBrowser"/>; forwards to the statics.</summary>
-    public static ILoopbackJoin Loopback { get; } = new StaticLoopbackJoin();
-
-    sealed class StaticLoopbackJoin : ILoopbackJoin {
-        public string? FirstHopUrl(int port) => SetupJoin.FirstHopUrl(port);
-        public bool Accept(string query)     => SetupJoin.Accept(query);
     }
 }

--- a/src/Capacitor.Cli.Core/Telemetry/TelemetryClient.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/TelemetryClient.cs
@@ -10,7 +10,7 @@ namespace Capacitor.Cli.Core.Telemetry;
 /// </summary>
 public sealed class TelemetryClient(
         HttpMessageHandler handler, TelemetrySpool spool, string token, string endpoint,
-        TimeProvider? timeProvider = null) {
+        TimeProvider? timeProvider = null) : ITelemetrySink {
     readonly List<TelemetryEvent> _queue = [];
 
     // Test seam only: production always uses the default (real) clock. Lets a test simulate a
@@ -19,6 +19,15 @@ public sealed class TelemetryClient(
 
     public void Enqueue(TelemetryEvent e) {
         lock (_queue) _queue.Add(e);
+    }
+
+    /// <summary>
+    /// Drops the queue without spooling it. Nothing here has been shipped, and the caller is
+    /// turning telemetry off — spilling to disk would park events for a later run to send, which
+    /// is the opposite of what the opt-out asked for.
+    /// </summary>
+    public void Discard() {
+        lock (_queue) _queue.Clear();
     }
 
     /// <summary>Ships queued + previously spooled events. Returns false when nothing reached

--- a/src/Capacitor.Cli.Core/Telemetry/TelemetryDeviceId.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/TelemetryDeviceId.cs
@@ -29,7 +29,7 @@ public static class TelemetryDeviceId {
     /// Returns the stable device id, creating and persisting one on first call. Returns null only
     /// when the id could neither be read, created, nor healed (e.g. the config directory itself is
     /// unwritable) — callers must fall back to an in-memory-only id rather than treat null as a
-    /// reason to disable telemetry (see <c>CliTelemetry.Initialize</c>): a disk hiccup here costs a
+    /// reason to disable telemetry: a disk hiccup here costs a
     /// marginally inflated unique-device count, not an entire session's worth of events.
     /// </summary>
     public static string? GetOrCreate(ConfigRoot config) {

--- a/src/Capacitor.Cli.Core/Telemetry/TelemetryStartup.cs
+++ b/src/Capacitor.Cli.Core/Telemetry/TelemetryStartup.cs
@@ -1,0 +1,30 @@
+namespace Capacitor.Cli.Core.Telemetry;
+
+/// <summary>
+/// What a process knows about telemetry before it builds a facade: which command it is running,
+/// which server decides the organization group, and whether the desktop app spawned it.
+///
+/// <para>Carrying suppression as a value is what lets a second facade in the same process honour
+/// it. <see cref="FromEnvironment"/> REMOVES the marker so nothing this process spawns can observe
+/// it, which also means nothing can re-read it — an MCP server re-deriving its own startup with
+/// <c>this with { Command = "mcp-server" }</c> inherits the decision instead of re-taking it.</para>
+/// </summary>
+public sealed record TelemetryStartup(string Command, string? ServerUrl, bool Suppressed, bool Debug) {
+    /// <summary>
+    /// The app-spawned-child marker: consumed for telemetry suppression and removed from the
+    /// process environment before command dispatch, so nothing this process spawns (a detached
+    /// daemon, hosted children) can observe it. Never touches the user's own KCAP_TELEMETRY choice.
+    /// </summary>
+    public const string SpawnNoTelemetryVar = "KCAP_APP_SPAWN_NO_TELEMETRY";
+
+    public static TelemetryStartup FromEnvironment(string command, string? serverUrl) {
+        var debug = Environment.GetEnvironmentVariable("KCAP_TELEMETRY_DEBUG") == "1";
+
+        if (string.IsNullOrEmpty(Environment.GetEnvironmentVariable(SpawnNoTelemetryVar)))
+            return new TelemetryStartup(command, serverUrl, Suppressed: false, debug);
+
+        Environment.SetEnvironmentVariable(SpawnNoTelemetryVar, null);
+
+        return new TelemetryStartup(command, serverUrl, Suppressed: true, debug);
+    }
+}

--- a/src/Capacitor.Cli/Commands/CommandServices.cs
+++ b/src/Capacitor.Cli/Commands/CommandServices.cs
@@ -5,6 +5,7 @@ using Capacitor.Cli.Core.Config;
 using Capacitor.Cli.Core.Harness;
 using Capacitor.Cli.Core.Http;
 using Capacitor.Cli.Core.Setup;
+using Capacitor.Cli.Core.Telemetry;
 using Microsoft.Extensions.DependencyInjection;
 
 namespace Capacitor.Cli.Commands;
@@ -19,7 +20,7 @@ public static class CommandServices {
     public static IServiceCollection AddCapacitorCli(
             this IServiceCollection services, ConfigRoot config, UserHome home, DaemonStore daemons,
             ProfileContext profiles, ProfileOverrides env, MachineAuth machine, HookClock clock,
-            string? baseUrl) {
+            string? baseUrl, TelemetryStartup telemetryStartup) {
         services
             .AddCapacitorContext(config, home, daemons, profiles)
             .AddCapacitorCommands();
@@ -40,6 +41,24 @@ public static class CommandServices {
 
         services.AddSingleton(_ => new CapacitorServer(baseUrl, config, profiles));
         services.AddCapacitorHttp(env, machine);
+        services.AddCapacitorTelemetry(config, telemetryStartup);
+
+        return services;
+    }
+
+    /// <summary>
+    /// The telemetry facade and the funnel it owns, so a command asks for the narrower one when the
+    /// funnel is all it uses. Both resolve the same facade.
+    ///
+    /// <para>Resolving one has no side effects — no console, no once-per-device marker consumed:
+    /// the privacy notice belongs to <c>CliTelemetry.Announce</c>, which Program.cs calls at the
+    /// point a run should show it.</para>
+    /// </summary>
+    public static IServiceCollection AddCapacitorTelemetry(
+            this IServiceCollection services, ConfigRoot config, TelemetryStartup startup) {
+        services.AddSingleton(startup);
+        services.AddSingleton(_ => CliTelemetry.Start(startup, config));
+        services.AddSingleton(sp => sp.GetRequiredService<CliTelemetry>().Funnel);
 
         return services;
     }

--- a/src/Capacitor.Cli/Commands/ConfigCommand.cs
+++ b/src/Capacitor.Cli/Commands/ConfigCommand.cs
@@ -8,7 +8,7 @@ using Capacitor.Cli.Core.Http;
 
 namespace Capacitor.Cli.Commands;
 
-public sealed class ConfigCommand(ConfigRoot config, ICapacitorHttpClient http) {
+public sealed class ConfigCommand(ConfigRoot config, ICapacitorHttpClient http, CliTelemetry telemetry) {
     public async Task<int> HandleAsync(string[] args) {
         if (args.Length < 2) {
             await Console.Error.WriteLineAsync("Usage: kcap config <show|set|unset> [key] [value]");
@@ -127,12 +127,12 @@ public sealed class ConfigCommand(ConfigRoot config, ICapacitorHttpClient http) 
         TelemetryState.SetEnabled(enabled, config);
 
         // Belt-and-braces, not the primary defence: Program.cs's pre-Initialize check (see
-        // Program.cs, right before CliTelemetry.Initialize) already stops telemetry from ever
+        // Program.cs, right before the facade starts) already stops telemetry from ever
         // activating for a plain `config set telemetry off`, so there is normally nothing left to
         // discard by the time this runs. But KCAP_TELEMETRY=1 legitimately overrides a persisted
         // "off" (finding: env outranks config), so Initialize can still have come up live despite
         // the value being applied here — tear it down in that case too.
-        if (!enabled) CliTelemetry.DiscardAndDisable();
+        if (!enabled) telemetry.DiscardAndDisable();
 
         return true;
     }
@@ -140,7 +140,7 @@ public sealed class ConfigCommand(ConfigRoot config, ICapacitorHttpClient http) 
     /// <summary>
     /// Pure recognizer for the "telemetry" value vocabulary. Shared by <see cref="TryApplyTelemetry"/>
     /// (which throws on an unrecognized value — invalid input is this command's problem to report)
-    /// and Program.cs's pre-<c>CliTelemetry.Initialize</c> short-circuit (which must NOT throw: an
+    /// and Program.cs's pre-start short-circuit (which must NOT throw: an
     /// invalid value there is reported normally once the command actually dispatches). Returns
     /// null for anything unrecognized.
     /// </summary>

--- a/src/Capacitor.Cli/Commands/LoginCommand.cs
+++ b/src/Capacitor.Cli/Commands/LoginCommand.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Telemetry;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
@@ -13,7 +14,7 @@ namespace Capacitor.Cli.Commands;
 public sealed class LoginCommand(
         ConfigRoot config, ProfileContext profiles, TokenStore tokens, IHttpClientFactory httpFactory,
         IAuthProxyClient proxy, GitHubOAuthClient github, WorkOSClient workos, IBrowserLauncher browser,
-        TenantProvisioningClient provisioning) {
+        TenantProvisioningClient provisioning, CliTelemetry telemetry) {
     public Task<int> HandleAsync(string[] args, string? baseUrl) =>
         HandleAsync(args, baseUrl, profiles.Name, NewFacade(), ConsoleAuthProgress.Instance);
 
@@ -81,8 +82,8 @@ public sealed class LoginCommand(
             // The same composite `kcap setup` uses: one operation must not behave differently
             // for being reached by a different command.
             new BrowserTenantPicker(browser, new SpectreTenantPicker(), ConsoleAuthProgress.Instance),
-            new SpectreTenantProvisioner(provisioning, ProvisioningEndpoint.Url),
-            beforeCommit: null) {
+            new SpectreTenantProvisioner(provisioning, ProvisioningEndpoint.Url, telemetry),
+            telemetry, beforeCommit: null) {
             KeyWatcher = ConsoleKeyWatcher.Instance
         };
 }

--- a/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpAnalyticsServer.cs
@@ -18,7 +18,8 @@ namespace Capacitor.Cli.Commands;
 /// the agent fetches the schema document, writes SQL, and self-repairs from the server's
 /// rejection reasons. Structure cloned from McpMemoryServer.
 /// </summary>
-sealed class McpAnalyticsServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http) {
+sealed class McpAnalyticsServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http,
+        TelemetryStartup startup) {
     internal const string NotLoggedInMessage = AuthRejectionNotice.NotLoggedIn;
 
     internal const string NotSupportedMessage =
@@ -39,13 +40,19 @@ sealed class McpAnalyticsServer(ConfigRoot config, ProfileContext profiles, Toke
         var repository = new CwdRepository(config, Directory.GetCurrentDirectory());
         var tools      = BuildToolsList();
 
-        // MCP servers are long-lived and denylisted under the top-level "mcp" command
-        // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
-        // "mcp-server" so per-tool-call events actually leave. Best-effort: a stale token on
-        // disk must never block the server from starting.
+        // Best-effort, and recorded even when the read throws: a stale token on disk must never
+        // block the server from starting, and an absent property is a different value in a funnel
+        // from a false one — "could not tell" belongs with "not logged in", not with a gap.
         var loggedIn = false;
         try { loggedIn = await tokens.LoadForProfileAsync(profiles.Name) is not null; } catch { }
-        CliTelemetry.Initialize("mcp-server", baseUrl, loggedIn, config);
+
+        // MCP servers are long-lived and denylisted under the top-level "mcp" command
+        // (CommandEvents.Denylisted) — a second facade under the reportable pseudo-command
+        // "mcp-server" is what lets per-tool-call events leave at all.
+        var telemetry = CliTelemetry.Start(startup with { Command = "mcp-server" }, config);
+        telemetry.AddSharedProperty("logged_in", loggedIn);
+
+        await using var mcp = new McpTelemetry(telemetry);
 
         var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
 
@@ -79,7 +86,7 @@ sealed class McpAnalyticsServer(ConfigRoot config, ProfileContext profiles, Toke
                 ok = McpTelemetry.ResponseOk(response);
                 return response;
             } finally {
-                McpTelemetry.ToolCalled("kcap-analytics", tool, ok, CommandTiming.ElapsedMs(start));
+                mcp.ToolCalled("kcap-analytics", tool, ok, CommandTiming.ElapsedMs(start));
             }
         }
 

--- a/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowResultServer.cs
@@ -23,7 +23,7 @@ namespace Capacitor.Cli.Commands;
 /// boundary so no flag regression can ever expose start_review_flow to an unattended reviewer.
 /// </summary>
 sealed class McpFlowResultServer(
-        ConfigRoot config, ProfileContext profiles, TokenStore store, ICapacitorHttpClient http) {
+        ConfigRoot config, ProfileContext profiles, TokenStore store, ICapacitorHttpClient http, TelemetryStartup startup) {
     internal const string AgentIdEnvVar = "KCAP_FLOW_AGENT_ID";
 
     /// <summary>Daemon-minted loopback capability a BORROWED reviewer delivers through: its sandbox
@@ -57,13 +57,19 @@ sealed class McpFlowResultServer(
 
         var tools = BuildToolsList();
 
-        // MCP servers are long-lived and denylisted under the top-level "mcp" command
-        // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
-        // "mcp-server" so per-tool-call events actually leave. Best-effort: a stale token on
-        // disk must never block the server from starting.
+        // Best-effort, and recorded even when the read throws: a stale token on disk must never
+        // block the server from starting, and an absent property is a different value in a funnel
+        // from a false one — "could not tell" belongs with "not logged in", not with a gap.
         var loggedIn = false;
         try { loggedIn = await store.LoadForProfileAsync(profiles.Name) is not null; } catch { }
-        CliTelemetry.Initialize("mcp-server", baseUrl, loggedIn, config);
+
+        // MCP servers are long-lived and denylisted under the top-level "mcp" command
+        // (CommandEvents.Denylisted) — a second facade under the reportable pseudo-command
+        // "mcp-server" is what lets per-tool-call events leave at all.
+        var telemetry = CliTelemetry.Start(startup with { Command = "mcp-server" }, config);
+        telemetry.AddSharedProperty("logged_in", loggedIn);
+
+        await using var mcp = new McpTelemetry(telemetry);
 
         // Validate the server_url shape once, locally (pure string check — no network, token,
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
@@ -159,7 +165,7 @@ sealed class McpFlowResultServer(
                 ok = McpTelemetry.ResponseOk(response);
                 return response;
             } finally {
-                McpTelemetry.ToolCalled("kcap-flow-result", tool, ok, CommandTiming.ElapsedMs(start));
+                mcp.ToolCalled("kcap-flow-result", tool, ok, CommandTiming.ElapsedMs(start));
             }
         }
 

--- a/src/Capacitor.Cli/Commands/McpFlowsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpFlowsServer.cs
@@ -15,7 +15,7 @@ using Capacitor.Cli.Core.Telemetry;
 namespace Capacitor.Cli.Commands;
 
 class McpFlowsServer(
-        ConfigRoot config, ProfileContext profiles, TokenStore store, ICapacitorHttpClient http) {
+        ConfigRoot config, ProfileContext profiles, TokenStore store, ICapacitorHttpClient http, TelemetryStartup startup) {
     public async Task<int> RunAsync(string? driverArg = null) {
         var baseUrl = profiles.Resolution.ServerUrl!;
 
@@ -34,13 +34,19 @@ class McpFlowsServer(
 
         var repository = new CwdRepository(config, cwd);
 
-        // MCP servers are long-lived and denylisted under the top-level "mcp" command
-        // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
-        // "mcp-server" so per-tool-call events actually leave. Best-effort: a stale token on
-        // disk must never block the server from starting.
+        // Best-effort, and recorded even when the read throws: a stale token on disk must never
+        // block the server from starting, and an absent property is a different value in a funnel
+        // from a false one — "could not tell" belongs with "not logged in", not with a gap.
         var loggedIn = false;
         try { loggedIn = await store.LoadForProfileAsync(profiles.Name) is not null; } catch { }
-        CliTelemetry.Initialize("mcp-server", baseUrl, loggedIn, config);
+
+        // MCP servers are long-lived and denylisted under the top-level "mcp" command
+        // (CommandEvents.Denylisted) — a second facade under the reportable pseudo-command
+        // "mcp-server" is what lets per-tool-call events leave at all.
+        var telemetry = CliTelemetry.Start(startup with { Command = "mcp-server" }, config);
+        telemetry.AddSharedProperty("logged_in", loggedIn);
+
+        await using var mcp = new McpTelemetry(telemetry);
 
         // Validate the server_url shape once, locally (pure string check — no network, token,
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
@@ -97,7 +103,7 @@ class McpFlowsServer(
                 ok = McpTelemetry.ResponseOk(response);
                 return response;
             } finally {
-                McpTelemetry.ToolCalled("kcap-flows", tool, ok, CommandTiming.ElapsedMs(start));
+                mcp.ToolCalled("kcap-flows", tool, ok, CommandTiming.ElapsedMs(start));
             }
         }
 

--- a/src/Capacitor.Cli/Commands/McpJudgeServer.cs
+++ b/src/Capacitor.Cli/Commands/McpJudgeServer.cs
@@ -13,7 +13,8 @@ using Capacitor.Cli.Core.Http;
 
 namespace Capacitor.Cli.Commands;
 
-sealed class McpJudgeServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http) {
+sealed class McpJudgeServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http,
+        TelemetryStartup startup) {
     /// <summary>
     /// Run as a session-scoped MCP server. All tool calls must use <paramref name="expectedSessionId"/>.
     /// </summary>
@@ -25,13 +26,19 @@ sealed class McpJudgeServer(ConfigRoot config, ProfileContext profiles, TokenSto
         var urlOk = HttpClientExtensions.IsAcceptableUrl(baseUrl);
         HttpClient? client = null;
 
-        // MCP servers are long-lived and denylisted under the top-level "mcp" command
-        // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
-        // "mcp-server" so per-tool-call events actually leave. Best-effort: a stale token on
-        // disk must never block the server from starting.
+        // Best-effort, and recorded even when the read throws: a stale token on disk must never
+        // block the server from starting, and an absent property is a different value in a funnel
+        // from a false one — "could not tell" belongs with "not logged in", not with a gap.
         var loggedIn = false;
         try { loggedIn = await tokens.LoadForProfileAsync(profiles.Name) is not null; } catch { }
-        CliTelemetry.Initialize("mcp-server", baseUrl, loggedIn, config);
+
+        // MCP servers are long-lived and denylisted under the top-level "mcp" command
+        // (CommandEvents.Denylisted) — a second facade under the reportable pseudo-command
+        // "mcp-server" is what lets per-tool-call events leave at all.
+        var telemetry = CliTelemetry.Start(startup with { Command = "mcp-server" }, config);
+        telemetry.AddSharedProperty("logged_in", loggedIn);
+
+        await using var mcp = new McpTelemetry(telemetry);
 
         var tools = BuildToolsList();
 
@@ -99,7 +106,7 @@ sealed class McpJudgeServer(ConfigRoot config, ProfileContext profiles, TokenSto
                 ok = McpTelemetry.ResponseOk(response);
                 return response;
             } finally {
-                McpTelemetry.ToolCalled("kcap-judge", tool, ok, CommandTiming.ElapsedMs(start));
+                mcp.ToolCalled("kcap-judge", tool, ok, CommandTiming.ElapsedMs(start));
             }
         }
     }

--- a/src/Capacitor.Cli/Commands/McpMemoryServer.cs
+++ b/src/Capacitor.Cli/Commands/McpMemoryServer.cs
@@ -13,7 +13,8 @@ using Capacitor.Cli.Core.Http;
 
 namespace Capacitor.Cli.Commands;
 
-sealed class McpMemoryServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http) {
+sealed class McpMemoryServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http,
+        TelemetryStartup startup) {
     internal const string NotLoggedInMessage = AuthRejectionNotice.NotLoggedIn;
 
     public async Task<int> RunAsync() {
@@ -23,13 +24,19 @@ sealed class McpMemoryServer(ConfigRoot config, ProfileContext profiles, TokenSt
         var machineId  = await ResolveMachineIdAsync();
         var tools      = BuildToolsList();
 
-        // MCP servers are long-lived and denylisted under the top-level "mcp" command
-        // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
-        // "mcp-server" so per-tool-call events actually leave. Best-effort: a stale token on
-        // disk must never block the server from starting.
+        // Best-effort, and recorded even when the read throws: a stale token on disk must never
+        // block the server from starting, and an absent property is a different value in a funnel
+        // from a false one — "could not tell" belongs with "not logged in", not with a gap.
         var loggedIn = false;
         try { loggedIn = await tokens.LoadForProfileAsync(profiles.Name) is not null; } catch { }
-        CliTelemetry.Initialize("mcp-server", baseUrl, loggedIn, config);
+
+        // MCP servers are long-lived and denylisted under the top-level "mcp" command
+        // (CommandEvents.Denylisted) — a second facade under the reportable pseudo-command
+        // "mcp-server" is what lets per-tool-call events leave at all.
+        var telemetry = CliTelemetry.Start(startup with { Command = "mcp-server" }, config);
+        telemetry.AddSharedProperty("logged_in", loggedIn);
+
+        await using var mcp = new McpTelemetry(telemetry);
 
         // Validate the server_url shape once, locally (pure string check — no network, token,
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
@@ -75,7 +82,7 @@ sealed class McpMemoryServer(ConfigRoot config, ProfileContext profiles, TokenSt
                 ok = McpTelemetry.ResponseOk(response);
                 return response;
             } finally {
-                McpTelemetry.ToolCalled("kcap-memory", tool, ok, CommandTiming.ElapsedMs(start));
+                mcp.ToolCalled("kcap-memory", tool, ok, CommandTiming.ElapsedMs(start));
             }
         }
 

--- a/src/Capacitor.Cli/Commands/McpReviewServer.cs
+++ b/src/Capacitor.Cli/Commands/McpReviewServer.cs
@@ -15,7 +15,8 @@ using Capacitor.Cli.Core.Http;
 
 namespace Capacitor.Cli.Commands;
 
-sealed class McpReviewServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http) {
+sealed class McpReviewServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http,
+        TelemetryStartup startup) {
     /// <summary>
     /// Run with an explicit session-default PR (used by <c>kcap review &lt;pr&gt;</c>).
     /// Tool calls may still override the default by passing a <c>pr</c> argument.
@@ -38,13 +39,19 @@ sealed class McpReviewServer(ConfigRoot config, ProfileContext profiles, TokenSt
 
         var tools = BuildToolsList();
 
-        // MCP servers are long-lived and denylisted under the top-level "mcp" command
-        // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
-        // "mcp-server" so per-tool-call events actually leave. Best-effort: a stale token on
-        // disk must never block the server from starting.
+        // Best-effort, and recorded even when the read throws: a stale token on disk must never
+        // block the server from starting, and an absent property is a different value in a funnel
+        // from a false one — "could not tell" belongs with "not logged in", not with a gap.
         var loggedIn = false;
         try { loggedIn = await tokens.LoadForProfileAsync(profiles.Name) is not null; } catch { }
-        CliTelemetry.Initialize("mcp-server", baseUrl, loggedIn, config);
+
+        // MCP servers are long-lived and denylisted under the top-level "mcp" command
+        // (CommandEvents.Denylisted) — a second facade under the reportable pseudo-command
+        // "mcp-server" is what lets per-tool-call events leave at all.
+        var telemetry = CliTelemetry.Start(startup with { Command = "mcp-server" }, config);
+        telemetry.AddSharedProperty("logged_in", loggedIn);
+
+        await using var mcp = new McpTelemetry(telemetry);
 
         // Validate the server_url shape once, locally (pure string check — no network, token,
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
@@ -89,7 +96,7 @@ sealed class McpReviewServer(ConfigRoot config, ProfileContext profiles, TokenSt
                 ok = McpTelemetry.ResponseOk(response);
                 return response;
             } finally {
-                McpTelemetry.ToolCalled("kcap-review", tool, ok, CommandTiming.ElapsedMs(start));
+                mcp.ToolCalled("kcap-review", tool, ok, CommandTiming.ElapsedMs(start));
             }
         }
 

--- a/src/Capacitor.Cli/Commands/McpSessionsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpSessionsServer.cs
@@ -13,7 +13,8 @@ using Capacitor.Cli.Core.Http;
 
 namespace Capacitor.Cli.Commands;
 
-sealed class McpSessionsServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http) {
+sealed class McpSessionsServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http,
+        TelemetryStartup startup) {
     internal const string NotLoggedInMessage = AuthRejectionNotice.NotLoggedIn;
 
     public async Task<int> RunAsync() {
@@ -22,13 +23,19 @@ sealed class McpSessionsServer(ConfigRoot config, ProfileContext profiles, Token
         var repository = new CwdRepository(config, Directory.GetCurrentDirectory());
         var tools      = BuildToolsList();
 
-        // MCP servers are long-lived and denylisted under the top-level "mcp" command
-        // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
-        // "mcp-server" so per-tool-call events actually leave. Best-effort: a stale token on
-        // disk must never block the server from starting.
+        // Best-effort, and recorded even when the read throws: a stale token on disk must never
+        // block the server from starting, and an absent property is a different value in a funnel
+        // from a false one — "could not tell" belongs with "not logged in", not with a gap.
         var loggedIn = false;
         try { loggedIn = await tokens.LoadForProfileAsync(profiles.Name) is not null; } catch { }
-        CliTelemetry.Initialize("mcp-server", baseUrl, loggedIn, config);
+
+        // MCP servers are long-lived and denylisted under the top-level "mcp" command
+        // (CommandEvents.Denylisted) — a second facade under the reportable pseudo-command
+        // "mcp-server" is what lets per-tool-call events leave at all.
+        var telemetry = CliTelemetry.Start(startup with { Command = "mcp-server" }, config);
+        telemetry.AddSharedProperty("logged_in", loggedIn);
+
+        await using var mcp = new McpTelemetry(telemetry);
 
         // Validate the server_url shape once, locally (pure string check — no network, token,
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
@@ -74,7 +81,7 @@ sealed class McpSessionsServer(ConfigRoot config, ProfileContext profiles, Token
                 ok = McpTelemetry.ResponseOk(response);
                 return response;
             } finally {
-                McpTelemetry.ToolCalled("kcap-sessions", tool, ok, CommandTiming.ElapsedMs(start));
+                mcp.ToolCalled("kcap-sessions", tool, ok, CommandTiming.ElapsedMs(start));
             }
         }
 

--- a/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
+++ b/src/Capacitor.Cli/Commands/McpWorkItemsServer.cs
@@ -19,7 +19,8 @@ namespace Capacitor.Cli.Commands;
 /// already attached to. Cloned from <see cref="McpMemoryServer"/>'s stdio JSON-RPC loop; unlike
 /// memory this server has no repo/machine context to resolve — the only per-call input is the
 /// session id and the declare selector, both carried in the tool arguments.</summary>
-sealed class McpWorkItemsServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http) {
+sealed class McpWorkItemsServer(ConfigRoot config, ProfileContext profiles, TokenStore tokens, ICapacitorHttpClient http,
+        TelemetryStartup startup) {
     internal const string NotLoggedInMessage = AuthRejectionNotice.NotLoggedIn;
 
     internal const string NoSessionIdMessage =
@@ -30,13 +31,19 @@ sealed class McpWorkItemsServer(ConfigRoot config, ProfileContext profiles, Toke
 
         var tools = BuildToolsList();
 
-        // MCP servers are long-lived and denylisted under the top-level "mcp" command
-        // (CommandEvents.Denylisted) — re-initialise under the reportable pseudo-command
-        // "mcp-server" so per-tool-call events actually leave. Best-effort: a stale token on
-        // disk must never block the server from starting.
+        // Best-effort, and recorded even when the read throws: a stale token on disk must never
+        // block the server from starting, and an absent property is a different value in a funnel
+        // from a false one — "could not tell" belongs with "not logged in", not with a gap.
         var loggedIn = false;
         try { loggedIn = await tokens.LoadForProfileAsync(profiles.Name) is not null; } catch { }
-        CliTelemetry.Initialize("mcp-server", baseUrl, loggedIn, config);
+
+        // MCP servers are long-lived and denylisted under the top-level "mcp" command
+        // (CommandEvents.Denylisted) — a second facade under the reportable pseudo-command
+        // "mcp-server" is what lets per-tool-call events leave at all.
+        var telemetry = CliTelemetry.Start(startup with { Command = "mcp-server" }, config);
+        telemetry.AddSharedProperty("logged_in", loggedIn);
+
+        await using var mcp = new McpTelemetry(telemetry);
 
         // Validate the server_url shape once, locally (pure string check — no network, token,
         // or stderr). Used to fail gracefully instead of hard-exiting mid-request (below).
@@ -78,7 +85,7 @@ sealed class McpWorkItemsServer(ConfigRoot config, ProfileContext profiles, Toke
                 ok = McpTelemetry.ResponseOk(response);
                 return response;
             } finally {
-                McpTelemetry.ToolCalled("kcap-workitems", tool, ok, CommandTiming.ElapsedMs(start));
+                mcp.ToolCalled("kcap-workitems", tool, ok, CommandTiming.ElapsedMs(start));
             }
         }
 

--- a/src/Capacitor.Cli/Commands/SetupCommand.cs
+++ b/src/Capacitor.Cli/Commands/SetupCommand.cs
@@ -418,7 +418,7 @@ public sealed class SetupCommand(
         TokenStore store, IHttpClientFactory httpFactory,
         IAuthProxyClient proxy, WorkOSClient workos, GitHubOAuthClient github, IBrowserLauncher browser,
         UserHome home, HarnessRegistry harnesses, AgentsPaths agents, ICapacitorHttpClient http,
-        TenantProvisioningClient provisioning, AuthProviderDiscovery discovery) {
+        TenantProvisioningClient provisioning, AuthProviderDiscovery discovery, CliTelemetry telemetry) {
     public async Task<int> HandleAsync(string[] args) {
         var serverUrlArg     = GetArg(args, "--server-url");
 
@@ -486,7 +486,7 @@ public sealed class SetupCommand(
 
         var profile = await AppConfig.LoadProfileConfig(config);
 
-        SetupFunnel.Started(
+        telemetry.Funnel.Started(
             hasExistingProfile: AppConfig.HasConfiguredProfile(profile),
             serverUrlProvided:  serverUrlArg is not null,
             noPrompt:           noPrompt);
@@ -1052,7 +1052,7 @@ public sealed class SetupCommand(
             installResult.PiExtensionInstalled, installResult.OpenCodeExtensionInstalled, installResult.AntigravityHooksInstalled,
         }.Count(installed => installed);
 
-        SetupFunnel.Succeeded(agentsConfigured);
+        telemetry.Funnel.Succeeded(agentsConfigured);
 
         return 0;
     }
@@ -1374,7 +1374,7 @@ public sealed class SetupCommand(
             ITenantProvisioner? provisioner, ITenantPicker? picker = null, RequestedWorkspace? requested = null) =>
         FacadeOverride?.Invoke(provisioner)
             ?? new OnboardingFacade(config, store, httpFactory, proxy, github, workos, StepProgress, browser,
-                picker ?? DefaultPicker(browser, () => true), provisioner,
+                picker ?? DefaultPicker(browser, () => true), provisioner, telemetry,
                 WorkspaceGuard(requested)) {
                 KeyWatcher = ConsoleKeyWatcher.Instance
             };
@@ -1786,7 +1786,7 @@ public sealed class SetupCommand(
         var signinMode = chosen == AuthProvider.WorkOS
             ? OAuthLoginFlow.ChooseWorkOSFlow(forceDevice) == WorkOSFlow.Device ? "device" : "browser"
             : forceDevice || headless ? "device" : "browser";
-        SetupFunnel.SigninOpened(signinMode, chosen);
+        telemetry.Funnel.SigninOpened(signinMode, chosen);
 
         // Armed for every WorkOS session, headless included: that path has a device grant now, so
         // a zero-workspace headless user now completes a sign-in and would otherwise hold a live
@@ -1798,7 +1798,7 @@ public sealed class SetupCommand(
 
         var provisioner = chosen == AuthProvider.WorkOS
             ? new SpectreTenantProvisioner(
-                provisioning, ProvisioningEndpoint.Url,
+                provisioning, ProvisioningEndpoint.Url, telemetry,
                 isInteractive: () => canPrompt, requested: requested)
             : null;
 
@@ -1809,18 +1809,18 @@ public sealed class SetupCommand(
         if (chosen == AuthProvider.GitHubApp) {
             switch (result) {
                 case AuthResult.Failed { Reason: AuthFailureReason.SigninDenied }:
-                    SetupFunnel.SigninFailed("github_token_denied");
+                    telemetry.Funnel.SigninFailed("github_token_denied");
 
                     break;
                 // Other and NoTenantsFound only occur once AcquireGitHubTokenAsync already succeeded.
                 case AuthResult.Committed:
                 case AuthResult.Failed { Reason: AuthFailureReason.Other }:
-                    SetupFunnel.SigninCompleted(AuthProvider.GitHubApp);
+                    telemetry.Funnel.SigninCompleted(AuthProvider.GitHubApp);
 
                     break;
                 case AuthResult.Failed { Reason: AuthFailureReason.NoTenantsFound }:
-                    SetupFunnel.SigninCompleted(AuthProvider.GitHubApp);
-                    SetupFunnel.TenantNone(AuthProvider.GitHubApp);
+                    telemetry.Funnel.SigninCompleted(AuthProvider.GitHubApp);
+                    telemetry.Funnel.TenantNone(AuthProvider.GitHubApp);
 
                     break;
             }
@@ -1969,7 +1969,7 @@ public sealed class SetupCommand(
 
             var version = typeof(SetupCommand).Assembly.GetName().Version?.ToString();
             var payload = new StringContent(
-                CliSetupPingBody(version, SetupJoin.Current),
+                CliSetupPingBody(version, telemetry.Join.Current),
                 System.Text.Encoding.UTF8,
                 "application/json");
 

--- a/src/Capacitor.Cli/Commands/SpectreTenantProvisioner.cs
+++ b/src/Capacitor.Cli/Commands/SpectreTenantProvisioner.cs
@@ -18,6 +18,7 @@ namespace Capacitor.Cli.Commands;
 public sealed class SpectreTenantProvisioner(
         TenantProvisioningClient client,
         string                   baseUrl,
+        CliTelemetry             telemetry,
         Func<bool>?              isInteractive = null,
         RequestedWorkspace?      requested = null) : ITenantProvisioner {
     const int PollIntervalMs = 4000;
@@ -54,7 +55,7 @@ public sealed class SpectreTenantProvisioner(
         }
 
         PromptHygiene.DiscardTypeAhead();
-        SetupFunnel.WorkspaceOffered();
+        telemetry.Funnel.WorkspaceOffered();
 
         // Three ways out, not two: discovery finding nothing does NOT mean the user has no
         // workspace, so offering only "create one" sends an existing member off to make a second.
@@ -65,7 +66,7 @@ public sealed class SpectreTenantProvisioner(
 
         if (choice == CancelChoice) {
             AnsiConsole.MarkupLine("  [dim]No tenant created.[/]");
-            SetupFunnel.WorkspaceDeclined();
+            telemetry.Funnel.WorkspaceDeclined();
             return ProvisionOffer.Declined;
         }
 
@@ -76,7 +77,7 @@ public sealed class SpectreTenantProvisioner(
                         ? ValidationResult.Error("Enter a workspace slug (e.g. acme) or a full server URL")
                         : ValidationResult.Success()));
 
-            SetupFunnel.WorkspaceRedirected();
+            telemetry.Funnel.WorkspaceRedirected();
             return ProvisionOffer.ExistingWorkspace(workspace.Trim());
         }
 
@@ -86,7 +87,7 @@ public sealed class SpectreTenantProvisioner(
 
         var slug = await PromptSlugAsync(orgName, tokens, ct);
         if (slug is null) {
-            SetupFunnel.WorkspaceDeclined();
+            telemetry.Funnel.WorkspaceDeclined();
             return ProvisionOffer.Declined;
         }
 
@@ -95,7 +96,7 @@ public sealed class SpectreTenantProvisioner(
             new ConfirmationPrompt($"  Create tenant [cyan]{Markup.Escape(orgName)}[/] at [cyan]{origin}[/]?") { DefaultValue = true });
         if (!confirm) {
             AnsiConsole.MarkupLine("  [dim]No tenant created.[/]");
-            SetupFunnel.WorkspaceDeclined();
+            telemetry.Funnel.WorkspaceDeclined();
             return ProvisionOffer.Declined;
         }
 
@@ -170,7 +171,7 @@ public sealed class SpectreTenantProvisioner(
         if (Scripted) Console.Error.WriteLine($"  ✗ {plain}");
         else          AnsiConsole.MarkupLine($"  [red]✗[/] {markup ?? Markup.Escape(plain)}");
 
-        SetupFunnel.WorkspaceFailed(funnelReason);
+        telemetry.Funnel.WorkspaceFailed(funnelReason);
     }
 
     void Note(string plain, string? markup = null) {
@@ -185,11 +186,12 @@ public sealed class SpectreTenantProvisioner(
 
     async Task<ProvisionOffer> ProvisionAsync(
             string orgName, string slug, string origin, WorkOSTokenSource tokens, CancellationToken ct) {
-        SetupFunnel.WorkspaceRequested();
-        var outcome = await client.ProvisionAsync(baseUrl, await tokens.GetAsync(ct), orgName, slug, ct);
+        telemetry.Funnel.WorkspaceRequested();
+        var outcome = await client.ProvisionAsync(
+            baseUrl, await tokens.GetAsync(ct), orgName, slug, telemetry.Join.Current, ct);
         switch (outcome.StatusCode) {
             case 200 when outcome.Body?.WorkosOrgId is { Length: > 0 } orgId:
-                SetupFunnel.WorkspaceProvisioned();
+                telemetry.Funnel.WorkspaceProvisioned();
                 return ProvisionOffer.Created(new ProvisionedTenant(orgId, slug, orgName, outcome.Body.Url ?? origin));
             case 202 or 200:
                 return await PollAsync(tokens, slug, orgName, origin, ct);
@@ -267,7 +269,7 @@ public sealed class SpectreTenantProvisioner(
 
                 switch (ProvisioningPoll.Classify(status.StatusCode, status.Body?.State, status.Body?.WorkosOrgId)) {
                     case PollVerdict.Active:
-                        SetupFunnel.WorkspaceProvisioned();
+                        telemetry.Funnel.WorkspaceProvisioned();
                         return ProvisionOffer.Created(new ProvisionedTenant(status.Body!.WorkosOrgId!, slug, orgName, status.Body.Url ?? origin));
                     case PollVerdict.ActiveNoOrg:
                         Fail($"{slug}.kcap.ai is live but isn't linked to an organization. Contact support.", "active_no_org");
@@ -292,7 +294,7 @@ public sealed class SpectreTenantProvisioner(
             }
             Retry($"Still provisioning. {waitPlain} once it's ready.",
                   markup: $"Still provisioning. {waitMarkup} once it's ready.");
-            SetupFunnel.WorkspaceFailed("poll_timeout");
+            telemetry.Funnel.WorkspaceFailed("poll_timeout");
             return ProvisionOffer.InProgress(slug);
         }
     }

--- a/src/Capacitor.Cli/Program.cs
+++ b/src/Capacitor.Cli/Program.cs
@@ -100,10 +100,16 @@ var machineEnv = MachineAuth.FromEnvironment();
 var profiles = await AppConfig.ResolveForRepo(args, config, serverEnv, gitTimeoutMs: isHook ? 1000 : 5000);
 var baseUrl  = profiles.Resolution.ServerUrl;
 
+// An app-spawned CLI child must not emit CLI-labeled telemetry nor consume the one-time privacy
+// notice on an invisible stderr. Consume-and-REMOVE before anything can spawn, so no grandchild
+// (detached daemon, hosted agents) observes the marker.
+var telemetryStartup = TelemetryStartup.FromEnvironment(command, baseUrl);
+
 // Composition root. Every context resolved above is registered once here; the dispatch switch below
 // asks for a command rather than handing each one its arguments.
 var services = new ServiceCollection()
-    .AddCapacitorCli(config, home, daemonPaths, profiles, serverEnv, machineEnv, clock, baseUrl);
+    .AddCapacitorCli(
+        config, home, daemonPaths, profiles, serverEnv, machineEnv, clock, baseUrl, telemetryStartup);
 
 await using var sp = services.BuildValidated();
 
@@ -111,7 +117,7 @@ TCommand Run<TCommand>() where TCommand : notnull => sp.GetRequiredService<TComm
 
 ISessionsApi Api() => sp.GetRequiredService<ISessionsApi>();
 
-// Telemetry: initialised once the server URL is known (it decides the `organization` group) and
+// Telemetry: started once the server URL is known (it decides the `organization` group) and
 // torn down from ProcessExit, which observes the exit code returned by top-level Main. Every
 // call swallows, so nothing here can fail a command.
 //
@@ -119,22 +125,10 @@ ISessionsApi Api() => sp.GetRequiredService<ISessionsApi>();
 // ProcessExit handler outlives that block anyway.
 var commandStart = System.Diagnostics.Stopwatch.GetTimestamp();
 
-// TokenStore.LoadAsync() is the LOCAL read (src/Capacitor.Cli.Core/Auth/TokenStore.cs:211) —
-// deliberately not GetValidTokensForProfileAsync(), which can refresh over the network. `logged_in` is a
-// cheap fact about disk, never a reason to make a request on the command path.
-//
-// Gated on IsReportable: denylisted commands (chiefly `hook`, thousands of invocations/day on
-// the agent's critical path) never send `logged_in` — CliTelemetry.Initialize below disables
-// itself for them regardless — so the disk read has no consumer and is worth skipping outright.
-var loggedIn = false;
-if (CommandEvents.IsReportable(command)) {
-    try { loggedIn = await sp.GetRequiredService<TokenStore>().LoadForProfileAsync(profiles.Name) is not null; } catch { }
-}
-
 // `kcap config set telemetry off` must never activate telemetry for the very invocation that
-// opts out: without this, Initialize below resolves Enabled from the not-yet-updated persisted
+// opts out: without this, the facade resolves enabled from the not-yet-updated persisted
 // flag, mints a device id, shows the first-run notice, and queues cli_first_run — all before
-// ConfigCommand ever runs. Pre-apply the "off" to disk here so Initialize sees it already
+// ConfigCommand ever runs. Pre-apply the "off" to disk here so the facade sees it already
 // persisted. Value recognition only (no throw on garbage — an invalid value is reported
 // normally once ConfigCommand actually dispatches); KCAP_TELEMETRY=1 still overrides a persisted
 // "off" exactly as it does everywhere else, since Resolve checks the env var first regardless of
@@ -145,14 +139,21 @@ if (args.Length >= 4 && command == "config" && args[1] == "set" && args[2] == "t
     TelemetryState.SetEnabled(false, config);
 }
 
-// spec decision 9: an app-spawned CLI child must not emit CLI-labeled telemetry nor consume
-// the one-time privacy notice on an invisible stderr. Consume-and-REMOVE before dispatch so
-// no grandchild (detached daemon, hosted agents) can observe the marker.
-var telemetrySuppressed = CliTelemetry.ConsumeSpawnMarker(
-    Environment.GetEnvironmentVariable,
-    k => Environment.SetEnvironmentVariable(k, null));
+var telemetry = sp.GetRequiredService<CliTelemetry>();
 
-CliTelemetry.Initialize(command, baseUrl, loggedIn, config, telemetrySuppressed);
+// TokenStore.LoadForProfileAsync is the LOCAL read — deliberately not the refreshing one, which can
+// go to the network. `logged_in` is a cheap fact about disk, never a reason to make a request on the
+// command path, and it is skipped for denylisted commands (chiefly `hook`, thousands of invocations
+// a day on the agent's critical path) whose facade is off anyway.
+if (telemetry.Enabled) {
+    var loggedIn = false;
+    try { loggedIn = await sp.GetRequiredService<TokenStore>().LoadForProfileAsync(profiles.Name) is not null; } catch { }
+    telemetry.AddSharedProperty("logged_in", loggedIn);
+}
+
+// After the bag is complete and before dispatch: this shows the one-time privacy notice and queues
+// cli_first_run, which is once per device — a property missing from it is missing for good.
+telemetry.Announce(config);
 
 AppDomain.CurrentDomain.ProcessExit += (_, _) => {
     // Environment.Exit runs no `finally` and no `using` disposal, so a leg that ends that way has no
@@ -161,8 +162,8 @@ AppDomain.CurrentDomain.ProcessExit += (_, _) => {
     // once, so a leg that already sent stays silent and a process with none armed is a no-op.
     FirstRunInterruptRelinquish.RunBeforeExit(InteractiveLifetime.ExitNoticeBudget);
 
-    CliTelemetry.RecordCommand(command, args, Environment.ExitCode, CommandTiming.ElapsedMs(commandStart));
-    CliTelemetry.FlushAndClose().GetAwaiter().GetResult();
+    telemetry.RecordCommand(command, args, Environment.ExitCode, CommandTiming.ElapsedMs(commandStart));
+    telemetry.FlushAndClose().GetAwaiter().GetResult();
 };
 
 // Everything from here to the end of command dispatch — including the --help,

--- a/test/Capacitor.App.Tests.Unit/ReauthCompositionTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ReauthCompositionTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Telemetry;
 using System.Reactive.Threading.Tasks;
 using Avalonia.Controls;
 using Avalonia.Threading;
@@ -28,7 +29,7 @@ public class ReauthCompositionTests {
                 config.Root, AuthFixtures.NewTokenStore(config.Root), new PlainHttpClientFactory(),
                 new AuthProxyClient(new HttpClient()), new(new PlainHttpClientFactory()), new(new PlainHttpClientFactory()),
                 "default", ServerUrl,
-                WizardComposition.BuildBridges(action => action(), new(new HttpClient())),
+                WizardComposition.BuildBridges(action => action(), new(new HttpClient()), CliTelemetry.Disabled()),
                 new ConsentFlipClaims(config.Root),
                 new AppStateStore(config.PathTo("app-state.json")),
                 new RecordingOpener(),
@@ -55,7 +56,7 @@ public class ReauthCompositionTests {
                 config.Root, AuthFixtures.NewTokenStore(config.Root), new PlainHttpClientFactory(),
                 new AuthProxyClient(new HttpClient()), new(new PlainHttpClientFactory()), new(new PlainHttpClientFactory()),
                 "default", ServerUrl,
-                WizardComposition.BuildBridges(action => action(), new(new HttpClient())),
+                WizardComposition.BuildBridges(action => action(), new(new HttpClient()), CliTelemetry.Disabled()),
                 new ConsentFlipClaims(config.Root),
                 new AppStateStore(config.PathTo("app-state.json")),
                 new RecordingOpener(),
@@ -87,7 +88,7 @@ public class ReauthCompositionTests {
                 config.Root, AuthFixtures.NewTokenStore(config.Root), new PlainHttpClientFactory(),
                 new AuthProxyClient(new HttpClient()), new(new PlainHttpClientFactory()), new(new PlainHttpClientFactory()),
                 "default", ServerUrl,
-                WizardComposition.BuildBridges(action => action(), new(new HttpClient())),
+                WizardComposition.BuildBridges(action => action(), new(new HttpClient()), CliTelemetry.Disabled()),
                 new ConsentFlipClaims(config.Root),
                 new AppStateStore(config.PathTo("app-state.json")),
                 new RecordingOpener(),

--- a/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SignInStepViewModelTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Telemetry;
 using System.Net;
 using System.Reactive.Threading.Tasks;
 using Avalonia.Controls;
@@ -82,9 +83,10 @@ public class SignInStepViewModelTests {
             Claims = new ConsentFlipClaims(_config.Root);
 
             var bridges = new WizardBridges(
-                action => action(),
+                action => action(), CliTelemetry.Disabled(),
                 progress => new WizardTenantProvisioner(
-                    new TenantProvisioningClient(new HttpClient(Signup)), "https://signup.example", progress, Time));
+                    new TenantProvisioningClient(new HttpClient(Signup)), "https://signup.example", progress,
+                    CliTelemetry.Disabled(), Time));
 
             Picker      = bridges.Picker;
             Progress    = bridges.Progress;

--- a/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardAuthBridgesTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Telemetry;
 using System.Net;
 using System.Text;
 using Capacitor.App.Services.Onboarding;
@@ -49,7 +50,7 @@ public class WizardAuthBridgesTests {
         var time     = new FakeTimeProvider();
         var client   = new TenantProvisioningClient(new HttpClient(handler));
 
-        return (new WizardTenantProvisioner(client, BaseUrl, progress, time), handler, progress, time);
+        return (new WizardTenantProvisioner(client, BaseUrl, progress, CliTelemetry.Disabled(), time), handler, progress, time);
     }
 
     /// The poll's only suspension is Task.Delay(interval, time, ct), whose continuation resumes

--- a/test/Capacitor.App.Tests.Unit/WizardCompositionTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardCompositionTests.cs
@@ -77,7 +77,7 @@ public class WizardCompositionHappyPathTests {
             Proxy       = new AuthProxyClient(new HttpClient(authHandler, disposeHandler: false)),
             Operation = spec => WizardSignInOperation.For(new OnboardingFacade(
                 spec.Root, spec.TokenStore, spec.HttpFactory, spec.Proxy, spec.GitHub, spec.WorkOS, spec.Progress,
-                new RecordingBrowser(), spec.Picker, spec.Provisioner, spec.BeforeCommit), spec.Profile),
+                new RecordingBrowser(), spec.Picker, spec.Provisioner, spec.Telemetry, spec.BeforeCommit), spec.Profile),
         };
 
         var summary = await AvaloniaSession.DispatchAsync(async () => {

--- a/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
+++ b/test/Capacitor.App.Tests.Unit/WizardStartupTests.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Telemetry;
 using System.Net;
 using System.Text;
 using System.Text.Json;
@@ -138,7 +139,7 @@ static class WizardFixtures {
         public GraphHarness(ConfigRoot root) {
             Root    = root;
             Claims  = new ConsentFlipClaims(_config.Root);
-            Bridges = WizardComposition.BuildBridges(action => action(), new(new HttpClient()));
+            Bridges = WizardComposition.BuildBridges(action => action(), new(new HttpClient()), CliTelemetry.Disabled());
             Surface = new WizardLifecycleSurface((prompt, _) => {
                 Prompts.Add(prompt);
                 return Task.FromResult(false);
@@ -797,7 +798,8 @@ public class WizardStartupTests {
     [Test]
     public async Task The_production_bridges_marshal_through_the_avalonia_dispatcher() {
         var (marshalled, hasProvisioner) = await AvaloniaSession.DispatchAsync(async () => {
-            var bridges = WizardComposition.BuildBridges(action => Dispatcher.UIThread.Post(action), new(new HttpClient()));
+            var bridges = WizardComposition.BuildBridges(
+            action => Dispatcher.UIThread.Post(action), new(new HttpClient()), CliTelemetry.Disabled());
             var posted = new TaskCompletionSource<bool>(TaskCreationOptions.RunContinuationsAsynchronously);
 
             // Posted from a background thread, exactly as the façade's flows raise their events.
@@ -1413,7 +1415,7 @@ public class WizardStartupResolutionTests {
 
         using var claimsRoot = new TempConfigRoot();
         var claims = new ConsentFlipClaims(claimsRoot.Root);
-        var bridges = WizardComposition.BuildBridges(action => action(), new(new HttpClient()));
+        var bridges = WizardComposition.BuildBridges(action => action(), new(new HttpClient()), CliTelemetry.Disabled());
         using var handler = new StubAuthHandler();
 
         var operation = WizardComposition.BuildOperation(
@@ -1422,7 +1424,7 @@ public class WizardStartupResolutionTests {
             bridges, claims,
             spec => WizardSignInOperation.For(new OnboardingFacade(
                 spec.Root, spec.TokenStore, spec.HttpFactory, spec.Proxy, spec.GitHub, spec.WorkOS, spec.Progress,
-                new RecordingBrowser(), spec.Picker, spec.Provisioner, spec.BeforeCommit), spec.Profile));
+                new RecordingBrowser(), spec.Picker, spec.Provisioner, spec.Telemetry, spec.BeforeCommit), spec.Profile));
 
         var result = await operation(new ConnectIntent.Paste("https://acme.example"), CancellationToken.None)
             .WaitAsync(TimeSpan.FromSeconds(10));
@@ -1444,7 +1446,7 @@ public class WizardStartupResolutionTests {
     public async Task Create_and_workos_discovery_route_through_the_auth_proxy(string intentName) {
         using var claimsRoot = new TempConfigRoot();
         var claims = new ConsentFlipClaims(claimsRoot.Root);
-        var bridges = WizardComposition.BuildBridges(action => action(), new(new HttpClient()));
+        var bridges = WizardComposition.BuildBridges(action => action(), new(new HttpClient()), CliTelemetry.Disabled());
         using var handler = new StubAuthHandler { Status = HttpStatusCode.ServiceUnavailable };
         ConnectIntent intent = intentName == "create"
             ? new ConnectIntent.Create()
@@ -1459,7 +1461,7 @@ public class WizardStartupResolutionTests {
                 spec = s;
                 return WizardSignInOperation.For(new OnboardingFacade(
                     s.Root, s.TokenStore, s.HttpFactory, s.Proxy, s.GitHub, s.WorkOS, s.Progress,
-                    new RecordingBrowser(), s.Picker, s.Provisioner, s.BeforeCommit), s.Profile);
+                    new RecordingBrowser(), s.Picker, s.Provisioner, s.Telemetry, s.BeforeCommit), s.Profile);
             });
 
         var result = await operation(intent, CancellationToken.None).WaitAsync(TimeSpan.FromSeconds(10));

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/AuthCancellationTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/AuthCancellationTests.cs
@@ -83,7 +83,7 @@ public class AuthCancellationTests {
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             orglessLogin:   () => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = nearExpiry, RefreshToken = "rt" }),
             orgSwitch:      (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
             orglessRefresh: (_, refreshedCt) => { refreshCt = refreshedCt; return Task.FromResult<WorkOSAuthResponse?>(null); },

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/AuthProgressTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/AuthProgressTests.cs
@@ -65,7 +65,7 @@ public class AuthProgressTests {
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             orglessLogin: () => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             orgSwitch: (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
             progress: progress);

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/CommitBoundaryTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/CommitBoundaryTests.cs
@@ -1,7 +1,6 @@
 using Capacitor.Cli.Core.Auth;
 using static Capacitor.Tests.Helpers.AuthFixtures;
 using Capacitor.Cli.Core.Config;
-using Capacitor.Cli.Core.Telemetry;
 using NSubstitute;
 using DiscoveryResult = Capacitor.Cli.Core.Auth.DiscoveryResult;
 
@@ -10,10 +9,8 @@ namespace Capacitor.Cli.Core.Tests.Unit.Auth;
 /// <summary>
 /// The ordered commit boundary itself: the claim hook runs last-cancellable and sees every
 /// identity before anything durable exists, then config + stamp + tokens publish to completion
-/// even under a cancel. Shares the sink key: WorkOS discovery emits into CliTelemetry's
-/// process-global sink.
+/// even under a cancel.
 /// </summary>
-[NotInParallel(nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink))]
 public class CommitBoundaryTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
@@ -207,7 +204,7 @@ public class CommitBoundaryTests {
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(switched));
 
@@ -348,7 +345,7 @@ public class CommitBoundaryTests {
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(
                 new WorkOSAuthResponse { User = new() { Id = "u", FirstName = "Ada" }, AccessToken = "acc", RefreshToken = "rt" }),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(
@@ -368,7 +365,7 @@ public class CommitBoundaryTests {
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(
                 new WorkOSAuthResponse { OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" }));
@@ -395,7 +392,7 @@ public class CommitBoundaryTests {
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(
                 new WorkOSAuthResponse { User = new() { Id = "u", FirstName = "Ada" }, AccessToken = "acc", RefreshToken = "rt" }),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/LoopbackOwnershipTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/LoopbackOwnershipTests.cs
@@ -99,7 +99,7 @@ public class LoopbackOwnershipTests {
         var fake = new DisposableFakeBrowser("?code=abc&state=mismatch");
 
         var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
-            Github, "client-id", "http://127.0.0.1:1/exchange", new RecordingBrowser(),
+            Github, "client-id", "http://127.0.0.1:1/exchange", new RecordingBrowser(), NoTelemetry.Join,
             browser: fake, timeout: TimeSpan.FromSeconds(1));
 
         await Assert.That(token).IsNull();
@@ -193,11 +193,55 @@ public class LoopbackOwnershipTests {
             if (!statement.Contains("using ", StringComparison.Ordinal))
                 violations.Add($"{file}:{line}: constructed outside a `using` declaration — {Squash(statement)}");
 
-            if (!arguments.Contains("SetupJoin.Loopback", StringComparison.Ordinal))
-                violations.Add($"{file}:{line}: does not pass the join collaborator — {Squash(arguments)}");
+            // Presence is not enough, and neither is the name: `join` is optional AND nullable on
+            // LoopbackBrowser, so a site can pass nothing, or pass null, and still compile. This
+            // guard is the only thing that refuses either.
+            switch (JoinArgument(arguments)) {
+                case null:
+                    violations.Add($"{file}:{line}: does not pass the join collaborator — {Squash(arguments)}");
+                    break;
+                case "null":
+                    violations.Add($"{file}:{line}: passes a null join collaborator — {Squash(arguments)}");
+                    break;
+            }
         }
 
         return violations;
+    }
+
+    /// <summary>
+    /// The value handed to <c>join</c>, or null when the site passes none. Named form first, then
+    /// the fourth positional slot; a ternary in the <c>hint</c> slot carries no top-level comma, so
+    /// depth-aware splitting is enough to keep the slots aligned.
+    /// </summary>
+    static string? JoinArgument(string arguments) {
+        var parts = SplitTopLevel(arguments);
+
+        foreach (var part in parts) {
+            var colon = part.IndexOf(':');
+            if (colon > 0 && part[..colon].Trim() == "join") return part[(colon + 1)..].Trim();
+        }
+
+        return parts.Count >= 4 && !parts[3].Contains(':') ? parts[3].Trim() : null;
+    }
+
+    static List<string> SplitTopLevel(string arguments) {
+        var parts = new List<string>();
+        var depth = 0;
+        var start = 0;
+
+        for (var i = 0; i < arguments.Length; i++) {
+            if (arguments[i] is '(' or '[' or '<') depth++;
+            else if (arguments[i] is ')' or ']' or '>') depth--;
+            else if (arguments[i] == ',' && depth == 0) {
+                parts.Add(arguments[start..i]);
+                start = i + 1;
+            }
+        }
+
+        parts.Add(arguments[start..]);
+
+        return parts;
     }
 
     static string Squash(string text) => string.Join(' ', text.Split('\n', StringSplitOptions.TrimEntries)).Trim();
@@ -212,10 +256,9 @@ public class LoopbackOwnershipTests {
     }
 
     // A guard that finds nothing to check reports success, so the floor is asserted rather than
-    // assumed. Both sites live in OAuthLoginFlow now — the GitHub flow and the WorkOS ladder —
-    // after upstream moved construction out of OnboardingFacade and into the ladder. The floor
-    // dropped from three sites in two files to two in one when that happened, which is exactly the
-    // kind of change worth re-deriving by hand rather than letting a scan quietly go empty.
+    // assumed. Both sites live in OAuthLoginFlow — the GitHub flow and the WorkOS ladder — so the
+    // floor is two sites in one file. Re-derive it by hand when it moves, rather than letting a
+    // scan quietly go empty.
     [Test]
     public async Task The_scan_actually_reaches_the_construction_sites() {
         var sites = FindSites(Path.Combine(RepoRoot(), "src"));
@@ -235,11 +278,11 @@ public class LoopbackOwnershipTests {
             "namespace Fixture;",
             "static class Owned {",
             "    static void Simple() {",
-            "        using var browser = new LoopbackBrowser(progress: progress, join: SetupJoin.Loopback);",
+            "        using var browser = new LoopbackBrowser(progress: progress, join: join);",
             "    }",
             "    static void NullableTernary(object? injected) {",
             "        using LoopbackBrowser? created =",
-            "            injected is null ? new LoopbackBrowser(progress: progress, join: SetupJoin.Loopback) : null;",
+            "            injected is null ? new LoopbackBrowser(progress: progress, join: join) : null;",
             "    }",
             "}",
         ]);
@@ -257,7 +300,7 @@ public class LoopbackOwnershipTests {
             "static class Leaked {",
             "    static void Go() {",
             "        var options = new OidcClientOptions {",
-            "            Browser = new LoopbackBrowser(progress: progress, join: SetupJoin.Loopback),",
+            "            Browser = new LoopbackBrowser(progress: progress, join: join),",
             "        };",
             "    }",
             "}",
@@ -267,6 +310,27 @@ public class LoopbackOwnershipTests {
 
         await Assert.That(violations.Count).IsEqualTo(1);
         await Assert.That(violations[0]).Contains("outside a `using` declaration");
+    }
+
+    // The form the compiler cannot refuse: `join` is optional and nullable, so this builds and runs
+    // with the collaborator silently absent.
+    [Test]
+    public async Task Scanner_flags_a_site_that_passes_a_null_join() {
+        using var tmp = new TempDir();
+
+        tmp.CreateFile("Nulled.cs", [
+            "namespace Fixture;",
+            "static class Nulled {",
+            "    static void Go() {",
+            "        using var browser = new LoopbackBrowser(progress: progress, join: null);",
+            "    }",
+            "}",
+        ]);
+
+        var violations = FindOwnershipViolations(tmp.Path);
+
+        await Assert.That(violations.Count).IsEqualTo(1);
+        await Assert.That(violations[0]).Contains("passes a null join collaborator");
     }
 
     [Test]
@@ -486,7 +550,7 @@ public class LoopbackOwnershipTests {
             "namespace Fixture;",
             "static class Nested {",
             "    static void Go() {",
-            "        using var browser = new LoopbackBrowser(openBrowser: Resolve(url), join: SetupJoin.Loopback);",
+            "        using var browser = new LoopbackBrowser(openBrowser: Resolve(url), join: join);",
             "    }",
             "}",
         ]);

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/OAuthFlowTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/OAuthFlowTests.cs
@@ -178,7 +178,7 @@ public class OAuthFlowTests {
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"access_token":"gho_abc"}"""));
 
         var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
-            Github, "Iv1.abc", $"{server.Urls[0]}/code-exchange", new RecordingBrowser(), FakeBrowser.WithCode("the_code"));
+            Github, "Iv1.abc", $"{server.Urls[0]}/code-exchange", new RecordingBrowser(), NoTelemetry.Join, FakeBrowser.WithCode("the_code"));
 
         await Assert.That(token).IsEqualTo("gho_abc");
     }
@@ -190,7 +190,7 @@ public class OAuthFlowTests {
             .RespondWith(Response.Create().WithStatusCode(200).WithBody("""{"access_token":"nope"}"""));
 
         var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
-            Github, "Iv1.abc", $"{server.Urls[0]}/code-exchange", new RecordingBrowser(),
+            Github, "Iv1.abc", $"{server.Urls[0]}/code-exchange", new RecordingBrowser(), NoTelemetry.Join,
             FakeBrowser.WithRawQuery("?code=the_code&state=attacker"));
 
         await Assert.That(token).IsNull();
@@ -203,7 +203,7 @@ public class OAuthFlowTests {
         var progress = new RecordingAuthProgress();
 
         var token = await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
-            Github, "Iv1.abc", "http://unused.test/code-exchange", new RecordingBrowser(),
+            Github, "Iv1.abc", "http://unused.test/code-exchange", new RecordingBrowser(), NoTelemetry.Join,
             FakeBrowser.NonSuccess(BrowserResultType.Timeout), progress: progress);
 
         await Assert.That(token).IsNull();
@@ -219,7 +219,7 @@ public class OAuthFlowTests {
         var       progress = new RecordingAuthProgress();
 
         await Assert.That(async () => await OAuthLoginFlow.RunGitHubBrowserFlowAsync(
-                Github, "Iv1.abc", "http://unused.test/code-exchange", new RecordingBrowser(),
+                Github, "Iv1.abc", "http://unused.test/code-exchange", new RecordingBrowser(), NoTelemetry.Join,
                 FakeBrowser.CancellingCaller(cts), ct: cts.Token, progress: progress))
             .Throws<OperationCanceledException>();
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/OnboardingFacadeTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/OnboardingFacadeTests.cs
@@ -2,7 +2,6 @@ using System.Net;
 using Capacitor.Cli.Core.Auth;
 using static Capacitor.Tests.Helpers.AuthFixtures;
 using Capacitor.Cli.Core.Config;
-using Capacitor.Cli.Core.Telemetry;
 using NSubstitute;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
@@ -13,10 +12,7 @@ namespace Capacitor.Cli.Core.Tests.Unit.Auth;
 /// <summary>
 /// Operation-level contract of <see cref="OnboardingFacade"/>: provider dispatch, discovery over
 /// every tenant, cancellation before the boundary, and the WorkOS retarget/provisioner arms.
-/// Shares the sink key because WorkOS discovery emits SetupFunnel events into CliTelemetry's
-/// process-global sink.
 /// </summary>
-[NotInParallel(nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink))]
 public class OnboardingFacadeTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/TenantProvisioningClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/TenantProvisioningClientTests.cs
@@ -7,11 +7,6 @@ using WireMock.Server;
 
 namespace Capacitor.Cli.Core.Tests.Unit.Auth;
 
-// Reads SetupJoin.Current (a telemetry static), so it shares the same resource lock as the other
-// telemetry-static tests (SetupFunnelTests/CliTelemetryTests) and cannot run beside one that mints.
-[NotInParallel([
-    nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink),
-])]
 public class TenantProvisioningClientTests {
     [Test]
     public async Task ProvisionAsync_sends_bearer_and_camelCase_body_and_parses_202() {
@@ -24,7 +19,7 @@ public class TenantProvisioningClientTests {
         using var http = new HttpClient();
         var client = new TenantProvisioningClient(http);
 
-        var outcome = await client.ProvisionAsync(server.Urls[0], "tok", "Acme Inc", "acme", CancellationToken.None);
+        var outcome = await client.ProvisionAsync(server.Urls[0], "tok", "Acme Inc", "acme", joinId: null, CancellationToken.None);
 
         await Assert.That(outcome.StatusCode).IsEqualTo(202);
         await Assert.That(outcome.Body!.State).IsEqualTo("provisioning");
@@ -49,7 +44,7 @@ public class TenantProvisioningClientTests {
         using var http = new HttpClient();
         var client = new TenantProvisioningClient(http);
 
-        var outcome = await client.ProvisionAsync(server.Urls[0], "tok", "Acme", "acme", CancellationToken.None);
+        var outcome = await client.ProvisionAsync(server.Urls[0], "tok", "Acme", "acme", joinId: null, CancellationToken.None);
         await Assert.That(outcome.StatusCode).IsEqualTo(409);
         await Assert.That(outcome.Body!.Reason).IsEqualTo("taken");
     }
@@ -155,49 +150,17 @@ public class TenantProvisioningClientTests {
         using var http = new HttpClient();
         var client = new TenantProvisioningClient(http);
 
-        var outcome = await client.ProvisionAsync(url, "tok", "Acme", "acme", CancellationToken.None);
+        var outcome = await client.ProvisionAsync(url, "tok", "Acme", "acme", joinId: null, CancellationToken.None);
         await Assert.That(outcome.StatusCode).IsEqualTo(0);
         await Assert.That(outcome.Body).IsNull();
     }
 
-    // The key is read off the process-wide static rather than threaded through
-    // OfferCreateAsync -> provisioner -> client: it is per-run state, the same shape CliTelemetry
-    // already has everywhere, and null by construction whenever telemetry is off.
+    /// <summary>`setup` is one of the two commands that mint, so a live facade has a key to carry.</summary>
     [Test]
     public async Task ProvisionAsync_carries_the_minted_join_key_on_the_wire() {
         using var tmp = new TempDir();
-        CliTelemetry.Reset();
-        SetupJoin.Reset();
-        CliTelemetry.TestSink = [];
-        CliTelemetry.Initialize("setup", null, loggedIn: false, new ConfigRoot(tmp.Path));
-        var key = SetupJoin.Mint();
-
-        try {
-            using var server = WireMockServer.Start();
-            server.Given(Request.Create().WithPath("/api/signup/provision").UsingPost())
-                .RespondWith(Response.Create().WithStatusCode(202)
-                    .WithBody("""{"slug":"acme","state":"provisioning"}""")
-                    .WithHeader("Content-Type", "application/json"));
-
-            using var http = new HttpClient();
-            await new TenantProvisioningClient(http)
-                .ProvisionAsync(server.Urls[0], "tok", "Acme Inc", "acme", CancellationToken.None);
-
-            var log  = server.FindLogEntries(Request.Create().WithPath("/api/signup/provision").UsingPost());
-            var body = JsonNode.Parse(log[0].RequestMessage.Body!)!;
-
-            await Assert.That(key).IsNotNull();
-            await Assert.That(body["joinId"]!.GetValue<string>()).IsEqualTo(key);
-        } finally {
-            CliTelemetry.Reset();
-            SetupJoin.Reset();
-        }
-    }
-
-    [Test]
-    public async Task ProvisionAsync_sends_no_joinId_when_telemetry_is_off() {
-        CliTelemetry.Reset();
-        SetupJoin.Reset();
+        var probe = TelemetryProbe.Live("setup", new ConfigRoot(tmp.Path));
+        var key   = probe.Telemetry.Join.Current;
 
         using var server = WireMockServer.Start();
         server.Given(Request.Create().WithPath("/api/signup/provision").UsingPost())
@@ -207,7 +170,29 @@ public class TenantProvisioningClientTests {
 
         using var http = new HttpClient();
         await new TenantProvisioningClient(http)
-            .ProvisionAsync(server.Urls[0], "tok", "Acme Inc", "acme", CancellationToken.None);
+            .ProvisionAsync(server.Urls[0], "tok", "Acme Inc", "acme", key, CancellationToken.None);
+
+        var log  = server.FindLogEntries(Request.Create().WithPath("/api/signup/provision").UsingPost());
+        var body = JsonNode.Parse(log[0].RequestMessage.Body!)!;
+
+        await Assert.That(key).IsNotNull();
+        await Assert.That(body["joinId"]!.GetValue<string>()).IsEqualTo(key);
+    }
+
+    /// <summary>A facade that is off mints nothing, so there is no key to put on the wire.</summary>
+    [Test]
+    public async Task ProvisionAsync_sends_no_joinId_when_telemetry_is_off() {
+        var telemetry = CliTelemetry.Disabled();
+
+        using var server = WireMockServer.Start();
+        server.Given(Request.Create().WithPath("/api/signup/provision").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(202)
+                .WithBody("""{"slug":"acme","state":"provisioning"}""")
+                .WithHeader("Content-Type", "application/json"));
+
+        using var http = new HttpClient();
+        await new TenantProvisioningClient(http).ProvisionAsync(
+            server.Urls[0], "tok", "Acme Inc", "acme", telemetry.Join.Current, CancellationToken.None);
 
         var log = server.FindLogEntries(Request.Create().WithPath("/api/signup/provision").UsingPost());
         await Assert.That(log[0].RequestMessage.Body!).DoesNotContain("joinId");

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSDiscoveryTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSDiscoveryTests.cs
@@ -1,14 +1,10 @@
 using System.Text;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
-using Capacitor.Cli.Core.Telemetry;
 using NSubstitute;
 
 namespace Capacitor.Cli.Core.Tests.Unit.Auth;
 
-// PublishAsync emits SetupFunnel events into CliTelemetry's process-global sink, so this class
-// must not run beside a test asserting on that sink's contents.
-[NotInParallel(nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink))]
 public class WorkOSDiscoveryTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
@@ -38,7 +34,7 @@ public class WorkOSDiscoveryTests {
         var switched = new WorkOSAuthResponse { User = new() { Id = "user_x" }, OrganizationId = "org_a", AccessToken = "acc2", RefreshToken = "rt2" };
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
-            "https://auth.kcap.ai", proxyConfig, proxy, picker,
+            "https://auth.kcap.ai", proxyConfig, proxy, picker, NoTelemetry.Funnel,
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(switched));
 
@@ -64,7 +60,7 @@ public class WorkOSDiscoveryTests {
     public async Task DiscoverAsync_errors_when_workos_not_configured() {
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "" },
-            Substitute.For<IAuthProxyClient>(), Substitute.For<ITenantPicker>(),
+            Substitute.For<IAuthProxyClient>(), Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             ()     => Task.FromResult<WorkOSAuthResponse?>(null),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
 
@@ -83,7 +79,7 @@ public class WorkOSDiscoveryTests {
         var switchCalled = false;
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => { switchCalled = true; return Task.FromResult<WorkOSAuthResponse?>(null); });
 
@@ -99,7 +95,7 @@ public class WorkOSDiscoveryTests {
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
 
@@ -123,7 +119,7 @@ public class WorkOSDiscoveryTests {
         var switched = new WorkOSAuthResponse { User = new() { Id = "user_x" }, OrganizationId = "org_new", AccessToken = "acc2", RefreshToken = "rt2" };
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
-            "https://auth.kcap.ai", proxyConfig, proxy, Substitute.For<ITenantPicker>(),
+            "https://auth.kcap.ai", proxyConfig, proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(switched),
             provisioner:  provisioner);
@@ -171,7 +167,7 @@ public class WorkOSDiscoveryTests {
 
         string? switchRefreshToken = null;
         var flow = await WorkOSDiscovery.DiscoverAsync(
-            "https://auth.kcap.ai", proxyConfig, proxy, Substitute.For<ITenantPicker>(),
+            "https://auth.kcap.ai", proxyConfig, proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             orglessLogin:   ()      => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:      (rt, _) => { switchRefreshToken = rt; return Task.FromResult<WorkOSAuthResponse?>(switched); },
             orglessRefresh: (_, _)  => Task.FromResult<WorkOSAuthResponse?>(
@@ -195,7 +191,7 @@ public class WorkOSDiscoveryTests {
         var switchCalled = false;
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => { switchCalled = true; return Task.FromResult<WorkOSAuthResponse?>(null); },
             provisioner: provisioner);
@@ -222,7 +218,7 @@ public class WorkOSDiscoveryTests {
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
             provisioner: provisioner);
@@ -245,7 +241,7 @@ public class WorkOSDiscoveryTests {
         var switchCalled = false;
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => { switchCalled = true; return Task.FromResult<WorkOSAuthResponse?>(null); },
             provisioner: provisioner);
@@ -295,7 +291,7 @@ public class WorkOSDiscoveryTests {
 
         return await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_p" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), NoTelemetry.Funnel,
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
             provisioner: provisioner);
@@ -320,7 +316,7 @@ public class WorkOSDiscoveryTests {
         var orgless  = new WorkOSAuthResponse { User = new() { Id = "user_x" }, AccessToken = "acc", RefreshToken = "rt" };
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
-            "https://auth.kcap.ai", proxyConfig, proxy, picker,
+            "https://auth.kcap.ai", proxyConfig, proxy, picker, NoTelemetry.Funnel,
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(null),
             progress:     progress);
@@ -363,7 +359,7 @@ public class WorkOSDiscoveryTests {
         };
 
         await WorkOSDiscovery.DiscoverAsync(
-            "https://auth.kcap.ai", proxyConfig, proxy, picker,
+            "https://auth.kcap.ai", proxyConfig, proxy, picker, NoTelemetry.Funnel,
             orglessLogin: ()     => Task.FromResult<WorkOSAuthResponse?>(orgless),
             orgSwitch:    (_, _) => Task.FromResult<WorkOSAuthResponse?>(
                 new WorkOSAuthResponse { User = new() { Id = "user_x" }, OrganizationId = "org_a", AccessToken = "a2", RefreshToken = "r2" }),

--- a/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSFlowLadderTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Auth/WorkOSFlowLadderTests.cs
@@ -91,7 +91,7 @@ public class WorkOSFlowLadderTests {
         var opener = new RecordingBrowser(opens: false);
 
         var result = await OAuthLoginFlow.AcquireWorkOSAsync(
-            workos, "client_d", organizationId: null, forceDevice: true, opener, browser,
+            workos, "client_d", organizationId: null, forceDevice: true, opener, NoTelemetry.Join, browser,
             progress: new RecordingAuthProgress(), keys: ScriptedKeyWatcher.Blind());
 
         await Assert.That(result!.AccessToken).IsEqualTo("acc");
@@ -108,7 +108,8 @@ public class WorkOSFlowLadderTests {
         var       progress = new RecordingAuthProgress();
 
         var result = await OAuthLoginFlow.AcquireWorkOSAsync(
-            workos, "client_d", organizationId: null, forceDevice: false, new RecordingBrowser(opens: false), new HangingBrowser(),
+            workos, "client_d", organizationId: null, forceDevice: false, new RecordingBrowser(opens: false),
+            NoTelemetry.Join, new HangingBrowser(),
             progress: progress, keys: keys);
 
         await Assert.That(result!.AccessToken).IsEqualTo("acc");
@@ -132,7 +133,8 @@ public class WorkOSFlowLadderTests {
         var       keys   = new ScriptedKeyWatcher('d', '\r', '\n');
 
         await OAuthLoginFlow.AcquireWorkOSAsync(
-            workos, "client_d", organizationId: null, forceDevice: false, new RecordingBrowser(opens: false), new HangingBrowser(),
+            workos, "client_d", organizationId: null, forceDevice: false, new RecordingBrowser(opens: false),
+            NoTelemetry.Join, new HangingBrowser(),
             progress: new RecordingAuthProgress(), keys: keys);
 
         await Assert.That(keys.Drained).IsEqualTo(2);
@@ -148,7 +150,7 @@ public class WorkOSFlowLadderTests {
         var       workos = new WorkOSClient(new PlainHttpClientFactory(stub));
 
         var result = await OAuthLoginFlow.AcquireWorkOSAsync(
-            workos, "client_d", organizationId: null, forceDevice: false, new RecordingBrowser(),
+            workos, "client_d", organizationId: null, forceDevice: false, new RecordingBrowser(), NoTelemetry.Join,
             FakeBrowser.NonSuccess(Duende.IdentityModel.OidcClient.Browser.BrowserResultType.UserCancel),
             progress: new RecordingAuthProgress(), keys: ScriptedKeyWatcher.Blind());
 
@@ -167,7 +169,7 @@ public class WorkOSFlowLadderTests {
 
         var result = await OAuthLoginFlow.AcquireWorkOSAsync(
             workos, "client_d", organizationId: null, forceDevice: false, new RecordingBrowser(opens: false),
-            new FakeBrowser(_ => throw new HttpListenerException(5, "Access is denied")),
+            NoTelemetry.Join, new FakeBrowser(_ => throw new HttpListenerException(5, "Access is denied")),
             progress: progress, keys: ScriptedKeyWatcher.Blind());
 
         await Assert.That(result!.AccessToken).IsEqualTo("acc");
@@ -189,7 +191,8 @@ public class WorkOSFlowLadderTests {
 
         var result = await OAuthLoginFlow.AcquireWorkOSAsync(
             workos, "client_d", organizationId: null, forceDevice: false,
-            new RecordingBrowser(opens: false), new FakeBrowser(_ => throw new BrowserLaunchException()),
+            new RecordingBrowser(opens: false), NoTelemetry.Join,
+            new FakeBrowser(_ => throw new BrowserLaunchException()),
             progress: progress, keys: ScriptedKeyWatcher.Blind());
 
         await Assert.That(result!.AccessToken).IsEqualTo("acc");
@@ -231,7 +234,7 @@ public class WorkOSFlowLadderTests {
 
         await Assert.That(async () => await OAuthLoginFlow.AcquireWorkOSAsync(
                   workos, "client_d", organizationId: null, forceDevice: false,
-                  new RecordingBrowser(), new HangingBrowser(),
+                  new RecordingBrowser(), NoTelemetry.Join, new HangingBrowser(),
                   server.Urls[0], cts.Token, new RecordingAuthProgress(), ScriptedKeyWatcher.Blind()))
             .Throws<OperationCanceledException>();
     }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Http/CapacitorHttpContainerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Http/CapacitorHttpContainerTests.cs
@@ -383,7 +383,7 @@ public class CapacitorHttpContainerTests : IDisposable {
             sp.GetRequiredService<IHttpClientFactory>(), sp.GetRequiredService<IAuthProxyClient>(),
             sp.GetRequiredService<GitHubOAuthClient>(), sp.GetRequiredService<WorkOSClient>(),
             new RecordingAuthProgress(), new RecordingBrowser(), AuthFixtures.PickerReturningFirst(),
-            provisioner: null, beforeCommit: null);
+            provisioner: null, NoTelemetry.Facade, beforeCommit: null);
 
         await facade.LoginAsync(Url, forceDevice: false, _profile, CancellationToken.None, adoptServer: true);
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/LocalIpc/AgentAttachClientTests.cs
@@ -551,16 +551,19 @@ public class AgentAttachClientTests {
         var sinkCalls = 0;
         var contexts = new List<string>();
         var attachedObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pumpParked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new AgentAttachClient(server.Path, AgentId,
             (_, _, _) => { attachedObserved.TrySetResult(); return Task.CompletedTask; },
-            async (_, ct) => await Task.Delay(Timeout.Infinite, ct),   // parks the pump; only Dispose unblocks it
+            // Parks the pump; only Dispose unblocks it. Signals on ENTRY, so the wait below is on
+            // the pump actually being inside the callback rather than on it having had time to be.
+            async (_, ct) => { pumpParked.TrySetResult(); await Task.Delay(Timeout.Infinite, ct); },
             (c, _) => { Interlocked.Increment(ref sinkCalls); lock (contexts) contexts.Add(c); throw new InvalidOperationException("sink bug"); });
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
         await attachedObserved.Task;                  // Windows RST guard — see comment above
         await server.SendStdoutAsync([1]);
-        await Task.Delay(50);                                       // pump is now parked inside the callback
+        await pumpParked.Task;
 
         server.CloseConnection();
         await client.SendInputAsync([1, 2, 3]);                     // the only producer that can possibly fail right now
@@ -588,16 +591,19 @@ public class AgentAttachClientTests {
         var sink = new RecordingSink();
         var gate = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var attachedObserved = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
+        var pumpBlocked = new TaskCompletionSource(TaskCreationOptions.RunContinuationsAsynchronously);
         var client = new AgentAttachClient(server.Path, AgentId,
             (_, _, _) => { attachedObserved.TrySetResult(); return Task.CompletedTask; },
-            async (_, _) => { await gate.Task; },        // blocks the pump, then returns normally (no fault)
+            // Blocks the pump, then returns normally (no fault). Signals on ENTRY, so the wait below
+            // is on the pump actually being inside the callback rather than on elapsed time.
+            async (_, _) => { pumpBlocked.TrySetResult(); await gate.Task; },
             sink.Callback);
         var run = client.RunAsync(80, 24, CancellationToken.None);
         await server.AcceptAndPumpInboundAsync();
         await server.SendAttachedAsync(AgentId, []);
         await attachedObserved.Task;                      // Windows RST guard — see comment above
         await server.SendStdoutAsync([1]);
-        await Task.Delay(50);                             // pump is now blocked inside the callback, gate not yet open
+        await pumpBlocked.Task;                           // inside the callback, gate not yet open
 
         server.CloseConnection();
         await client.SendInputAsync([9]);                 // the writer claims ConnectionLost, closes the local transport

--- a/test/Capacitor.Cli.Core.Tests.Unit/ProcessRunnerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/ProcessRunnerTests.cs
@@ -124,11 +124,13 @@ public class ProcessRunnerTests {
 
         await Assert.ThrowsAsync<OperationCanceledException>(() =>
             runner.RunAsync(
-                "/bin/sh", ["-c", $"sleep 0.3; touch {marker}"],
+                "/bin/sh", ["-c", $"sleep 2; touch {marker}"],
                 new RunOptions(CancelMode: CancelMode.KillTree), cts.Token));
 
-        // Killed before it could reach `touch` — unlike AbandonWait, it never gets there.
-        await Task.Delay(TimeSpan.FromSeconds(1));
+        // Killed before it could reach `touch` — unlike AbandonWait, it never gets there. The child
+        // sleeps longer than the kill needs and the wait outlasts the child, so a kill that failed
+        // shows up as a marker rather than as a margin this races.
+        await Task.Delay(TimeSpan.FromSeconds(4));
         await Assert.That(File.Exists(marker)).IsFalse();
     }
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/JoinChainBrowserTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/JoinChainBrowserTests.cs
@@ -1,7 +1,6 @@
 using System.Text.Json;
 using System.Text.Json.Nodes;
 using Capacitor.Cli.Core.Auth;
-using Capacitor.Cli.Core.Telemetry;
 using Duende.IdentityModel.OidcClient.Browser;
 
 namespace Capacitor.Cli.Core.Tests.Unit.Telemetry;
@@ -37,9 +36,8 @@ namespace Capacitor.Cli.Core.Tests.Unit.Telemetry;
 /// ONLY. The device id is what crosses back, so the merge is still fully exercised.</para>
 /// </summary>
 [NotInParallel]
-public class JoinChainBrowserTests : IDisposable {
-    readonly TempDir _tmp = new();
-    public void Dispose() => _tmp.Dispose();
+public class JoinChainBrowserTests {
+    [TempDir] public required TempDir Tmp { get; init; }
 
     const string GateEnvVar      = "KCAP_JOIN_BROWSER_E2E";
     const string HandshakeEnvVar = "KCAP_JOIN_BROWSER_HANDSHAKE";
@@ -65,22 +63,14 @@ public class JoinChainBrowserTests : IDisposable {
 
         try {
             Environment.SetEnvironmentVariable("KCAP_SIGNUP_URL", baseUrl);
-            CliTelemetry.Reset();
-            SetupJoin.Reset();
-
-            var config = new ConfigRoot(_tmp.Path);
-            var sink = new List<TelemetryEvent>();
-            CliTelemetry.TestSink = sink;
-            CliTelemetry.Initialize("setup", null, loggedIn: false, config);
-            TelemetryTestGuards.AssertEnabled("setup", config);
-
-            var key = SetupJoin.Mint();
+            var probe = TelemetryProbe.Live("setup", new ConfigRoot(Tmp.Path), debug: true);
+            var key   = probe.Join.Mint();
             await Assert.That(key).IsNotNull();
 
             var port     = OAuthLoginFlow.GetAvailablePort();
             var redirect = $"http://127.0.0.1:{port}/callback";
 
-            using var browser = new LoopbackBrowser(new RecordingBrowser(), join: SetupJoin.Loopback) {
+            using var browser = new LoopbackBrowser(new RecordingBrowser(), join: probe.Join) {
                 DrainCap = DriverBudget, DisposeWait = TimeSpan.FromSeconds(10),
             };
 
@@ -97,7 +87,7 @@ public class JoinChainBrowserTests : IDisposable {
 
             // The hops and the return to /joined happen in the browser after the closing page is
             // served, so the merge lands asynchronously. Poll the shared properties for it.
-            var merged = await WaitForMerge(sink, DriverBudget);
+            var merged = await WaitForMerge(probe, DriverBudget);
 
             await Assert.That(merged).IsNotNull()
                 .Because("a real browser must carry the web identity back to /joined");
@@ -108,8 +98,6 @@ public class JoinChainBrowserTests : IDisposable {
         } finally {
             Environment.SetEnvironmentVariable("KCAP_SIGNUP_URL", priorSignup);
             try { File.Delete(handshake!); } catch { /* best effort */ }
-            CliTelemetry.Reset();
-            SetupJoin.Reset();
         }
     }
 
@@ -136,15 +124,15 @@ public class JoinChainBrowserTests : IDisposable {
     /// Probing with a real capture is how the other suites read shared state, and it is what a real
     /// event would carry.
     /// </summary>
-    static async Task<JsonObject?> WaitForMerge(List<TelemetryEvent> sink, TimeSpan budget) {
+    static async Task<JsonObject?> WaitForMerge(TelemetryProbe probe, TimeSpan budget) {
         var deadline = DateTimeOffset.UtcNow + budget;
 
         while (DateTimeOffset.UtcNow < deadline) {
-            sink.Clear();
-            CliTelemetry.Capture("cli_browser_e2e_probe", new JsonObject());
+            probe.Sink.Discard();
+            probe.Telemetry.Capture("cli_browser_e2e_probe", new JsonObject());
 
-            if (sink.Count > 0 && sink[^1].Properties["web_device_id_capacitor"] is not null)
-                return sink[^1].Properties;
+            if (probe.Events.Count > 0 && probe.Events[^1].Properties["web_device_id_capacitor"] is not null)
+                return probe.Events[^1].Properties;
 
             await Task.Delay(500);
         }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/JoinChainLiveTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/JoinChainLiveTests.cs
@@ -29,12 +29,11 @@ namespace Capacitor.Cli.Core.Tests.Unit.Telemetry;
 /// below has <c>$device_id</c> ONLY. That still exercises the full merge — the device id is what
 /// crosses back — while writing nothing into the real PostHog project.</para>
 /// </summary>
-// Bare [NotInParallel], not the CliTelemetry.TestSink key: this captures Console, which is
+// Bare [NotInParallel]: this captures Console, which is
 // process-global, and ConsoleOutput rejects an overlapping capture. Ungrouped is strictly stronger.
 [NotInParallel]
-public class JoinChainLiveTests : IDisposable {
-    readonly TempDir _tmp = new();
-    public void Dispose() => _tmp.Dispose();
+public class JoinChainLiveTests {
+    [TempDir] public required TempDir Tmp { get; init; }
 
     const string GateEnvVar = "KCAP_JOIN_E2E";
 
@@ -56,29 +55,19 @@ public class JoinChainLiveTests : IDisposable {
         using var console = ConsoleOutput.StartErrorCapture();
 
         var priorSignup = Environment.GetEnvironmentVariable("KCAP_SIGNUP_URL");
-        var priorDebug  = Environment.GetEnvironmentVariable("KCAP_TELEMETRY_DEBUG");
 
         try {
             // FirstHopUrl reads this, which is the whole reason the override exists.
             Environment.SetEnvironmentVariable("KCAP_SIGNUP_URL", baseUrl);
-            Environment.SetEnvironmentVariable("KCAP_TELEMETRY_DEBUG", "1");
 
-            CliTelemetry.Reset();
-            SetupJoin.Reset();
-
-            var config = new ConfigRoot(_tmp.Path);
-            var sink = new List<TelemetryEvent>();
-            CliTelemetry.TestSink = sink;
-            CliTelemetry.Initialize("setup", null, loggedIn: false, config);
-            TelemetryTestGuards.AssertEnabled("setup", config);
-
-            var key = SetupJoin.Mint();
+            var probe = TelemetryProbe.Live("setup", new ConfigRoot(Tmp.Path), debug: true);
+            var key   = probe.Join.Mint();
             await Assert.That(key).IsNotNull();
 
             var port     = OAuthLoginFlow.GetAvailablePort();
             var redirect = $"http://127.0.0.1:{port}/callback";
 
-            using var browser = new LoopbackBrowser(new RecordingBrowser(), join: SetupJoin.Loopback) {
+            using var browser = new LoopbackBrowser(new RecordingBrowser(), join: probe.Join) {
                 DrainCap = TimeSpan.FromSeconds(30), DisposeWait = TimeSpan.FromSeconds(10),
             };
 
@@ -123,9 +112,9 @@ public class JoinChainLiveTests : IDisposable {
             await Assert.That(result.ResultType).IsEqualTo(BrowserResultType.Success);
 
             // 3. The merge actually happened, on the real return trip.
-            sink.Clear();
-            CliTelemetry.Capture("cli_e2e_probe", new JsonObject());
-            var props = sink[^1].Properties;
+            probe.Sink.Discard();
+            probe.Telemetry.Capture("cli_e2e_probe", new JsonObject());
+            var props = probe.Events[^1].Properties;
 
             await Assert.That(props["join_id"]!.GetValue<string>()).IsEqualTo(key);
             await Assert.That(props["web_device_id_capacitor"]!.GetValue<string>()).IsEqualTo(CapDeviceId);
@@ -137,9 +126,6 @@ public class JoinChainLiveTests : IDisposable {
             await Assert.That(printed).DoesNotContain(key!);
         } finally {
             Environment.SetEnvironmentVariable("KCAP_SIGNUP_URL", priorSignup);
-            Environment.SetEnvironmentVariable("KCAP_TELEMETRY_DEBUG", priorDebug);
-            CliTelemetry.Reset();
-            SetupJoin.Reset();
         }
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/McpTelemetryTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/McpTelemetryTests.cs
@@ -3,40 +3,19 @@ using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Core.Tests.Unit.Telemetry;
 
-// CliTelemetry's statics (TestSink, the Initialize-set state) stay process-global; the
-// telemetry files live under this test's own root.
-[NotInParallel([
-    nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink)
-])]
 public class McpTelemetryTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
-    // CliTelemetry holds process-global static state (Enabled, TestSink, ...). A prior test
-    // elsewhere in the suite (e.g. one that persists `telemetry off`) can leave Enabled=false
-    // behind via CliTelemetry.DiscardAndDisable — reset before touching TestSink so every test
-    // here starts from pristine state rather than inheriting whatever ran before it.
-    [Before(Test)]
-    public void ResetTelemetry() => CliTelemetry.Reset();
-
-    List<TelemetryEvent> StartCapturing() {
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize("mcp-server", null, loggedIn: false, Config.Root);
-
-        TelemetryTestGuards.AssertEnabled("mcp-server", Config.Root);
-
-        sink.Clear();
-
-        return sink;
-    }
+    TelemetryProbe StartCapturing() => TelemetryProbe.Live("mcp-server", Config.Root);
 
     [Test]
     public async Task Tool_call_records_server_tool_and_outcome() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
-        McpTelemetry.ToolCalled("kcap-memory", "search_memories", ok: true, durationMs: 120);
+        await using var mcp = new McpTelemetry(probe.Telemetry);
+        mcp.ToolCalled("kcap-memory", "search_memories", ok: true, durationMs: 120);
 
-        var e = sink.Single();
+        var e = probe.Events.Single();
         await Assert.That(e.Name).IsEqualTo("mcp_tool_called");
         await Assert.That(e.Properties["server"]!.GetValue<string>()).IsEqualTo("kcap-memory");
         await Assert.That(e.Properties["tool"]!.GetValue<string>()).IsEqualTo("search_memories");
@@ -46,11 +25,12 @@ public class McpTelemetryTests {
 
     [Test]
     public async Task Failed_tool_call_is_recorded_as_not_ok() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
-        McpTelemetry.ToolCalled("kcap-sessions", "get_turn", ok: false, durationMs: 5);
+        await using var mcp = new McpTelemetry(probe.Telemetry);
+        mcp.ToolCalled("kcap-sessions", "get_turn", ok: false, durationMs: 5);
 
-        await Assert.That(sink.Single().Properties["ok"]!.GetValue<bool>()).IsFalse();
+        await Assert.That(probe.Events.Single().Properties["ok"]!.GetValue<bool>()).IsFalse();
     }
 
     // Tool arguments can contain repo paths, prompts, and session ids. An earlier draft of this
@@ -59,20 +39,39 @@ public class McpTelemetryTests {
     // Inverted to an allowlist so ANY unexpected key fails the test, regardless of its name.
     [Test]
     public async Task No_argument_data_is_carried() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
-        McpTelemetry.ToolCalled("kcap-memory", "save_memory", ok: true, durationMs: 1);
+        await using var mcp = new McpTelemetry(probe.Telemetry);
+        mcp.ToolCalled("kcap-memory", "save_memory", ok: true, durationMs: 1);
 
         // The four event-specific properties, plus every shared property CliTelemetry.Capture
-        // merges in (see CliTelemetry.Initialize's `_shared` object) — nothing else may appear.
+        // merges in — nothing else may appear.
         var allowed = new HashSet<string> {
             "server", "tool", "ok", "duration_ms",
             "source", "cli_version", "build_channel", "os", "arch", "is_ci", "is_headless",
             "has_server", "logged_in"
         };
 
-        var keys = sink.Single().Properties.Select(p => p.Key).ToArray();
+        var keys = probe.Events.Single().Properties.Select(p => p.Key).ToArray();
         await Assert.That(keys.All(allowed.Contains)).IsTrue();
+    }
+
+    // A server exits when its harness closes stdin, which for most sessions is long before the
+    // periodic flush interval. Everything queued by then would otherwise be neither sent nor
+    // spooled: the process-exit flush belongs to the facade the top-level command built, and the
+    // top-level "mcp" command is denylisted, so that facade is off and has nothing to ship.
+    [Test]
+    public async Task Ending_a_session_ships_what_it_queued() {
+        var probe = StartCapturing();
+
+        await using (var mcp = new McpTelemetry(probe.Telemetry)) {
+            mcp.ToolCalled("kcap-memory", "search_memories", ok: true, durationMs: 1);
+
+            await Assert.That(probe.Sink.Flushes).IsEqualTo(0)
+                .Because("one call is far short of the periodic flush interval");
+        }
+
+        await Assert.That(probe.Sink.Flushes).IsEqualTo(1);
     }
 
     [Test]

--- a/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/SetupFunnelTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/SetupFunnelTests.cs
@@ -1,54 +1,31 @@
 using Capacitor.Cli.Core.Auth;
-using Capacitor.Cli.Core.Telemetry;
 using NSubstitute;
 using TUnit.Assertions.Enums;
 
 namespace Capacitor.Cli.Core.Tests.Unit.Telemetry;
 
-// CliTelemetry's statics (TestSink, the Initialize-set state) stay process-global; the
-// telemetry files live under this test's own root.
-[NotInParallel([
-    nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink)
-])]
 public class SetupFunnelTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
-    // CliTelemetry holds process-global static state (Enabled, TestSink, ...). A prior test
-    // elsewhere in the suite (e.g. one that persists `telemetry off`) can leave Enabled=false
-    // behind via CliTelemetry.DiscardAndDisable — reset before touching TestSink so every test
-    // here starts from pristine state rather than inheriting whatever ran before it.
-    [Before(Test)]
-    public void ResetTelemetry() => CliTelemetry.Reset();
-
-    List<TelemetryEvent> StartCapturing() {
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize("setup", null, loggedIn: false, Config.Root);
-
-        TelemetryTestGuards.AssertEnabled("setup", Config.Root);
-
-        sink.Clear();   // drop cli_first_run
-
-        return sink;
-    }
+    TelemetryProbe StartCapturing() => TelemetryProbe.Live("setup", Config.Root);
 
     [Test]
     public async Task Happy_path_emits_the_full_sequence() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
-        SetupFunnel.Started(hasExistingProfile: false, serverUrlProvided: false, noPrompt: false);
-        SetupFunnel.SigninOpened("browser", "workos");
-        SetupFunnel.SigninCompleted("workos");
-        SetupFunnel.TenantNone("workos");
-        SetupFunnel.WorkspaceOffered();
-        SetupFunnel.WorkspaceRequested();
-        SetupFunnel.WorkspaceProvisioned();
-        SetupFunnel.Succeeded(agentsConfigured: 3);
+        probe.Telemetry.Funnel.Started(hasExistingProfile: false, serverUrlProvided: false, noPrompt: false);
+        probe.Telemetry.Funnel.SigninOpened("browser", "workos");
+        probe.Telemetry.Funnel.SigninCompleted("workos");
+        probe.Telemetry.Funnel.TenantNone("workos");
+        probe.Telemetry.Funnel.WorkspaceOffered();
+        probe.Telemetry.Funnel.WorkspaceRequested();
+        probe.Telemetry.Funnel.WorkspaceProvisioned();
+        probe.Telemetry.Funnel.Succeeded(agentsConfigured: 3);
 
         // CollectionOrdering.Matching: IsEquivalentTo defaults to set comparison (any order) and
         // would pass even on a transposed sequence — this is exactly the funnel's ordering that
         // matters (a PostHog ordered funnel converts on step order, not just step presence).
-        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(new[] {
+        await Assert.That(probe.Names).IsEquivalentTo(new[] {
             "cli_setup_started", "cli_setup_signin_opened", "cli_setup_signin_completed",
             "cli_setup_tenant_none", "cli_setup_workspace_offered", "cli_setup_workspace_requested",
             "cli_setup_workspace_provisioned", "cli_setup_succeeded",
@@ -57,37 +34,37 @@ public class SetupFunnelTests {
 
     [Test]
     public async Task Abandoned_at_signup_stops_after_the_offer() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
-        SetupFunnel.Started(false, false, false);
-        SetupFunnel.SigninCompleted("workos");
-        SetupFunnel.TenantNone("workos");
-        SetupFunnel.WorkspaceOffered();
-        SetupFunnel.WorkspaceDeclined();
+        probe.Telemetry.Funnel.Started(false, false, false);
+        probe.Telemetry.Funnel.SigninCompleted("workos");
+        probe.Telemetry.Funnel.TenantNone("workos");
+        probe.Telemetry.Funnel.WorkspaceOffered();
+        probe.Telemetry.Funnel.WorkspaceDeclined();
 
-        await Assert.That(sink[^1].Name).IsEqualTo("cli_setup_workspace_declined");
-        await Assert.That(sink.Any(e => e.Name == "cli_setup_succeeded")).IsFalse();
+        await Assert.That(probe.Events[^1].Name).IsEqualTo("cli_setup_workspace_declined");
+        await Assert.That(probe.Names.Any(n => n == "cli_setup_succeeded")).IsFalse();
     }
 
     [Test]
     public async Task Provisioning_failure_carries_a_reason() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
-        SetupFunnel.WorkspaceFailed("slug_taken");
+        probe.Telemetry.Funnel.WorkspaceFailed("slug_taken");
 
-        await Assert.That(sink[^1].Name).IsEqualTo("cli_setup_workspace_failed");
-        await Assert.That(sink[^1].Properties["reason"]!.GetValue<string>()).IsEqualTo("slug_taken");
+        await Assert.That(probe.Events[^1].Name).IsEqualTo("cli_setup_workspace_failed");
+        await Assert.That(probe.Events[^1].Properties["reason"]!.GetValue<string>()).IsEqualTo("slug_taken");
     }
 
     [Test]
     public async Task Started_carries_its_entry_conditions() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
         // Mixed, not all-true: all-true would pass under a transposed mapping (e.g.
         // ["no_prompt"] = serverUrlProvided) just as easily as the correct one.
-        SetupFunnel.Started(hasExistingProfile: true, serverUrlProvided: false, noPrompt: true);
+        probe.Telemetry.Funnel.Started(hasExistingProfile: true, serverUrlProvided: false, noPrompt: true);
 
-        var props = sink[0].Properties;
+        var props = probe.Events[0].Properties;
         await Assert.That(props["has_existing_profile"]!.GetValue<bool>()).IsTrue();
         await Assert.That(props["server_url_provided"]!.GetValue<bool>()).IsFalse();
         await Assert.That(props["no_prompt"]!.GetValue<bool>()).IsTrue();
@@ -95,11 +72,11 @@ public class SetupFunnelTests {
 
     [Test]
     public async Task Succeeded_reports_a_count_not_vendor_names() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
-        SetupFunnel.Succeeded(agentsConfigured: 4);
+        probe.Telemetry.Funnel.Succeeded(agentsConfigured: 4);
 
-        await Assert.That(sink[^1].Properties["agents_configured"]!.GetValue<int>()).IsEqualTo(4);
+        await Assert.That(probe.Events[^1].Properties["agents_configured"]!.GetValue<int>()).IsEqualTo(4);
     }
 
     // Guards collisions with events OTHER producers own: the server's own cli_setup_completed,
@@ -114,25 +91,25 @@ public class SetupFunnelTests {
             "cli_auth_return",
         ];
 
-        var sink = StartCapturing();
-        SetupFunnel.Started(false, false, false);
-        SetupFunnel.SigninOpened("browser", "workos");
-        SetupFunnel.SigninCompleted("workos");
-        SetupFunnel.SigninFailed("timeout");
-        SetupFunnel.TenantNone("workos");
-        SetupFunnel.WorkspaceOffered();
-        SetupFunnel.WorkspaceDeclined();
-        SetupFunnel.WorkspaceRedirected();
-        SetupFunnel.WorkspaceRequested();
-        SetupFunnel.WorkspaceProvisioned();
-        SetupFunnel.WorkspaceFailed("poll_timeout");
-        SetupFunnel.Succeeded(1);
+        var probe = StartCapturing();
+        probe.Telemetry.Funnel.Started(false, false, false);
+        probe.Telemetry.Funnel.SigninOpened("browser", "workos");
+        probe.Telemetry.Funnel.SigninCompleted("workos");
+        probe.Telemetry.Funnel.SigninFailed("timeout");
+        probe.Telemetry.Funnel.TenantNone("workos");
+        probe.Telemetry.Funnel.WorkspaceOffered();
+        probe.Telemetry.Funnel.WorkspaceDeclined();
+        probe.Telemetry.Funnel.WorkspaceRedirected();
+        probe.Telemetry.Funnel.WorkspaceRequested();
+        probe.Telemetry.Funnel.WorkspaceProvisioned();
+        probe.Telemetry.Funnel.WorkspaceFailed("poll_timeout");
+        probe.Telemetry.Funnel.Succeeded(1);
 
-        // Without this, an Emit that silently no-ops would leave sink empty and the loop below
+        // Without this, an Emit that silently no-ops would leave the sink empty and the loop below
         // would assert nothing — a test that cannot fail. 12 = the 12 calls above.
-        await Assert.That(sink.Count).IsEqualTo(12);
+        await Assert.That(probe.Events.Count).IsEqualTo(12);
 
-        foreach (var e in sink)
+        foreach (var e in probe.Events)
             await Assert.That(serverEvents.Contains(e.Name)).IsFalse();
     }
 
@@ -144,7 +121,7 @@ public class SetupFunnelTests {
     // which is exactly the case that anchoring on the overall outcome gets wrong.
     [Test]
     public async Task WorkOSDiscovery_emits_signin_completed_before_tenant_none_for_a_zero_tenant_run() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
         var proxy = Substitute.For<IAuthProxyClient>();
         proxy.DiscoverWorkOSTenantsAsync(Arg.Any<string>(), Arg.Any<string>())
@@ -152,7 +129,7 @@ public class SetupFunnelTests {
 
         var flow = await WorkOSDiscovery.DiscoverAsync(
             "https://auth.kcap.ai", new ProxyConfigResponse { WorkOSClientId = "client_d" },
-            proxy, Substitute.For<ITenantPicker>(),
+            proxy, Substitute.For<ITenantPicker>(), probe.Telemetry.Funnel,
             ()     => Task.FromResult<WorkOSAuthResponse?>(new WorkOSAuthResponse { AccessToken = "acc", RefreshToken = "rt" }),
             (_, _) => Task.FromResult<WorkOSAuthResponse?>(null));
 
@@ -160,7 +137,7 @@ public class SetupFunnelTests {
         // sign-in itself worked fine.
         await Assert.That(flow).IsTypeOf<WorkOSDiscoveryFlow.NoTenants>();
 
-        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+        await Assert.That(probe.Names).IsEquivalentTo(
             new[] { "cli_setup_signin_completed", "cli_setup_tenant_none" }, CollectionOrdering.Matching);
     }
 }

--- a/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/SetupJoinMintPlacementGuardTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/SetupJoinMintPlacementGuardTests.cs
@@ -7,72 +7,54 @@ namespace Capacitor.Cli.Core.Tests.Unit.Telemetry;
 /// Where the join key is minted, and — because the bugs it guards are silent — that the
 /// once-per-device <c>cli_first_run</c> event actually carries it.
 ///
-/// <para>The key is minted in <c>CliTelemetry.Initialize</c>, gated to the two interactive auth
+/// <para>The key is minted as the facade starts, gated to the two interactive auth
 /// commands (<c>setup</c>/<c>login</c>), BEFORE <c>NoticeAndFirstRun</c> captures <c>cli_first_run</c>.
 /// Two placement bugs are cheap to reintroduce and produce no error at all. Mint AFTER
 /// <c>cli_first_run</c> and that once-ever event ships without the key, with no later run able to
 /// repair it. Mint UNCONDITIONALLY and every <c>recap</c>/<c>import</c> carries a key that correlates
 /// nothing, redefining a per-auth-run id as a process id.</para>
 ///
-/// <para>Pinned behaviourally, not by source shape: the mint no longer opens a command handler — the
-/// form the earlier guard scanned for — so "is it the first code" says nothing now. The behavioural
-/// tests capture <c>cli_first_run</c> through a <c>TestSink</c> (no network, no disk), which is the
-/// only form that proves the ordering rather than a proxy for it. A source enumeration still backs
-/// them up, because a mint added to a second file would slip past a test that only drives
-/// <c>Initialize</c>.</para>
+/// <para>Pinned behaviourally, not by source shape: the behavioural tests capture
+/// <c>cli_first_run</c> into the facade's own sink (no network, no disk), which is the only form
+/// that proves the ordering rather than a proxy for it. A source enumeration backs them up, because
+/// a mint added to a second file would slip past a test that only starts a facade.</para>
 /// </summary>
-[NotInParallel([
-    nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink),
-])]
-public class SetupJoinMintPlacementGuardTests : IDisposable {
-    readonly TempDir _tmp = new();
-    public void Dispose() => _tmp.Dispose();
-
-    // CliTelemetry AND SetupJoin both hold process-global static state; reset both so a test here
-    // starts from pristine state rather than inheriting a prior Enabled=false or an already-minted key.
-    [Before(Test)]
-    public void ResetStatics() {
-        CliTelemetry.Reset();
-        SetupJoin.Reset();
-    }
+public class SetupJoinMintPlacementGuardTests {
+    [TempDir] public required TempDir Tmp { get; init; }
 
     // The regression this whole feature's contract turns on: cli_first_run is captured once per
-    // device, inside Initialize, and for an auth run it must carry the join key. Minting after
+    // device, as the facade starts, and for an auth run it must carry the join key. Minting after
     // NoticeAndFirstRun leaves it without one, and being once-ever, no later run repairs it.
     [Test]
     [Arguments("setup")]
     [Arguments("login")]
     public async Task cli_first_run_carries_the_join_key_for_an_auth_command(string command) {
-        var config = new ConfigRoot(_tmp.Path);
-        var sink   = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize(command, null, loggedIn: false, config);
-        TelemetryTestGuards.AssertEnabled(command, config);
+        var config = new ConfigRoot(Tmp.Path);
+        var probe  = TelemetryProbe.Start(command, config);
+        TelemetryTestGuards.AssertEnabled(command, config, probe.Telemetry);
 
-        await Assert.That(SetupJoin.Current).IsNotNull().Because("an auth command mints the key");
+        await Assert.That(probe.Telemetry.Join.Current).IsNotNull().Because("an auth command mints the key");
 
-        var firstRun = sink.SingleOrDefault(e => e.Name == "cli_first_run");
+        var firstRun = probe.Events.SingleOrDefault(e => e.Name == "cli_first_run");
         await Assert.That(firstRun).IsNotNull()
             .Because("a fresh device's first auth command emits cli_first_run");
         await Assert.That(firstRun!.Properties[SetupJoin.PropertyName]?.GetValue<string>())
-            .IsEqualTo(SetupJoin.Current)
+            .IsEqualTo(probe.Telemetry.Join.Current)
             .Because("cli_first_run must carry the minted key, which requires the mint to precede NoticeAndFirstRun");
     }
 
     // recap is reportable, so a fresh device still emits cli_first_run for it — but it has no auth run
-    // to correlate, so it must mint nothing. An unconditional mint in Initialize is exactly what this
-    // catches: it would set Current and stamp join_id onto recap/import events.
+    // to correlate, so it must mint nothing. An unconditional mint as the facade starts is exactly what
+    // this catches: it would set Current and stamp join_id onto recap/import events.
     [Test]
     public async Task A_non_auth_command_mints_no_join_key() {
-        var config = new ConfigRoot(_tmp.Path);
-        var sink   = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize("recap", null, loggedIn: false, config);
-        TelemetryTestGuards.AssertEnabled("recap", config);
+        var config = new ConfigRoot(Tmp.Path);
+        var probe  = TelemetryProbe.Start("recap", config);
+        TelemetryTestGuards.AssertEnabled("recap", config, probe.Telemetry);
 
-        await Assert.That(SetupJoin.Current).IsNull().Because("a non-auth command must not mint the key");
+        await Assert.That(probe.Telemetry.Join.Current).IsNull().Because("a non-auth command must not mint the key");
 
-        var firstRun = sink.SingleOrDefault(e => e.Name == "cli_first_run");
+        var firstRun = probe.Events.SingleOrDefault(e => e.Name == "cli_first_run");
         await Assert.That(firstRun).IsNotNull().Because("recap is reportable, so a fresh device still emits cli_first_run");
         await Assert.That(firstRun!.Properties.ContainsKey(SetupJoin.PropertyName)).IsFalse()
             .Because("no auth run means no join_id on the event");
@@ -80,15 +62,15 @@ public class SetupJoinMintPlacementGuardTests : IDisposable {
 
     // === Source backstop: the mint lives in exactly one file. ===
 
-    // A mint in a second file is invisible to the behavioural tests above — they only drive
-    // Initialize. Enumerating src/ catches a mint re-added to a command handler or buried in a lane,
-    // the two homes the earlier design used and the two this one deliberately moved away from.
+    // A mint in a second file is invisible to the behavioural tests above — they only start a
+    // facade. Enumerating src/ catches a mint in a command handler or buried in a lane, either of
+    // which mints too late (past cli_first_run) or only on the lane that happens to run.
     [Test]
     public async Task Only_CliTelemetry_mints_the_join_key() {
         var minting = FindMintingFiles(SrcRoot()).Order().ToArray();
 
         await Assert.That(minting).IsEquivalentTo(new[] { "CliTelemetry.cs" })
-            .Because("the join key is minted once, in CliTelemetry.Initialize; a mint anywhere else is "
+            .Because("the join key is minted once, as the facade starts; a mint anywhere else is "
                    + "either too late (past cli_first_run) or lane-dependent");
     }
 
@@ -98,18 +80,18 @@ public class SetupJoinMintPlacementGuardTests : IDisposable {
         using var tmp = new TempDir();
         tmp.CreateFile("Real.cs", [
             "namespace Fixture;",
-            "static class Real { static void Go() { SetupJoin.Mint(); } }",
+            "static class Real { static void Go() { telemetry.Join.Mint(); } }",
         ]);
         tmp.CreateFile("Documented.cs", [
             "namespace Fixture;",
-            "// never SetupJoin.Mint() from here",
+            "// never Join.Mint() from here",
             "static class Documented { }",
         ]);
 
         await Assert.That(FindMintingFiles(tmp.Path)).IsEquivalentTo(new[] { "Real.cs" });
     }
 
-    const string Mint = "SetupJoin.Mint()";
+    const string Mint = "Join.Mint()";
 
     static string SrcRoot() => Path.Combine(RepoRoot(), "src");
 

--- a/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/SetupJoinTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/SetupJoinTests.cs
@@ -4,56 +4,34 @@ using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Core.Tests.Unit.Telemetry;
 
-// Bare [NotInParallel], not the CliTelemetry.TestSink key SetupFunnelTests uses: the debug-output
-// tests here capture Console, which is process-global, and ConsoleOutput rejects an overlapping
-// capture outright. Ungrouped is strictly stronger, so it covers the shared telemetry statics too.
+// The debug-output tests here capture Console, which is process-global, and ConsoleOutput rejects
+// an overlapping capture outright.
 [NotInParallel]
-public class SetupJoinTests : IDisposable {
-    readonly TempDir _tmp = new();
-    public void Dispose() => _tmp.Dispose();
+public class SetupJoinTests {
+    [TempDir] public required TempDir Tmp { get; init; }
 
-    // CliTelemetry AND SetupJoin both hold process-global static state. A prior test elsewhere
-    // in the suite can leave Enabled=false behind via DiscardAndDisable, and a prior test here
-    // can leave a key minted — reset both before touching either.
-    [Before(Test)]
-    public void ResetStatics() {
-        CliTelemetry.Reset();
-        SetupJoin.Reset();
-    }
-
-    List<TelemetryEvent> StartCapturing() {
-        var config = new ConfigRoot(_tmp.Path);
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize("setup", null, loggedIn: false, config);
-
-        TelemetryTestGuards.AssertEnabled("setup", config);
-
-        sink.Clear(); // drop cli_first_run
-
-        return sink;
-    }
+    TelemetryProbe StartCapturing() => TelemetryProbe.Live("setup", new ConfigRoot(Tmp.Path));
 
     [Test]
     public async Task Mint_returns_32_lowercase_hex_and_sets_Current() {
-        StartCapturing();
+        var probe = StartCapturing();
 
-        var key = SetupJoin.Mint();
+        var key = probe.Join.Mint();
 
         await Assert.That(key).IsNotNull();
         await Assert.That(key!.Length).IsEqualTo(32);
         await Assert.That(key.All(c => char.IsAsciiDigit(c) || (c >= 'a' && c <= 'f'))).IsTrue();
-        await Assert.That(SetupJoin.Current).IsEqualTo(key);
+        await Assert.That(probe.Join.Current).IsEqualTo(key);
     }
 
     [Test]
     public async Task Mint_stamps_join_id_on_every_subsequent_event() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
-        var key = SetupJoin.Mint();
-        SetupFunnel.Started(false, false, false);
+        var key = probe.Join.Mint();
+        probe.Funnel.Started(false, false, false);
 
-        await Assert.That(sink[^1].Properties["join_id"]!.GetValue<string>()).IsEqualTo(key);
+        await Assert.That(probe.Events[^1].Properties["join_id"]!.GetValue<string>()).IsEqualTo(key);
     }
 
     // Every opt-out route — KCAP_TELEMETRY=0, DO_NOT_TRACK, the persisted flag, the
@@ -61,37 +39,39 @@ public class SetupJoinTests : IDisposable {
     // every downstream surface is off by construction rather than by four separate guards.
     [Test]
     public async Task Mint_is_a_null_no_op_when_telemetry_is_disabled() {
-        // No StartCapturing: Reset left Enabled false, which is what every opt-out produces.
-        var key = SetupJoin.Mint();
+        var join = CliTelemetry.Disabled().Join;
+
+        var key = join.Mint();
 
         await Assert.That(key).IsNull();
-        await Assert.That(SetupJoin.Current).IsNull();
+        await Assert.That(join.Current).IsNull();
     }
 
     [Test]
     public async Task Mint_twice_keeps_the_first_key() {
-        StartCapturing();
+        var probe = StartCapturing();
 
-        var first  = SetupJoin.Mint();
-        var second = SetupJoin.Mint();
+        var first  = probe.Join.Mint();
+        var second = probe.Join.Mint();
 
         await Assert.That(second).IsEqualTo(first);
-        await Assert.That(SetupJoin.Current).IsEqualTo(first);
+        await Assert.That(probe.Join.Current).IsEqualTo(first);
     }
 
     [Test]
     public async Task FirstHopUrl_targets_the_provisioning_endpoint_with_key_and_port() {
-        StartCapturing();
-        var key = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key = probe.Join.Mint();
 
-        var url = SetupJoin.FirstHopUrl(54321);
+        var url = probe.Join.FirstHopUrl(54321);
 
         await Assert.That(url).IsEqualTo($"{ProvisioningEndpoint.Url}/api/cli/return?j={key}&p=54321");
     }
 
     [Test]
     public async Task FirstHopUrl_is_null_without_a_key() {
-        await Assert.That(SetupJoin.FirstHopUrl(54321)).IsNull();
+        // A facade that is off mints nothing, so there is no key to build a hop from.
+        await Assert.That(CliTelemetry.Disabled().Join.FirstHopUrl(54321)).IsNull();
     }
 
     // The key is the bridge token. A debug run would otherwise print it to stderr on every
@@ -99,17 +79,12 @@ public class SetupJoinTests : IDisposable {
     // the property is attached.
     [Test]
     public async Task Debug_output_prints_a_placeholder_never_the_key() {
-        Environment.SetEnvironmentVariable("KCAP_TELEMETRY_DEBUG", "1");
         using var console = ConsoleOutput.StartErrorCapture();
-        string? key;
 
-        try {
-            StartCapturing();
-            key = SetupJoin.Mint();
-            CliTelemetry.Capture("cli_test_event", new JsonObject());
-        } finally {
-            Environment.SetEnvironmentVariable("KCAP_TELEMETRY_DEBUG", null);
-        }
+        var probe = TelemetryProbe.Live("setup", new ConfigRoot(Tmp.Path), debug: true);
+        var key   = probe.Join.Mint();
+
+        probe.Telemetry.Capture("cli_test_event", new JsonObject());
 
         var text = console.GetCapturedError();
         await Assert.That(key).IsNotNull();
@@ -117,45 +92,34 @@ public class SetupJoinTests : IDisposable {
         await Assert.That(text).DoesNotContain(key!);
     }
 
-    // An event with no key must render exactly as it did before this existed. A non-auth command is
-    // the "no key" state now that setup/login mint in Initialize: it enables telemetry but mints nothing.
+    // An event with no key must render with no placeholder at all. A non-auth command is the "no
+    // key" state: it enables telemetry but mints nothing.
     [Test]
     public async Task Debug_output_is_unchanged_for_an_event_with_no_key() {
-        Environment.SetEnvironmentVariable("KCAP_TELEMETRY_DEBUG", "1");
         using var console = ConsoleOutput.StartErrorCapture();
 
-        try {
-            var config = new ConfigRoot(_tmp.Path);
-            CliTelemetry.TestSink = new List<TelemetryEvent>();
-            CliTelemetry.Initialize("recap", null, loggedIn: false, config);
-            TelemetryTestGuards.AssertEnabled("recap", config);
+        var probe = TelemetryProbe.Live("recap", new ConfigRoot(Tmp.Path), debug: true);
 
-            CliTelemetry.Capture("cli_test_event", new JsonObject { ["k"] = "v" });
-        } finally {
-            Environment.SetEnvironmentVariable("KCAP_TELEMETRY_DEBUG", null);
-        }
+        probe.Telemetry.Capture("cli_test_event", new JsonObject { ["k"] = "v" });
 
         await Assert.That(console.GetCapturedError()).DoesNotContain("[set]");
         await Assert.That(console.GetCapturedError()).Contains("\"k\":\"v\"");
     }
 
     // The key lives in memory for one auth attempt only, so nothing on the machine can replay it
-    // into a later run. Scoped honestly: with a TestSink set, CliTelemetry leaves _client null, so
-    // the SPOOL — the one component that does write properties to disk, on a failed flush — is not
-    // reachable from here. This asserts only that minting and flushing write nothing to the
-    // telemetry state files. The spool's own strip is covered directly, against a real
-    // TelemetrySpool, in TelemetrySpoolTests; there is no endpoint seam that would let this test
-    // drive the real client without posting to production.
+    // into a later run. Scoped honestly: a recording sink never reaches the SPOOL — the one
+    // component that does write properties to disk, on a failed flush — so this asserts only that
+    // minting and flushing write nothing to the telemetry state files. The spool's own strip is
+    // covered directly, against a real TelemetrySpool, in TelemetrySpoolTests; there is no endpoint
+    // seam that would let this test drive the real client without posting to production.
     [Test]
     public async Task Minting_writes_nothing_to_the_telemetry_state_files() {
-        var dir = _tmp.CreateDir("state");
-        var config = new ConfigRoot(dir.Path);
-        CliTelemetry.TestSink = [];
-        CliTelemetry.Initialize("setup", null, loggedIn: false, config);
-        TelemetryTestGuards.AssertEnabled("setup", config);
+        var dir = Tmp.CreateDir("state");
 
-        var key = SetupJoin.Mint();
-        await CliTelemetry.FlushAndClose();
+        var probe = TelemetryProbe.Live("setup", new ConfigRoot(dir.Path));
+
+        var key = probe.Join.Mint();
+        await probe.Telemetry.FlushAndClose();
 
         var written = Directory.GetFiles(dir, "*", SearchOption.AllDirectories);
 
@@ -165,41 +129,43 @@ public class SetupJoinTests : IDisposable {
             await Assert.That(await File.ReadAllTextAsync(file)).DoesNotContain(key!);
     }
 
+    // One key per auth run, and a run is a facade: two in the same process must not share one,
+    // which is what stops one auth attempt's key reaching the next.
     [Test]
-    public async Task Reset_clears_the_key() {
-        StartCapturing();
-        SetupJoin.Mint();
+    public async Task Each_facade_mints_its_own_key() {
+        var probe = StartCapturing();
+        var next  = TelemetryProbe.Live("setup", new ConfigRoot(Tmp.CreateDir("second").Path));
 
-        SetupJoin.Reset();
-
-        await Assert.That(SetupJoin.Current).IsNull();
+        await Assert.That(probe.Join.Current).IsNotNull();
+        await Assert.That(next.Join.Current).IsNotNull();
+        await Assert.That(next.Join.Current).IsNotEqualTo(probe.Join.Current);
     }
 
-    // The adapter LoopbackBrowser is handed, so it stays decoupled from the statics.
+    // SetupJoin IS the ILoopbackJoin the browser is handed, so the browser stays decoupled from it.
     [Test]
-    public async Task The_loopback_adapter_forwards_to_the_statics() {
-        StartCapturing();
-        var key = SetupJoin.Mint();
+    public async Task The_loopback_join_builds_the_first_hop_url() {
+        var probe = StartCapturing();
+        var key = probe.Join.Mint();
 
-        await Assert.That(SetupJoin.Loopback.FirstHopUrl(4242))
+        await Assert.That(probe.Join.FirstHopUrl(4242))
             .IsEqualTo($"{ProvisioningEndpoint.Url}/api/cli/return?j={key}&p=4242");
     }
 
     // Capture an event and read back the merged shared bag.
-    static JsonObject SharedOf(List<TelemetryEvent> sink) {
-        CliTelemetry.Capture("cli_probe", new JsonObject());
+    static JsonObject SharedOf(TelemetryProbe probe) {
+        probe.Telemetry.Capture("cli_probe", new JsonObject());
 
-        return sink[^1].Properties;
+        return probe.Events[^1].Properties;
     }
 
     [Test]
     public async Task Accept_merges_all_three_properties_on_a_key_match() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
 
-        SetupJoin.Accept($"?j={key}&v=redesign&w1=cap-device-1&w2=www-device-2");
+        probe.Join.Accept($"?j={key}&v=redesign&w1=cap-device-1&w2=www-device-2");
 
-        var props = SharedOf(sink);
+        var props = SharedOf(probe);
         await Assert.That(props["site_variant"]!.GetValue<string>()).IsEqualTo("redesign");
         await Assert.That(props["web_device_id_capacitor"]!.GetValue<string>()).IsEqualTo("cap-device-1");
         await Assert.That(props["web_device_id_www"]!.GetValue<string>()).IsEqualTo("www-device-2");
@@ -209,12 +175,12 @@ public class SetupJoinTests : IDisposable {
     // browser tab or web page can cause a GET there. Only a key match is.
     [Test]
     public async Task Accept_drops_everything_on_a_key_mismatch() {
-        var sink = StartCapturing();
-        SetupJoin.Mint();
+        var probe = StartCapturing();
+        probe.Join.Mint();
 
-        SetupJoin.Accept("?j=00000000000000000000000000000000&v=legacy&w1=attacker");
+        probe.Join.Accept("?j=00000000000000000000000000000000&v=legacy&w1=attacker");
 
-        var props = SharedOf(sink);
+        var props = SharedOf(probe);
         await Assert.That(props["site_variant"]).IsNull();
         await Assert.That(props["web_device_id_capacitor"]).IsNull();
         await Assert.That(props["web_device_id_www"]).IsNull();
@@ -222,23 +188,23 @@ public class SetupJoinTests : IDisposable {
 
     [Test]
     public async Task Accept_drops_everything_when_j_is_missing() {
-        var sink = StartCapturing();
-        SetupJoin.Mint();
+        var probe = StartCapturing();
+        probe.Join.Mint();
 
-        SetupJoin.Accept("?v=legacy&w1=cap-device-1");
+        probe.Join.Accept("?v=legacy&w1=cap-device-1");
 
-        await Assert.That(SharedOf(sink)["web_device_id_capacitor"]).IsNull();
+        await Assert.That(SharedOf(probe)["web_device_id_capacitor"]).IsNull();
     }
 
     [Test]
     public async Task A_second_matching_Accept_can_never_overwrite_merged_state() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
 
-        SetupJoin.Accept($"?j={key}&v=legacy&w1=first");
-        SetupJoin.Accept($"?j={key}&v=redesign&w1=second");
+        probe.Join.Accept($"?j={key}&v=legacy&w1=first");
+        probe.Join.Accept($"?j={key}&v=redesign&w1=second");
 
-        var props = SharedOf(sink);
+        var props = SharedOf(probe);
         await Assert.That(props["site_variant"]!.GetValue<string>()).IsEqualTo("legacy");
         await Assert.That(props["web_device_id_capacitor"]!.GetValue<string>()).IsEqualTo("first");
     }
@@ -248,13 +214,13 @@ public class SetupJoinTests : IDisposable {
     // 15-second window is not a real threat.
     [Test]
     public async Task A_mismatch_does_not_burn_the_join() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
 
-        SetupJoin.Accept("?j=00000000000000000000000000000000&w1=attacker");
-        SetupJoin.Accept($"?j={key}&w1=genuine");
+        probe.Join.Accept("?j=00000000000000000000000000000000&w1=attacker");
+        probe.Join.Accept($"?j={key}&w1=genuine");
 
-        await Assert.That(SharedOf(sink)["web_device_id_capacitor"]!.GetValue<string>()).IsEqualTo("genuine");
+        await Assert.That(SharedOf(probe)["web_device_id_capacitor"]!.GetValue<string>()).IsEqualTo("genuine");
     }
 
     // The common case today: the arm cookie only exists for visitors the experiment assigned,
@@ -262,12 +228,12 @@ public class SetupJoinTests : IDisposable {
     // that required it would reject every valid web id alongside it and ship dead.
     [Test]
     public async Task Missing_v_still_merges_the_web_ids() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
 
-        SetupJoin.Accept($"?j={key}&w1=cap-device-1&w2=www-device-2");
+        probe.Join.Accept($"?j={key}&w1=cap-device-1&w2=www-device-2");
 
-        var props = SharedOf(sink);
+        var props = SharedOf(probe);
         await Assert.That(props["site_variant"]).IsNull();
         await Assert.That(props["web_device_id_capacitor"]!.GetValue<string>()).IsEqualTo("cap-device-1");
         await Assert.That(props["web_device_id_www"]!.GetValue<string>()).IsEqualTo("www-device-2");
@@ -275,24 +241,24 @@ public class SetupJoinTests : IDisposable {
 
     [Test]
     public async Task An_out_of_vocabulary_v_never_discards_the_web_ids() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
 
-        SetupJoin.Accept($"?j={key}&v=whatever&w1=cap-device-1&w2=www-device-2");
+        probe.Join.Accept($"?j={key}&v=whatever&w1=cap-device-1&w2=www-device-2");
 
-        var props = SharedOf(sink);
+        var props = SharedOf(probe);
         await Assert.That(props["site_variant"]).IsNull();
         await Assert.That(props["web_device_id_capacitor"]!.GetValue<string>()).IsEqualTo("cap-device-1");
     }
 
     [Test]
     public async Task One_malformed_web_id_never_discards_the_good_one() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
 
-        SetupJoin.Accept($"?j={key}&v=legacy&w1=has%20a%20space&w2=www-device-2");
+        probe.Join.Accept($"?j={key}&v=legacy&w1=has%20a%20space&w2=www-device-2");
 
-        var props = SharedOf(sink);
+        var props = SharedOf(probe);
         await Assert.That(props["site_variant"]!.GetValue<string>()).IsEqualTo("legacy");
         await Assert.That(props["web_device_id_capacitor"]).IsNull();
         await Assert.That(props["web_device_id_www"]!.GetValue<string>()).IsEqualTo("www-device-2");
@@ -300,14 +266,14 @@ public class SetupJoinTests : IDisposable {
 
     [Test]
     public async Task An_over_long_web_id_is_dropped() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
         var tooLong = new string('a', 65);
         var atLimit = new string('b', 64);
 
-        SetupJoin.Accept($"?j={key}&w1={tooLong}&w2={atLimit}");
+        probe.Join.Accept($"?j={key}&w1={tooLong}&w2={atLimit}");
 
-        var props = SharedOf(sink);
+        var props = SharedOf(probe);
         await Assert.That(props["web_device_id_capacitor"]).IsNull();
         await Assert.That(props["web_device_id_www"]!.GetValue<string>()).IsEqualTo(atLimit);
     }
@@ -316,14 +282,14 @@ public class SetupJoinTests : IDisposable {
     // email address, and the character class makes importing one structurally impossible.
     [Test]
     public async Task An_email_shaped_web_id_can_never_reach_the_property_bag() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
         var email = Uri.EscapeDataString("someone@example.com");
         var other = Uri.EscapeDataString("other@example.com");
 
-        SetupJoin.Accept($"?j={key}&w1={email}&w2={other}");
+        probe.Join.Accept($"?j={key}&w1={email}&w2={other}");
 
-        var props = SharedOf(sink);
+        var props = SharedOf(probe);
         await Assert.That(props["web_device_id_capacitor"]).IsNull();
         await Assert.That(props["web_device_id_www"]).IsNull();
         await Assert.That(props.ToJsonString()).DoesNotContain("@");
@@ -332,42 +298,42 @@ public class SetupJoinTests : IDisposable {
     // A mismatched value is attacker-chosen, so it must not surface anywhere at all.
     [Test]
     public async Task A_mismatched_value_never_reaches_debug_output() {
-        Environment.SetEnvironmentVariable("KCAP_TELEMETRY_DEBUG", "1");
         using var console = ConsoleOutput.StartErrorCapture();
 
-        try {
-            StartCapturing();
-            SetupJoin.Mint();
+        var probe = TelemetryProbe.Live("setup", new ConfigRoot(Tmp.Path), debug: true);
+        probe.Join.Mint();
 
-            SetupJoin.Accept("?j=00000000000000000000000000000000&w1=attacker-chosen-value");
-            CliTelemetry.Capture("cli_probe", new JsonObject());
-        } finally {
-            Environment.SetEnvironmentVariable("KCAP_TELEMETRY_DEBUG", null);
-        }
+        probe.Join.Accept("?j=00000000000000000000000000000000&w1=attacker-chosen-value");
+        probe.Telemetry.Capture("cli_probe", new JsonObject());
 
-        await Assert.That(console.GetCapturedError()).DoesNotContain("attacker-chosen-value");
+        var printed = console.GetCapturedError();
+
+        // Without this the assertion below passes on an empty buffer, which is what a debug run
+        // that never printed looks like.
+        await Assert.That(printed).Contains("cli_probe");
+        await Assert.That(printed).DoesNotContain("attacker-chosen-value");
     }
 
     [Test]
     public async Task Accept_without_a_minted_key_is_a_no_op() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
 
-        SetupJoin.Accept("?j=00000000000000000000000000000000&w1=cap-device-1");
+        probe.Join.Accept("?j=00000000000000000000000000000000&w1=cap-device-1");
 
-        await Assert.That(SharedOf(sink)["web_device_id_capacitor"]).IsNull();
+        await Assert.That(SharedOf(probe)["web_device_id_capacitor"]).IsNull();
     }
 
     // Nothing here may throw: an exception escaping into the NativeAOT runtime aborts the
     // process, and this runs on a background thread nobody is watching.
     [Test]
     public async Task Accept_survives_a_junk_query_without_throwing() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
 
         foreach (var junk in new[] { "", "?", "?????", "&&&", "?j", "?=x", "?j=", $"?j={key}&w1" })
-            SetupJoin.Accept(junk);
+            probe.Join.Accept(junk);
 
-        await Assert.That(SharedOf(sink)["web_device_id_capacitor"]).IsNull();
+        await Assert.That(SharedOf(probe)["web_device_id_capacitor"]).IsNull();
     }
 
     // The return hop is merged on a background thread while the foreground is still running the
@@ -380,24 +346,24 @@ public class SetupJoinTests : IDisposable {
     // The event most likely to vanish is the one the feature exists to measure.
     [Test]
     public async Task Capturing_while_the_return_hop_merges_never_drops_an_event() {
-        var sink = StartCapturing();
+        var probe = StartCapturing();
         const int captures = 300;
 
         // A wide enumeration, so the window is reliably hit rather than occasionally: each capture
         // walks every shared property, and an insert during that walk is what faults.
-        for (var i = 0; i < 2000; i++) CliTelemetry.AddSharedProperty($"seed_{i}", i);
+        for (var i = 0; i < 2000; i++) probe.Telemetry.AddSharedProperty($"seed_{i}", i);
 
         var merging = Task.Run(() => {
             // Distinct names, so each is an insert rather than an overwrite — an insert is what
             // invalidates an enumeration already in flight.
-            for (var i = 0; i < captures; i++) CliTelemetry.AddSharedProperty($"probe_{i}", i);
+            for (var i = 0; i < captures; i++) probe.Telemetry.AddSharedProperty($"probe_{i}", i);
         });
 
-        for (var i = 0; i < captures; i++) CliTelemetry.Capture("cli_probe", new JsonObject());
+        for (var i = 0; i < captures; i++) probe.Telemetry.Capture("cli_probe", new JsonObject());
 
         await merging;
 
-        await Assert.That(sink.Count).IsEqualTo(captures)
+        await Assert.That(probe.Events.Count).IsEqualTo(captures)
             .Because("a concurrent merge must not silently swallow a captured event");
     }
 
@@ -405,13 +371,13 @@ public class SetupJoinTests : IDisposable {
     // web identity — one host's id present and the other's still missing.
     [Test]
     public async Task The_returned_context_is_merged_as_one_batch() {
-        var sink = StartCapturing();
-        var key  = SetupJoin.Mint();
+        var probe = StartCapturing();
+        var key  = probe.Join.Mint();
 
-        SetupJoin.Accept($"?j={key}&v=legacy&w1=cap-1&w2=www-1");
+        probe.Join.Accept($"?j={key}&v=legacy&w1=cap-1&w2=www-1");
 
-        CliTelemetry.Capture("cli_probe", new JsonObject());
-        var props = sink[^1].Properties;
+        probe.Telemetry.Capture("cli_probe", new JsonObject());
+        var props = probe.Events[^1].Properties;
 
         await Assert.That(props["site_variant"]!.GetValue<string>()).IsEqualTo("legacy");
         await Assert.That(props["web_device_id_capacitor"]!.GetValue<string>()).IsEqualTo("cap-1");

--- a/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/SpawnMarkerTests.cs
+++ b/test/Capacitor.Cli.Core.Tests.Unit/Telemetry/SpawnMarkerTests.cs
@@ -2,72 +2,69 @@ using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Core.Tests.Unit.Telemetry;
 
-[NotInParallel(nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink))]
 public class SpawnMarkerTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
+    /// <summary>
+    /// Reading the marker consumes it, so these mutate the real environment — the only place it
+    /// lives. Bare, because a concurrent peer spawning a child would inherit whatever is set.
+    /// </summary>
     [Test]
-    public async Task Consume_removes_marker_and_reports_presence() {
-        CliTelemetry.Reset();
-        var env = new Dictionary<string, string?> { [CliTelemetry.SpawnNoTelemetryVar] = "1" };
-        var suppressed = CliTelemetry.ConsumeSpawnMarker(k => env.GetValueOrDefault(k), k => env.Remove(k));
+    [NotInParallel]
+    public async Task The_marker_is_read_once_and_removed_from_the_environment() {
+        using var marker = EnvScope.Exclusive(TelemetryStartup.SpawnNoTelemetryVar, "1");
 
-        await Assert.That(suppressed).IsTrue();
-        await Assert.That(env.ContainsKey(CliTelemetry.SpawnNoTelemetryVar)).IsFalse();
+        var startup = TelemetryStartup.FromEnvironment("login", serverUrl: null);
+
+        await Assert.That(startup.Suppressed).IsTrue();
+        await Assert.That(Environment.GetEnvironmentVariable(TelemetryStartup.SpawnNoTelemetryVar)).IsNull()
+            .Because("nothing this process spawns may observe it");
     }
 
     [Test]
-    public async Task Consume_without_marker_is_inert() {
-        CliTelemetry.Reset();
-        var env = new Dictionary<string, string?>();
-        var suppressed = CliTelemetry.ConsumeSpawnMarker(k => env.GetValueOrDefault(k), k => env.Remove(k));
+    [NotInParallel]
+    public async Task No_marker_suppresses_nothing() {
+        using var marker = EnvScope.Exclusive(TelemetryStartup.SpawnNoTelemetryVar, null);
 
-        await Assert.That(suppressed).IsFalse();
+        await Assert.That(TelemetryStartup.FromEnvironment("login", serverUrl: null).Suppressed).IsFalse();
+    }
+
+    /// <summary>The marker is ours; the opt-out is the user's, and consuming one must not touch the other.</summary>
+    [Test]
+    [NotInParallel]
+    public async Task Consuming_the_marker_leaves_the_users_own_KCAP_TELEMETRY_alone() {
+        using var marker = EnvScope.Exclusive(TelemetryStartup.SpawnNoTelemetryVar, "1");
+        using var choice = EnvScope.Exclusive("KCAP_TELEMETRY", "1");
+
+        TelemetryStartup.FromEnvironment("login", serverUrl: null);
+
+        await Assert.That(Environment.GetEnvironmentVariable("KCAP_TELEMETRY")).IsEqualTo("1");
     }
 
     [Test]
-    public async Task Marker_does_not_touch_users_own_KCAP_TELEMETRY() {
-        CliTelemetry.Reset();
-        var env = new Dictionary<string, string?> {
-            [CliTelemetry.SpawnNoTelemetryVar] = "1",
-            ["KCAP_TELEMETRY"] = "1",
-        };
-        CliTelemetry.ConsumeSpawnMarker(k => env.GetValueOrDefault(k), k => env.Remove(k));
+    public async Task A_suppressed_startup_yields_a_facade_that_captures_nothing() {
+        var probe = TelemetryProbe.Start("login", Config.Root, suppressed: true);
 
-        await Assert.That(env["KCAP_TELEMETRY"]).IsEqualTo("1");
+        probe.Funnel.Started(hasExistingProfile: false, serverUrlProvided: false, noPrompt: false);
+
+        await Assert.That(probe.Telemetry.Enabled).IsFalse();
+        await Assert.That(probe.Events).IsEmpty();
     }
 
+    /// <summary>
+    /// The marker is gone from the environment once read, so a second facade in the same process
+    /// cannot re-take the decision — inheriting the value is the only way it survives, which is what
+    /// an MCP server does when it re-derives its own under the "mcp-server" pseudo-command.
+    /// </summary>
     [Test]
-    public async Task Initialize_with_suppressed_true_keeps_telemetry_disabled() {
-        CliTelemetry.Reset();
-        CliTelemetry.TestSink = new();
+    public async Task Suppression_travels_to_a_second_facade_in_the_same_process() {
+        var startup = new TelemetryStartup("mcp", ServerUrl: null, Suppressed: true, Debug: false);
 
-        CliTelemetry.Initialize("login", null, false, Config.Root, suppressed: true);
+        var probe = TelemetryProbe.Start(startup with { Command = "mcp-server" }, Config.Root);
 
-        await Assert.That(CliTelemetry.Enabled).IsFalse();
-        await Assert.That(CliTelemetry.TestSink).Count().IsEqualTo(0);
-    }
+        probe.Telemetry.Capture("mcp_tool_called", []);
 
-    [Test]
-    public async Task Suppression_is_sticky_across_multiple_initialize_calls() {
-        CliTelemetry.Reset();
-        CliTelemetry.TestSink = new();
-
-        // First init: consume marker and suppress
-        var env = new Dictionary<string, string?> { [CliTelemetry.SpawnNoTelemetryVar] = "1" };
-        var consumed = CliTelemetry.ConsumeSpawnMarker(k => env.GetValueOrDefault(k), k => env.Remove(k));
-        await Assert.That(consumed).IsTrue();
-
-        // First initialize call with suppression
-        CliTelemetry.Initialize("mcp", null, false, Config.Root, suppressed: true);
-        await Assert.That(CliTelemetry.Enabled).IsFalse();
-
-        // Second initialize call WITHOUT suppressed parameter (like MCP handlers do)
-        // This mimics McpWorkItemsServer.cs:34 calling Initialize("mcp-server", baseUrl, loggedIn)
-        CliTelemetry.Initialize("mcp-server", null, false, Config.Root);
-
-        // Telemetry must still be suppressed (sticky suppression prevents re-enabling)
-        await Assert.That(CliTelemetry.Enabled).IsFalse();
-        await Assert.That(CliTelemetry.TestSink).Count().IsEqualTo(0);
+        await Assert.That(probe.Telemetry.Enabled).IsFalse();
+        await Assert.That(probe.Events).IsEmpty();
     }
 }

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpMetricsTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/AcpMetricsTests.cs
@@ -10,6 +10,10 @@ namespace Capacitor.Cli.Daemon.Tests.Unit.Acp;
 /// <see cref="MeterListener"/> — the same mechanism <c>dotnet-counters</c> uses. No reconnect
 /// counters are covered here — none exist yet (a later phase).
 /// </summary>
+// Bare: the meter is process-global, and its writers are not just this class — production's
+// AcpInteractionBridge records the same instrument, so any test driving it contaminates a listener
+// here. A key can only exclude tests that carry it, which those writers have no reason to.
+[NotInParallel]
 public class AcpMetricsTests {
     [Test]
     public async Task AllCounters_CanBeIncremented_WithoutThrowing() =>

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/BorrowedReviewAuthBrokerTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Acp/BorrowedReviewAuthBrokerTests.cs
@@ -287,7 +287,7 @@ public class BorrowedReviewAuthBrokerTests {
         Skip.When(OperatingSystem.IsWindows(), "POSIX shell command");
 
         var (result, elapsed) = Timed(() => BorrowedReviewTokenCommand.Run(
-            "head -c 33554432 /dev/zero | tr '\\0' 'x' 1>&2; exit 1"));
+            $"head -c {FloodBytes} /dev/zero | tr '\\0' 'x' 1>&2; exit 1"));
 
         await Assert.That(result).IsNull();
         await Assert.That(elapsed).IsLessThan(BorrowedReviewTokenCommand.Timeout);
@@ -299,7 +299,7 @@ public class BorrowedReviewAuthBrokerTests {
         Skip.When(OperatingSystem.IsWindows(), "POSIX shell command");
 
         var (result, elapsed) = Timed(() => BorrowedReviewTokenCommand.Run(
-            "head -c 33554432 /dev/zero | tr '\\0' 'y'"));
+            $"head -c {FloodBytes} /dev/zero | tr '\\0' 'y'"));
 
         await Assert.That(result).IsNull();
         await Assert.That(elapsed).IsLessThan(BorrowedReviewTokenCommand.Timeout);
@@ -313,11 +313,18 @@ public class BorrowedReviewAuthBrokerTests {
         Skip.When(OperatingSystem.IsWindows(), "POSIX shell command");
 
         var (token, elapsed) = Timed(() => BorrowedReviewTokenCommand.Run(
-            "printf 'tok-first\\n'; head -c 33554432 /dev/zero | tr '\\0' 'z'"));
+            $"printf 'tok-first\\n'; head -c {FloodBytes} /dev/zero | tr '\\0' 'z'"));
 
         await Assert.That(token).IsEqualTo("tok-first");
         await Assert.That(elapsed).IsLessThan(BorrowedReviewTokenCommand.Timeout);
     }
+
+    /// <summary>
+    /// Enough to prove the pipe keeps being drained — a pipe buffer is 64 KiB, so a writer that
+    /// nobody reads blocks long before this — without spending so much of the machine that the
+    /// elapsed-time assertions below race whatever else the suite is running.
+    /// </summary>
+    const int FloodBytes = 4 * 1024 * 1024;
 
     static (string? Result, TimeSpan Elapsed) Timed(Func<string?> run) {
         var started = DateTime.UtcNow;

--- a/test/Capacitor.Cli.Tests.Unit/Commands/CliTelemetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/CliTelemetryTests.cs
@@ -4,43 +4,26 @@ using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Tests.Unit.Commands;
 
-// CliTelemetry's own statics (TestSink, the Initialize-set state) are process-global and stay that
-// way — making the facade an instance is a behaviour change, not a path change. So the key names
-// them, and every class driving the facade carries it. The telemetry FILES need no key any more:
-// they live under this test's own root.
-[NotInParallel(nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink))]
 public class CliTelemetryTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
-    // CliTelemetry holds process-global static state (Enabled, TestSink, ...). A prior test
-    // elsewhere in the suite (e.g. one that persists `telemetry off`) can leave Enabled=false
-    // behind via CliTelemetry.DiscardAndDisable — reset before touching TestSink so every test
-    // here starts from pristine state rather than inheriting whatever ran before it. This
-    // subsumes the ad hoc CliTelemetry.Reset() call some tests below used to make individually.
-    [Before(Test)]
-    public void ResetTelemetry() => CliTelemetry.Reset();
+    TelemetryProbe StartCapturing(string command = "setup", string? serverUrl = null) {
+        var probe = TelemetryProbe.Start(command, Config.Root, serverUrl);
 
-    List<TelemetryEvent> StartCapturing(string command = "setup", string? serverUrl = null) {
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize(command, serverUrl, loggedIn: false, Config.Root);
+        TelemetryTestGuards.AssertEnabled(command, Config.Root, probe.Telemetry);
 
-        TelemetryTestGuards.AssertEnabled(command, Config.Root);
-
-        return sink;
+        return probe;
     }
 
     [Test]
     public async Task Capture_records_the_event_with_shared_properties() {
-        // StartCapturing() always begins from a brand-new device state file (this test's own root),
-        // so Initialize's first-run notice fires and "cli_first_run" lands in the sink too (see
-        // First_run_emits_cli_first_run_once_per_device below) — filter by name rather than assume
-        // this is the only event, the same way Record_command_emits_cli_command_with_exit_code does.
-        var sink = StartCapturing();
+        // A brand-new device state file (this test's own root) means the first-run notice fires and
+        // cli_first_run lands here too, so filter by name rather than assume a single event.
+        var probe = StartCapturing();
 
-        CliTelemetry.Capture("cli_setup_started", new JsonObject { ["no_prompt"] = false });
+        probe.Telemetry.Capture("cli_setup_started", new JsonObject { ["no_prompt"] = false });
 
-        var e = sink.Single(x => x.Name == "cli_setup_started");
+        var e = probe.Only("cli_setup_started");
         await Assert.That(e.Properties["source"]!.GetValue<string>()).IsEqualTo("cli");
         await Assert.That(e.Properties.ContainsKey("cli_version")).IsTrue();
         await Assert.That(e.Properties.ContainsKey("os")).IsTrue();
@@ -51,188 +34,155 @@ public class CliTelemetryTests {
 
     [Test]
     public async Task Record_command_emits_cli_command_with_exit_code() {
-        var sink = StartCapturing("daemon");
+        var probe = StartCapturing("daemon");
 
-        CliTelemetry.RecordCommand("daemon", ["daemon", "start", "--foreground"], exitCode: 0, durationMs: 42);
+        probe.Telemetry.RecordCommand("daemon", ["daemon", "start", "--foreground"], exitCode: 0, durationMs: 42);
 
-        var e = sink.Single(x => x.Name == "cli_command");
+        var e = probe.Only("cli_command");
         await Assert.That(e.Properties["command"]!.GetValue<string>()).IsEqualTo("daemon");
         await Assert.That(e.Properties["subcommand"]!.GetValue<string>()).IsEqualTo("start");
         await Assert.That(e.Properties["exit_code"]!.GetValue<int>()).IsEqualTo(0);
         await Assert.That(e.Properties["duration_ms"]!.GetValue<long>()).IsEqualTo(42L);
     }
 
-    // Initialise with a REPORTABLE command so Enabled stays true, which means RecordCommand's own
-    // `!CommandEvents.IsReportable(command)` guard — not Initialize's — is what suppresses the
-    // event. Load-bearing for Task 10: a long-lived MCP server process calls
-    // Initialize("mcp-server", …) once, then RecordCommand may be called per-invocation with a
-    // different, potentially denylisted, command string. Initialising with "hook" here would let
-    // Initialize's Enabled=false short-circuit RecordCommand before its own guard ever runs.
-    // End-to-end version of CommandEventsTests.Unrecognised_tokens_report_unknown: proves the
-    // redaction actually reaches the emitted event's `command` property, not just the pure
-    // allowlist function. `command` here is NOT denylisted (it's not a real verb at all), so
-    // RecordCommand proceeds — CommandEvents.ReportableCommand is what has to catch it.
+    // Started under a REPORTABLE command so the facade stays live, which means RecordCommand's own
+    // `!CommandEvents.IsReportable(command)` guard — not the facade's — is what suppresses the
+    // event. Load-bearing: a long-lived MCP server starts one facade, then RecordCommand may be
+    // called per-invocation with a different, potentially denylisted, command string. Starting
+    // under "hook" here would let the facade come up off and short-circuit RecordCommand before
+    // its own guard ever ran. `command` here is not denylisted (it is not a verb at all), so
+    // RecordCommand proceeds and CommandEvents.ReportableCommand is what has to catch it.
     [Test]
     public async Task Record_command_redacts_an_unrecognised_verb_to_unknown() {
-        var sink = StartCapturing("status");
+        var probe = StartCapturing("status");
 
-        CliTelemetry.RecordCommand(
+        probe.Telemetry.RecordCommand(
             "/Users/me/work/acme-private", ["/Users/me/work/acme-private"], exitCode: 1, durationMs: 3);
 
-        var e = sink.Single(x => x.Name == "cli_command");
-        await Assert.That(e.Properties["command"]!.GetValue<string>()).IsEqualTo("unknown");
+        await Assert.That(probe.Only("cli_command").Properties["command"]!.GetValue<string>()).IsEqualTo("unknown");
     }
 
     [Test]
     public async Task Denylisted_commands_emit_nothing() {
-        var sink = StartCapturing("status");
+        var probe = StartCapturing("status");
 
-        CliTelemetry.RecordCommand("hook", ["hook", "--claude"], exitCode: 0, durationMs: 5);
+        probe.Telemetry.RecordCommand("hook", ["hook", "--claude"], exitCode: 0, durationMs: 5);
 
-        await Assert.That(sink.Any(x => x.Name == "cli_command")).IsFalse();
+        await Assert.That(probe.Names.Contains("cli_command")).IsFalse();
     }
 
     [Test]
     public async Task Disabled_telemetry_captures_nothing() {
         TelemetryState.SetEnabled(false, Config.Root);
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize("setup", null, loggedIn: false, Config.Root);
+        var probe = TelemetryProbe.Start("setup", Config.Root);
 
-        CliTelemetry.Capture("cli_setup_started", new JsonObject());
-        CliTelemetry.RecordCommand("setup", ["setup"], 0, 1);
+        probe.Telemetry.Capture("cli_setup_started", new JsonObject());
+        probe.Telemetry.RecordCommand("setup", ["setup"], 0, 1);
 
-        await Assert.That(CliTelemetry.Enabled).IsFalse();
-        await Assert.That(sink.Count).IsEqualTo(0);
+        await Assert.That(probe.Telemetry.Enabled).IsFalse();
+        await Assert.That(probe.Events).IsEmpty();
     }
 
-    // An uninitialised facade must be inert, not merely non-throwing: a swallowed exception and
-    // a correctly-skipped capture look identical from the outside unless state is asserted.
+    // The null object must be inert, not merely non-throwing: a swallowed exception and a
+    // correctly-skipped capture look identical from the outside unless state is asserted.
     [Test]
-    public async Task Capture_before_initialize_is_inert() {
-        // No CliTelemetry.Initialize call in this test — [Before(Test)]'s Reset() above is what
-        // makes "uninitialised" actually mean uninitialised, rather than inheriting Enabled=true
-        // from whatever the previous test in the run left behind.
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
+    public async Task A_disabled_facade_is_inert() {
+        var telemetry = CliTelemetry.Disabled();
 
-        CliTelemetry.Capture("orphan", new JsonObject());
-        CliTelemetry.RecordCommand("status", ["status"], 0, 1);
-        await CliTelemetry.FlushAndClose();
+        telemetry.Capture("orphan", new JsonObject());
+        telemetry.RecordCommand("status", ["status"], 0, 1);
+        await telemetry.FlushAndClose();
 
-        await Assert.That(CliTelemetry.Enabled).IsFalse();
-        await Assert.That(sink.Count).IsEqualTo(0);
+        await Assert.That(telemetry.Enabled).IsFalse();
+        await Assert.That(telemetry.Join.Current).IsNull();
     }
 
     [Test]
     public async Task First_run_emits_cli_first_run_once_per_device() {
-        var firstSink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = firstSink;
-        CliTelemetry.Initialize("setup", null, loggedIn: false, Config.Root);
+        var first  = TelemetryProbe.Start("setup", Config.Root);
+        var second = TelemetryProbe.Start("status", Config.Root);
 
-        var secondSink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = secondSink;
-        CliTelemetry.Initialize("status", null, loggedIn: false, Config.Root);
-
-        await Assert.That(firstSink.Any(e => e.Name == "cli_first_run")).IsTrue();
-        await Assert.That(secondSink.Any(e => e.Name == "cli_first_run")).IsFalse();
+        await Assert.That(first.Names.Contains("cli_first_run")).IsTrue();
+        await Assert.That(second.Names.Contains("cli_first_run")).IsFalse();
     }
 
-    // Task 10: "mcp-server" is the pseudo-command MCP servers re-initialise under (see
-    // McpTelemetry). An agent-spawned MCP server's stderr is not watched by a human, and on a
-    // fresh machine it can plausibly be the very first kcap-family process ever run — so it must
-    // never consume the once-per-device first-run notice on a human's behalf. The first
-    // human-invoked, reportable command afterward must still see it.
+    // "mcp-server" is the pseudo-command MCP servers start under (see McpTelemetry). An
+    // agent-spawned MCP server's stderr is not watched by a human, and on a fresh machine it can
+    // plausibly be the very first kcap-family process ever run — so it must never consume the
+    // once-per-device first-run notice on a human's behalf. The first human-invoked, reportable
+    // command afterward must still see it.
     [Test]
-    public async Task Mcp_server_initialise_does_not_consume_the_first_run_notice() {
-        var mcpSink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = mcpSink;
-        CliTelemetry.Initialize("mcp-server", null, loggedIn: false, Config.Root);
+    public async Task Mcp_server_start_does_not_consume_the_first_run_notice() {
+        var mcp   = TelemetryProbe.Start("mcp-server", Config.Root);
+        var human = TelemetryProbe.Start("status", Config.Root);
 
-        var humanSink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = humanSink;
-        CliTelemetry.Initialize("status", null, loggedIn: false, Config.Root);
-
-        await Assert.That(mcpSink.Any(e => e.Name == "cli_first_run")).IsFalse();
-        await Assert.That(humanSink.Any(e => e.Name == "cli_first_run")).IsTrue();
+        await Assert.That(mcp.Names.Contains("cli_first_run")).IsFalse();
+        await Assert.That(human.Names.Contains("cli_first_run")).IsTrue();
         await Assert.That(TelemetryState.Read(Config.Root).NoticeShown).IsTrue();
     }
 
-    // The property "never mint a device id while opted out" still holds — only its enforcement
-    // point moved. TelemetryDeviceId.GetOrCreate no longer has any notion of state.Enabled to
-    // re-check (TelemetryDeviceIdTests.Get_or_create_is_unaffected_by_telemetry_state pins that it
-    // now mints even when called directly against a disabled state); Initialize's own
-    // `if (!Enabled) return;` is the one gate left, and it must never reach
-    // TelemetryDeviceId.GetOrCreate at all when TelemetrySettings.Resolve says disabled.
+    // TelemetryDeviceId.GetOrCreate has no notion of the persisted flag to re-check
+    // (TelemetryDeviceIdTests.Get_or_create_is_unaffected_by_telemetry_state pins that it mints
+    // even when called directly against a disabled state), so the facade's own resolve is the one
+    // gate left: it must never reach TelemetryDeviceId.GetOrCreate when the settings say disabled.
     [Test]
-    public async Task Initialize_never_mints_a_device_id_while_opted_out_via_persisted_config() {
+    public async Task Starting_never_mints_a_device_id_while_opted_out_via_persisted_config() {
         TelemetryState.SetEnabled(false, Config.Root);
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
 
-        CliTelemetry.Initialize("status", null, loggedIn: false, Config.Root);
+        var probe = TelemetryProbe.Start("status", Config.Root);
 
-        await Assert.That(CliTelemetry.Enabled).IsFalse();
+        await Assert.That(probe.Telemetry.Enabled).IsFalse();
         await Assert.That(TelemetryDeviceId.ReadPersisted(Config.Root)).IsNull();
     }
 
-    // Regression test for the P2 finding: GetOrCreateDeviceId used to independently veto minting
-    // whenever the PERSISTED flag was false, regardless of what TelemetrySettings.Resolve (which
-    // already accounts for KCAP_TELEMETRY outranking the persisted config) had decided. That made
-    // the documented top-priority env var unable to opt back in once a user had persisted "off" —
-    // Initialize would resolve Enabled=true, call GetOrCreateDeviceId, get null back from the
-    // stale independent check, and disable itself right back. Mutates the REAL process env var
-    // (TelemetrySettings.Resolve(bool?) reads it live), safe under this class's shared
-    // [NotInParallel] lock — no other suite in this run touches the real KCAP_TELEMETRY var.
+    // KCAP_TELEMETRY outranks the persisted flag, so a user who persisted "off" can still opt back
+    // in with it — which requires the device id to be minted on that path. A device-id check that
+    // vetoed minting off the persisted flag independently would make the documented top-priority
+    // env var unable to do so.
+    //
+    // Bare [NotInParallel] because this mutates the real process environment: a concurrent peer
+    // spawning a child would inherit it, and EnvScope.Exclusive enforces the constraint.
     [Test]
+    [NotInParallel]
     public async Task Kcap_telemetry_env_var_overrides_a_persisted_off_and_mints_a_device_id() {
         TelemetryState.SetEnabled(false, Config.Root);
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
 
-        var saved = Environment.GetEnvironmentVariable("KCAP_TELEMETRY");
-        Environment.SetEnvironmentVariable("KCAP_TELEMETRY", "1");
-        try {
-            CliTelemetry.Initialize("status", null, loggedIn: false, Config.Root);
+        using var env = EnvScope.Exclusive("KCAP_TELEMETRY", "1");
 
-            await Assert.That(CliTelemetry.Enabled).IsTrue();
-            await Assert.That(TelemetryDeviceId.ReadPersisted(Config.Root)).IsNotNull();
-        } finally {
-            Environment.SetEnvironmentVariable("KCAP_TELEMETRY", saved);
-        }
+        var probe = TelemetryProbe.Start("status", Config.Root);
+
+        await Assert.That(probe.Telemetry.Enabled).IsTrue();
+        await Assert.That(TelemetryDeviceId.ReadPersisted(Config.Root)).IsNotNull();
     }
 
-    // Regression test for the P1 finding's belt-and-braces half. Program.cs now pre-applies
-    // `config set telemetry off` to disk before calling Initialize (see Program.cs), so the plain
-    // case never activates telemetry at all. But Initialize CAN still come up live despite a
-    // persisted "off" — KCAP_TELEMETRY=1 legitimately overrides it (finding 2) — so this
-    // simulates that: telemetry is already live with cli_first_run queued (as if it had resolved
-    // enabled for whatever reason) by the time `config set telemetry off` runs, and asserts
-    // ConfigCommand.TryApplyTelemetry's CliTelemetry.DiscardAndDisable() tears it down completely
-    // in the SAME process — discarding what's queued, disabling the facade, and deleting the id —
-    // rather than leaving it to survive to this process's own ProcessExit flush.
+    // Program.cs pre-applies `config set telemetry off` to disk before starting the facade, so the
+    // plain case never activates telemetry at all. But the facade CAN still come up live despite a
+    // persisted "off" — KCAP_TELEMETRY=1 legitimately overrides it — so this simulates that:
+    // telemetry is already live with cli_first_run queued by the time `config set telemetry off`
+    // runs, and asserts TryApplyTelemetry's DiscardAndDisable tears it down completely in the SAME
+    // process — dropping what is queued, disabling the facade, and deleting the id — rather than
+    // leaving it to survive to this process's own ProcessExit flush.
     [Test]
     public async Task Opting_out_via_config_tears_down_telemetry_in_the_same_process_and_deletes_the_id() {
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize("config", null, loggedIn: false, Config.Root);
+        var probe = TelemetryProbe.Start("config", Config.Root);
 
         // Sanity: telemetry actually came up live and minted an id — otherwise the assertions
         // below would trivially pass having exercised nothing.
-        await Assert.That(CliTelemetry.Enabled).IsTrue();
+        await Assert.That(probe.Telemetry.Enabled).IsTrue();
         await Assert.That(TelemetryDeviceId.ReadPersisted(Config.Root)).IsNotNull();
-        await Assert.That(sink.Any(e => e.Name == "cli_first_run")).IsTrue();
+        await Assert.That(probe.Names.Contains("cli_first_run")).IsTrue();
 
-        var exit = await new ConfigCommand(Config.Root, new FixedCapacitorHttpClient()).HandleAsync(["config", "set", "telemetry", "off"]);
+        var exit = await new ConfigCommand(Config.Root, new FixedCapacitorHttpClient(), probe.Telemetry)
+            .HandleAsync(["config", "set", "telemetry", "off"]);
 
         await Assert.That(exit).IsEqualTo(0);
-        await Assert.That(CliTelemetry.Enabled).IsFalse();
-        await Assert.That(sink).IsEmpty();
+        await Assert.That(probe.Telemetry.Enabled).IsFalse();
+        await Assert.That(probe.Events).IsEmpty();
         await Assert.That(TelemetryDeviceId.ReadPersisted(Config.Root)).IsNull();
         await Assert.That(TelemetryState.PersistedEnabled(Config.Root)).IsFalse();
 
         // The disabled facade must not resurrect anything on the exit-time flush either.
-        await CliTelemetry.FlushAndClose();
-        await Assert.That(sink).IsEmpty();
+        await probe.Telemetry.FlushAndClose();
+        await Assert.That(probe.Events).IsEmpty();
     }
 }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/CommandContainerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/CommandContainerTests.cs
@@ -21,7 +21,8 @@ public class CommandContainerTests {
             .AddCapacitorCli(
                 Config.Root, Home, Daemons.Store,
                 baseUrl is null ? Resolutions.None(Config.Root) : Resolutions.At(baseUrl, Config.Root),
-                ProfileOverrides.None, MachineAuth.None, new HookClock(TimeProvider.System), baseUrl)
+                ProfileOverrides.None, MachineAuth.None, new HookClock(TimeProvider.System), baseUrl,
+                NoTelemetry.Startup)
             // What Program.cs builds with, so a registration this rejects is one a run would too.
             .BuildServiceProvider(new ServiceProviderOptions { ValidateOnBuild = true, ValidateScopes = true });
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ConfigCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ConfigCommandTests.cs
@@ -229,13 +229,13 @@ public class ConfigCommandTests {
         Directory.CreateDirectory(tmp.Path);
         await File.WriteAllTextAsync(AppConfig.GetConfigPath(root), """{"active_profile":"","profiles":{}}""");
 
-        await new ConfigCommand(root, new FixedCapacitorHttpClient()).HandleAsync(["config", "set", "skills.auto_sync", "true"]);
+        await new ConfigCommand(root, new FixedCapacitorHttpClient(), NoTelemetry.Facade).HandleAsync(["config", "set", "skills.auto_sync", "true"]);
 
         var cfg = await AppConfig.LoadProfileConfig(root);
         await Assert.That(cfg.Profiles.ContainsKey("")).IsFalse();
         await Assert.That(cfg.Profiles["default"].Skills!.AutoSync!.Value).IsTrue();
 
-        await new ConfigCommand(root, new FixedCapacitorHttpClient()).HandleAsync(["config", "unset", "skills.auto_sync"]);
+        await new ConfigCommand(root, new FixedCapacitorHttpClient(), NoTelemetry.Facade).HandleAsync(["config", "unset", "skills.auto_sync"]);
         var after = await AppConfig.LoadProfileConfig(root);
         await Assert.That(after.Profiles["default"].Skills!.AutoSync).IsNull();
     }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ConfigSetTelemetryCompositionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ConfigSetTelemetryCompositionTests.cs
@@ -1,6 +1,5 @@
 using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core.Config;
-using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Tests.Unit.Commands;
 
@@ -14,13 +13,7 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 /// <c>ApplySet(profile, "telemetry", …)</c> — which throws "Unknown config key" — AFTER the
 /// telemetry flag had already been persisted. A user would see a confusing crash right after
 /// their opt-out silently took effect, and every existing test would stay green.
-///
-/// <para>Holds the <see cref="CliTelemetry.TestSink"/> key: the path it drives reaches
-/// <see cref="CliTelemetry.DiscardAndDisable"/>, which clears whatever sink is live — including a
-/// concurrently-running funnel test's. The on-disk state needs no key: config.json, telemetry.json
-/// and the device id all live under this test's own root.</para>
 /// </summary>
-[NotInParallel(nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink))]
 public class ConfigSetTelemetryCompositionTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
@@ -38,7 +31,7 @@ public class ConfigSetTelemetryCompositionTests {
         await ConfigMutator.MutateAsync(Config.Root, _ => seeded);
         var before = await File.ReadAllTextAsync(ConfigPath);
 
-        var exit = await new ConfigCommand(Config.Root, new FixedCapacitorHttpClient()).HandleAsync(["config", "set", "telemetry", "off"]);
+        var exit = await new ConfigCommand(Config.Root, new FixedCapacitorHttpClient(), NoTelemetry.Facade).HandleAsync(["config", "set", "telemetry", "off"]);
 
         await Assert.That(exit).IsEqualTo(0);
         var after = await File.ReadAllTextAsync(ConfigPath);
@@ -51,7 +44,7 @@ public class ConfigSetTelemetryCompositionTests {
         // LoadProfileConfig/SaveProfileConfig, not merely that it round-trips one unchanged.
         await Assert.That(File.Exists(ConfigPath)).IsFalse();
 
-        var exit = await new ConfigCommand(Config.Root, new FixedCapacitorHttpClient()).HandleAsync(["config", "set", "telemetry", "off"]);
+        var exit = await new ConfigCommand(Config.Root, new FixedCapacitorHttpClient(), NoTelemetry.Facade).HandleAsync(["config", "set", "telemetry", "off"]);
 
         await Assert.That(exit).IsEqualTo(0);
         await Assert.That(File.Exists(ConfigPath)).IsFalse();

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ConfigTelemetryKeyTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ConfigTelemetryKeyTests.cs
@@ -4,8 +4,6 @@ using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Tests.Unit.Commands;
 
-// TryApplyTelemetry reaches CliTelemetry.DiscardAndDisable, whose statics are process-global.
-[NotInParallel(nameof(CliTelemetry) + "." + nameof(CliTelemetry.TestSink))]
 public class ConfigTelemetryKeyTests {
     // One root per case covers both files: SetEnabled(false) deletes the device id as a side effect.
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
@@ -16,7 +14,7 @@ public class ConfigTelemetryKeyTests {
     [Arguments("0")]
     [Arguments("no")]
     public async Task Telemetry_off_persists_disabled(string value) {
-        await Assert.That(new ConfigCommand(Config.Root, new FixedCapacitorHttpClient()).TryApplyTelemetry("telemetry", value)).IsTrue();
+        await Assert.That(new ConfigCommand(Config.Root, new FixedCapacitorHttpClient(), NoTelemetry.Facade).TryApplyTelemetry("telemetry", value)).IsTrue();
         await Assert.That(TelemetryState.PersistedEnabled(Config.Root)).IsFalse();
     }
 
@@ -26,18 +24,18 @@ public class ConfigTelemetryKeyTests {
     [Arguments("1")]
     [Arguments("yes")]
     public async Task Telemetry_on_persists_enabled(string value) {
-        await Assert.That(new ConfigCommand(Config.Root, new FixedCapacitorHttpClient()).TryApplyTelemetry("telemetry", value)).IsTrue();
+        await Assert.That(new ConfigCommand(Config.Root, new FixedCapacitorHttpClient(), NoTelemetry.Facade).TryApplyTelemetry("telemetry", value)).IsTrue();
         await Assert.That(TelemetryState.PersistedEnabled(Config.Root)).IsTrue();
     }
 
     [Test]
     public async Task Other_keys_are_not_claimed() {
-        await Assert.That(new ConfigCommand(Config.Root, new FixedCapacitorHttpClient()).TryApplyTelemetry("server_url", "https://acme.kcap.ai")).IsFalse();
+        await Assert.That(new ConfigCommand(Config.Root, new FixedCapacitorHttpClient(), NoTelemetry.Facade).TryApplyTelemetry("server_url", "https://acme.kcap.ai")).IsFalse();
     }
 
     [Test]
     public async Task Invalid_telemetry_value_throws_with_an_actionable_message() {
-        var ex = Assert.Throws<ArgumentException>(() => new ConfigCommand(Config.Root, new FixedCapacitorHttpClient()).TryApplyTelemetry("telemetry", "banana"));
+        var ex = Assert.Throws<ArgumentException>(() => new ConfigCommand(Config.Root, new FixedCapacitorHttpClient(), NoTelemetry.Facade).TryApplyTelemetry("telemetry", "banana"));
 
         await Assert.That(ex!.Message.Contains("on")).IsTrue();
         await Assert.That(ex.Message.Contains("off")).IsTrue();

--- a/test/Capacitor.Cli.Tests.Unit/Commands/Harness/ClaudeHookCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/Harness/ClaudeHookCommandTests.cs
@@ -701,7 +701,9 @@ public class ClaudeHookCommandTests {
         var exit  = await ClaudeHookCommand.WithHardCap(inner, TimeSpan.FromMilliseconds(50));
         sw.Stop();
         await Assert.That(exit).IsEqualTo(0);
-        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(1));
+        // The property is that the cap beat the inner, not what scheduling latency the cap's own
+        // timer saw: anything under the inner's ten seconds can only be the cap having fired.
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(5));
     }
 
     [Test]

--- a/test/Capacitor.Cli.Tests.Unit/Commands/LoginFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/LoginFacadeParityTests.cs
@@ -2,7 +2,6 @@ using Capacitor.Cli.Commands;
 using Capacitor.Cli.Core.Auth;
 using static Capacitor.Tests.Helpers.AuthFixtures;
 using Capacitor.Cli.Core.Config;
-using Capacitor.Cli.Core.Telemetry;
 
 namespace Capacitor.Cli.Tests.Unit.Commands;
 
@@ -11,22 +10,11 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 /// `OAuthLoginFlow.LoginWithDiscoveryAsync`: same exit codes, same final banner line, same
 /// per-tenant token/profile publication, and no funnel events of the login path's own.
 /// </summary>
-/// <remarks>
-/// Bare, not keyed: <c>CliTelemetry.TestSink</c> is a process-global static, and the tests that
-/// contaminate it do not touch it deliberately — they run a real <c>kcap setup</c>, whose funnel
-/// lands in whatever sink is installed. A key can only exclude tests that carry it, so the writers
-/// would each have to opt in; exclusivity is the only guard that covers a reader asserting the sink
-/// is empty.
-/// </remarks>
-[NotInParallel]
 public class LoginFacadeParityTests {
     [TempConfigRoot] public required TempConfigRoot Config { get; init; }
 
     string TokensDir  => Config.PathTo("tokens");
     string ConfigPath => AppConfig.GetConfigPath(Config.Root);
-
-    [Before(Test)]
-    public void Cleanup() => CliTelemetry.Reset();
 
     ProfileConfig ReadConfig() => ConfigMutator.LoadPure(ConfigPath);
 
@@ -59,17 +47,15 @@ public class LoginFacadeParityTests {
 
     [Test]
     public async Task Discover_github_zero_funnel_events_of_its_own() {
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize("login", null, loggedIn: false, Config.Root);
-        sink.Clear(); // drop cli_first_run
+        var probe = TelemetryProbe.Live("login", Config.Root);
 
         using var handler = AuthHttp.Script(
             proxyConfig: """{"github_client_id":"cid"}""",
             tenants: TwoGitHubTenants);
 
         var progress = new RecordingAuthProgress();
-        var facade   = NewFacade(Config.Root, progress, handler, PickerReturningFirst());
+        var facade   = NewFacade(
+            Config.Root, progress, handler, PickerReturningFirst(), telemetry: probe.Telemetry);
 
         var exit = await LoginCommand.HandleAsync(["login", "--discover", "--github", "--device"], null, ProfileConfig.DefaultName, facade, progress);
 
@@ -77,7 +63,7 @@ public class LoginFacadeParityTests {
         // The GitHub discover path has no SetupFunnel calls anywhere in its Core dependency chain
         // (unlike WorkOS discovery, which fires its embedded signin_completed/tenant_none events
         // regardless of caller) — login must not have grown any of its own.
-        await Assert.That(sink).IsEmpty();
+        await Assert.That(probe.Events).IsEmpty();
     }
 
     // ── login: known server ──────────────────────────────────────────────────

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpAnalyticsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpAnalyticsServerTests.cs
@@ -9,7 +9,7 @@ public class McpAnalyticsServerTests {
 
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpAnalyticsServer Server() =>
-        new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), new FixedCapacitorHttpClient());
+        new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     static JsonObject Args(string json) => JsonNode.Parse(json)!.AsObject();
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowResultServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowResultServerTests.cs
@@ -12,7 +12,7 @@ public class McpFlowResultServerTests {
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpFlowResultServer Server() =>
         new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root),
-            new FixedCapacitorHttpClient());
+            new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     static JsonObject Args(string? roundToken = "round-1", string? kind = "findings", string? findings = "1. issue") {
         var o = new JsonObject();
@@ -327,7 +327,7 @@ public class McpFlowResultServerTests {
         try {
             var exit = await new McpFlowResultServer(
                 Config.Root, Resolutions.At("https://example.test", Config.Root),
-                AuthFixtures.NewTokenStore(Config.Root), new FixedCapacitorHttpClient()).RunAsync();
+                AuthFixtures.NewTokenStore(Config.Root), new FixedCapacitorHttpClient(), NoTelemetry.Startup).RunAsync();
             await Assert.That(exit).IsEqualTo(2);
         } finally {
             Environment.SetEnvironmentVariable(McpFlowResultServer.AgentIdEnvVar, prior);

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerReviewerVendorsTests.cs
@@ -13,7 +13,7 @@ public class McpFlowsServerReviewerVendorsTests {
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpFlowsServer Server() =>
         new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root),
-            new FixedCapacitorHttpClient());
+            new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     static JsonObject ToolCall() => new() {
         ["params"] = new JsonObject { ["name"] = "list_reviewer_vendors", ["arguments"] = new JsonObject() }

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerSettlementRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerSettlementRetryTests.cs
@@ -29,7 +29,7 @@ public class McpFlowsServerSettlementRetryTests {
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpFlowsServer Server() =>
         new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root),
-            new FixedCapacitorHttpClient());
+            new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     // Every wait in both retry lanes runs on the injected clock, so these tests are instant and
     // the requested schedule is directly assertable (VirtualFlowRetryClock.Delays).

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerTests.cs
@@ -13,7 +13,7 @@ public class McpFlowsServerTests {
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpFlowsServer Server() =>
         new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root),
-            new FixedCapacitorHttpClient());
+            new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     // The ack retry's 2s wait now runs on the injected clock, so these tests stay instant while
     // still asserting the real schedule (VirtualFlowRetryClock.Delays records every requested wait).

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerVendorOverrideTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpFlowsServerVendorOverrideTests.cs
@@ -17,7 +17,7 @@ public class McpFlowsServerVendorOverrideTests {
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpFlowsServer Server() =>
         new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root),
-            new FixedCapacitorHttpClient());
+            new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     static JsonObject StartArguments(string? vendor = null) {
         var args = new JsonObject {

--- a/test/Capacitor.Cli.Tests.Unit/Commands/McpWorkItemsServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/McpWorkItemsServerTests.cs
@@ -9,7 +9,7 @@ public class McpWorkItemsServerTests {
 
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpWorkItemsServer Server() =>
-        new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), new FixedCapacitorHttpClient());
+        new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root), new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     const string CapacitorSessionIdEnvVar = "KCAP_SESSION_ID";
     const string CodexThreadIdEnvVar      = "CODEX_THREAD_ID";

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ParticipantUnreachableRetryTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ParticipantUnreachableRetryTests.cs
@@ -30,7 +30,7 @@ public class ParticipantUnreachableRetryTests {
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpFlowsServer Server() =>
         new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root),
-            new FixedCapacitorHttpClient());
+            new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     static VirtualFlowRetryClock Clock() => new();
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorFallbackTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ReviewerVendorFallbackTests.cs
@@ -20,7 +20,7 @@ public class ReviewerVendorFallbackTests {
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpFlowsServer Server() =>
         new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root),
-            new FixedCapacitorHttpClient());
+            new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     // The wire shape TryParseCodedError accepts: a JSON object with a non-empty string "error"
     // plus a string "message" — the CLI-side reading of the server's FlowReviewerResultError.

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupChosenServerTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupChosenServerTests.cs
@@ -26,7 +26,7 @@ public class SetupChosenServerTests {
             AuthFixtures.NewTokenStore(Config.Root), factory,
             new AuthProxyClient(new HttpClient()), new WorkOSClient(factory), new GitHubOAuthClient(factory),
             new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), new TenantProvisioningClient(new HttpClient()),
-            new AuthProviderDiscovery(factory));
+            new AuthProviderDiscovery(factory), NoTelemetry.Facade);
     }
 
     /// A first run: nothing resolved a server before the command started, which is the case that

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupCommandTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupCommandTests.cs
@@ -871,7 +871,7 @@ public class SetupCommandTests {
         var passed = Resolutions.At("https://example.test", Config.Root);
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -902,7 +902,7 @@ public class SetupCommandTests {
         };
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -925,7 +925,7 @@ public class SetupCommandTests {
         try {
             // Completing without an unhandled exception is the assertion: a non-zero exit
             // code must be swallowed (warned about, not propagated) so setup still finishes.
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -946,7 +946,7 @@ public class SetupCommandTests {
         try {
             // Completing without the InvalidOperationException escaping is the assertion —
             // import is best-effort and must never fail setup.
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        false,
@@ -965,7 +965,7 @@ public class SetupCommandTests {
         SetupCommand.ImportRunnerOverride = _ => throw new InvalidOperationException("must not run import");
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).RunImportStepAsync(
                 currentRepo:       null,
                 authSatisfied:     true,
                 skipImport:        false,
@@ -984,7 +984,7 @@ public class SetupCommandTests {
         SetupCommand.ImportRunnerOverride = _ => throw new InvalidOperationException("must not run import");
 
         try {
-            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunImportStepAsync(
+            await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).RunImportStepAsync(
                 currentRepo:       ("acme", "widgets"),
                 authSatisfied:     true,
                 skipImport:        true,
@@ -1049,7 +1049,7 @@ public class SetupCommandTests {
         try {
             var args = BuildArgs("--server-url", server.Url!, "--no-prompt", "--default-visibility", "org_public");
 
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(captured).IsNotNull();
@@ -1085,7 +1085,7 @@ public class SetupCommandTests {
 
             // Completing with exit 0 without the override's exception escaping is the
             // assertion — --skip-import must suppress the Step 6 call entirely.
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
         } finally {
@@ -1113,7 +1113,7 @@ public class SetupCommandTests {
         try {
             var args = BuildArgs("--server-url", schemeLessServerUrl, "--no-prompt");
 
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(captured).IsNotNull();
@@ -1148,7 +1148,7 @@ public class SetupCommandTests {
         try {
             var args = BuildArgs("--server-url", server.Url!, "--no-prompt");
 
-            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(args);
+            var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).HandleAsync(args);
 
             await Assert.That(exit).IsEqualTo(0);
             await Assert.That(captured).IsNotNull();
@@ -1335,7 +1335,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_rejects_half_a_pair_before_doing_anything() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme"]);
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).HandleAsync(["setup", "--org", "Acme"]);
 
         await Assert.That(exit).IsEqualTo(1);
         await Assert.That(capture.GetCapturedError()).Contains("--slug");
@@ -1346,7 +1346,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_rejects_creating_and_pointing_at_a_server_at_once() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).HandleAsync(
             ["setup", "--org", "Acme", "--slug", "acme", "--server-url", "https://other.kcap.ai"]);
 
         await Assert.That(exit).IsEqualTo(1);
@@ -1358,7 +1358,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_rejects_a_provider_that_cannot_create() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--org", "Acme", "--slug", "acme", "--github"]);
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).HandleAsync(["setup", "--org", "Acme", "--slug", "acme", "--github"]);
 
         await Assert.That(exit).IsEqualTo(1);
         await Assert.That(capture.GetCapturedError()).Contains("--github");
@@ -1369,7 +1369,7 @@ public class SetupCommandTests {
     public async Task HandleAsync_still_requires_a_server_url_with_no_prompt_and_no_answers() {
         using var capture = ConsoleOutput.StartErrorCapture();
 
-        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).HandleAsync(["setup", "--no-prompt"]);
+        var exit = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery, NoTelemetry.Facade).HandleAsync(["setup", "--no-prompt"]);
 
         await Assert.That(exit).IsEqualTo(1);
         await Assert.That(capture.GetCapturedError()).Contains("--server-url is required");

--- a/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/SetupFacadeParityTests.cs
@@ -75,10 +75,7 @@ public class SetupFacadeParityTests {
     string ConfigPath => AppConfig.GetConfigPath(Config.Root);
 
     [Before(Test)]
-    public void Cleanup() {
-        CliTelemetry.Reset();
-        SetupCommand.FacadeOverride = null;
-    }
+    public void Cleanup() => SetupCommand.FacadeOverride = null;
 
     [After(Test)]
     public void ResetFacadeOverride() => SetupCommand.FacadeOverride = null;
@@ -87,17 +84,13 @@ public class SetupFacadeParityTests {
 
     bool TokenFileExists(string profile) => File.Exists(Path.Combine(TokensDir, $"{profile}.json"));
 
-    List<TelemetryEvent> StartCapturingFunnel() {
-        var sink = new List<TelemetryEvent>();
-        CliTelemetry.TestSink = sink;
-        CliTelemetry.Initialize("setup", null, loggedIn: false, Config.Root);
+    TelemetryProbe StartCapturingFunnel() => TelemetryProbe.Live("setup", Config.Root);
 
-        TelemetryTestGuards.AssertEnabled("setup", Config.Root);
-
-        sink.Clear(); // drop cli_first_run
-
-        return sink;
-    }
+    SetupCommand Command(CliTelemetry telemetry) =>
+        new(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None,
+            AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(),
+            Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(),
+            Provisioning, Discovery, telemetry);
 
     // ── Step 1: RunDiscoveryAsync (GitHub) ──────────────────────────────────
 
@@ -110,7 +103,7 @@ public class SetupFacadeParityTests {
         SetupCommand.FacadeOverride = _ =>
             NewFacade(Config.Root, new RecordingAuthProgress(), handler, PickerReturningFirst());
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await Command(NoTelemetry.Facade).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNotNull();
         await Assert.That(discovered!.Value.LoginComplete).IsTrue();
@@ -127,7 +120,7 @@ public class SetupFacadeParityTests {
 
     [Test]
     public async Task RunDiscoveryAsync_github_committed_fires_signin_opened_then_signin_completed() {
-        var sink = StartCapturingFunnel();
+        var probe = StartCapturingFunnel();
 
         using var handler = AuthHttp.Script(
             proxyConfig: """{"github_client_id":"cid"}""",
@@ -136,34 +129,34 @@ public class SetupFacadeParityTests {
         SetupCommand.FacadeOverride = _ =>
             NewFacade(Config.Root, new RecordingAuthProgress(), handler, PickerReturningFirst());
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await Command(probe.Telemetry).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNotNull();
-        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+        await Assert.That(probe.Names).IsEquivalentTo(
             new[] { "cli_setup_signin_opened", "cli_setup_signin_completed" }, CollectionOrdering.Matching);
     }
 
     [Test]
     public async Task RunDiscoveryAsync_github_zero_tenants_emits_signin_completed_and_tenant_none() {
-        var sink = StartCapturingFunnel();
+        var probe = StartCapturingFunnel();
 
         using var handler = AuthHttp.Script(proxyConfig: """{"github_client_id":"cid"}""", tenants: "[]");
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await Command(probe.Telemetry).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         // Today's setup fires SigninCompleted unconditionally once the token is acquired, and
         // TenantNone additionally when discovery then finds nothing — the two co-occur here.
-        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+        await Assert.That(probe.Names).IsEquivalentTo(
             new[] { "cli_setup_signin_opened", "cli_setup_signin_completed", "cli_setup_tenant_none" },
             CollectionOrdering.Matching);
     }
 
     [Test]
     public async Task RunDiscoveryAsync_github_post_acquisition_discovery_error_still_emits_signin_completed() {
-        var sink = StartCapturingFunnel();
+        var probe = StartCapturingFunnel();
 
         // No `tenants:` stub — /discover-tenants 500s AFTER the device flow already handed out a
         // token, landing AuthFailureReason.Other (not NoTenantsFound).
@@ -171,16 +164,16 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await Command(probe.Telemetry).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
-        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+        await Assert.That(probe.Names).IsEquivalentTo(
             new[] { "cli_setup_signin_opened", "cli_setup_signin_completed" }, CollectionOrdering.Matching);
     }
 
     [Test]
     public async Task RunDiscoveryAsync_github_signin_denied_emits_signin_failed() {
-        var sink = StartCapturingFunnel();
+        var probe = StartCapturingFunnel();
 
         using var handler = AuthHttp.Script(
             proxyConfig: """{"github_client_id":"cid"}""",
@@ -188,27 +181,27 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await Command(probe.Telemetry).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
-        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+        await Assert.That(probe.Names).IsEquivalentTo(
             new[] { "cli_setup_signin_opened", "cli_setup_signin_failed" }, CollectionOrdering.Matching);
     }
 
     [Test]
     public async Task RunDiscoveryAsync_github_unreachable_proxy_fires_no_extra_funnel_event() {
-        var sink = StartCapturingFunnel();
+        var probe = StartCapturingFunnel();
 
         using var handler = AuthHttp.Script(); // no /config route — proxy unreachable
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await Command(probe.Telemetry).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         // Other/Unreachable failures map to nothing beyond SigninOpened — only SigninDenied and
         // NoTenantsFound get a second event.
-        await Assert.That(sink.Select(e => e.Name).ToArray()).IsEquivalentTo(
+        await Assert.That(probe.Names).IsEquivalentTo(
             new[] { "cli_setup_signin_opened" }, CollectionOrdering.Matching);
     }
 
@@ -221,7 +214,7 @@ public class SetupFacadeParityTests {
 
         using var console = ConsoleOutput.StartErrorCapture("\n");
 
-        var discovered = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunDiscoveryAsync(["--github"], forceDevice: true);
+        var discovered = await Command(NoTelemetry.Facade).RunDiscoveryAsync(["--github"], forceDevice: true);
 
         await Assert.That(discovered).IsNull();
         await Assert.That(console.GetCapturedError()).Contains(SetupAuthProgress.UnreachableGuidance);
@@ -240,7 +233,7 @@ public class SetupFacadeParityTests {
             return NewFacade(Config.Root, new RecordingAuthProgress(), handler);
         };
 
-        await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery)
+        await Command(NoTelemetry.Facade)
             .RunDiscoveryAsync([], forceDevice: true, new RequestedWorkspace("Acme", "acme"));
 
         await Assert.That(captured).IsTypeOf<SpectreTenantProvisioner>();
@@ -351,7 +344,7 @@ public class SetupFacadeParityTests {
         int exitCode;
 
         try {
-            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+            exitCode = await Command(NoTelemetry.Facade).RunLoginStepAsync(
                 loginComplete: true, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
                 forceDevice: false, activeProfile: "acme");
         } finally {
@@ -369,7 +362,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await Command(NoTelemetry.Facade).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.None, serverUrl: "https://none.example",
             forceDevice: false, activeProfile: "default");
 
@@ -391,7 +384,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await Command(NoTelemetry.Facade).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.None, serverUrl: "https://none.example",
             forceDevice: false, activeProfile: "default");
 
@@ -404,7 +397,7 @@ public class SetupFacadeParityTests {
 
         SetupCommand.FacadeOverride = _ => NewFacade(Config.Root, new RecordingAuthProgress(), handler);
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await Command(NoTelemetry.Facade).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
             forceDevice: true, activeProfile: "acme");
 
@@ -428,7 +421,7 @@ public class SetupFacadeParityTests {
 
         using var console = ConsoleOutput.StartCapture();
 
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await Command(NoTelemetry.Facade).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
             forceDevice: true, activeProfile: "acme");
 
@@ -453,7 +446,7 @@ public class SetupFacadeParityTests {
         int exitCode;
 
         try {
-            exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+            exitCode = await Command(NoTelemetry.Facade).RunLoginStepAsync(
                 loginComplete: true, provider: provider, serverUrl: "https://acme.kcap.ai",
                 forceDevice: false, activeProfile: "acme");
         } finally {
@@ -472,7 +465,7 @@ public class SetupFacadeParityTests {
 
         // The provider param is Step 1's resolved value; Step 2 re-fetches /auth/config for the
         // actual login, so a server reporting an unrelated/unknown provider by then still fails.
-        var exitCode = await new SetupCommand(Config.Root, Resolutions.None(Config.Root), ProfileOverrides.None, MachineAuth.None, AuthFixtures.NewTokenStore(Config.Root), HttpFactory, Proxy, Workos, Github, new RecordingBrowser(), Home, TestHarnesses.Under(Home), new AgentsPaths(Home), new FixedCapacitorHttpClient(), Provisioning, Discovery).RunLoginStepAsync(
+        var exitCode = await Command(NoTelemetry.Facade).RunLoginStepAsync(
             loginComplete: false, provider: AuthProvider.GitHubApp, serverUrl: "https://acme.kcap.ai",
             forceDevice: false, activeProfile: "acme");
 

--- a/test/Capacitor.Cli.Tests.Unit/Commands/StatusWaitArgumentTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/StatusWaitArgumentTests.cs
@@ -22,7 +22,7 @@ public class StatusWaitArgumentTests {
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpFlowsServer Server() =>
         new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root),
-            new FixedCapacitorHttpClient());
+            new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     static readonly TimeSpan PollInterval       = TimeSpan.FromSeconds(3);
     static readonly TimeSpan PollCap            = TimeSpan.FromMinutes(8);

--- a/test/Capacitor.Cli.Tests.Unit/Commands/TenantProvisionerHeadlessTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/TenantProvisionerHeadlessTests.cs
@@ -10,10 +10,7 @@ namespace Capacitor.Cli.Tests.Unit.Commands;
 /// prompt and Spectre throws rather than returning. Either the two answers arrive as flags, or there
 /// is nothing to ask and the run has to say so.
 /// </summary>
-/// <remarks>
-/// Bare rather than keyed: these write SetupFunnel events into the process-global telemetry sink,
-/// which the facade-parity suites read back as an exact ordered set, and they capture Console.
-/// </remarks>
+/// <remarks>These capture Console, which is process-global.</remarks>
 [NotInParallel]
 public class TenantProvisionerHeadlessTests {
     const string BaseUrl = "https://signup.example";
@@ -26,7 +23,7 @@ public class TenantProvisionerHeadlessTests {
     [Test]
     public async Task Declines_instead_of_throwing_when_there_is_no_terminal_to_prompt_on() {
         var provisioner = new SpectreTenantProvisioner(
-            new TenantProvisioningClient(new HttpClient()), BaseUrl,
+            new TenantProvisioningClient(new HttpClient()), BaseUrl, NoTelemetry.Facade,
             isInteractive: () => false);
 
         var offer = await provisioner.OfferCreateAsync(Tokens());
@@ -231,7 +228,8 @@ public class TenantProvisionerHeadlessTests {
     }
 
     static SpectreTenantProvisioner Provisioner(StubHandler handler, Func<bool> isInteractive, RequestedWorkspace requested) =>
-        new(new TenantProvisioningClient(new HttpClient(handler, disposeHandler: false)), BaseUrl, isInteractive, requested);
+        new(new TenantProvisioningClient(new HttpClient(handler, disposeHandler: false)), BaseUrl,
+            NoTelemetry.Facade, isInteractive, requested);
 
     sealed class StubHandler : HttpMessageHandler {
         public List<string>    Paths                 { get; } = [];

--- a/test/Capacitor.Cli.Tests.Unit/Commands/ToolCallBudgetTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Commands/ToolCallBudgetTests.cs
@@ -22,7 +22,7 @@ public class ToolCallBudgetTests {
     // Resolutions.None: these tests exercise routing, not profile selection.
     McpFlowsServer Server() =>
         new(Config.Root, Resolutions.None(Config.Root), AuthFixtures.NewTokenStore(Config.Root),
-            new FixedCapacitorHttpClient());
+            new FixedCapacitorHttpClient(), NoTelemetry.Startup);
 
     static JsonObject StartArguments() => new() {
         ["kind"]         = "code-review",

--- a/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/SecretRedactorTests.cs
@@ -50,7 +50,9 @@ public class SecretRedactorTests {
 
         await Assert.That(result).DoesNotContain(secretMarker);
         await Assert.That(result).IsEqualTo(SecretRedactor.OversizeLinePlaceholder);
-        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromMilliseconds(100));
+        // A wedged regex does not return at all, so the budget only has to be short of "hung" —
+        // tightening it further measures the scheduler rather than the size cap.
+        await Assert.That(sw.Elapsed).IsLessThan(TimeSpan.FromSeconds(2));
     }
 
     [Test]

--- a/test/Capacitor.Tests.Helpers/AuthFixtures.cs
+++ b/test/Capacitor.Tests.Helpers/AuthFixtures.cs
@@ -1,3 +1,4 @@
+using Capacitor.Cli.Core.Telemetry;
 using Capacitor.Cli.Core;
 using Capacitor.Cli.Core.Auth;
 using Capacitor.Cli.Core.Config;
@@ -34,7 +35,11 @@ public static class AuthFixtures {
             Func<CancellationToken, Task<WorkOSAuthResponse?>>?         workosLogin   = null,
             IBrowser?                                                   workosBrowser = null,
             string?                                                     workosApiBase = null,
-            IBrowserLauncher?                                           browser       = null) {
+            IBrowserLauncher?                                           browser       = null,
+            // A facade that is off unless a test hands one in, like every other collaborator
+            // defaulted here: a test that does not observe telemetry must not have to name it, and
+            // one that does gets an empty sink rather than a silent pass if it forgets.
+            CliTelemetry?                                               telemetry     = null) {
         var factory = new PlainHttpClientFactory(handler);
 
         return new OnboardingFacade(
@@ -42,7 +47,8 @@ public static class AuthFixtures {
                 new AuthProxyClient(factory.CreateClient(CapacitorClients.Anonymous)),
                 new GitHubOAuthClient(factory), new WorkOSClient(factory),
                 progress, browser ?? new RecordingBrowser(),
-                picker ?? Substitute.For<ITenantPicker>(), provisioner, beforeCommit) {
+                picker ?? Substitute.For<ITenantPicker>(), provisioner,
+                telemetry ?? CliTelemetry.Disabled(), beforeCommit) {
             WorkOSOrglessLogin    = workosLogin,
             WorkOSBrowser         = workosBrowser,
             WorkOSApiBaseOverride = workosApiBase

--- a/test/Capacitor.Tests.Helpers/NoTelemetry.cs
+++ b/test/Capacitor.Tests.Helpers/NoTelemetry.cs
@@ -1,0 +1,18 @@
+using Capacitor.Cli.Core.Telemetry;
+
+namespace Capacitor.Tests.Helpers;
+
+/// <summary>
+/// Collaborators from a facade that is off, for a test that drives a lane which reports telemetry
+/// but does not observe it. Naming it at the call site is the point: a test reading
+/// <c>NoTelemetry.Funnel</c> is saying it expects nothing to be emitted, where a probe would say
+/// the opposite.
+/// </summary>
+public static class NoTelemetry {
+    public static CliTelemetry Facade => CliTelemetry.Disabled();
+
+    /// <summary>A suppressed startup, so anything that starts its own facade from it comes up off.</summary>
+    public static TelemetryStartup Startup => new("test", ServerUrl: null, Suppressed: true, Debug: false);
+    public static SetupFunnel  Funnel => Facade.Funnel;
+    public static SetupJoin    Join   => Facade.Join;
+}

--- a/test/Capacitor.Tests.Helpers/RecordingTelemetrySink.cs
+++ b/test/Capacitor.Tests.Helpers/RecordingTelemetrySink.cs
@@ -1,0 +1,36 @@
+using Capacitor.Cli.Core.Telemetry;
+
+namespace Capacitor.Tests.Helpers;
+
+/// <summary>
+/// Keeps what a <see cref="CliTelemetry"/> captures instead of shipping it. One per facade, so what
+/// a test reads back was written by the facade that test built and by nothing else.
+/// </summary>
+public sealed class RecordingTelemetrySink : ITelemetrySink {
+    readonly List<TelemetryEvent> _events = [];
+
+    public IReadOnlyList<TelemetryEvent> Events {
+        get { lock (_events) return [.. _events]; }
+    }
+
+    public IReadOnlyList<string> Names {
+        get { lock (_events) return [.. _events.Select(e => e.Name)]; }
+    }
+
+    /// <summary>How many times the facade asked to ship — a flush with nothing queued still counts.</summary>
+    public int Flushes { get; private set; }
+
+    public void Enqueue(TelemetryEvent e) {
+        lock (_events) _events.Add(e);
+    }
+
+    public Task<bool> FlushAsync(string distinctId, string? orgGroup, TimeSpan budget) {
+        Flushes++;
+
+        return Task.FromResult(true);
+    }
+
+    public void Discard() {
+        lock (_events) _events.Clear();
+    }
+}

--- a/test/Capacitor.Tests.Helpers/TelemetryProbe.cs
+++ b/test/Capacitor.Tests.Helpers/TelemetryProbe.cs
@@ -1,0 +1,64 @@
+using Capacitor.Cli.Core;
+using Capacitor.Cli.Core.Telemetry;
+
+namespace Capacitor.Tests.Helpers;
+
+/// <summary>
+/// A telemetry facade and the sink it writes to, built together so a test reads back only its own
+/// events. Nothing here is shared: two probes in the same process see nothing of each other, which
+/// is why tests that assert on telemetry need no parallelism constraint.
+/// </summary>
+public sealed class TelemetryProbe {
+    TelemetryProbe(CliTelemetry telemetry, RecordingTelemetrySink sink) {
+        Telemetry = telemetry;
+        Sink      = sink;
+    }
+
+    public CliTelemetry           Telemetry { get; }
+    public RecordingTelemetrySink Sink      { get; }
+
+    public SetupJoin   Join   => Telemetry.Join;
+    public SetupFunnel Funnel => Telemetry.Funnel;
+
+    public IReadOnlyList<TelemetryEvent> Events => Sink.Events;
+    public IReadOnlyList<string>         Names  => Sink.Names;
+
+    public static TelemetryProbe Start(
+            string command, ConfigRoot config, string? serverUrl = null,
+            bool loggedIn = false, bool suppressed = false, bool debug = false) =>
+        Start(new TelemetryStartup(command, serverUrl, suppressed, debug), config, loggedIn);
+
+    public static TelemetryProbe Start(TelemetryStartup startup, ConfigRoot config, bool loggedIn = false) {
+        var sink      = new RecordingTelemetrySink();
+        var telemetry = CliTelemetry.Start(startup, config, () => sink);
+
+        // Program.cs completes the bag before announcing, so a probe does too — every event a test
+        // reads back then carries what a real run's would.
+        telemetry.AddSharedProperty("logged_in", loggedIn);
+        telemetry.Announce(config);
+
+        return new TelemetryProbe(telemetry, sink);
+    }
+
+    /// <summary>
+    /// A facade that must come up live, with <c>cli_first_run</c> already dropped — it says nothing
+    /// about what the test goes on to do. Throws a diagnosis rather than recording nothing when
+    /// telemetry resolves off, since an empty sink otherwise surfaces as an opaque "sequence
+    /// contains no elements" from whatever assertion runs next.
+    /// </summary>
+    public static TelemetryProbe Live(
+            string command, ConfigRoot config, string? serverUrl = null, bool loggedIn = false, bool debug = false) {
+        var probe = Start(command, config, serverUrl, loggedIn, suppressed: false, debug);
+
+        TelemetryTestGuards.AssertEnabled(command, config, probe.Telemetry);
+        probe.Sink.Discard();
+
+        return probe;
+    }
+
+    /// <summary>The events captured under <paramref name="name"/>, in the order they were captured.</summary>
+    public IReadOnlyList<TelemetryEvent> Captured(string name) => [.. Events.Where(e => e.Name == name)];
+
+    /// <summary>The one event captured under <paramref name="name"/>; throws when there is not exactly one.</summary>
+    public TelemetryEvent Only(string name) => Captured(name).Single();
+}

--- a/test/Capacitor.Tests.Helpers/TelemetryTestGuards.cs
+++ b/test/Capacitor.Tests.Helpers/TelemetryTestGuards.cs
@@ -12,20 +12,20 @@ namespace Capacitor.Tests.Helpers;
 /// applies — because a CI-only failure here was misdiagnosed once already.</para>
 /// </summary>
 public static class TelemetryTestGuards {
-    /// <summary>Throws with a diagnosis if <see cref="CliTelemetry.Initialize"/> left telemetry off.</summary>
-    public static void AssertEnabled(string command, ConfigRoot config) {
-        if (CliTelemetry.Enabled) return;
+    /// <summary>Throws with a diagnosis if the facade came up off.</summary>
+    public static void AssertEnabled(string command, ConfigRoot config, CliTelemetry telemetry) {
+        if (telemetry.Enabled) return;
 
         var decision = TelemetrySettings.Resolve(TelemetryState.PersistedEnabled(config));
 
         throw new InvalidOperationException(
-            $"CliTelemetry did not enable after Initialize(\"{command}\").\n"
+            $"CliTelemetry did not enable after Start(\"{command}\").\n"
           + $"  resolver   = {decision.Enabled} (reason={decision.Reason})\n"
           + $"  reportable = {CommandEvents.IsReportable(command)}\n"
           + $"  configRoot = {config.Directory}\n"
           + $"  DO_NOT_TRACK = {Env("DO_NOT_TRACK")}, KCAP_TELEMETRY = {Env("KCAP_TELEMETRY")}\n"
           + "Read it as: resolver=False -> an env var or the persisted flag disabled it; "
-          + "reportable=False -> the command is denylisted; both True -> Initialize threw "
+          + "reportable=False -> the command is denylisted; both True -> Start threw "
           + "internally and its catch disabled telemetry. (A failed device-id write can no longer "
           + "be the cause: TelemetryDeviceId.GetOrCreate() falling back to an in-memory id no "
           + "longer disables the facade.)");


### PR DESCRIPTION
Closes #890 — AI-2705

## What & why

Telemetry reached the process through a static facade: seven mutable statics behind a
`Reset()` whose own doc said every toucher must call it first, plus `SetupJoin` and
`McpTelemetry`. Seventeen test classes were serialised to keep those apart, and the keyed
cohort guarding eleven of them was unsound — the funnel's callers read the same sink and
never carried the key. The facade is now a value built at each entry and injected, with
`SetupJoin`/`SetupFunnel` as instances it owns; `Reset()` and `TestSink` are deleted rather
than injected, so there is nothing left to keep apart.

## Where to look

`Start` and `Announce` are deliberately separate: resolving the facade from a container must
not print a privacy disclosure or consume the once-per-device marker. Suppression rides in
`TelemetryStartup` because the spawn marker is removed as it is read, so a second facade in
the same process can only inherit the decision, never re-take it. The desktop wizard is handed
a facade that is off — it shows no notice and offers no opt-out, so its funnel must stay inert.

The second commit is unrelated to telemetry and touches no telemetry file. Those six tests were
winning on timing rather than sequencing, and they fail on `main` too.

## Verification

Core 3263/3263 · CLI 4020/4020 · App 1739/1739 · the two daemon classes 40/40.
`dotnet publish -c Release`: no IL2026/IL3050.

Each assertion rewritten here was checked by mutation, and every mutation reverted:

| mutation | result |
| --- | --- |
| `startup.Debug` never reaches the facade | 3 debug tests fail, including one that previously could not |
| `startup.Suppressed` ignored | both spawn-marker tests fail |
| `SetupJoin` state back to `static` | 10 join tests fail |
| a throwing sink's exception escapes the writer | the rewired IPC test fails |
| losing exceptions reported twice | 4 IPC tests fail |
| the reader stops draining after the first line | both flood tests fail at the 10s timeout |
