### PR TITLE
Restore the desktop window when reopened from the Dock

### DIFF
--- a/src/Capacitor.App/App.axaml.cs
+++ b/src/Capacitor.App/App.axaml.cs
@@ -203,13 +203,12 @@ public partial class App : Application {
 
     public override void OnFrameworkInitializationCompleted() {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop) {
-            // The steady-state mode (spec §9): closing the main window hides it to the tray, so
-            // the app must never exit on last-window-close. Set here, before StartAsync fires, so
-            // it holds from the very first window onward; ShowStartupError pins the same value
-            // again on the failure path, where it is now redundant but self-documenting (its own
-            // comment explains the exit-code bug that pin fixes).
+            // Closing the main window hides it; only an explicit quit ends the process.
             desktop.ShutdownMode = ShutdownMode.OnExplicitShutdown;
             desktop.ShutdownRequested += OnShutdownRequested;
+            var windowLifecycle = new DesktopWindowLifecycle(this.TryGetFeature<IActivatableLifetime>(),
+                () => _shutdownStarted ? null : MainWindowAction(_coordinator), AppKitDock.SetVisible);
+            desktop.Exit += (_, _) => windowLifecycle.Dispose();
             // Before StartAsync: it shows its first window (the install guard or the wizard) synchronously.
             new AppMenuBar(new ShellUrlOpener(), () => desktop.Windows, () => MainWindowAction(_coordinator)).Install();
             _ = StartAsync(desktop);

--- a/src/Capacitor.App/Services/DesktopWindowLifecycle.cs
+++ b/src/Capacitor.App/Services/DesktopWindowLifecycle.cs
@@ -1,0 +1,68 @@
+using Avalonia;
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+
+namespace Capacitor.App.Services;
+
+/// Install before the first window is shown. Minimized windows remain visible to Avalonia and
+/// keep the Dock entry; hiding or closing the last window leaves the app in the tray.
+public sealed class DesktopWindowLifecycle : IDisposable {
+    readonly IActivatableLifetime? _activation;
+    readonly Func<Action?> _showMainWindow;
+    readonly Action<bool> _setDockVisibility;
+    readonly IDisposable _visibilitySubscription;
+    readonly HashSet<Window> _visibleWindows = [];
+    bool? _dockVisible;
+    bool _disposed;
+
+    public DesktopWindowLifecycle(IActivatableLifetime? activation, Func<Action?> showMainWindow, Action<bool> setDockVisibility) {
+        _activation = activation;
+        _showMainWindow = showMainWindow;
+        _setDockVisibility = setDockVisibility;
+        // IsVisible changes before the native Show call, so the Dock policy is restored before
+        // AppKit activates the window. Opened is too late for that ordering.
+        _visibilitySubscription = Window.IsVisibleProperty.Changed.AddClassHandler<Window>((window, _) => OnVisibilityChanged(window));
+        if (_activation is not null) _activation.Activated += OnActivated;
+    }
+
+    void OnActivated(object? sender, ActivatedEventArgs e) {
+        if (e.Kind == ActivationKind.Reopen) _showMainWindow()?.Invoke();
+    }
+
+    void OnVisibilityChanged(Window window) {
+        if (window.IsVisible) {
+            if (!_visibleWindows.Add(window)) return;
+            window.Closed += OnClosed;
+        } else if (!Remove(window)) {
+            return;
+        }
+
+        UpdateDockVisibility();
+    }
+
+    void OnClosed(object? sender, EventArgs e) {
+        if (sender is Window window && Remove(window)) UpdateDockVisibility();
+    }
+
+    bool Remove(Window window) {
+        if (!_visibleWindows.Remove(window)) return false;
+        window.Closed -= OnClosed;
+        return true;
+    }
+
+    void UpdateDockVisibility() {
+        var visible = _visibleWindows.Count != 0;
+        if (_dockVisible == visible) return;
+        _dockVisible = visible;
+        _setDockVisibility(visible);
+    }
+
+    public void Dispose() {
+        if (_disposed) return;
+        _disposed = true;
+        if (_activation is not null) _activation.Activated -= OnActivated;
+        _visibilitySubscription.Dispose();
+        foreach (var window in _visibleWindows) window.Closed -= OnClosed;
+        _visibleWindows.Clear();
+    }
+}

--- a/src/Capacitor.App/Services/MainWindowCoordinator.cs
+++ b/src/Capacitor.App/Services/MainWindowCoordinator.cs
@@ -1,55 +1,45 @@
+using Avalonia.Controls;
 using Capacitor.App.Views;
 
 namespace Capacitor.App.Services;
 
-/// Owns the app's single main window across hide-to-tray cycles (spec §9). Closing the window
-/// hides it — the app keeps living in the tray — and the tray's "Open Kurrent Capacitor" re-shows
-/// that same instance. A window is only ever really closed during a quit, and a later
-/// ShowMainWindow then builds a fresh one from the factory: Avalonia refuses to Show() a closed
-/// window, and nothing is lost because no state lives in the view (everything displayed is
-/// projected from the live service).
+/// Retains the main window across hide-to-tray cycles. Avalonia cannot show a window after a
+/// real close, so only that path discards the instance.
 /// <param name="releaseWorkspace">
-/// Starts the tracked teardown of whatever session workspace the window still owns. Invoked on BOTH
-/// exits (spec §3): an intercepted close only hides the window, so its ViewModels stay alive and an
-/// invisible terminal would otherwise keep clamping the PTY for every other viewer; a real close
-/// discards the window, and the one the next ShowMainWindow builds must not inherit that attach.
-/// Idempotent by construction — a VM that already swapped back to the shell has nothing to release.
+/// Releases the workspace on hide and close: an invisible terminal must not keep clamping the
+/// PTY for other viewers. The callback must tolerate a workspace that has already been released.
 /// </param>
 public sealed class MainWindowCoordinator(Func<MainWindow> windowFactory, Action<MainWindow>? releaseWorkspace = null) {
     MainWindow? _window;
 
-    /// Set by App.OnShutdownRequested's FIRST (deferring) pass, so the second pass's real window
-    /// teardown is never cancelled by the interception below.
+    /// Prevents reopening and lets window teardown complete during deferred shutdown.
     public bool QuitInProgress { get; set; }
 
-    /// The tracked window — live (visible or hidden) from the first ShowMainWindow until a real
-    /// close. Null outside that window; App reads it once to assign desktop.MainWindow.
+    /// The retained window, whether visible or hidden; null after a real close.
     public MainWindow? Window => _window;
 
     public void ShowMainWindow() {
+        if (QuitInProgress) return;
+
         if (_window is null) {
-            var window = windowFactory(); // the factory shows it (App.BuildAndShowMainWindow)
+            var window = windowFactory();
             window.CloseInterceptor = OnWindowClosing;
-            // Only a REAL close reaches this (an intercepted one is cancelled before Closed) —
-            // the identity check keeps a late event from a superseded window from clearing a
-            // newer one.
             window.Closed += (_, _) => {
-                // Released off the window that is actually closing, never off _window: a late event
-                // from a superseded window must not tear down the current one's workspace.
+                // A late close must release its own workspace without discarding a newer window.
                 releaseWorkspace?.Invoke(window);
                 if (ReferenceEquals(_window, window)) _window = null;
             };
             _window = window;
         }
 
-        _window.Show();    // no-op when already visible
-        _window.Activate(); // bring it forward when it was merely behind other windows
+        if (_window.WindowState == WindowState.Minimized) _window.WindowState = WindowState.Normal;
+        _window.Show();
+        _window.Activate();
     }
 
-    /// Called from MainWindow.Closing. True → the close must be cancelled; the window is hidden
-    /// here instead.
+    /// Returns true when the close must be cancelled because the window was hidden instead.
     public bool OnWindowClosing() {
-        if (QuitInProgress) return false; // a real close — the Closed handler above releases instead
+        if (QuitInProgress) return false;
 
         if (_window is not null) releaseWorkspace?.Invoke(_window);
         _window?.Hide();

--- a/src/Capacitor.App/Views/AppKitDock.cs
+++ b/src/Capacitor.App/Views/AppKitDock.cs
@@ -1,0 +1,28 @@
+using System.Runtime.InteropServices;
+
+namespace Capacitor.App.Views;
+
+public static partial class AppKitDock {
+    const string ObjC = "/usr/lib/libobjc.A.dylib";
+
+    public static void SetVisible(bool visible) {
+        if (!OperatingSystem.IsMacOS()) return;
+
+        var app = Send(GetClass("NSApplication"), Selector("sharedApplication"));
+        nint policy = visible ? 0 : 1; // NSApplicationActivationPolicyRegular / Accessory
+        if (Send(app, Selector("activationPolicy")) != policy)
+            SetActivationPolicy(app, Selector("setActivationPolicy:"), policy);
+    }
+
+    [LibraryImport(ObjC, EntryPoint = "objc_getClass", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint GetClass(string name);
+
+    [LibraryImport(ObjC, EntryPoint = "sel_registerName", StringMarshalling = StringMarshalling.Utf8)]
+    private static partial nint Selector(string name);
+
+    [LibraryImport(ObjC, EntryPoint = "objc_msgSend")]
+    private static partial nint Send(nint receiver, nint selector);
+
+    [LibraryImport(ObjC, EntryPoint = "objc_msgSend")]
+    private static partial byte SetActivationPolicy(nint receiver, nint selector, nint policy);
+}

--- a/test/Capacitor.App.Tests.Unit/DesktopWindowLifecycleTests.cs
+++ b/test/Capacitor.App.Tests.Unit/DesktopWindowLifecycleTests.cs
@@ -1,0 +1,190 @@
+using Avalonia.Controls;
+using Avalonia.Controls.ApplicationLifetimes;
+using Avalonia.Threading;
+using Capacitor.App.Services;
+using Capacitor.App.Views;
+using TUnit.Assertions.Enums;
+
+namespace Capacitor.App.Tests.Unit;
+
+[NotInParallel("AvaloniaSession")]
+public class DesktopWindowLifecycleTests {
+    [Test]
+    public Task Dock_reopen_after_close_restores_the_same_window_and_releases_its_workspace_once() =>
+        AvaloniaSession.RunOnUiAsync(async () => {
+            using var fixture = new Fixture();
+            fixture.Coordinator.ShowMainWindow();
+            var window = fixture.Coordinator.Window!;
+            window.Close();
+            await Assert.That(window.IsVisible).IsFalse();
+
+            fixture.Activation.Raise(ActivationKind.Reopen);
+            fixture.Activation.Raise(ActivationKind.Reopen);
+            Dispatcher.UIThread.RunJobs();
+
+            await Assert.That(window.IsVisible).IsTrue();
+            await Assert.That(fixture.Coordinator.Window).IsSameReferenceAs(window);
+            await Assert.That(fixture.Builds).IsEqualTo(1);
+            await Assert.That(fixture.Releases).IsEqualTo(1);
+            await Assert.That(fixture.DockVisibility).IsEquivalentTo([true, false, true], CollectionOrdering.Matching);
+        });
+
+    [Test]
+    public Task Settings_keeps_the_Dock_visible_until_the_last_window_closes() =>
+        AvaloniaSession.RunOnUiAsync(async () => {
+            using var fixture = new Fixture();
+            fixture.Coordinator.ShowMainWindow();
+            var settings = new SettingsWindow();
+            try {
+                settings.Show();
+                fixture.Coordinator.Window!.Close();
+                await Assert.That(fixture.DockVisibility).IsEquivalentTo([true], CollectionOrdering.Matching);
+
+                settings.Close();
+                await Assert.That(fixture.DockVisibility).IsEquivalentTo([true, false], CollectionOrdering.Matching);
+
+                fixture.Coordinator.ShowMainWindow();
+                await Assert.That(fixture.DockVisibility).IsEquivalentTo([true, false, true], CollectionOrdering.Matching);
+            } finally {
+                settings.Close();
+            }
+        });
+
+    [Test]
+    public Task Minimize_keeps_the_Dock_visible_and_reopen_restores_the_window() =>
+        AvaloniaSession.RunOnUiAsync(async () => {
+            using var fixture = new Fixture();
+            fixture.Coordinator.ShowMainWindow();
+            var window = fixture.Coordinator.Window!;
+            window.WindowState = WindowState.Minimized;
+            await Assert.That(fixture.DockVisibility).IsEquivalentTo([true], CollectionOrdering.Matching);
+
+            fixture.Activation.Raise(ActivationKind.Reopen);
+
+            await Assert.That(window.WindowState).IsEqualTo(WindowState.Normal);
+            await Assert.That(fixture.DockVisibility).IsEquivalentTo([true], CollectionOrdering.Matching);
+        });
+
+    [Test]
+    [Arguments(WindowState.Maximized)]
+    [Arguments(WindowState.FullScreen)]
+    public Task Reopen_preserves_an_expanded_window(WindowState state) =>
+        AvaloniaSession.RunOnUiAsync(async () => {
+            using var fixture = new Fixture();
+            fixture.Coordinator.ShowMainWindow();
+            fixture.Coordinator.Window!.WindowState = state;
+
+            fixture.Activation.Raise(ActivationKind.Reopen);
+
+            await Assert.That(fixture.Coordinator.Window.WindowState).IsEqualTo(state);
+        });
+
+    [Test]
+    [Arguments(ActivationKind.Background)]
+    [Arguments(ActivationKind.File)]
+    [Arguments(ActivationKind.OpenUri)]
+    public Task Other_activation_kinds_do_not_reopen_a_hidden_window(ActivationKind kind) =>
+        AvaloniaSession.RunOnUiAsync(async () => {
+            using var fixture = new Fixture();
+            fixture.Coordinator.ShowMainWindow();
+            fixture.Coordinator.Window!.Close();
+
+            fixture.Activation.Raise(kind);
+
+            await Assert.That(fixture.Coordinator.Window.IsVisible).IsFalse();
+        });
+
+    [Test]
+    public Task Reopen_resolves_the_action_after_startup_finishes() =>
+        AvaloniaSession.RunOnUiAsync(async () => {
+            using var fixture = new Fixture { Ready = false };
+            fixture.Activation.Raise(ActivationKind.Reopen);
+            await Assert.That(fixture.Builds).IsEqualTo(0);
+
+            fixture.Ready = true;
+            fixture.Activation.Raise(ActivationKind.Reopen);
+
+            await Assert.That(fixture.Builds).IsEqualTo(1);
+            await Assert.That(fixture.Coordinator.Window!.IsVisible).IsTrue();
+        });
+
+    [Test]
+    public Task Reopen_and_tray_open_during_quit_do_not_show_or_rebuild_the_window() =>
+        AvaloniaSession.RunOnUiAsync(async () => {
+            using var fixture = new Fixture();
+            fixture.Coordinator.ShowMainWindow();
+            var window = fixture.Coordinator.Window!;
+            window.Close();
+            fixture.Coordinator.QuitInProgress = true;
+
+            fixture.Activation.Raise(ActivationKind.Reopen);
+            fixture.Coordinator.ShowMainWindow();
+            await Assert.That(window.IsVisible).IsFalse();
+
+            window.Close();
+            fixture.Activation.Raise(ActivationKind.Reopen);
+            fixture.Coordinator.ShowMainWindow();
+            await Assert.That(fixture.Coordinator.Window).IsNull();
+            await Assert.That(fixture.Builds).IsEqualTo(1);
+        });
+
+    [Test]
+    public Task Disposal_detaches_activation_and_window_tracking() =>
+        AvaloniaSession.RunOnUiAsync(async () => {
+            using var fixture = new Fixture();
+            fixture.Coordinator.ShowMainWindow();
+            fixture.Lifecycle.Dispose();
+            fixture.Lifecycle.Dispose();
+            fixture.Coordinator.Window!.Close();
+
+            fixture.Activation.Raise(ActivationKind.Reopen);
+            var other = new Window();
+            other.Show();
+            other.Close();
+
+            await Assert.That(fixture.Coordinator.Window.IsVisible).IsFalse();
+            await Assert.That(fixture.DockVisibility).IsEquivalentTo([true], CollectionOrdering.Matching);
+        });
+
+    [Test]
+    public Task A_platform_without_activation_support_still_tracks_window_visibility() =>
+        AvaloniaSession.RunOnUiAsync(async () => {
+            var visibility = new List<bool>();
+            using var lifecycle = new DesktopWindowLifecycle(null, () => null, visibility.Add);
+            var window = new Window();
+            window.Show();
+            window.Hide();
+            window.Show();
+            window.Close();
+
+            await Assert.That(visibility).IsEquivalentTo([true, false, true, false], CollectionOrdering.Matching);
+        });
+
+    sealed class Fixture : IDisposable {
+        public FakeActivatableLifetime Activation { get; } = FakeActivatableLifetime.Create();
+        public List<bool> DockVisibility { get; } = [];
+        public MainWindowCoordinator Coordinator { get; }
+        public DesktopWindowLifecycle Lifecycle { get; }
+        public bool Ready { get; set; } = true;
+        public int Builds { get; private set; }
+        public int Releases { get; private set; }
+
+        public Fixture() {
+            Coordinator = new MainWindowCoordinator(() => {
+                Builds++;
+                var window = new MainWindow();
+                window.Show();
+                return window;
+            }, _ => Releases++);
+            Lifecycle = new DesktopWindowLifecycle(Activation.Lifetime,
+                () => Capacitor.App.App.MainWindowAction(Ready ? Coordinator : null), DockVisibility.Add);
+        }
+
+        public void Dispose() {
+            Lifecycle.Dispose();
+            Coordinator.QuitInProgress = true;
+            Coordinator.Window?.Close();
+            Dispatcher.UIThread.RunJobs();
+        }
+    }
+}

--- a/test/Capacitor.App.Tests.Unit/FakeActivatableLifetime.cs
+++ b/test/Capacitor.App.Tests.Unit/FakeActivatableLifetime.cs
@@ -1,0 +1,28 @@
+using System.Reflection;
+using Avalonia.Controls.ApplicationLifetimes;
+
+namespace Capacitor.App.Tests.Unit;
+
+// Avalonia prohibits implementing this interface in C#; DispatchProxy supplies the test double.
+public class FakeActivatableLifetime : DispatchProxy {
+    EventHandler<ActivatedEventArgs>? _activated;
+
+    public IActivatableLifetime Lifetime => (IActivatableLifetime)this;
+
+    public static FakeActivatableLifetime Create() =>
+        (FakeActivatableLifetime)Create<IActivatableLifetime, FakeActivatableLifetime>();
+
+    public void Raise(ActivationKind kind) => _activated?.Invoke(this, new ActivatedEventArgs(kind));
+
+    protected override object? Invoke(MethodInfo? targetMethod, object?[]? args) {
+        switch (targetMethod?.Name) {
+            case "add_Activated": _activated += (EventHandler<ActivatedEventArgs>)args![0]!; return null;
+            case "remove_Activated": _activated -= (EventHandler<ActivatedEventArgs>)args![0]!; return null;
+            case "add_Deactivated":
+            case "remove_Deactivated": return null;
+            case "TryEnterBackground":
+            case "TryLeaveBackground": return false;
+            default: throw new NotSupportedException($"Unexpected activation call: {targetMethod?.Name}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #894 — AI-2713

## What & why

Closing the main window leaves Capacitor running in the tray; a macOS reopen request restores the retained window. Track visible windows to remove the Dock entry when the last window hides or closes and restore it before a window is shown.

## Where to look

Dock policy changes follow window visibility before the native Show call. Auxiliary and minimized windows retain the Dock entry, and shutdown prevents reopening.

## Verification

- `dotnet run --project test/Capacitor.App.Tests.Unit/Capacitor.App.Tests.Unit.csproj --no-build --no-restore`: 1,896 passed.
- Clean rebuild of the desktop app and test suite: zero warnings and errors.
- 12 lifecycle regression cases passed, including close/reopen, window reuse, auxiliary windows, minimization, and shutdown.
- Isolated native macOS probe passed: titlebar close followed by OS Reopen, tray callback restoration, actual regular/accessory activation policies, minimized restoration, and clean exit.