### PR TITLE
Give each vendor probe a dedicated thread

### DIFF
--- a/docs/CHANGES.md
+++ b/docs/CHANGES.md
@@ -6,6 +6,16 @@ diff. `CLAUDE.md` holds the invariants; `docs/superpowers/specs/` holds the full
 Not release notes. Each entry is written as of the change that produced it and is not revised as the
 code moves on; where an entry disagrees with the code, the code wins.
 
+## Vendor probes run on dedicated threads
+
+A startup probe pass overlaps N vendor `--version` probes so they cost one budget rather than the
+sum, but each probe blocks its thread on `WaitForExit` for up to its whole budget, and the thread
+pool is not told about that kind of block. Queued on the pool, the probes start only as the pool
+grows, about one thread a second once it is saturated, and the pass serializes again. Every probe
+therefore runs on its own long-running thread. The test that pins this saturates the pool first
+with the same silent kind of wait; a `Task.Wait` there would be compensated by the pool and prove
+nothing.
+
 ## The application menu keeps its exported Settings item
 
 Avalonia's macOS exporter captures the application menu after initialization and observes its

--- a/src/Capacitor.Cli.Daemon/DaemonRunner.cs
+++ b/src/Capacitor.Cli.Daemon/DaemonRunner.cs
@@ -1565,8 +1565,12 @@ public static partial class DaemonRunner {
             IEnumerable<string> vendors, Func<string, T> probe, T timedOut,
             int ceilingMs = ConcurrentProbeCeilingMs) {
         var tasks = new Dictionary<string, Task<T>>(StringComparer.Ordinal);
+        // A probe blocks its thread for its whole budget, so each gets a dedicated one. Queued on the
+        // thread pool they start only as the pool grows — one thread a second once it is saturated —
+        // which serializes the very pass this seam exists to overlap.
         foreach (var vendor in vendors)
-            tasks.TryAdd(vendor, Task.Run(() => probe(vendor)));
+            tasks.TryAdd(vendor, Task.Factory.StartNew(
+                () => probe(vendor), CancellationToken.None, TaskCreationOptions.LongRunning, TaskScheduler.Default));
 
         if (tasks.Count == 0) return FrozenDictionary<string, T>.Empty;
 

--- a/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerConcurrentProbeTests.cs
+++ b/test/Capacitor.Cli.Daemon.Tests.Unit/DaemonRunnerConcurrentProbeTests.cs
@@ -7,39 +7,43 @@ namespace Capacitor.Cli.Daemon.Tests.Unit;
 /// on — the probes overlap, and a probe still unfinished at the ceiling maps to the miss value without
 /// holding the rest of the pass hostage.
 /// </summary>
-[ParallelLimiter<SubprocessLimit>]
 public class DaemonRunnerConcurrentProbeTests {
-    static void InterlockedMax(ref int target, int value) {
-        int seen;
-        do { seen = Volatile.Read(ref target); }
-        while (value > seen && Interlocked.CompareExchange(ref target, value, seen) != seen);
-    }
-
-    /// <summary>A sequential pass can never hold two probes in flight at once, so an observed peak of
-    /// two or more is proof the pass overlapped them.</summary>
+    /// <summary>Every probe waits for all of its peers to be in flight before it returns, so a pass that
+    /// ran them one at a time could never complete even one. The thread pool is saturated first: the
+    /// overlap has to hold when the daemon's pool is busy, and a probe queued on it would start only as
+    /// the pool grew. The pool is process-wide, hence the bare exclusion. Both waits are event waits,
+    /// like the real probe's WaitForExit: a Task.Wait on a pool thread tells the pool it is blocked and
+    /// gets a compensating thread, which is exactly what the probes do not get.</summary>
     [Test]
-    public async Task ProbeVendorsConcurrently_OverlapsProbes_RatherThanSerializing() {
+    [NotInParallel]
+    public async Task ProbeVendorsConcurrently_OverlapsProbes_EvenWhenThreadPoolIsSaturated() {
         string[] vendors = ["a", "b", "c", "d", "e"];
-        var current       = 0;
-        var maxConcurrent = 0;
+        using var hold  = new ManualResetEventSlim(false);
+        // Not disposed: a probe stranded by a regression can still be inside Wait when the pass returns.
+        var allInFlight = new CountdownEvent(vendors.Length);
 
-        var result = DaemonRunner.ProbeVendorsConcurrently(
-            vendors,
-            vendor => {
-                var now = Interlocked.Increment(ref current);
-                InterlockedMax(ref maxConcurrent, now);
-                Thread.Sleep(300);   // hold the slot so peers can pile up
-                Interlocked.Decrement(ref current);
+        ThreadPool.GetMinThreads(out var minWorkers, out _);
+        var blockers = Enumerable.Range(0, Math.Max(minWorkers, ThreadPool.ThreadCount) + 4)
+            .Select(_ => Task.Run(() => hold.Wait()))
+            .ToArray();
 
-                return vendor + "-ok";
-            },
-            timedOut: "TIMEOUT");
+        IReadOnlyDictionary<string, string> result;
+        try {
+            result = DaemonRunner.ProbeVendorsConcurrently(
+                vendors,
+                vendor => {
+                    allInFlight.Signal();
 
-        await Assert.That(maxConcurrent).IsGreaterThanOrEqualTo(2)
-            .Because("a sequential pass would never show two probes in flight at once");
+                    return allInFlight.Wait(2_000) ? vendor + "-ok" : vendor + "-alone";
+                },
+                timedOut: "TIMEOUT",
+                ceilingMs: 2_000);
+        }
+        finally { hold.Set(); }
+        await Task.WhenAll(blockers);
+
         await Assert.That(result.Keys).IsEquivalentTo(vendors);
-        await Assert.That(result.Values.All(v => v == "TIMEOUT")).IsFalse();
-        await Assert.That(result["c"]).IsEqualTo("c-ok");
+        await Assert.That(result.Values).IsEquivalentTo(vendors.Select(v => v + "-ok").ToArray());
     }
 
     /// <summary>A single slow vendor is cut at the ceiling and maps to the miss value; the vendors that
@@ -47,16 +51,21 @@ public class DaemonRunnerConcurrentProbeTests {
     [Test]
     public async Task ProbeVendorsConcurrently_SlowVendorMapsToTimeout_FastVendorsStillResolve() {
         string[] vendors = ["fast1", "slow", "fast2"];
+        var wedged = new TaskCompletionSource();
 
-        var result = DaemonRunner.ProbeVendorsConcurrently(
-            vendors,
-            vendor => {
-                if (vendor == "slow") Thread.Sleep(4_000);
+        IReadOnlyDictionary<string, string> result;
+        try {
+            result = DaemonRunner.ProbeVendorsConcurrently(
+                vendors,
+                vendor => {
+                    if (vendor == "slow") wedged.Task.Wait();
 
-                return vendor + "-v";
-            },
-            timedOut: "TIMEOUT",
-            ceilingMs: 800);
+                    return vendor + "-v";
+                },
+                timedOut: "TIMEOUT",
+                ceilingMs: 800);
+        }
+        finally { wedged.SetResult(); }
 
         await Assert.That(result["fast1"]).IsEqualTo("fast1-v");
         await Assert.That(result["fast2"]).IsEqualTo("fast2-v");


### PR DESCRIPTION
Closes #911 — AI-2729

## What & why

`ProbeVendorsConcurrently` ran each vendor probe on `Task.Run`. A probe blocks its thread in `WaitForExit` for up to its whole budget, and the pool is not told about that kind of block, so once the pool is saturated the queued probes start about one thread a second and the pass serializes — the flaky assertion was observing exactly that under full-suite load. Each probe now runs on its own long-running thread, which holds the overlap regardless of pool state. The two timing tests become a rendezvous that cannot pass sequentially and a gate that cannot finish before the ceiling.

## Where to look

The saturation test blocks pool threads with `ManualResetEventSlim.Wait`, not `Task.Wait`: a `Task.Wait` on a pool thread is compensated with a new thread, and with it the test passed against the unfixed code. The assertion quoted in the issue belongs to the sibling `…OverlapsProbes…` test; both tests share this cause.

## Verification

Repro with a saturated pool (12 cores, 16 blocked threads): `Task.Run` gave `maxConcurrent=1` over 4.3s and `fast2=TIMEOUT`; `LongRunning` gave `maxConcurrent=5` in 303ms and `fast2=fast2-v`.

`ProbeVendorsConcurrently_OverlapsProbes_EvenWhenThreadPoolIsSaturated` fails before the fix (every probe times out at the 2s ceiling) and passes after; the class passes 5/5 repeated runs. Full `Capacitor.Cli.Daemon.Tests.Unit`: 3233 total, 3193 passed, 2 failed, both pre-existing (`AcpMetricsTests` shared-meter race, passes in isolation; codex schema pin vs locally installed codex 0.151.0). `dotnet publish -c Release` of the daemon: 0 IL warnings.
