### PR TITLE
Allow uncapped hosted agents with max_agents=0

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Download `Kurrent-Capacitor-osx-arm64.dmg` from https://www.kurrent.io/download/
 
 The app must run from the Applications folder — launched from the disk image or from Downloads it offers to move itself there first, because the terminal link and the background service point at its location.
 
-Open **Settings…** from the application menu (⌘,) or the tray to edit the daemon for the app's selected profile. **Save** applies capacity to a current running daemon immediately; lowering it leaves existing agents running and limits new launches. When the daemon is stopped or needs an update, the saved capacity applies when it next starts. **Rename and restart daemon** is available when no agents are active and the new name is free. After confirmation it replaces the old background service and relaunches the app. An unbundled development build asks you to restart the app yourself. Rename waits for startup to finish and requires a CLI that supports retiring the old service. If `KCAP_DAEMON_NAME` sets the name, remove that override and restart the app before renaming.
+Open **Settings…** from the application menu (⌘,) or the tray to edit the daemon for the app's selected profile. **Save** applies capacity to a current running daemon immediately; lowering it leaves existing agents running and limits new launches. Set it to **0** for no limit. When the daemon is stopped or needs an update, the saved capacity applies when it next starts. **Rename and restart daemon** is available when no agents are active and the new name is free. After confirmation it replaces the old background service and relaunches the app. An unbundled development build asks you to restart the app yourself. Rename waits for startup to finish and requires a CLI that supports retiring the old service. If `KCAP_DAEMON_NAME` sets the name, remove that override and restart the app before renaming.
 
 Updates arrive through the app: it checks a few times a day, downloads in the background and asks before restarting ("Check for Updates…" in the menu bar checks now). A bundled `kcap update` reports this and does nothing else. The bundled CLI follows the app's channel; the npm package stays the headless/CI channel.
 
@@ -870,7 +870,7 @@ kcap daemon service ensure                 # install-or-start from a fresh statu
 kcap daemon service uninstall              # stop and remove the service
 ```
 
-`install` pins the active profile via `KCAP_PROFILE` and captures your current `PATH` into the unit, so the supervised daemon resolves the same server URL, `claude`/`codex` binaries, and profile settings it would from your shell. Pass `--profile P` to pin a different profile, `--max-agents N` to bake an override, or `--no-start` to register without starting (`--no-start` cannot be combined with `--verify`, whose whole job is to prove the *started* daemon is ready). The service restarts the daemon on crash/`SIGKILL` but **not** on a clean stop. `stop` unloads it from the OS supervisor (launchd `bootout` / equivalent; the unit file is retained) rather than merely signaling the process.
+`install` pins the active profile via `KCAP_PROFILE` and captures your current `PATH` into the unit, so the supervised daemon resolves the same server URL, `claude`/`codex` binaries, and profile settings it would from your shell. Pass `--profile P` to pin a different profile, `--max-agents N` to bake an override (`0` = unlimited), or `--no-start` to register without starting (`--no-start` cannot be combined with `--verify`, whose whole job is to prove the *started* daemon is ready). The service restarts the daemon on crash/`SIGKILL` but **not** on a clean stop. `stop` unloads it from the OS supervisor (launchd `bootout` / equivalent; the unit file is retained) rather than merely signaling the process.
 
 `status --json` prints a machine-readable snapshot (service/job/daemon pids, binary paths, and transaction-marker state) instead of the human summary, and exits non-zero if the underlying service state can't be determined — for scripts that need to decide whether to attach, start, or repair a service without parsing human-readable text.
 
@@ -1466,6 +1466,7 @@ kcap config set daemon.codex_path  /opt/codex/bin/codex
 |-----|---------|-------------|
 | `daemon.claude_path` | `"claude"` | Path to the Claude CLI binary. Resolved via `PATH` when not an absolute path. |
 | `daemon.codex_path`  | `"codex"`  | Path to the Codex CLI binary. Resolved via `PATH` when not an absolute path. |
+| `daemon.max_agents`  | `5`        | Maximum concurrent hosted coding agents. `0` means unlimited. Also settable per launch with `--max-agents`, the `KCAP_MAX_AGENTS` env var, or the desktop app's **Settings…**; a running daemon applies a change without a restart. |
 
 You can also override these at runtime with environment variables (take precedence over the profile):
 

--- a/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
+++ b/src/Capacitor.App/ViewModels/MainWindowViewModel.cs
@@ -359,9 +359,10 @@ public sealed class MainWindowViewModel : ReactiveObject, IActivatableViewModel 
                 .DisposeWith(disposables);
 
             _agentCountText = status.CombineLatest(snapshots, (st, snap) => (st, snap))
-                .Select(t => t.st.State == AttachState.Connected
-                    ? $"{t.snap.Daemon.ActiveAgents} of {t.snap.Daemon.MaxAgents} agents"
-                    : "—")
+                .Select(t => t.st.State != AttachState.Connected ? "—"
+                    : t.snap.Daemon.MaxAgents == 0
+                        ? $"{t.snap.Daemon.ActiveAgents} agents (unlimited)"
+                        : $"{t.snap.Daemon.ActiveAgents} of {t.snap.Daemon.MaxAgents} agents")
                 .ToProperty(this, x => x.AgentCountText, "—")
                 .DisposeWith(disposables);
 

--- a/src/Capacitor.App/ViewModels/SettingsViewModel.cs
+++ b/src/Capacitor.App/ViewModels/SettingsViewModel.cs
@@ -104,8 +104,8 @@ public sealed class SettingsViewModel : ReactiveObject, IDisposable {
 
     public string? NameError => string.IsNullOrWhiteSpace(Name) || DaemonStore.Sanitize(Name) != Name
         ? "Use lowercase letters, numbers, dots, hyphens or underscores, with no surrounding spaces or repeated hyphens." : null;
-    public string? CapacityError => Capacity is not { } value || value < 1 || value > int.MaxValue || decimal.Truncate(value) != value
-        ? "Enter a whole number of at least 1." : null;
+    public string? CapacityError => Capacity is not { } value || value < 0 || value > int.MaxValue || decimal.Truncate(value) != value
+        ? "Enter a whole number (0 = unlimited)." : null;
     public string? RenameHint => !_canRenameOnPlatform ? "Renaming is available on macOS."
         : _needsAppRestart ? "Restart this app to manage the renamed daemon."
         : _nameOverridden ? "The name is set by KCAP_DAEMON_NAME. Remove that environment override and restart the app before renaming."
@@ -116,7 +116,9 @@ public sealed class SettingsViewModel : ReactiveObject, IDisposable {
             : !Idle ? "Waiting for the daemon’s current agent count…" : "Renaming restarts the daemon and relaunches this app.";
     public string StatusLine => _status.State switch {
         AttachState.Connected when _snapshot is { } snap =>
-            $"Running as {snap.Daemon.Name}, {snap.Daemon.ActiveAgents} of {snap.Daemon.MaxAgents} agents",
+            snap.Daemon.MaxAgents == 0
+                ? $"Running as {snap.Daemon.Name}, {snap.Daemon.ActiveAgents} agents (unlimited)"
+                : $"Running as {snap.Daemon.Name}, {snap.Daemon.ActiveAgents} of {snap.Daemon.MaxAgents} agents",
         AttachState.Unreachable => "Daemon not running. Changes apply when it starts.",
         _ => "Connecting to daemon…",
     };

--- a/src/Capacitor.App/Views/SettingsWindow.axaml
+++ b/src/Capacitor.App/Views/SettingsWindow.axaml
@@ -30,10 +30,10 @@
                     BorderThickness="1" CornerRadius="12" Padding="20">
                 <StackPanel Spacing="10">
                     <TextBlock Text="Capacity" FontWeight="SemiBold" Foreground="{StaticResource KcapTextBrush}" />
-                    <TextBlock Text="Maximum agents running at once. Existing agents keep running when you lower this limit."
+                    <TextBlock Text="Maximum agents running at once, or 0 for unlimited. Existing agents keep running when you lower this limit."
                                TextWrapping="Wrap" Foreground="{StaticResource KcapMutedBrush}" FontSize="12" />
                     <Grid ColumnDefinitions="140,*,Auto">
-                        <NumericUpDown x:Name="CapacityInput" Value="{Binding Capacity, Mode=TwoWay}" Minimum="1"
+                        <NumericUpDown x:Name="CapacityInput" Value="{Binding Capacity, Mode=TwoWay}" Minimum="0"
                                        Maximum="2147483647" Increment="1" FormatString="0" IsEnabled="{Binding CanEdit}" />
                         <Button Grid.Column="2" x:Name="SaveButton" Content="Save" Classes="kcapPrimary"
                                 Command="{Binding SaveCommand}" Padding="20,8" />

--- a/src/Capacitor.Cli.Core/Resources/help-config.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-config.txt
@@ -10,7 +10,7 @@ Subcommands:
 Config keys:
   server_url              Server URL
   daemon.name                 Daemon name
-  daemon.max_agents           Max concurrent hosted coding agents
+  daemon.max_agents           Max concurrent hosted coding agents (0 = unlimited)
   daemon.claude_path          Path to claude binary (default: claude)
   daemon.codex_path           Path to codex binary (default: codex)
   default_visibility          Default session visibility (private, project, org_public, public)

--- a/src/Capacitor.Cli.Core/Resources/help-daemon.txt
+++ b/src/Capacitor.Cli.Core/Resources/help-daemon.txt
@@ -18,7 +18,7 @@ Subcommands:
 Options for start:
   --name <name>           Daemon name (defaults to OS username)
   --server-url <url>      Server URL
-  --max-agents <n>        Max concurrent hosted coding agents (default: 5)
+  --max-agents <n>        Max concurrent hosted coding agents (default: 5; 0 = unlimited)
   --log-file <path>       Log to file instead of console
   --log-level <level>     Log verbosity: trace|debug|information|warning|error|
                           critical|none (default: information). Also settable via

--- a/src/Capacitor.Cli.Daemon/DaemonConfig.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonConfig.cs
@@ -459,8 +459,8 @@ public class DaemonConfig {
             errors.Add($"ServerUrl must be a valid http/https URL, got: {UnusableUrlDiagnostic.Sanitize(ServerUrl)}");
         }
 
-        if (MaxConcurrentAgents < 1) {
-            errors.Add("MaxConcurrentAgents must be at least 1");
+        if (MaxConcurrentAgents < 0) {
+            errors.Add("MaxConcurrentAgents must be 0 (unlimited) or a positive number");
         }
 
         if (string.IsNullOrWhiteSpace(WorktreeRoot)) {

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -111,14 +111,14 @@ public static partial class DaemonRunner {
                 case "--log-file": logFile = args[++i]; break;
                 case "--stderr-file": stderrFile = args[++i]; break;
                 case "--log-level": logLevelArg = ParseLogLevel(args[++i]); break;
-                case "--max-agents" when int.TryParse(args[i + 1], out var n) && n >= 1:
+                case "--max-agents" when int.TryParse(args[i + 1], out var n) && n >= 0:
                     config.MaxConcurrentAgents = n;
                     maxAgentsFromArgs = true;
                     i++;
 
                     break;
                 case "--max-agents":
-                    await Console.Error.WriteLineAsync($"Invalid --max-agents value: {args[i + 1]} (must be a positive integer)");
+                    await Console.Error.WriteLineAsync($"Invalid --max-agents value: {args[i + 1]} (must be 0 for unlimited, or a positive integer)");
 
                     return 1;
             }
@@ -179,7 +179,7 @@ public static partial class DaemonRunner {
             config.CodexPath = profileDaemon.CodexPath;
 
         if (Environment.GetEnvironmentVariable("KCAP_MAX_AGENTS") is { } maxAgents) {
-            if (int.TryParse(maxAgents, out var n) && n >= 1)
+            if (int.TryParse(maxAgents, out var n) && n >= 0)
                 config.MaxConcurrentAgents = n;
             else
                 await Console.Error.WriteLineAsync($"Warning: ignoring invalid KCAP_MAX_AGENTS={maxAgents}");

--- a/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
+++ b/src/Capacitor.Cli.Daemon/Services/AgentOrchestrator.cs
@@ -2043,7 +2043,8 @@ internal partial class AgentOrchestrator : IAsyncDisposable {
         var activityClock = CreateActivityClock();
 
         try {
-            if (EffectiveCount >= _config.MaxConcurrentAgents) {
+            // MaxConcurrentAgents == 0 is unlimited: the gate is skipped entirely, never compared.
+            if (_config.MaxConcurrentAgents > 0 && EffectiveCount >= _config.MaxConcurrentAgents) {
                 await _server.LaunchFailedAsync(agentId, $"At max capacity ({_config.MaxConcurrentAgents} agents)");
 
                 return new CommandOutcome(CommandOutcomeKind.LaunchRejected, agentId, RejectReason: CommandRejectedReason.DaemonCapacity);

--- a/src/Capacitor.Cli.Daemon/Services/DaemonSettingsIpc.cs
+++ b/src/Capacitor.Cli.Daemon/Services/DaemonSettingsIpc.cs
@@ -23,7 +23,8 @@ internal sealed partial class DaemonSettingsIpc(
     // Validate everything before applying anything, so a put is all-or-nothing as settings grow.
     DaemonSettingsAckDto Apply(DaemonSettingsPutDto? dto) {
         if (!SettingsWire.HasAnySetting(dto)) return Refuse(DaemonSettingsReasons.Malformed);
-        if (dto!.MaxAgents is < 1) return Refuse(DaemonSettingsReasons.InvalidMaxAgents);
+        // 0 is unlimited; only a negative value is invalid.
+        if (dto!.MaxAgents is < 0) return Refuse(DaemonSettingsReasons.InvalidMaxAgents);
 
         if (dto.MaxAgents is { } max) {
             config.MaxConcurrentAgents = max;

--- a/src/Capacitor.Cli/Commands/ConfigCommand.cs
+++ b/src/Capacitor.Cli/Commands/ConfigCommand.cs
@@ -208,7 +208,7 @@ public sealed class ConfigCommand(ConfigRoot config, ICapacitorHttpClient http) 
         Console.Error.WriteLine("Keys:");
         Console.Error.WriteLine("  server_url                  Server URL");
         Console.Error.WriteLine("  daemon.name                 Daemon name");
-        Console.Error.WriteLine("  daemon.max_agents           Max concurrent hosted coding agents");
+        Console.Error.WriteLine("  daemon.max_agents           Max concurrent hosted coding agents (0 = unlimited)");
         Console.Error.WriteLine("  daemon.claude_path          Path to claude binary (default: claude)");
         Console.Error.WriteLine("  daemon.codex_path           Path to codex binary (default: codex)");
         Console.Error.WriteLine("  update_check                All kcap update nudging: stderr hint, server headers (banner/notification), in-agent nudge (true/false)");

--- a/src/Capacitor.Cli/Commands/DaemonCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonCommands.cs
@@ -1026,7 +1026,7 @@ public sealed class DaemonCommands(
         Console.Error.WriteLine("Options for start:");
         Console.Error.WriteLine("  --name <name>         Daemon name (defaults to OS username)");
         Console.Error.WriteLine("  --server-url <url>    Server URL");
-        Console.Error.WriteLine("  --max-agents <n>      Max concurrent hosted coding agents (default: 5)");
+        Console.Error.WriteLine("  --max-agents <n>      Max concurrent hosted coding agents (default: 5; 0 = unlimited)");
         Console.Error.WriteLine("  --log-file <path>     Log to file instead of console");
         Console.Error.WriteLine("  -d, --detach          Run in background (logs to file automatically)");
 

--- a/src/Capacitor.Cli/Commands/DaemonServiceCommands.cs
+++ b/src/Capacitor.Cli/Commands/DaemonServiceCommands.cs
@@ -81,8 +81,8 @@ sealed class DaemonServiceCommands(
     internal static List<string> ExtraArgs(string? maxAgentsFlag) {
         if (maxAgentsFlag is null) return [];
 
-        if (!int.TryParse(maxAgentsFlag, out var maxAgents) || maxAgents < 1)
-            throw new ArgumentException($"--max-agents must be a positive integer (got '{maxAgentsFlag}').");
+        if (!int.TryParse(maxAgentsFlag, out var maxAgents) || maxAgents < 0)
+            throw new ArgumentException($"--max-agents must be 0 (unlimited) or a positive integer (got '{maxAgentsFlag}').");
 
         return ["--max-agents", maxAgents.ToString()];
     }

--- a/test/Capacitor.App.Tests.Unit/SettingsViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/SettingsViewModelTests.cs
@@ -131,7 +131,7 @@ public class SettingsViewModelTests {
         using var vm = Make(store, Connected());
         await Assert.That(vm.CanSave).IsFalse();
         await Assert.That(vm.CanRename).IsFalse();
-        vm.Capacity = 0;
+        vm.Capacity = -1;
         vm.Name = "Bad Name";
         await Assert.That(vm.CanSave).IsFalse();
         await Assert.That(vm.NameError).IsNotNull();
@@ -143,6 +143,15 @@ public class SettingsViewModelTests {
         await Assert.That(vm.CanRename).IsTrue();
         await Assert.That(store.Load().Name).IsEqualTo("daemon-a");
         await Assert.That(store.Load().MaxAgents).IsEqualTo(5);
+    });
+
+    [Test]
+    public Task Zero_capacity_is_valid_and_means_unlimited() => AvaloniaSession.RunOnUiAsync(async () => {
+        var store = Seed();
+        using var vm = Make(store, Connected());
+        vm.Capacity = 0;
+        await Assert.That(vm.CapacityError).IsNull();
+        await Assert.That(vm.CanSave).IsTrue();
     });
 
     [Test]

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/DaemonSettingsIpcTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/DaemonSettingsIpcTests.cs
@@ -143,7 +143,6 @@ public class DaemonSettingsIpcTests {
     [Arguments("[]", "malformed")]
     [Arguments("{}", "malformed")]
     [Arguments("""{"max_agents":null}""", "malformed")]
-    [Arguments("""{"max_agents":0}""", "invalid_max_agents")]
     [Arguments("""{"max_agents":-3}""", "invalid_max_agents")]
     public async Task An_invalid_put_changes_nothing_and_names_why(string payload, string reason) {
         var server = new CaptureServerConnection();
@@ -154,6 +153,36 @@ public class DaemonSettingsIpcTests {
             await Assert.That(h.Config.MaxConcurrentAgents).IsEqualTo(5);
             await h.Orchestrator.CapabilityRefreshForTest;
             await Assert.That(server.RegisterDaemonCalls).IsEqualTo(0);
+        });
+    }
+
+    [Test]
+    public async Task Zero_max_agents_is_accepted_as_unlimited() {
+        await RunAsync(new CaptureServerConnection(), async (h, ct) => {
+            var ack = await PutAsync(h, """{"max_agents":0}""", ct);
+
+            await Assert.That(ack).IsEqualTo(new DaemonSettingsAckDto(true, null, 0));
+            await Assert.That(h.Config.MaxConcurrentAgents).IsEqualTo(0);
+        });
+    }
+
+    [Test]
+    public async Task Unlimited_capacity_admits_a_launch_past_the_capacity_gate() {
+        var server = new SeqCaptureServerConnection();
+        await RunAsync(server, async (h, ct) => {
+            h.Orchestrator.SeedAgentForTest("s1");
+            h.Orchestrator.SeedAgentForTest("s2");
+            await PutAsync(h, """{"max_agents":0}""", ct);
+
+            await h.Orchestrator.HandleLaunchAgentForTest(new LaunchAgentCommand(
+                AgentId: "past", Prompt: "hi", Model: "opus", Effort: null,
+                RepoPath: "/tmp/does-not-matter", Tools: null, AttachmentIds: null, Vendor: "claude",
+                Epoch: h.Orchestrator.DaemonEpochForTest, Seq: 1, CommandId: "cmd-1"));
+            await WaitHarness.SpinUntilAsync(() => server.Rejects.Count > 0, TimeSpan.FromSeconds(10));
+
+            // Reached repo validation (Semantic) rather than being rejected for capacity — the
+            // gate is skipped when unlimited, even with two agents already seeded.
+            await Assert.That(server.Rejects.Single().Reason).IsEqualTo(CommandRejectedReason.Semantic);
         });
     }
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/HealBarrierReportTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/HealBarrierReportTests.cs
@@ -64,8 +64,9 @@ public class HealBarrierReportTests {
     // A Seq'd LaunchAgentCommand the shipped launch would reject at capacity flows through the
     // processor as a terminal LaunchRejected(daemon_capacity) CommandOutcome, so the sequenced lane
     // emits a CommandRejected (in addition to the legacy LaunchFailed) and the watermark still
-    // advances. A daemon already at capacity (one seeded agent, cap 1) rejects the next admission at
-    // the capacity gate, before any launcher/worktree side effect. (Capacity 0 now means unlimited.)
+    // advances. Capacity 0 is the unlimited sentinel, so forcing a rejection needs a finite cap: a
+    // daemon at cap 1 with one seeded agent rejects the next admission at the gate, before any
+    // launcher/worktree side effect.
     [Test]
     public async Task Sequenced_launch_over_capacity_emits_daemon_capacity_rejection() {
         var server = new SeqCaptureServerConnection();

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/Services/HealBarrierReportTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/Services/HealBarrierReportTests.cs
@@ -61,18 +61,19 @@ public class HealBarrierReportTests {
         await Assert.That(orch.ReadLiveness("rev")).IsEqualTo(AgentLiveness.Dead); // genuinely dead at the end
     }
 
-    // Phase B2-b (sequenced-settlement design §4.2.2/§5.5): a Seq'd LaunchAgentCommand the shipped launch
-    // would reject at capacity flows through the processor as a terminal LaunchRejected(daemon_capacity)
-    // CommandOutcome, so the sequenced lane emits a CommandRejected (in addition to the legacy
-    // LaunchFailed) and the watermark still advances. MaxConcurrentAgents=0 makes the very first admission
-    // check reject with no launcher/worktree side effects.
+    // A Seq'd LaunchAgentCommand the shipped launch would reject at capacity flows through the
+    // processor as a terminal LaunchRejected(daemon_capacity) CommandOutcome, so the sequenced lane
+    // emits a CommandRejected (in addition to the legacy LaunchFailed) and the watermark still
+    // advances. A daemon already at capacity (one seeded agent, cap 1) rejects the next admission at
+    // the capacity gate, before any launcher/worktree side effect. (Capacity 0 now means unlimited.)
     [Test]
     public async Task Sequenced_launch_over_capacity_emits_daemon_capacity_rejection() {
         var server = new SeqCaptureServerConnection();
         await using var orch = AgentOrchestratorHarness.BuildOrchestrator(
             server, new SpyPtyProcessFactory(),
             new Dictionary<string, IHostedAgentLauncher> { ["claude"] = new SpyHostedAgentLauncher("claude", cliPath: "spy-claude") },
-            configure: c => c.MaxConcurrentAgents = 0);
+            configure: c => c.MaxConcurrentAgents = 1);
+        orch.SeedAgentForTest("occupant"); // fills the single slot, so the next admission is over capacity
 
         await orch.HandleLaunchAgentForTest(new LaunchAgentCommand(
             AgentId: "cap", Prompt: "hi", Model: "opus", Effort: null,

--- a/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
+++ b/test/Capacitor.Cli.Tests.Unit/Services/UnitWriterExpansionTests.cs
@@ -304,13 +304,18 @@ public class UnitWriterExpansionTests {
     [Arguments("8;calc")]
     [Arguments("abc")]
     [Arguments("")]
-    [Arguments("0")]
     [Arguments("-1")]
     [Arguments("8.5")]
-    public async Task ServiceExtraArgs_rejects_a_non_positive_integer(string bad) {
+    public async Task ServiceExtraArgs_rejects_a_negative_or_non_integer(string bad) {
         var ex = Assert.Throws<ArgumentException>(() => DaemonServiceCommands.ExtraArgs(bad));
 
         await Assert.That(ex!.Message).Contains("positive integer");
+    }
+
+    /// 0 is the unlimited sentinel and must round-trip into the persisted unit, not be rejected.
+    [Test]
+    public async Task ServiceExtraArgs_accepts_zero_as_unlimited() {
+        await Assert.That(DaemonServiceCommands.ExtraArgs("0")).IsEquivalentTo(["--max-agents", "0"]);
     }
 
     [Test]


### PR DESCRIPTION
Closes #902 — AI-2720

## What & why

The 5-agent limit was only a default, but nothing let you turn it off. `max_agents = 0` now means unlimited: the capacity gate is skipped entirely, and every entry point (`daemon.max_agents`, `--max-agents`, `KCAP_MAX_AGENTS`, the live settings IPC, and the desktop app's **Settings…**) accepts 0 while still rejecting negatives. The default stays 5.

## Where to look

The gate at `AgentOrchestrator` guards on `MaxConcurrentAgents > 0` before comparing. Agent-count displays (rail footer, Settings status line) render 0 as "N agents (unlimited)" instead of "N of 0". `daemon.max_agents` is now documented in the README config table; the desktop capacity field allows 0 with a matching hint.

## Verification

`dotnet build Capacitor.slnx` → 0 warnings; CLI `dotnet publish -c Release` → no IL2026/IL3050. Tests: DaemonSettingsIpcTests 12/12 (new: 0 accepted as unlimited; a launch under `max_agents=0` reaches repo validation instead of a capacity reject with two agents seeded), SettingsViewModelTests 25/25 (new: 0 is valid), MainWindowViewModelTests 51/51, core SettingsWireContractsTests 7/7 and ConfigDefaultsTests 16/16.
