### PR TITLE
Recall sent prompts with the arrow keys in the chat composer

### DIFF
--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -142,6 +142,18 @@ public sealed class ChatTabViewModel : ReactiveObject {
         }
     }
 
+    readonly ComposerHistory _history = new();
+    /// Replaces the composer text with the next older sent prompt; false when nothing changed.
+    public bool RecallOlder() => Recall(_history.Older(ComposerText));
+    /// Replaces the composer text with the next newer sent prompt, or the draft past the newest.
+    public bool RecallNewer() => Recall(_history.Newer(ComposerText));
+
+    bool Recall(string? text) {
+        if (text is null) return false;
+        ComposerText = text;
+        return true;
+    }
+
     public ReactiveCommand<Unit, Unit> SendCommand { get; }
     public ReactiveCommand<Unit, Unit> InterruptCommand { get; }
     public ReactiveCommand<string, Unit> OpenLinkCommand { get; }
@@ -332,6 +344,7 @@ public sealed class ChatTabViewModel : ReactiveObject {
                 outcome = ChatSendOutcome.Unconfirmed;
             }
             if (_lifetimeToken.IsCancellationRequested) return;
+            if (outcome != ChatSendOutcome.Rejected) _history.Record(snapshot);
             if (outcome == ChatSendOutcome.Rejected || (outcome == ChatSendOutcome.Accepted && _projection is null))
                 _queuedMessages.Remove(queued);
             else if (outcome == ChatSendOutcome.Unconfirmed)

--- a/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
+++ b/src/Capacitor.App/ViewModels/ChatTabViewModel.cs
@@ -143,14 +143,23 @@ public sealed class ChatTabViewModel : ReactiveObject {
     }
 
     readonly ComposerHistory _history = new();
+    int _recallEdits = -1;
     /// Replaces the composer text with the next older sent prompt; false when nothing changed.
-    public bool RecallOlder() => Recall(_history.Older(ComposerText));
+    public bool RecallOlder() => Recall(_history.Older(Recallable()));
     /// Replaces the composer text with the next newer sent prompt, or the draft past the newest.
-    public bool RecallNewer() => Recall(_history.Newer(ComposerText));
+    public bool RecallNewer() => Recall(_history.Newer(Recallable()));
+
+    /// Text equality cannot prove a recall was left alone — an edit undone by hand lands on the
+    /// same string — so the edit count decides, as it does for the sent draft.
+    string Recallable() {
+        if (_composerEdits != _recallEdits) _history.EndNavigation();
+        return ComposerText;
+    }
 
     bool Recall(string? text) {
         if (text is null) return false;
         ComposerText = text;
+        _recallEdits = _composerEdits;
         return true;
     }
 

--- a/src/Capacitor.App/ViewModels/ComposerHistory.cs
+++ b/src/Capacitor.App/ViewModels/ComposerHistory.cs
@@ -1,0 +1,49 @@
+namespace Capacitor.App.ViewModels;
+
+/// Prompts sent from one composer, recalled with ↑/↓ the way a shell recalls commands. Recall
+/// starts only from a blank composer and continues only while the box still shows the recalled
+/// text unchanged: an edit turns it back into the user's own draft.
+public sealed class ComposerHistory {
+    public const int Capacity = 100;
+
+    readonly List<string> _entries = new();
+    int _cursor;
+    string? _shown;
+    string _draft = "";
+
+    public void Record(string text) {
+        if (_entries.Count == 0 || !string.Equals(_entries[^1], text, StringComparison.Ordinal)) {
+            _entries.Add(text);
+            if (_entries.Count > Capacity) _entries.RemoveAt(0);
+        }
+        EndNavigation();
+    }
+
+    /// The next older prompt, or null when there is none or `current` is a draft of the user's own.
+    public string? Older(string current) {
+        if (!IsShowing(current)) {
+            if (!string.IsNullOrWhiteSpace(current)) return null;
+            _draft = current;
+            _cursor = _entries.Count;
+        }
+        if (_cursor == 0) return null;
+        _cursor--;
+        return _shown = _entries[_cursor];
+    }
+
+    /// The next newer prompt, the stashed draft once past the newest, or null outside navigation.
+    public string? Newer(string current) {
+        if (!IsShowing(current)) return null;
+        _cursor++;
+        if (_cursor < _entries.Count) return _shown = _entries[_cursor];
+        EndNavigation();
+        return _draft;
+    }
+
+    bool IsShowing(string current) => _shown is not null && string.Equals(_shown, current, StringComparison.Ordinal);
+
+    void EndNavigation() {
+        _shown = null;
+        _cursor = _entries.Count;
+    }
+}

--- a/src/Capacitor.App/ViewModels/ComposerHistory.cs
+++ b/src/Capacitor.App/ViewModels/ComposerHistory.cs
@@ -42,7 +42,8 @@ public sealed class ComposerHistory {
 
     bool IsShowing(string current) => _shown is not null && string.Equals(_shown, current, StringComparison.Ordinal);
 
-    void EndNavigation() {
+    /// Leaves whatever the composer shows as the user's own draft.
+    public void EndNavigation() {
         _shown = null;
         _cursor = _entries.Count;
     }

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -65,12 +65,25 @@ public partial class ChatTabView : UserControl {
 
     /// A bare Enter is always consumed — it sends when the composer can send, and otherwise does
     /// nothing, leaving the text and the hint that says why. Shift+Enter falls through to the
-    /// TextBox's own newline.
+    /// TextBox's own newline. ↑/↓ recall sent prompts only from the first/last line, so inside a
+    /// multi-line recall they stay the TextBox's own caret moves until the caret reaches an edge.
     void OnComposerKeyDown(object? sender, KeyEventArgs e) {
         if (e.Key == Key.Escape && e.KeyModifiers == KeyModifiers.None) {
             e.Handled = true;
             if (DataContext is ChatTabViewModel chat && ((ICommand)chat.InterruptCommand).CanExecute(null))
                 chat.InterruptCommand.Execute().Subscribe();
+            return;
+        }
+        if (e.Key is Key.Up or Key.Down && e.KeyModifiers == KeyModifiers.None) {
+            if (DataContext is not ChatTabViewModel tab) return;
+            var text = ComposerInput.Text ?? "";
+            var caret = Math.Clamp(ComposerInput.CaretIndex, 0, text.Length);
+            var recalled = e.Key == Key.Up
+                ? text.IndexOf('\n', 0, caret) < 0 && tab.RecallOlder()
+                : text.IndexOf('\n', caret) < 0 && tab.RecallNewer();
+            if (!recalled) return;
+            e.Handled = true;
+            ComposerInput.CaretIndex = ComposerInput.Text?.Length ?? 0;
             return;
         }
         if (e.Key != Key.Enter || e.KeyModifiers.HasFlag(KeyModifiers.Shift)) return;

--- a/src/Capacitor.App/Views/ChatTabView.axaml.cs
+++ b/src/Capacitor.App/Views/ChatTabView.axaml.cs
@@ -1,5 +1,6 @@
 using System.Windows.Input;
 using Avalonia.Controls;
+using Avalonia.Controls.Presenters;
 using Avalonia.Controls.Primitives;
 using Avalonia.Input;
 using Avalonia.Interactivity;
@@ -63,6 +64,17 @@ public partial class ChatTabView : UserControl {
         if (_followTail && !atBottom) scroll.ScrollToEnd();
     }
 
+    /// The composer wraps, so the rendered rows, not the newlines, say whether the caret has a row
+    /// above or below it; the newline count stands in only before the box has a text presenter.
+    (int Line, int Lines) ComposerCaretLine() {
+        var text = ComposerInput.Text ?? "";
+        var caret = Math.Clamp(ComposerInput.CaretIndex, 0, text.Length);
+        var layout = ComposerInput.GetVisualDescendants().OfType<TextPresenter>().FirstOrDefault()?.TextLayout;
+        if (layout is { TextLines.Count: > 0 })
+            return (layout.GetLineIndexFromCharacterIndex(caret, false), layout.TextLines.Count);
+        return (text.AsSpan(0, caret).Count('\n'), text.AsSpan().Count('\n') + 1);
+    }
+
     /// A bare Enter is always consumed — it sends when the composer can send, and otherwise does
     /// nothing, leaving the text and the hint that says why. Shift+Enter falls through to the
     /// TextBox's own newline. ↑/↓ recall sent prompts only from the first/last line, so inside a
@@ -75,12 +87,9 @@ public partial class ChatTabView : UserControl {
             return;
         }
         if (e.Key is Key.Up or Key.Down && e.KeyModifiers == KeyModifiers.None) {
-            if (DataContext is not ChatTabViewModel tab) return;
-            var text = ComposerInput.Text ?? "";
-            var caret = Math.Clamp(ComposerInput.CaretIndex, 0, text.Length);
-            var recalled = e.Key == Key.Up
-                ? text.IndexOf('\n', 0, caret) < 0 && tab.RecallOlder()
-                : text.IndexOf('\n', caret) < 0 && tab.RecallNewer();
+            if (DataContext is not ChatTabViewModel tab || ComposerInput.SelectionStart != ComposerInput.SelectionEnd) return;
+            var (line, lines) = ComposerCaretLine();
+            var recalled = e.Key == Key.Up ? line == 0 && tab.RecallOlder() : line == lines - 1 && tab.RecallNewer();
             if (!recalled) return;
             e.Handled = true;
             ComposerInput.CaretIndex = ComposerInput.Text?.Length ?? 0;

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -757,6 +757,45 @@ public class ChatTabViewModelTests {
         });
     }
 
+    /// A send that went out is recallable whether or not the transcript has echoed it yet; a
+    /// rejected one never left the box, so there is nothing to recall.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Recall_walks_the_sent_prompts_and_skips_a_rejected_send() {
+        await RunOnUiAsync(async () => {
+            var input = new ScriptedInput();
+            var h = new Harness(TranscriptChat.Journal, input: input);
+            await h.PushAsync(Agent("a1", "pi", hasTerminal: false) with { Status = "Running" });
+
+            h.Chat.ComposerText = "first";
+            var send = h.Chat.SendCommand.Execute().ToTask();
+            input.Pending!.SetResult(ChatSendOutcome.Accepted);
+            await send;
+            h.Chat.ComposerText = "refused";
+            send = h.Chat.SendCommand.Execute().ToTask();
+            input.Pending!.SetResult(ChatSendOutcome.Rejected);
+            await send;
+            h.Chat.ComposerText = "second";
+            send = h.Chat.SendCommand.Execute().ToTask();
+            input.Pending!.SetResult(ChatSendOutcome.Unconfirmed);
+            await send;
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("second");
+            h.Chat.ComposerText = "";
+
+            await Assert.That(h.Chat.RecallOlder()).IsTrue();
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("second");
+            await Assert.That(h.Chat.RecallOlder()).IsTrue();
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("first");
+            await Assert.That(h.Chat.RecallOlder()).IsFalse();
+            await Assert.That(h.Chat.RecallNewer()).IsTrue();
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("second");
+            await Assert.That(h.Chat.RecallNewer()).IsTrue();
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("");
+            await Assert.That(h.Chat.RecallNewer()).IsFalse();
+            await h.TeardownAsync();
+        });
+    }
+
     /// Text alone cannot decide this: an edit during the round trip that ends on the sent text is
     /// still the user's own draft, and clearing it would erase what they typed.
     [Test]

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewModelTests.cs
@@ -796,6 +796,35 @@ public class ChatTabViewModelTests {
         });
     }
 
+    /// Text equality cannot prove a recall was left alone: an edit undone by hand lands on the
+    /// same string, and that string is the user's own draft now.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Recall_ends_when_a_recalled_prompt_is_edited_and_restored() {
+        await RunOnUiAsync(async () => {
+            var input = new ScriptedInput();
+            var h = new Harness(TranscriptChat.Journal, input: input);
+            await h.PushAsync(Agent("a1", "pi", hasTerminal: false) with { Status = "Running" });
+
+            foreach (var text in new[] { "first", "second" }) {
+                h.Chat.ComposerText = text;
+                var send = h.Chat.SendCommand.Execute().ToTask();
+                input.Pending!.SetResult(ChatSendOutcome.Accepted);
+                await send;
+            }
+            h.Chat.ComposerText = "";
+            await Assert.That(h.Chat.RecallOlder()).IsTrue();
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("second");
+
+            h.Chat.ComposerText = "second!";
+            h.Chat.ComposerText = "second";
+            await Assert.That(h.Chat.RecallOlder()).IsFalse();
+            await Assert.That(h.Chat.RecallNewer()).IsFalse();
+            await Assert.That(h.Chat.ComposerText).IsEqualTo("second");
+            await h.TeardownAsync();
+        });
+    }
+
     /// Text alone cannot decide this: an edit during the round trip that ends on the sent text is
     /// still the user's own draft, and clearing it would erase what they typed.
     [Test]

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -147,6 +147,22 @@ public class ChatTabViewSmokeTests {
             Dispatcher.UIThread.RunJobs();
         }
 
+        public void Press(PhysicalKey key) {
+            Window.KeyPressQwerty(key, RawInputModifiers.None);
+            Dispatcher.UIThread.RunJobs();
+        }
+
+        /// Types, sends with Enter and lets the CR go out, so the next send is accepted.
+        public async Task SendAsync(params string[] lines) {
+            for (var i = 0; i < lines.Length; i++) {
+                if (i > 0) PressEnter(RawInputModifiers.Shift);
+                Type(lines[i]);
+            }
+            PressEnter(RawInputModifiers.None);
+            Time.Advance(CrDelay);
+            await Terminal.PendingDeliveryForTesting!;
+        }
+
         public async Task LoadAsync(string path) {
             Daemon.Agents.AddOrUpdate(Agent("a1", "claude", hasTerminal: true) with { TranscriptPath = path });
             await (Terminal.PendingResolveWorkForTesting ?? Task.CompletedTask);
@@ -419,6 +435,45 @@ public class ChatTabViewSmokeTests {
             await Assert.That(banner.GetVisualDescendants().OfType<TextBlock>().Any(t => t.Text == "Delivery unconfirmed" && t.IsVisible)).IsTrue();
             await host.AppendLinesAndTickAsync(path, UserLine.Replace("hello", "queued follow-up"));
             await Assert.That(banner.IsVisible).IsFalse();
+            await host.CloseAsync();
+        });
+    }
+
+    /// Pins the arrow keys' contract: ↑ in an empty composer recalls the last sent prompt, ↑ inside
+    /// a multi-line recall climbs to the first line before stepping older, ↓ past the newest
+    /// restores the empty box, and neither key touches a draft the user typed.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Up_recalls_sent_prompts_and_down_returns_to_the_empty_draft() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.AttachAsync(Tmp.CreateFile("recall.jsonl", UserLine));
+            await host.SendAsync("first");
+            await host.SendAsync("top", "bottom");
+            var multi = "top" + Environment.NewLine + "bottom";
+            await Assert.That(host.Composer.Text ?? "").IsEqualTo("");
+
+            host.Press(PhysicalKey.ArrowUp);
+            await Assert.That(host.Composer.Text).IsEqualTo(multi);
+            await Assert.That(host.Composer.CaretIndex).IsEqualTo(multi.Length);
+
+            host.Press(PhysicalKey.ArrowUp);
+            await Assert.That(host.Composer.Text).IsEqualTo(multi);
+            await Assert.That(host.Composer.CaretIndex).IsLessThanOrEqualTo(3);
+
+            host.Press(PhysicalKey.ArrowUp);
+            await Assert.That(host.Composer.Text).IsEqualTo("first");
+            host.Press(PhysicalKey.ArrowUp);
+            await Assert.That(host.Composer.Text).IsEqualTo("first");
+
+            host.Press(PhysicalKey.ArrowDown);
+            await Assert.That(host.Composer.Text).IsEqualTo(multi);
+            host.Press(PhysicalKey.ArrowDown);
+            await Assert.That(host.Composer.Text ?? "").IsEqualTo("");
+
+            host.Type("typing");
+            host.Press(PhysicalKey.ArrowUp);
+            await Assert.That(host.Composer.Text).IsEqualTo("typing");
             await host.CloseAsync();
         });
     }

--- a/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ChatTabViewSmokeTests.cs
@@ -478,6 +478,62 @@ public class ChatTabViewSmokeTests {
         });
     }
 
+    /// A selection makes ↑/↓ the TextBox's own collapse-and-move, so a recall must not replace
+    /// the text underneath it.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Arrow_keys_over_a_selection_leave_the_recalled_text_alone() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.AttachAsync(Tmp.CreateFile("recall-selection.jsonl", UserLine));
+            await host.SendAsync("first");
+            await host.SendAsync("second");
+
+            host.Press(PhysicalKey.ArrowUp);
+            await Assert.That(host.Composer.Text).IsEqualTo("second");
+            host.Composer.SelectionStart = 0;
+            host.Composer.SelectionEnd = 3;
+            host.Press(PhysicalKey.ArrowUp);
+            await Assert.That(host.Composer.Text).IsEqualTo("second");
+
+            host.Composer.SelectionStart = 6;
+            host.Composer.SelectionEnd = 2;
+            host.Press(PhysicalKey.ArrowDown);
+            await Assert.That(host.Composer.Text).IsEqualTo("second");
+            await host.CloseAsync();
+        });
+    }
+
+    /// The composer wraps, so a long prompt with no newline still has rows above the caret: ↑ from
+    /// its end climbs those rows first and recalls the older prompt only from the top one.
+    [Test]
+    [NotInParallel("AvaloniaSession")]
+    public async Task Up_climbs_the_wrapped_rows_of_a_recall_before_stepping_older() {
+        await RunOnUiAsync(async () => {
+            var host = new Host();
+            await host.AttachAsync(Tmp.CreateFile("recall-wrap.jsonl", UserLine));
+            await host.SendAsync("first");
+            var wrapped = string.Join(' ', Enumerable.Repeat("wrapped", 60));
+            await host.SendAsync(wrapped);
+
+            host.Press(PhysicalKey.ArrowUp);
+            await Assert.That(host.Composer.Text).IsEqualTo(wrapped);
+            await Assert.That(host.Composer.GetLineCount()).IsGreaterThan(1);
+
+            host.Press(PhysicalKey.ArrowUp);
+            await Assert.That(host.Composer.Text).IsEqualTo(wrapped);
+            await Assert.That(host.Composer.CaretIndex).IsLessThan(wrapped.Length);
+
+            var presses = 1;
+            while (host.Composer.Text == wrapped && presses < 20) {
+                host.Press(PhysicalKey.ArrowUp);
+                presses++;
+            }
+            await Assert.That(host.Composer.Text).IsEqualTo("first");
+            await host.CloseAsync();
+        });
+    }
+
     /// Pins the other half of the key contract: Shift+Enter stays the TextBox's own newline and
     /// sends nothing.
     [Test]

--- a/test/Capacitor.App.Tests.Unit/ComposerHistoryTests.cs
+++ b/test/Capacitor.App.Tests.Unit/ComposerHistoryTests.cs
@@ -1,0 +1,95 @@
+using System.Globalization;
+using Capacitor.App.ViewModels;
+
+namespace Capacitor.App.Tests.Unit;
+
+public class ComposerHistoryTests {
+    static ComposerHistory With(params string[] sent) {
+        var history = new ComposerHistory();
+        foreach (var text in sent) history.Record(text);
+        return history;
+    }
+
+    [Test]
+    public async Task Older_on_an_empty_composer_recalls_the_last_sent_prompt() {
+        var history = With("first", "second");
+        await Assert.That(history.Older("")).IsEqualTo("second");
+    }
+
+    [Test]
+    public async Task Older_walks_back_and_stops_at_the_oldest() {
+        var history = With("first", "second");
+        await Assert.That(history.Older("")).IsEqualTo("second");
+        await Assert.That(history.Older("second")).IsEqualTo("first");
+        await Assert.That(history.Older("first")).IsNull();
+    }
+
+    [Test]
+    public async Task Older_leaves_a_typed_draft_alone() {
+        var history = With("first");
+        await Assert.That(history.Older("typing")).IsNull();
+    }
+
+    [Test]
+    public async Task Older_with_nothing_sent_recalls_nothing() {
+        await Assert.That(new ComposerHistory().Older("")).IsNull();
+    }
+
+    [Test]
+    public async Task Newer_walks_forward_and_then_restores_the_draft() {
+        var history = With("first", "second");
+        await Assert.That(history.Older("  ")).IsEqualTo("second");
+        await Assert.That(history.Older("second")).IsEqualTo("first");
+        await Assert.That(history.Newer("first")).IsEqualTo("second");
+        await Assert.That(history.Newer("second")).IsEqualTo("  ");
+        await Assert.That(history.Newer("  ")).IsNull();
+    }
+
+    [Test]
+    public async Task Newer_outside_navigation_does_nothing() {
+        var history = With("first");
+        await Assert.That(history.Newer("")).IsNull();
+        await Assert.That(history.Newer("typing")).IsNull();
+    }
+
+    /// An edited recall is the user's own draft: neither key steps away from it.
+    [Test]
+    public async Task An_edit_to_a_recalled_prompt_ends_navigation() {
+        var history = With("first", "second");
+        await Assert.That(history.Older("")).IsEqualTo("second");
+        await Assert.That(history.Older("second edited")).IsNull();
+        await Assert.That(history.Newer("second edited")).IsNull();
+    }
+
+    [Test]
+    public async Task Record_collapses_consecutive_duplicates() {
+        var history = With("a", "a", "b", "a");
+        await Assert.That(history.Older("")).IsEqualTo("a");
+        await Assert.That(history.Older("a")).IsEqualTo("b");
+        await Assert.That(history.Older("b")).IsEqualTo("a");
+        await Assert.That(history.Older("a")).IsNull();
+    }
+
+    [Test]
+    public async Task Record_ends_navigation() {
+        var history = With("first");
+        await Assert.That(history.Older("")).IsEqualTo("first");
+        history.Record("third");
+        await Assert.That(history.Newer("first")).IsNull();
+        await Assert.That(history.Older("")).IsEqualTo("third");
+    }
+
+    [Test]
+    public async Task Record_drops_the_oldest_past_capacity() {
+        var history = With(Enumerable.Range(0, ComposerHistory.Capacity + 1).Select(i => i.ToString(CultureInfo.InvariantCulture)).ToArray());
+        var current = "";
+        string? recalled = null;
+        for (var i = 0; i < ComposerHistory.Capacity; i++) {
+            recalled = history.Older(current);
+            await Assert.That(recalled).IsNotNull();
+            current = recalled!;
+        }
+        await Assert.That(recalled).IsEqualTo("1");
+        await Assert.That(history.Older(current)).IsNull();
+    }
+}


### PR DESCRIPTION
AI-2731 (no GitHub issue exists for this one; the Linear issue is the tracker record)

## What & why

In the desktop app's chat tab, ↑ in an empty composer recalls the most recent prompt sent from that tab, repeated ↑ walks older, and ↓ walks newer until it restores the empty draft, the way Claude Desktop and most chat apps behave. History is in-memory, per tab, for this app run; consecutive duplicates collapse and it is capped at 100 entries. A prompt the server rejected is not recorded.

## Where to look

Recall starts only from a blank composer and continues only while the box still shows the recalled text unchanged; any edit turns it back into an ordinary draft. Inside a multi-line recall, ↑/↓ stay the TextBox's own caret moves until the caret sits on the first/last line, so long prompts remain editable.

## Verification

```
dotnet run --project test/Capacitor.App.Tests.Unit -- --treenode-filter '/*/*/ComposerHistoryTests|ChatTabViewModelTests|ChatTabViewSmokeTests/*'
Test run summary: Passed!  total: 96  failed: 0  succeeded: 96
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
